### PR TITLE
Downgrade client to stable version

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.138.0-preview" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="15.131.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NuGet.Packaging" Version="4.8.0" />
     <PackageReference Include="Octokit" Version="0.32.0" />


### PR DESCRIPTION
This is so the prod build (which builds stable packages) won't fail nuget package.  There are no stable 16.* versions