### PR TITLE
Fix OnDelete.Restrict

### DIFF
--- a/src/Maestro/Maestro.Data/BuildAssetRegistryContext.cs
+++ b/src/Maestro/Maestro.Data/BuildAssetRegistryContext.cs
@@ -119,12 +119,14 @@ namespace Maestro.Data
             builder.Entity<ChannelReleasePipeline>()
                 .HasOne(crp => crp.Channel)
                 .WithMany(c => c.ChannelReleasePipelines)
-                .HasForeignKey(rcp => rcp.ChannelId);
+                .HasForeignKey(rcp => rcp.ChannelId)
+                .OnDelete(DeleteBehavior.Restrict);
             
             builder.Entity<ChannelReleasePipeline>()
                 .HasOne(crp => crp.ReleasePipeline)
                 .WithMany(rp => rp.ChannelReleasePipelines)
-                .HasForeignKey(crp => crp.ReleasePipelineId);
+                .HasForeignKey(crp => crp.ReleasePipelineId)
+                .OnDelete(DeleteBehavior.Restrict);
             
             builder.Entity<ApplicationUserPersonalAccessToken>()
                 .HasIndex(

--- a/src/Maestro/Maestro.Data/Migrations/20190111011037_onDeleteRestrict.Designer.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20190111011037_onDeleteRestrict.Designer.cs
@@ -4,14 +4,16 @@ using Maestro.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Maestro.Data.Migrations
 {
     [DbContext(typeof(BuildAssetRegistryContext))]
-    partial class BuildAssetRegistryContextModelSnapshot : ModelSnapshot
+    [Migration("20190111011037_onDeleteRestrict")]
+    partial class onDeleteRestrict
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Maestro/Maestro.Data/Migrations/20190111011037_onDeleteRestrict.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20190111011037_onDeleteRestrict.cs
@@ -1,0 +1,61 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Maestro.Data.Migrations
+{
+    public partial class onDeleteRestrict : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ChannelReleasePipelines_Channels_ChannelId",
+                table: "ChannelReleasePipelines");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ChannelReleasePipelines_ReleasePipeline_ReleasePipelineId",
+                table: "ChannelReleasePipelines");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ChannelReleasePipelines_Channels_ChannelId",
+                table: "ChannelReleasePipelines",
+                column: "ChannelId",
+                principalTable: "Channels",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ChannelReleasePipelines_ReleasePipeline_ReleasePipelineId",
+                table: "ChannelReleasePipelines",
+                column: "ReleasePipelineId",
+                principalTable: "ReleasePipeline",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ChannelReleasePipelines_Channels_ChannelId",
+                table: "ChannelReleasePipelines");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ChannelReleasePipelines_ReleasePipeline_ReleasePipelineId",
+                table: "ChannelReleasePipelines");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ChannelReleasePipelines_Channels_ChannelId",
+                table: "ChannelReleasePipelines",
+                column: "ChannelId",
+                principalTable: "Channels",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ChannelReleasePipelines_ReleasePipeline_ReleasePipelineId",
+                table: "ChannelReleasePipelines",
+                column: "ReleasePipelineId",
+                principalTable: "ReleasePipeline",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}


### PR DESCRIPTION
@JohnTortugo when you responded to @ChadNedzlek's feedback you updated just the data context model snapshot which didn't actually do anything. This change updates the DbContext to specify Restrict for those foreign keys.