### PR TITLE
Specify a temporary path to clone repositories

### DIFF
--- a/src/Maestro/SubscriptionActorService/.config/settings.Production.json
+++ b/src/Maestro/SubscriptionActorService/.config/settings.Production.json
@@ -1,3 +1,4 @@
 {
-  "KeyVaultUri": "https://maestroprod.vault.azure.net/"
+  "KeyVaultUri": "https://maestroprod.vault.azure.net/",
+  "DarcTemporaryRepoRoot": "D:\\"
 }

--- a/src/Maestro/SubscriptionActorService/.config/settings.Staging.json
+++ b/src/Maestro/SubscriptionActorService/.config/settings.Staging.json
@@ -1,3 +1,4 @@
 {
-  "KeyVaultUri": "https://maestroint.vault.azure.net/"
+  "KeyVaultUri": "https://maestroint.vault.azure.net/",
+  "DarcTemporaryRepoRoot": "D:\\"
 }

--- a/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
+++ b/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
@@ -33,8 +33,12 @@ namespace SubscriptionActorService
 
         public async Task<IRemote> CreateAsync(string repoUrl, long installationId)
         {
-            var settings = new DarcSettings();
+            DarcSettings settings = new DarcSettings();
             Uri repoUri = new Uri(repoUrl);
+
+            // Look up the setting for where the repo root should be held.  Default to empty,
+            // which will use the temp directory.
+            settings.TemporaryRepositoryRoot = Configuration.GetValue<string>("DarcTemporaryRepoRoot", null);
 
             switch (repoUri.Host)
             {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Maestro.Client;
@@ -25,13 +26,21 @@ namespace Microsoft.DotNet.DarcLib
 
             _logger = logger;
 
+            // If a temporary repository root was not provided, use the environment
+            // provided temp directory
+            string temporaryRepositoryRoot = settings.TemporaryRepositoryRoot;
+            if (string.IsNullOrEmpty(temporaryRepositoryRoot))
+            {
+                temporaryRepositoryRoot = Path.GetTempPath();
+            }
+
             if (settings.GitType == GitRepoType.GitHub)
             {
-                _gitClient = new GitHubClient(settings.PersonalAccessToken, _logger);
+                _gitClient = new GitHubClient(settings.PersonalAccessToken, _logger, temporaryRepositoryRoot);
             }
             else if (settings.GitType == GitRepoType.AzureDevOps)
             {
-                _gitClient = new AzureDevOpsClient(settings.PersonalAccessToken, _logger);
+                _gitClient = new AzureDevOpsClient(settings.PersonalAccessToken, _logger, temporaryRepositoryRoot);
             }
 
             // Only initialize the file manager if we have a git client, which excludes "None"

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/AzureDevOpsClient.cs
@@ -46,7 +46,8 @@ namespace Microsoft.DotNet.DarcLib
         ///     PAT for Azure DevOps. This PAT should cover all
         ///     organizations that may be accessed in a single operation.
         /// </param>
-        public AzureDevOpsClient(string accessToken, ILogger logger)
+        public AzureDevOpsClient(string accessToken, ILogger logger, string temporaryRepositoryPath)
+            : base (temporaryRepositoryPath)
         {
             _personalAccessToken = accessToken;
             _logger = logger;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/DarcSettings.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/DarcSettings.cs
@@ -23,5 +23,11 @@ namespace Microsoft.DotNet.DarcLib
         public string BuildAssetRegistryBaseUri { get; set; }
 
         public GitRepoType GitType { get; set; }
+
+        /// <summary>
+        ///     If the git clients need to clone a repository for whatever reason,
+        ///     this denotes the root of where the repository should be cloned.
+        /// </summary>
+        public string TemporaryRepositoryRoot { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -48,7 +48,8 @@ namespace Microsoft.DotNet.DarcLib
             _product = new ProductHeaderValue("DarcLib", version);
         }
 
-        public GitHubClient(string accessToken, ILogger logger)
+        public GitHubClient(string accessToken, ILogger logger, string temporaryRepositoryPath)
+            : base(temporaryRepositoryPath)
         {
             _personalAccessToken = accessToken;
             _logger = logger;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
@@ -13,6 +13,13 @@ namespace Microsoft.DotNet.DarcLib
 {
     public class RemoteRepoBase
     {
+        protected RemoteRepoBase(string temporaryRepositoryPath)
+        {
+            TemporaryRepositoryPath = temporaryRepositoryPath;
+        }
+
+        protected string TemporaryRepositoryPath { get; set; }
+
         /// <summary>
         /// We used to group commits in a tree object so there would be only one commit per 
         /// change but this doesn't work for trees that end up being too big (around 20K files).
@@ -35,7 +42,7 @@ namespace Microsoft.DotNet.DarcLib
             string dotnetMaestro = "dotnet-maestro";
             using (_logger.BeginScope("Pushing files to {branch}", branch))
             {
-                string tempRepoFolder = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                string tempRepoFolder = Path.Combine(TemporaryRepositoryPath, Path.GetRandomFileName());
 
                 try
                 {


### PR DESCRIPTION
The normal temp path for service fabric applications tends to be too long to clone some repositories like aspnet/AspNetCore