### PR TITLE
Allow filtering of source repo in update-dependencies

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
@@ -57,6 +57,14 @@ namespace Microsoft.DotNet.Darc.Operations
                 // find all repository uris, optionally restricted by the input dependency parameter.
                 IEnumerable<DependencyDetail> dependencies = await local.GetDependenciesAsync(_options.Name);
 
+                // If the source repository was specified, filter away any local dependencies not from that
+                // source repository.
+                if (!string.IsNullOrEmpty(_options.SourceRepository))
+                {
+                    dependencies = dependencies.Where(
+                        dependency => dependency.RepoUri.Contains(_options.SourceRepository, StringComparison.OrdinalIgnoreCase));
+                }
+
                 if (!dependencies.Any())
                 {
                     Console.WriteLine("Found no dependencies to update.");
@@ -89,6 +97,13 @@ namespace Microsoft.DotNet.Darc.Operations
                 }
                 else
                 {
+                    if (string.IsNullOrEmpty(_options.Channel))
+                    {
+                        Console.WriteLine($"Please suppy either a channel name (--channel), a packages folder (--packages-folder) " +
+                            $"or a specific dependency name and version (--name and --version).");
+                        return Constants.ErrorCode;
+                    }
+
                     // Start channel query.
                     var channel = remote.GetChannelAsync(_options.Channel);
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateDependenciesCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateDependenciesCommandLineOptions.cs
@@ -20,6 +20,9 @@ namespace Microsoft.DotNet.Darc.Options
         [Option('v', "version", HelpText = "The new version of dependency --name.")]
         public string Version { get; set; }
 
+        [Option("source-repo", HelpText = "Only update dependencies whose source uri contains this string.")]
+        public string SourceRepository { get; set; }
+
         [Option("packages-folder", HelpText = "An optional path to a folder which contains the NuGet " +
             "packages whose versions will be used to update existing dependencies.")]
         public string PackagesFolder { get; set; }


### PR DESCRIPTION
Until we have the diamond dependency issue figured out, this will help ASPNet do manual updates