### PR TITLE
Add --exact and --regex options to subscription operations

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetSubscriptionsOperation.cs
@@ -35,14 +35,10 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 var subscriptions = (await remote.GetSubscriptionsAsync()).Where(subscription =>
                 {
-                    return (string.IsNullOrEmpty(_options.TargetRepository) ||
-                        subscription.TargetRepository.Contains(_options.TargetRepository, StringComparison.OrdinalIgnoreCase)) &&
-                    (string.IsNullOrEmpty(_options.TargetBranch) ||
-                        subscription.TargetBranch.Contains(_options.TargetBranch, StringComparison.OrdinalIgnoreCase)) &&
-                    (string.IsNullOrEmpty(_options.SourceRepository) ||
-                        subscription.SourceRepository.Contains(_options.SourceRepository, StringComparison.OrdinalIgnoreCase)) &&
-                    (string.IsNullOrEmpty(_options.Channel) ||
-                        subscription.Channel.Name.Contains(_options.Channel, StringComparison.OrdinalIgnoreCase));
+                    return (_options.SubscriptionParameterMatches(_options.TargetRepository, subscription.TargetRepository) &&
+                                _options.SubscriptionParameterMatches(_options.TargetBranch, subscription.TargetBranch) &&
+                                _options.SubscriptionParameterMatches(_options.SourceRepository, subscription.SourceRepository) &&
+                                _options.SubscriptionParameterMatches(_options.Channel, subscription.Channel.Name));
                 });
 
                 if (subscriptions.Count() == 0)

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/TriggerSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/TriggerSubscriptionsOperation.cs
@@ -66,14 +66,10 @@ namespace Microsoft.DotNet.Darc.Operations
 
                     IEnumerable<Subscription> subscriptions = (await remote.GetSubscriptionsAsync()).Where(subscription =>
                     {
-                        return (string.IsNullOrEmpty(_options.TargetRepository) ||
-                            subscription.TargetRepository.Contains(_options.TargetRepository, StringComparison.OrdinalIgnoreCase)) &&
-                        (string.IsNullOrEmpty(_options.TargetBranch) ||
-                            subscription.TargetBranch.Contains(_options.TargetBranch, StringComparison.OrdinalIgnoreCase)) &&
-                        (string.IsNullOrEmpty(_options.SourceRepository) ||
-                            subscription.SourceRepository.Contains(_options.SourceRepository, StringComparison.OrdinalIgnoreCase)) &&
-                        (string.IsNullOrEmpty(_options.Channel) ||
-                            subscription.Channel.Name.Contains(_options.Channel, StringComparison.OrdinalIgnoreCase));
+                        return (_options.SubscriptionParameterMatches(_options.TargetRepository, subscription.TargetRepository) &&
+                                _options.SubscriptionParameterMatches(_options.TargetBranch, subscription.TargetBranch) &&
+                                _options.SubscriptionParameterMatches(_options.SourceRepository, subscription.SourceRepository) &&
+                                _options.SubscriptionParameterMatches(_options.Channel, subscription.Channel.Name));
                     });
 
                     if (subscriptions.Count() == 0)

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GetSubscriptionsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GetSubscriptionsCommandLineOptions.cs
@@ -8,20 +8,8 @@ using Microsoft.DotNet.Darc.Operations;
 namespace Microsoft.DotNet.Darc.Options
 {
     [Verb("get-subscriptions", HelpText = "Get information about subscriptions.")]
-    class GetSubscriptionsCommandLineOptions : CommandLineOptions
+    class GetSubscriptionsCommandLineOptions : SubscriptionsCommandLineOptions
     {
-        [Option("target-repo", HelpText = "Filter by target repo (matches substring).")]
-        public string TargetRepository { get; set; }
-
-        [Option("source-repo", HelpText = "Filter by source repo (matches substring).")]
-        public string SourceRepository { get; set; }
-
-        [Option("channel", HelpText = "Filter by source channel (matches substring).")]
-        public string Channel { get; set; }
-
-        [Option("target-branch", HelpText = "Filter by target branch (matches substring).")]
-        public string TargetBranch { get; set; }
-
         public override Operation GetOperation()
         {
             return new GetSubscriptionsOperation(this);

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
@@ -27,12 +27,20 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("regex", SetName = "regex", HelpText = "Match subscription parameters using regex (cannot be used with --exact).")]
         public bool RegexMatch { get; set; }
 
+        /// <summary>
+        ///     Compare input command line options against subscription parameters
+        /// </summary>
+        /// <param name="inputParameter">Input command line option</param>
+        /// <param name="subscriptionProperty">Subscription options.</param>
+        /// <returns>True if it's a match, false otherwise.</returns>
         public bool SubscriptionParameterMatches(string inputParameter, string subscriptionProperty)
         {
+            // If the parameter isn't set, it's a match
             if (string.IsNullOrEmpty(inputParameter))
             {
                 return true;
             }
+            // Compare properties ignoring case because branch, repo, etc. names cannot differ only by case.
             else if (ExactMatch && inputParameter.Equals(subscriptionProperty, StringComparison.OrdinalIgnoreCase))
             {
                 return true;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
@@ -1,0 +1,50 @@
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommandLine;
+using System.Text.RegularExpressions;
+using System;
+
+namespace Microsoft.DotNet.Darc.Options
+{
+    abstract class SubscriptionsCommandLineOptions : CommandLineOptions
+    {
+        [Option("target-repo", HelpText = "Filter by target repo (matches substring unless --exact or --regex is passd).")]
+        public string TargetRepository { get; set; }
+
+        [Option("source-repo", HelpText = "Filter by source repo (matches substring unless --exact or --regex is passd).")]
+        public string SourceRepository { get; set; }
+
+        [Option("channel", HelpText = "Filter by source channel (matches substring unless --exact or --regex is passd).")]
+        public string Channel { get; set; }
+
+        [Option("target-branch", HelpText = "Filter by target branch (matches substring unless --exact or --regex is passd).")]
+        public string TargetBranch { get; set; }
+
+        [Option("exact", SetName = "exact", HelpText = "Match subscription parameters exactly (cannot be used with --regex).")]
+        public bool ExactMatch { get; set; }
+
+        [Option("regex", SetName = "regex", HelpText = "Match subscription parameters using regex (cannot be used with --exact).")]
+        public bool RegexMatch { get; set; }
+
+        public bool SubscriptionParameterMatches(string inputParameter, string subscriptionProperty)
+        {
+            if (string.IsNullOrEmpty(inputParameter))
+            {
+                return true;
+            }
+            else if (ExactMatch && inputParameter == subscriptionProperty)
+            {
+                return true;
+            }
+            else if (RegexMatch && Regex.IsMatch(subscriptionProperty, inputParameter))
+            {
+                return true;
+            }
+            else
+            {
+                return subscriptionProperty.Contains(inputParameter, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
@@ -33,11 +33,11 @@ namespace Microsoft.DotNet.Darc.Options
             {
                 return true;
             }
-            else if (ExactMatch && inputParameter == subscriptionProperty)
+            else if (ExactMatch && inputParameter.Equals(subscriptionProperty, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
-            else if (RegexMatch && Regex.IsMatch(subscriptionProperty, inputParameter))
+            else if (RegexMatch && Regex.IsMatch(subscriptionProperty, inputParameter, RegexOptions.IgnoreCase))
             {
                 return true;
             }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/TriggerSubscriptionsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/TriggerSubscriptionsCommandLineOptions.cs
@@ -8,25 +8,13 @@ using Microsoft.DotNet.Darc.Operations;
 namespace Microsoft.DotNet.Darc.Options
 {
     [Verb("trigger-subscriptions", HelpText = "Trigger a subscription or set of subscriptions matching criteria.")]
-    internal class TriggerSubscriptionsCommandLineOptions : CommandLineOptions
+    internal class TriggerSubscriptionsCommandLineOptions : SubscriptionsCommandLineOptions
     {
         [Option("id", HelpText = "Trigger a specific subscription by id.")]
         public string Id { get; set; }
 
         [Option('q', "quiet", HelpText = "Do not confirm which subscriptions are about to be triggered.")]
         public bool NoConfirmation { get; set; }
-
-        [Option("target-repo", HelpText = "Filter by target repo (matches substring).")]
-        public string TargetRepository { get; set; }
-
-        [Option("source-repo", HelpText = "Filter by source repo (matches substring).")]
-        public string SourceRepository { get; set; }
-
-        [Option("channel", HelpText = "Filter by source channel (matches substring).")]
-        public string Channel { get; set; }
-
-        [Option("target-branch", HelpText = "Filter by target branch (matches substring).")]
-        public string TargetBranch { get; set; }
 
         public override Operation GetOperation()
         {


### PR DESCRIPTION
Nate pointed out that there was no way to trigger just AspNetCore subscriptions because AspNetCore-Tooling is a subscription.  This adds regex and exact options and refactors them into a common class