### PR TITLE
Add new build info properties to Maestro build manifest model

### DIFF
--- a/src/Maestro/Client/src/Generated/Models/BuildData.cs
+++ b/src/Maestro/Client/src/Generated/Models/BuildData.cs
@@ -26,7 +26,20 @@ namespace Microsoft.DotNet.Maestro.Client.Models
         /// <summary>
         /// Initializes a new instance of the BuildData class.
         /// </summary>
-        public BuildData(string repository, string commit, string buildNumber, string branch = default(string), IList<AssetData> assets = default(IList<AssetData>), IList<int?> dependencies = default(IList<int?>))
+        public BuildData(string repository, 
+            string commit, 
+            string buildNumber, 
+            string branch = default(string), 
+            IList<AssetData> assets = default(IList<AssetData>), 
+            IList<int?> dependencies = default(IList<int?>),
+            string initialAssetsLocation = null,
+            string azureDevOpsBuildId = null,
+            string azureDevOpsBuildDefinitionId = null,
+            string azureDevOpsAccount = null,
+            string azureDevOpsProject = null,
+            string azureDevOpsBuildNumber = null,
+            string azureDevOpsRepository = null,
+            string azureDevOpsBranch = null)
         {
             Repository = repository;
             Branch = branch;
@@ -35,6 +48,15 @@ namespace Microsoft.DotNet.Maestro.Client.Models
             Assets = assets;
             Dependencies = dependencies;
             CustomInit();
+
+            InitialAssetsLocation = initialAssetsLocation;
+            AzureDevOpsBuildId = azureDevOpsBuildId;
+            AzureDevOpsBuildDefinitionId = azureDevOpsBuildDefinitionId;
+            AzureDevOpsAccount = azureDevOpsAccount;
+            AzureDevOpsProject = azureDevOpsProject;
+            AzureDevOpsBuildNumber = azureDevOpsBuildNumber;
+            AzureDevOpsRepository = azureDevOpsRepository;
+            AzureDevOpsBranch = azureDevOpsBranch;
         }
 
         /// <summary>
@@ -71,7 +93,35 @@ namespace Microsoft.DotNet.Maestro.Client.Models
         /// </summary>
         [JsonProperty(PropertyName = "dependencies")]
         public IList<int?> Dependencies { get; set; }
+        
+        #region Properties to be used in new publishing flow
 
+        [JsonProperty(PropertyName = "InitialAssetsLocation")]
+        public string InitialAssetsLocation { get; set; }
+
+        [JsonProperty(PropertyName = "AzureDevOpsBuildId")]
+        public string AzureDevOpsBuildId { get; set; }
+
+        [JsonProperty(PropertyName = "AzureDevOpsBuildDefinitionId")]
+        public string AzureDevOpsBuildDefinitionId { get; set; }
+
+        [JsonProperty(PropertyName = "AzureDevOpsAccount")]
+        public string AzureDevOpsAccount { get; set; }
+
+        [JsonProperty(PropertyName = "AzureDevOpsProject")]
+        public string AzureDevOpsProject { get; set; }
+
+        [JsonProperty(PropertyName = "AzureDevOpsBuildNumber")]
+        public string AzureDevOpsBuildNumber { get; set; }
+
+        [JsonProperty(PropertyName = "AzureDevOpsRepository")]
+        public string AzureDevOpsRepository { get; set; }
+
+        [JsonProperty(PropertyName = "AzureDevOpsBranch")]
+        public string AzureDevOpsBranch { get; set; }
+
+        #endregion
+        
         /// <summary>
         /// Validate the object.
         /// </summary>

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
@@ -30,6 +30,34 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
         [XmlAttribute(AttributeName = "Location")]
         public string Location { get; set; }
+
+        #region Properties to be used in new publishing flow
+
+        [XmlAttribute(AttributeName = "InitialAssetsLocation")]
+        public string InitialAssetsLocation { get; set; }
+
+        [XmlAttribute(AttributeName = "AzureDevOpsBuildId")]
+        public string AzureDevOpsBuildId { get; set; }
+
+        [XmlAttribute(AttributeName = "AzureDevOpsBuildDefinitionId")]
+        public string AzureDevOpsBuildDefinitionId { get; set; }
+
+        [XmlAttribute(AttributeName = "AzureDevOpsAccount")]
+        public string AzureDevOpsAccount { get; set; }
+
+        [XmlAttribute(AttributeName = "AzureDevOpsProject")]
+        public string AzureDevOpsProject { get; set; }
+
+        [XmlAttribute(AttributeName = "AzureDevOpsBuildNumber")]
+        public string AzureDevOpsBuildNumber { get; set; }
+
+        [XmlAttribute(AttributeName = "AzureDevOpsRepository")]
+        public string AzureDevOpsRepository { get; set; }
+
+        [XmlAttribute(AttributeName = "AzureDevOpsBranch")]
+        public string AzureDevOpsBranch { get; set; }
+
+        #endregion
     }
 
     [XmlRoot(ElementName = "Package")]

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -100,7 +100,13 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
                     foreach (Package package in manifest.Packages)
                     {
-                        AddAsset(assets, package.Id, package.Version, manifest.Location, "NugetFeed", package.NonShipping);
+                        AddAsset(
+                            assets, 
+                            package.Id, 
+                            package.Version, 
+                            manifest.InitialAssetsLocation ?? manifest.Location,
+                            (manifest.InitialAssetsLocation == null) ? "NugetFeed" : "Container",
+                            package.NonShipping);
                     }
 
                     foreach (Blob blob in manifest.Blobs)
@@ -113,10 +119,32 @@ namespace Microsoft.DotNet.Maestro.Tasks
                             version = string.Empty;
                         }
 
-                        AddAsset(assets, blob.Id, version, manifest.Location, "Container", blob.NonShipping);
+                        AddAsset(
+                            assets, 
+                            blob.Id, 
+                            version, 
+                            manifest.InitialAssetsLocation ?? manifest.Location, 
+                            "Container", 
+                            blob.NonShipping);
                     }
 
-                    buildsManifestMetadata.Add(new BuildData(manifest.Name, manifest.Commit, manifest.BuildId, manifest.Branch, assets, new List<int?>()));
+                    var buildInfo = new BuildData(
+                        manifest.Name, 
+                        manifest.Commit, 
+                        manifest.BuildId, 
+                        manifest.Branch, 
+                        assets, 
+                        new List<int?>(),
+                        manifest.InitialAssetsLocation,
+                        manifest.AzureDevOpsBuildId,
+                        manifest.AzureDevOpsBuildDefinitionId,
+                        manifest.AzureDevOpsAccount,
+                        manifest.AzureDevOpsProject,
+                        manifest.AzureDevOpsBuildNumber,
+                        manifest.AzureDevOpsRepository,
+                        manifest.AzureDevOpsBranch);
+
+                    buildsManifestMetadata.Add(buildInfo);
                 }
             }
 


### PR DESCRIPTION
Once this PR (https://github.com/dotnet/arcade/pull/1884) is merged the build manifest produced by Arcade will have new properties describing the AzDO build. The current PR captures those fields and will forward them to Maestro - which will handle the properties once this PR https://github.com/dotnet/arcade-services/pull/94 is merged.