### PR TITLE
Update subscriptions work

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
@@ -21,6 +21,6 @@
     <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="5.1.0" />
+    <PackageReference Include="YamlDotNet.Signed" Version="5.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/AddSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/AddSubscriptionPopUp.cs
@@ -87,50 +87,6 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
             }
         }
 
-        /// <summary>
-        /// Validate the merge policies specified in YAML
-        /// </summary>
-        /// <returns>True if the merge policies are valid, false otherwise.</returns>
-        private bool ValidateMergePolicies(List<MergePolicy> mergePolicies)
-        {
-            foreach (MergePolicy policy in mergePolicies)
-            {
-                switch (policy.Name)
-                {
-                    case "AllChecksSuccessful":
-                        // Should either have no properties, or one called "ignoreChecks"
-                        object ignoreChecksProperty = null;
-                        if (policy.Properties != null &&
-                            (policy.Properties.Count > 1 ||
-                            (policy.Properties.Count == 1 &&
-                            !policy.Properties.TryGetValue("ignoreChecks", out ignoreChecksProperty))))
-                        {
-                            _logger.LogError($"AllChecksSuccessful merge policy should have no properties, or an 'ignoreChecks' property. See help.");
-                            return false;
-                        }
-                        break;
-                    case "RequireChecks":
-                        // Should have 'checks' property.
-                        object checksProperty = null;
-                        if (policy.Properties != null &&
-                            (policy.Properties.Count != 1 ||
-                            !policy.Properties.TryGetValue("checks", out checksProperty)))
-                        {
-                            _logger.LogError($"RequireChecks merge policy should have a list of required checks specified with 'checks'. See help.");
-                            return false;
-                        }
-                        break;
-                    case "NoExtraCommits":
-                        break;
-                    default:
-                        _logger.LogError($"Unknown merge policy {policy.Name}");
-                        return false;
-                }
-            }
-
-            return true;
-        }
-
         public override int ProcessContents(IList<Line> contents)
         {
             SubscriptionData outputYamlData;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/SubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/SubscriptionPopUp.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Darc.Models.PopUps
+{
+    public abstract class SubscriptionPopUp : EditorPopUp
+    {
+        private readonly ILogger _logger;
+
+        public SubscriptionPopUp(string path, ILogger logger)
+            : base(path)
+        {
+            Path = path;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Validate the merge policies specified in YAML
+        /// </summary>
+        /// <returns>True if the merge policies are valid, false otherwise.</returns>
+        internal bool ValidateMergePolicies(List<MergePolicy> mergePolicies)
+        {
+            foreach (MergePolicy policy in mergePolicies)
+            {
+                switch (policy.Name)
+                {
+                    case "AllChecksSuccessful":
+                        // Should either have no properties, or one called "ignoreChecks"
+                        object ignoreChecksProperty = null;
+                        if (policy.Properties != null &&
+                            (policy.Properties.Count > 1 ||
+                            (policy.Properties.Count == 1 &&
+                            !policy.Properties.TryGetValue("ignoreChecks", out ignoreChecksProperty))))
+                        {
+                            _logger.LogError($"AllChecksSuccessful merge policy should have no properties, or an 'ignoreChecks' property. See help.");
+                            return false;
+                        }
+                        break;
+                    case "RequireChecks":
+                        // Should have 'checks' property.
+                        object checksProperty = null;
+                        if (policy.Properties != null &&
+                            (policy.Properties.Count != 1 ||
+                            !policy.Properties.TryGetValue("checks", out checksProperty)))
+                        {
+                            _logger.LogError($"RequireChecks merge policy should have a list of required checks specified with 'checks'. See help.");
+                            return false;
+                        }
+                        break;
+                    case "NoExtraCommits":
+                        break;
+                    default:
+                        _logger.LogError($"Unknown merge policy {policy.Name}");
+                        return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
@@ -73,6 +73,7 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
 
             _yamlData = new SubscriptionData
             {
+                Id = GetCurrentSettingForDisplay(subscription.Id.ToString(), subscription.Id.ToString(), false),
                 Channel = GetCurrentSettingForDisplay(subscription.Channel.Name, subscription.Channel.Name, false),
                 SourceRepository = GetCurrentSettingForDisplay(subscription.SourceRepository, subscription.SourceRepository, false),
                 Batchable = GetCurrentSettingForDisplay(subscription.Policy.Batchable.ToString(), subscription.Policy.Batchable.ToString(), false),
@@ -150,11 +151,6 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
                 return Constants.ErrorCode;
             }
 
-            if (!bool.Parse(outputYamlData.Batchable) && outputYamlData.MergePolicies == null)
-            {
-                return Constants.ErrorCode;
-            }
-
             // Validate the merge policies
             if (outputYamlData.MergePolicies != null &&!ValidateMergePolicies(outputYamlData.MergePolicies))
             {
@@ -202,6 +198,9 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
             public const string updateFrequencyElement = "Update Frequency";
             public const string mergePolicyElement = "Merge Policies";
             public const string enabled = "Enabled";
+
+            [YamlMember(ApplyNamingConventions = false)]
+            public string Id { get; set; }
 
             [YamlMember(Alias = channelElement, ApplyNamingConventions = false)]
             public string Channel { get; set; }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
@@ -12,25 +12,27 @@ using YamlDotNet.Serialization;
 
 namespace Microsoft.DotNet.Darc.Models.PopUps
 {
-    public class AddSubscriptionPopUp : SubscriptionPopUp
+    public class UpdateSubscriptionPopUp : SubscriptionPopUp
     {
         private readonly ILogger _logger;
+
         private SubscriptionData _yamlData;
+
         public string Channel => _yamlData.Channel;
+
         public string SourceRepository => _yamlData.SourceRepository;
-        public string TargetRepository => _yamlData.TargetRepository;
-        public string TargetBranch => _yamlData.TargetBranch;
+
+        public bool Batchable => bool.Parse(_yamlData.Batchable);
+
         public string UpdateFrequency => _yamlData.UpdateFrequency;
+
+        public bool Enabled => bool.Parse(_yamlData.Enabled);
+
         public List<MergePolicy> MergePolicies => _yamlData.MergePolicies;
 
-        public AddSubscriptionPopUp(string path,
+        public UpdateSubscriptionPopUp(string path,
                                     ILogger logger,
-                                    string channel,
-                                    string sourceRepository,
-                                    string targetRepository,
-                                    string targetBranch,
-                                    string updateFrequency,
-                                    List<MergePolicy> mergePolicies,
+                                    Subscription subscription,
                                     IEnumerable<string> suggestedChannels,
                                     IEnumerable<string> suggestedRepositories,
                                     IEnumerable<string> availableUpdateFrequencies,
@@ -40,95 +42,55 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
             _logger = logger;
             _yamlData = new SubscriptionData
             {
-                Channel = GetCurrentSettingForDisplay(channel, "<required>", false),
-                SourceRepository = GetCurrentSettingForDisplay(sourceRepository, "<required>", false),
-                TargetRepository = GetCurrentSettingForDisplay(targetRepository, "<required>", false),
-                TargetBranch = GetCurrentSettingForDisplay(targetBranch, "<required>", false),
-                UpdateFrequency = GetCurrentSettingForDisplay(updateFrequency, $"<'{string.Join("', '", Constants.AvailableFrequencies)}'>", false),
-                MergePolicies = new List<MergePolicy>(mergePolicies)
+                Channel = GetCurrentSettingForDisplay(subscription.Channel.Name, subscription.Channel.Name, false),
+                SourceRepository = GetCurrentSettingForDisplay(subscription.SourceRepository, subscription.SourceRepository, false),
+                Batchable = GetCurrentSettingForDisplay(subscription.Policy.Batchable.ToString(), subscription.Policy.Batchable.ToString(), false),
+                UpdateFrequency = GetCurrentSettingForDisplay(subscription.Policy.UpdateFrequency, subscription.Policy.UpdateFrequency, false),
+                Enabled = GetCurrentSettingForDisplay(subscription.Enabled.ToString(), subscription.Enabled.ToString(), false),
+                MergePolicies = new List<MergePolicy>(subscription.Policy.MergePolicies)
             };
 
             ISerializer serializer = new SerializerBuilder().Build();
+
             string yaml = serializer.Serialize(_yamlData);
+
             string[] lines = yaml.Split(Environment.NewLine);
 
             // Initialize line contents.  Augment the input lines with suggestions and explanation
             Contents = new Collection<Line>(new List<Line>
             {
-                new Line("Use this form to create a new subscription.", true),
-                new Line("A subscription maps a build of a source repository that has been applied to a specific channel", true),
-                new Line("onto a specific branch in a target repository.  The subscription has a trigger (update frequency)", true),
-                new Line("and merge policy.  For additional information about subscriptions, please see", true),
-                new Line("https://github.com/dotnet/arcade/blob/master/Documentation/BranchesChannelsAndSubscriptions.md", true),
-                new Line("", true),
-                new Line("Fill out the following form.  Suggested values for fields are shown below.", true),
+                new Line($"Use this form to update the values of subscription '{subscription.Id}'.", true),
                 new Line()
             });
+
             foreach (string line in lines)
             {
                 Contents.Add(new Line(line));
             }
+
             // Add helper comments
-            Contents.Add(new Line($"Suggested repository URLs for '{SubscriptionData.sourceRepoElement}' or '{SubscriptionData.targetRepoElement}':", true));
-            foreach (string suggestedRepo in suggestedRepositories) {
+            Contents.Add(new Line($"Suggested repository URLs for '{SubscriptionData.sourceRepoElement}':", true));
+
+            foreach (string suggestedRepo in suggestedRepositories)
+            {
                 Contents.Add(new Line($"  {suggestedRepo}", true));
             }
+
             Contents.Add(new Line("", true));
             Contents.Add(new Line("Suggested Channels", true));
+
             foreach (string suggestedChannel in suggestedChannels)
             {
                 Contents.Add(new Line($"  {suggestedChannel}", true));
             }
+
             Contents.Add(new Line("", true));
             Contents.Add(new Line("Available Merge Policies", true));
+
             foreach (string mergeHelp in availableMergePolicyHelp)
             {
                 Contents.Add(new Line($"  {mergeHelp}", true));
             }
-        }
-
-        /// <summary>
-        /// Validate the merge policies specified in YAML
-        /// </summary>
-        /// <returns>True if the merge policies are valid, false otherwise.</returns>
-        private bool ValidateMergePolicies(List<MergePolicy> mergePolicies)
-        {
-            foreach (MergePolicy policy in mergePolicies)
-            {
-                switch (policy.Name)
-                {
-                    case "AllChecksSuccessful":
-                        // Should either have no properties, or one called "ignoreChecks"
-                        object ignoreChecksProperty = null;
-                        if (policy.Properties != null &&
-                            (policy.Properties.Count > 1 ||
-                            (policy.Properties.Count == 1 &&
-                            !policy.Properties.TryGetValue("ignoreChecks", out ignoreChecksProperty))))
-                        {
-                            _logger.LogError($"AllChecksSuccessful merge policy should have no properties, or an 'ignoreChecks' property. See help.");
-                            return false;
-                        }
-                        break;
-                    case "RequireChecks":
-                        // Should have 'checks' property.
-                        object checksProperty = null;
-                        if (policy.Properties != null &&
-                            (policy.Properties.Count != 1 ||
-                            !policy.Properties.TryGetValue("checks", out checksProperty)))
-                        {
-                            _logger.LogError($"RequireChecks merge policy should have a list of required checks specified with 'checks'. See help.");
-                            return false;
-                        }
-                        break;
-                    case "NoExtraCommits":
-                        break;
-                    default:
-                        _logger.LogError($"Unknown merge policy {policy.Name}");
-                        return false;
-                }
-            }
-
-            return true;
         }
 
         public override int ProcessContents(IList<Line> contents)
@@ -137,9 +99,6 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
 
             try
             {
-                // Join the lines back into a string and deserialize as YAML.
-                // TODO: Alter the popup/ux manager to pass along the raw file to avoid this unnecessary
-                // operation once authenticate ends up as YAML.
                 string yamlString = contents.Aggregate<Line, string>("", (current, line) => $"{current}{System.Environment.NewLine}{line.Text}");
                 IDeserializer serializer = new DeserializerBuilder().Build();
                 outputYamlData = serializer.Deserialize<SubscriptionData>(yamlString);
@@ -147,6 +106,13 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
             catch (Exception e)
             {
                 _logger.LogError(e, "Failed to parse input yaml.  Please see help for correct format.");
+                return Constants.ErrorCode;
+            }
+
+            // Make sure Batchable and Enabled are valid bools
+            if (!bool.TryParse(outputYamlData.Batchable, out bool batchable) || !bool.TryParse(outputYamlData.Batchable, out bool enabled))
+            {
+                _logger.LogError("Either Batchable or Enabled is not a valid boolean values.");
                 return Constants.ErrorCode;
             }
 
@@ -173,20 +139,6 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
                 return Constants.ErrorCode;
             }
 
-            _yamlData.TargetRepository = ParseSetting(outputYamlData.TargetRepository, _yamlData.TargetRepository, false);
-            if (string.IsNullOrEmpty(_yamlData.TargetRepository))
-            {
-                _logger.LogError("Target repository URL must be non-empty");
-                return Constants.ErrorCode;
-            }
-
-            _yamlData.TargetBranch = ParseSetting(outputYamlData.TargetBranch, _yamlData.TargetBranch, false);
-            if (string.IsNullOrEmpty(_yamlData.TargetBranch))
-            {
-                _logger.LogError("Target branch must be non-empty");
-                return Constants.ErrorCode;
-            }
-
             _yamlData.UpdateFrequency = ParseSetting(outputYamlData.UpdateFrequency, _yamlData.UpdateFrequency, false);
             if (string.IsNullOrEmpty(_yamlData.UpdateFrequency) || 
                 !Constants.AvailableFrequencies.Contains(_yamlData.UpdateFrequency, StringComparer.OrdinalIgnoreCase))
@@ -203,25 +155,30 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
         /// Helper class for YAML encoding/decoding purposes.
         /// This is used so that we can have friendly alias names for elements.
         /// </summary>
-        class SubscriptionData
+        private class SubscriptionData
         {
             public const string channelElement = "Channel";
             public const string sourceRepoElement = "Source Repository URL";
-            public const string targetRepoElement = "Target Repository URL";
-            public const string targetBranchElement = "Target Branch";
+            public const string batchable = "Is batchable";
             public const string updateFrequencyElement = "Update Frequency";
             public const string mergePolicyElement = "Merge Policies";
+            public const string enabled = "Enabled";
 
             [YamlMember(Alias = channelElement, ApplyNamingConventions = false)]
             public string Channel { get; set; }
+
             [YamlMember(Alias = sourceRepoElement, ApplyNamingConventions = false)]
             public string SourceRepository { get; set; }
-            [YamlMember(Alias = targetRepoElement, ApplyNamingConventions = false)]
-            public string TargetRepository { get; set; }
-            [YamlMember(Alias = targetBranchElement, ApplyNamingConventions = false)]
-            public string TargetBranch { get; set; }
+
+            [YamlMember(Alias = batchable, ApplyNamingConventions = false)]
+            public string Batchable { get; set; }
+
             [YamlMember(Alias = updateFrequencyElement, ApplyNamingConventions = false)]
             public string UpdateFrequency { get; set; }
+
+            [YamlMember(Alias = enabled, ApplyNamingConventions = false)]
+            public string Enabled { get; set; }
+
             [YamlMember(Alias = mergePolicyElement, ApplyNamingConventions = false)]
             public List<MergePolicy> MergePolicies { get; set; }
         }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateSubscriptionOperation.cs
@@ -100,23 +100,5 @@ namespace Microsoft.DotNet.Darc.Operations
                 return Constants.ErrorCode;
             }
         }
-
-        private IList<MergePolicy> UpdatedMergePolicies(IList<MergePolicy> originalPolicies, IList<MergePolicy> updatedPolicies)
-        {
-            // If batchable is set to true, MergePolicies have to be null
-            if (updatedPolicies == null)
-            {
-                return null;
-            }
-
-            // If there were no passed in updates to merge policies we set the original list
-            if (!updatedPolicies.Any())
-            {
-                return originalPolicies;
-            }
-
-            // Return the updated policies since it has changes in it
-            return updatedPolicies;
-        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateSubscriptionOperation.cs
@@ -1,0 +1,155 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Darc.Helpers;
+using Microsoft.DotNet.Darc.Models.PopUps;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Darc.Operations
+{
+    class UpdateSubscriptionOperation : Operation
+    {
+        UpdateSubscriptionCommandLineOptions _options;
+
+        public UpdateSubscriptionOperation(UpdateSubscriptionCommandLineOptions options)
+            : base(options)
+        {
+            _options = options;
+        }
+
+        /// <summary>
+        /// Implements the 'update-subscription' operation
+        /// </summary>
+        /// <param name="options"></param>
+        public override async Task<int> ExecuteAsync()
+        {
+            DarcSettings darcSettings = LocalSettings.GetDarcSettings(_options, Logger);
+            // No need to set up a git type or PAT here.
+            Remote remote = new Remote(darcSettings, Logger);
+
+            if (_options.IgnoreChecks.Count() > 0 && !_options.AllChecksSuccessfulMergePolicy)
+            {
+                Logger.LogError($"--ignore-checks must be combined with --all-checks-passed");
+                return Constants.ErrorCode;
+            }
+            // Parse the merge policies
+            List<MergePolicy> mergePolicies = new List<MergePolicy>();
+
+            if (_options.NoExtraCommitsMergePolicy)
+            {
+                mergePolicies.Add(new MergePolicy("NoExtraCommits", null));
+            }
+
+            if (_options.AllChecksSuccessfulMergePolicy)
+            {
+                mergePolicies.Add(new MergePolicy("AllChecksSuccessful", new Dictionary<string, object>
+                {
+                    { "ignoreChecks", _options.IgnoreChecks }
+                }));
+            }
+
+            if (_options.RequireChecksMergePolicy.Count() > 0)
+            {
+                mergePolicies.Add(new MergePolicy("RequireChecks", new Dictionary<string, object>
+                {
+                    { "checks", _options.RequireChecksMergePolicy }
+                }));
+            }
+
+            // First, try to get the subscription
+
+
+            if (!_options.Quiet)
+            {
+
+            }
+
+            string channel = _options.Channel;
+            string sourceRepository = _options.SourceRepository;
+            string updateFrequency = _options.UpdateFrequency;
+            bool batchable = _options.Batchable;
+
+            // If in quiet (non-interactive mode), ensure that all options were passed, then
+            // just call the remote API
+            if (_options.Quiet)
+            {
+                if (string.IsNullOrEmpty(channel) ||
+                    string.IsNullOrEmpty(sourceRepository) ||
+                    string.IsNullOrEmpty(updateFrequency) ||
+                    !Constants.AvailableFrequencies.Contains(updateFrequency, StringComparer.OrdinalIgnoreCase))
+                {
+                    Logger.LogError($"Missing input parameters for the subscription. Please see command help or remove --quiet/-q for interactive mode");
+                    return Constants.ErrorCode;
+                }
+            }
+            else
+            {
+                // Grab existing subscriptions to get suggested values.
+                // TODO: When this becomes paged, set a max number of results to avoid
+                // pulling too much.
+                var suggestedRepos = remote.GetSubscriptionsAsync();
+                var suggestedChannels = remote.GetChannelsAsync();
+
+                // Help the user along with a form.  We'll use the API to gather suggested values
+                // from existing subscriptions based on the input parameters.
+                AddSubscriptionPopUp initEditorPopUp =
+                    new AddSubscriptionPopUp("add-subscription/add-subscription-todo",
+                                             Logger,
+                                             channel,
+                                             sourceRepository,
+                                             targetRepository,
+                                             targetBranch,
+                                             updateFrequency,
+                                             mergePolicies,
+                                             (await suggestedChannels).Select(suggestedChannel => suggestedChannel.Name),
+                                             (await suggestedRepos).SelectMany(subscription => new List<string> { subscription.SourceRepository, subscription.TargetRepository }).ToHashSet(),
+                                             Constants.AvailableFrequencies,
+                                             Constants.AvailableMergePolicyYamlHelp);
+
+                UxManager uxManager = new UxManager(Logger);
+                int exitCode = uxManager.PopUp(initEditorPopUp);
+                if (exitCode != Constants.SuccessCode)
+                {
+                    return exitCode;
+                }
+                channel = initEditorPopUp.Channel;
+                sourceRepository = initEditorPopUp.SourceRepository;
+                targetRepository = initEditorPopUp.TargetRepository;
+                targetBranch = initEditorPopUp.TargetBranch;
+                updateFrequency = initEditorPopUp.UpdateFrequency;
+                mergePolicies = initEditorPopUp.MergePolicies;
+            }
+
+            try
+            {
+                var newSubscription = await remote.CreateSubscriptionAsync(channel,
+                                                                           sourceRepository,
+                                                                           targetRepository,
+                                                                           targetBranch,
+                                                                           updateFrequency,
+                                                                           mergePolicies);
+                Console.WriteLine($"Successfully created new subscription with id '{newSubscription.Id}'.");
+                return Constants.SuccessCode;
+            }
+            catch (ApiErrorException e) when (e.Response.StatusCode == System.Net.HttpStatusCode.BadRequest)
+            {
+                // Could have been some kind of validation error (e.g. channel doesn't exist)
+                Logger.LogError($"Failed to create subscription: {e.Response.Content}");
+                return Constants.ErrorCode;
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, $"Failed to create subscription.");
+                return Constants.ErrorCode;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateSubscriptionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateSubscriptionCommandLineOptions.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommandLine;
+using Microsoft.DotNet.Darc.Operations;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Darc.Options
+{
+    [Verb("update-subscription", HelpText = "Update an existing subscription.")]
+    class UpdateSubscriptionCommandLineOptions : CommandLineOptions
+    {
+        [Option("id", Required = true, HelpText = "Subscription's id.")]
+        public string Id { get; set; }
+
+        [Option("channel", HelpText = "Name of channel to pull from.")]
+        public string Channel { get; set; }
+
+        [Option("source-repo", HelpText = "Source repository for the subscription.")]
+        public string SourceRepository { get; set; }
+
+        [Option("batchable", HelpText = "Whether the subscription is batchable or not.")]
+        public bool Batchable { get; set; }
+
+        [Option("update-frequency", HelpText = "Frequency of updates. Valid values are: 'none', 'everyDay', or 'everyBuild'.")]
+        public string UpdateFrequency { get; set; }
+
+        [Option("all-checks-passed", HelpText = "PR is automatically merged if there is at least one checks and all are passed. " +
+            "Optionally provide a comma separated list of ignored check with --ignore-checks.")]
+        public bool AllChecksSuccessfulMergePolicy { get; set; }
+
+        [Option("ignore-checks", Separator = ',', HelpText = "For use with --all-checks-passed. A set of checks that are ignored.")]
+        public IEnumerable<string> IgnoreChecks { get; set; }
+
+        [Option("no-extra-commits", HelpText = "PR is automatically merged if no non-bot commits exist in the PR.")]
+        public bool NoExtraCommitsMergePolicy { get; set; }
+
+        [Option("require-checks", Separator = ',', HelpText = "PR is automatically merged if the specified checks are passed. " +
+            "Provide a comma separate list of required checks.")]
+        public IEnumerable<string> RequireChecksMergePolicy { get; set; }
+
+        [Option("enabled", HelpText = "Whether the subscription is enabled or not.")]
+        public bool Enabled { get; set; }
+
+        [Option('q', "quiet", HelpText = "Non-interactive mode (requires all elements to be passed on the command line).")]
+        public bool Quiet { get; set; }
+
+        public override Operation GetOperation()
+        {
+            return new UpdateSubscriptionOperation(this);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateSubscriptionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateSubscriptionCommandLineOptions.cs
@@ -14,38 +14,6 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("id", Required = true, HelpText = "Subscription's id.")]
         public string Id { get; set; }
 
-        [Option("channel", HelpText = "Name of channel to pull from.")]
-        public string Channel { get; set; }
-
-        [Option("source-repo", HelpText = "Source repository for the subscription.")]
-        public string SourceRepository { get; set; }
-
-        [Option("batchable", HelpText = "Whether the subscription is batchable or not.")]
-        public bool Batchable { get; set; }
-
-        [Option("update-frequency", HelpText = "Frequency of updates. Valid values are: 'none', 'everyDay', or 'everyBuild'.")]
-        public string UpdateFrequency { get; set; }
-
-        [Option("all-checks-passed", HelpText = "PR is automatically merged if there is at least one checks and all are passed. " +
-            "Optionally provide a comma separated list of ignored check with --ignore-checks.")]
-        public bool AllChecksSuccessfulMergePolicy { get; set; }
-
-        [Option("ignore-checks", Separator = ',', HelpText = "For use with --all-checks-passed. A set of checks that are ignored.")]
-        public IEnumerable<string> IgnoreChecks { get; set; }
-
-        [Option("no-extra-commits", HelpText = "PR is automatically merged if no non-bot commits exist in the PR.")]
-        public bool NoExtraCommitsMergePolicy { get; set; }
-
-        [Option("require-checks", Separator = ',', HelpText = "PR is automatically merged if the specified checks are passed. " +
-            "Provide a comma separate list of required checks.")]
-        public IEnumerable<string> RequireChecksMergePolicy { get; set; }
-
-        [Option("enabled", HelpText = "Whether the subscription is enabled or not.")]
-        public bool Enabled { get; set; }
-
-        [Option('q', "quiet", HelpText = "Non-interactive mode (requires all elements to be passed on the command line).")]
-        public bool Quiet { get; set; }
-
         public override Operation GetOperation()
         {
             return new UpdateSubscriptionOperation(this);

--- a/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
@@ -68,6 +68,7 @@ namespace Microsoft.DotNet.Darc
                     typeof(RetrySubscriptionUpdateCommandLineOptions),
                     typeof(TriggerSubscriptionsCommandLineOptions),
                     typeof(UpdateDependenciesCommandLineOptions),
+                    typeof(UpdateSubscriptionCommandLineOptions),
                     typeof(VerifyCommandLineOptions),
                 };
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -283,6 +283,12 @@ namespace Microsoft.DotNet.DarcLib
             return _barClient.Subscriptions.RetrySubscriptionActionAsyncAsync(subscriptionGuid, actionIdentifier);
         }
 
+        public async Task<Subscription> UpdateSubscriptionAsync(Guid subscriptionId, SubscriptionUpdate subscription)
+        {
+            CheckForValidBarClient();
+            return await _barClient.Subscriptions.UpdateSubscriptionAsync(subscriptionId, subscription);
+        }
+
         public async Task CreateNewBranchAsync(string repoUri, string baseBranch, string newBranch)
         {
             await _gitClient.CreateBranchAsync(repoUri, newBranch, baseBranch);


### PR DESCRIPTION
Work for https://github.com/dotnet/arcade/issues/1935

Editing subscriptions only supports non-quiet mode (pop up) given the amount of permutations possible. With the pop up the user defines explicitly the changes which we will take wholesale validating that the data is valid.