### PR TITLE
Do not fail if dependency graph walk yields a valid node with no eng/Versions.Details.xml

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyGraphOperation.cs
@@ -216,7 +216,7 @@ namespace Microsoft.DotNet.Darc.Operations
         /// <param name="graph">Graph to log incoherencies for</param>
         private void LogIncoherencies(DependencyGraph graph)
         {
-            if (!graph.IncoherentNodes.Any())
+            if (!graph.IncoherentNodes.Any() || !_options.IncludeCoherency)
             {
                 return;
             }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GetDependencyGraphCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GetDependencyGraphCommandLineOptions.cs
@@ -39,6 +39,9 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("include-toolset", HelpText = "Include toolset dependencies.")]
         public bool IncludeToolset { get; set; }
 
+        [Option("coherency", HelpText = "Report coherency information.")]
+        public bool IncludeCoherency { get; set; }
+
         public override Operation GetOperation()
         {
             return new GetDependencyGraphOperation(this);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
@@ -456,6 +456,13 @@ namespace Microsoft.DotNet.DarcLib
                 }
                 return dependencies;
             }
+            catch (DependencyFileNotFoundException exc)
+            {
+                // This is not an error. Dependencies can be specified with explicit shas that
+                // may not have eng/Version.Details at that point.
+                logger.LogWarning($"{repoUri}@{commit} does not have an eng/Version.Details.xml.");
+                return null;
+            }
             catch (Exception exc)
             {
                 logger.LogError(exc, $"Something failed while trying the fetch the " +

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
@@ -456,7 +456,7 @@ namespace Microsoft.DotNet.DarcLib
                 }
                 return dependencies;
             }
-            catch (DependencyFileNotFoundException exc)
+            catch (DependencyFileNotFoundException)
             {
                 // This is not an error. Dependencies can be specified with explicit shas that
                 // may not have eng/Version.Details at that point.

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
@@ -459,7 +459,7 @@ namespace Microsoft.DotNet.DarcLib
             catch (DependencyFileNotFoundException)
             {
                 // This is not an error. Dependencies can be specified with explicit shas that
-                // may not have eng/Version.Details at that point.
+                // may not have eng/Version.Details.xml at that point.
                 logger.LogWarning($"{repoUri}@{commit} does not have an eng/Version.Details.xml.");
                 return null;
             }


### PR DESCRIPTION
If a valid sha/repo combo is present, but the eng/Version.Details.xml file is not found,
this is probably because the mentioned sha is not onboarded onto dependency flow.  This is fine
in isolated cases.  Log as warning and then continue.