### PR TITLE
Create a new HTTP request each time we retry an Azure DevOps operation.

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/AzureDevOpsClient.cs
@@ -654,18 +654,18 @@ namespace Microsoft.DotNet.DarcLib
             var rng = new Random();
             using (HttpClient client = CreateHttpClient(accountName, projectName, versionOverride, baseAddressSubpath))
             {
-                HttpRequestManager requestManager = new HttpRequestManager(client,
-                                                                           method,
-                                                                           requestPath,
-                                                                           logger,
-                                                                           body,
-                                                                           versionOverride,
-                                                                           logFailure);
 
                 while (true)
                 {
                     try
                     {
+                        HttpRequestManager requestManager = new HttpRequestManager(client,
+                                                                                   method,
+                                                                                   requestPath,
+                                                                                   logger,
+                                                                                   body,
+                                                                                   versionOverride,
+                                                                                   logFailure);
                         using (var response = await requestManager.ExecuteAsync())
                         {
                             return JObject.Parse(await response.Content.ReadAsStringAsync());


### PR DESCRIPTION
This fixes this error when we are fetching files from AzDo and a request is ok to fail, like when trying the different versionTypes when trying to fetch a file:
`The request message was already sent. Cannot send the same request message multiple times.`