### PR TITLE
Handle AzDO URLs with users in them

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/AzureDevOpsClient.cs
@@ -768,6 +768,7 @@ namespace Microsoft.DotNet.DarcLib
         /// </remarks>
         public static (string accountName, string projectName, string repoName) ParseRepoUri(string repoUri)
         {
+            // TODO: remove the if block below once https://github.com/dotnet/arcade/issues/2121 is closed
             // If repoUri includes the user in the account we remove it otherwise Regex matching would fail for URIs like
             // https://dnceng@dev.azure.com/dnceng/internal/_git/repo
             if (Uri.TryCreate(repoUri, UriKind.Absolute, out Uri parsedUri))

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/AzureDevOpsClient.cs
@@ -768,6 +768,16 @@ namespace Microsoft.DotNet.DarcLib
         /// </remarks>
         public static (string accountName, string projectName, string repoName) ParseRepoUri(string repoUri)
         {
+            // If repoUri includes the user in the account we remove it otherwise Regex matching would fail for URIs like
+            // https://dnceng@dev.azure.com/dnceng/internal/_git/repo
+            if (Uri.TryCreate(repoUri, UriKind.Absolute, out Uri parsedUri))
+            {
+                if (!string.IsNullOrEmpty(parsedUri.UserInfo))
+                {
+                    repoUri = repoUri.Replace($"{parsedUri.UserInfo}@", string.Empty);
+                }
+            }
+
             Match m = RepositoryUriPattern.Match(repoUri);
             if (!m.Success)
             {

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/AzureDevOpsClientTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/AzureDevOpsClientTests.cs
@@ -26,7 +26,6 @@ namespace Microsoft.DotNet.Darc.Tests
 
         [Theory]
         [InlineData("https://dev.azure.com/dcn-eng/public-s/_git/foo-23bar")]
-        [InlineData("https://dnceng@dev.azure.com/dnceng/public/_git/foo-core")]
         private void ParseInvalidRepoUriTests(string inputUri)
         {
             Xunit.Assert.Throws<ArgumentException>(() => AzureDevOpsClient.ParseRepoUri(inputUri));


### PR DESCRIPTION
This one fixes a scenario in particular when in a graph there are AzDo dependencies which have a repo URL that includes the user.

This doesn't fixes https://github.com/dotnet/arcade/issues/2121 completely since I'm not touching the API but fixes a fraction of it