### PR TITLE
Use show-toplevel to get root of Git repo instead of parent of .git folder.

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
             CancellationToken cancellationToken)
         {
             var logger = new MSBuildLogger(Log);
-            var local = new Local(LocalHelpers.GetGitDir(logger), logger);
+            var local = new Local(logger);
             IEnumerable<DependencyDetail> dependencies = await local.GetDependenciesAsync();
             var builds = new Dictionary<int, bool>();
             foreach (var dep in dependencies)

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
@@ -18,7 +18,6 @@ namespace Microsoft.DotNet.Darc.Helpers
     public class UxManager
     {
         private readonly string _editorPath;
-        private readonly string _gitDir;
         private readonly string _rootDir;
         private readonly ILogger _logger;
         private bool _popUpClosed = false;
@@ -26,7 +25,6 @@ namespace Microsoft.DotNet.Darc.Helpers
         public UxManager(ILogger logger)
         {
             _editorPath = LocalHelpers.GetEditorPath(logger);
-            _gitDir = LocalHelpers.GetGitDir(logger);
             _rootDir = LocalHelpers.GetRootDir(logger);
             _logger = logger;
         }
@@ -39,9 +37,9 @@ namespace Microsoft.DotNet.Darc.Helpers
                 return Constants.ErrorCode;
             }
 
-            if (string.IsNullOrEmpty(_gitDir))
+            if (string.IsNullOrEmpty(_rootDir))
             {
-                _logger.LogError("Failed to get git's directory...");
+                _logger.LogError("Failed to get git root directory...");
                 return Constants.ErrorCode;
             }
 
@@ -52,7 +50,7 @@ namespace Microsoft.DotNet.Darc.Helpers
 
             try
             {
-                string path = Path.Combine(_gitDir, popUp.Path);
+                string path = Path.Combine(Path.GetTempPath(), Path.GetTempFileName(), popUp.Path);
                 string dirPath = Path.GetDirectoryName(path);
 
                 Directory.CreateDirectory(dirPath);

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.Darc.Helpers
     {
         private readonly string _editorPath;
         private readonly string _gitDir;
+        private readonly string _rootDir;
         private readonly ILogger _logger;
         private bool _popUpClosed = false;
 
@@ -26,6 +27,7 @@ namespace Microsoft.DotNet.Darc.Helpers
         {
             _editorPath = LocalHelpers.GetEditorPath(logger);
             _gitDir = LocalHelpers.GetGitDir(logger);
+            _rootDir = LocalHelpers.GetRootDir(logger);
             _logger = logger;
         }
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
@@ -37,12 +37,6 @@ namespace Microsoft.DotNet.Darc.Helpers
                 return Constants.ErrorCode;
             }
 
-            if (string.IsNullOrEmpty(_rootDir))
-            {
-                _logger.LogError("Failed to get git root directory...");
-                return Constants.ErrorCode;
-            }
-
             int result = Constants.ErrorCode;
             int tries = Constants.MaxPopupTries;
 
@@ -50,7 +44,7 @@ namespace Microsoft.DotNet.Darc.Helpers
 
             try
             {
-                string path = Path.Combine(Path.GetTempPath(), Path.GetTempFileName(), popUp.Path);
+                string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), popUp.Path);
                 string dirPath = Path.GetDirectoryName(path);
 
                 Directory.CreateDirectory(dirPath);

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddDependencyOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddDependencyOperation.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Darc.Operations
         {
             DependencyType type = _options.Type.ToLower() == "toolset" ? DependencyType.Toolset : DependencyType.Product;
 
-            Local local = new Local(LocalHelpers.GetGitDir(Logger), Logger);
+            Local local = new Local(Logger);
 
             DependencyDetail dependency = new DependencyDetail
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependenciesOperation.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
         public override async Task<int> ExecuteAsync()
         {
-            Local local = new Local(LocalHelpers.GetGitDir(Logger), Logger);
+            Local local = new Local(Logger);
 
             try
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyGraphOperation.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Darc.Operations
                         Console.WriteLine($"Getting root dependencies from local repository...");
 
                         // Grab root dependency set from local repo
-                        Local local = new Local(LocalHelpers.GetGitDir(Logger), Logger);
+                        Local local = new Local(Logger);
                         rootDependencies = await local.GetDependenciesAsync(
                             _options.AssetName);
                     }
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Darc.Operations
                     graph = await DependencyGraph.BuildRemoteDependencyGraphAsync(
                         remoteFactory,
                         rootDependencies,
-                        _options.RepoUri ?? LocalHelpers.GetGitDir(Logger),
+                        _options.RepoUri ?? LocalHelpers.GetRootDir(Logger),
                         _options.Version ?? LocalHelpers.GetGitCommit(Logger),
                         _options.IncludeToolset,
                         Logger);
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 {
                     Console.WriteLine($"Getting root dependencies from local repository...");
 
-                    Local local = new Local(LocalHelpers.GetGitDir(Logger), Logger);
+                    Local local = new Local(Logger);
                     rootDependencies = await local.GetDependenciesAsync(
                         _options.AssetName);
 
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.Darc.Operations
                         rootDependencies,
                         _options.IncludeToolset,
                         Logger,
-                        LocalHelpers.GetGitDir(Logger),
+                        LocalHelpers.GetRootDir(Logger),
                         LocalHelpers.GetGitCommit(Logger),
                         _options.ReposFolder,
                         _options.RemotesMap);

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 IRemoteFactory remoteFactory = new RemoteFactory(_options);
                 IRemote barOnlyRemote = remoteFactory.GetBarOnlyRemote(Logger);
-                Local local = new Local(LocalHelpers.GetGitDir(Logger), Logger);
+                Local local = new Local(Logger);
                 List<DependencyDetail> dependenciesToUpdate = new List<DependencyDetail>();
                 bool someUpToDate = false;
                 string finalMessage = $"Local dependencies updated from channel '{_options.Channel}'.";

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VerifyOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VerifyOperation.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Darc.Operations
         /// <returns>Process exit code.</returns>
         public override async Task<int> ExecuteAsync()
         {
-            Local local = new Local(LocalHelpers.GetGitDir(Logger), Logger);
+            Local local = new Local(Logger);
 
             try
             {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -24,7 +25,7 @@ namespace Microsoft.DotNet.DarcLib
 
         public Local(string gitPath, ILogger logger)
         {
-            _repo = Directory.GetParent(gitPath).FullName;
+            _repo = LocalHelpers.GetRootDir(logger);
             _logger = logger;
             _gitClient = new LocalGitClient(_logger);
             _fileManager = new GitFileManager(_gitClient, _logger);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -23,9 +23,9 @@ namespace Microsoft.DotNet.DarcLib
         // TODO: Make these not constants and instead attempt to give more accurate information commit, branch, repo name, etc.)
         private readonly string _repo;
 
-        public Local(ILogger logger)
+        public Local(ILogger logger, string overrideRootPath = null)
         {
-            _repo = LocalHelpers.GetRootDir(logger);
+            _repo = overrideRootPath ?? LocalHelpers.GetRootDir(logger);
             _logger = logger;
             _gitClient = new LocalGitClient(_logger);
             _fileManager = new GitFileManager(_gitClient, _logger);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.DarcLib
         // TODO: Make these not constants and instead attempt to give more accurate information commit, branch, repo name, etc.)
         private readonly string _repo;
 
-        public Local(string gitPath, ILogger logger)
+        public Local(ILogger logger)
         {
             _repo = LocalHelpers.GetRootDir(logger);
             _logger = logger;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
@@ -40,25 +40,13 @@ namespace Microsoft.DotNet.DarcLib.Helpers
             return editor;
         }
 
-        public static string GetGitDir(ILogger logger)
-        {
-            string dir = ExecuteCommand("git", "rev-parse --absolute-git-dir", logger);
-
-            if (string.IsNullOrEmpty(dir))
-            {
-                throw new Exception("'.git' directory was not found. Check if git is installed and that a .git directory exists in the root of your repository.");
-            }
-
-            return dir;
-        }
-
         public static string GetRootDir(ILogger logger)
         {
             string dir = ExecuteCommand("git", "rev-parse --show-toplevel", logger);
 
             if (string.IsNullOrEmpty(dir))
             {
-                throw new Exception("'.git' directory was not found. Check if git is installed and that a .git directory exists in the root of your repository.");
+                throw new Exception("Root directory of the repo was not found. Check if git is installed and that a .git directory exists in the root of your repository.");
             }
 
             return dir;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
@@ -52,6 +52,18 @@ namespace Microsoft.DotNet.DarcLib.Helpers
             return dir;
         }
 
+        public static string GetRootDir(ILogger logger)
+        {
+            string dir = ExecuteCommand("git", "rev-parse --show-toplevel", logger);
+
+            if (string.IsNullOrEmpty(dir))
+            {
+                throw new Exception("'.git' directory was not found. Check if git is installed and that a .git directory exists in the root of your repository.");
+            }
+
+            return dir;
+        }
+
         /// <summary>
         ///     Get the current git commit sha.
         /// </summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.DarcLib.Helpers
 
             if (string.IsNullOrEmpty(dir))
             {
-                throw new Exception("Root directory of the repo was not found. Check if git is installed and that a .git directory exists in the root of your repository.");
+                throw new Exception("Root directory of the repo was not found. Check that git is installed and that you are in a folder which is a git repo (.git folder should be present).");
             }
 
             return dir;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.DarcLib
         public Task<List<GitFile>> GetFilesAtCommitAsync(string repoUri, string commit, string path)
         {
             string gitDir = LocalHelpers.GetGitDir(_logger);
-            string repoDir = Directory.GetParent(gitDir).FullName;
+            string repoDir = LocalHelpers.GetRootDir(_logger);
             string sourceFolder = Path.Combine(repoDir, path);
             return Task.Run(() => Directory.GetFiles(
                 sourceFolder,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -68,7 +68,6 @@ namespace Microsoft.DotNet.DarcLib
 
         public Task<List<GitFile>> GetFilesAtCommitAsync(string repoUri, string commit, string path)
         {
-            string gitDir = LocalHelpers.GetGitDir(_logger);
             string repoDir = LocalHelpers.GetRootDir(_logger);
             string sourceFolder = Path.Combine(repoDir, path);
             return Task.Run(() => Directory.GetFiles(

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
@@ -374,8 +374,7 @@ namespace Microsoft.DotNet.DarcLib
                 {
                     // If a repo folder or a mapping was not set we use the current parent's 
                     // parent folder.
-                    string gitDir = LocalHelpers.GetGitDir(logger);
-                    string parent = Directory.GetParent(gitDir).FullName;
+                    string parent = LocalHelpers.GetRootDir(logger);
                     folder = Directory.GetParent(parent).FullName;
                 }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
@@ -415,11 +415,7 @@ namespace Microsoft.DotNet.DarcLib
 
                     if (Directory.Exists(testPath))
                     {
-                        Local local = new Local(
-                            Path.Combine(
-                                testPath,
-                                ".git"),
-                            logger);
+                        Local local = new Local(logger);
                         dependencies = await local.GetDependenciesAsync();
                     }
                 }
@@ -436,10 +432,7 @@ namespace Microsoft.DotNet.DarcLib
 
                     if (!string.IsNullOrEmpty(repoPath))
                     {
-                        // Local's constructor expects the repo's .git folder to be passed in. In this 
-                        // particular case we could pass any folder under 'repoPath' or even a fake one 
-                        // but we use .git to keep things consistent to what Local expects
-                        Local local = new Local($"{repoPath}/.git", logger);
+                        Local local = new Local(logger);
                         string fileContents = LocalHelpers.GitShow(
                             repoPath,
                             commit,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
@@ -415,7 +415,7 @@ namespace Microsoft.DotNet.DarcLib
 
                     if (Directory.Exists(testPath))
                     {
-                        Local local = new Local(logger);
+                        Local local = new Local(logger, testPath);
                         dependencies = await local.GetDependenciesAsync();
                     }
                 }

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
@@ -267,8 +267,8 @@ namespace Microsoft.DotNet.Darc.Tests
             using (StreamReader expectedOutputsReader = new StreamReader(expectedOutputFilePath))
             using (StreamReader actualOutputsReader = new StreamReader(actualOutputFilePath))
             {
-                string expectedOutput = await expectedOutputsReader.ReadToEndAsync();
-                string actualOutput = await actualOutputsReader.ReadToEndAsync();
+                string expectedOutput = TestHelpers.NormalizeLineEndings(await expectedOutputsReader.ReadToEndAsync());
+                string actualOutput = TestHelpers.NormalizeLineEndings(await actualOutputsReader.ReadToEndAsync());
                 Assert.Equal(
                     expectedOutput,
                     actualOutput);

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/TestHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/TestHelpers.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.DotNet.Darc.Tests
+{
+    static internal class TestHelpers
+    {
+        static internal string NormalizeLineEndings(string text)
+        {
+            return text.Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", Environment.NewLine);
+        }
+    }
+}


### PR DESCRIPTION
Submodules generally have their .git directory in the parent repo's .git directory, so this assumption breaks for them.

Fixes #184.