### PR TITLE
Catch failures during updates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ trigger:
 - production
 pr:
 - master
+- production
 
 # Three phases for each of the three OSes we want to run on
 jobs:

--- a/src/Maestro/DependencyUpdater/DependencyUpdater.cs
+++ b/src/Maestro/DependencyUpdater/DependencyUpdater.cs
@@ -146,7 +146,7 @@ namespace DependencyUpdater
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         [CronSchedule("0 0 5 1/1 * ? *", TimeZones.PST)]
-        public async Task CheckSubscriptionsAsync(CancellationToken cancellationToken)
+        public async Task CheckDailySubscriptionsAsync(CancellationToken cancellationToken)
         {
             var subscriptionsToUpdate = from sub in Context.Subscriptions
                 where sub.Enabled
@@ -202,8 +202,15 @@ namespace DependencyUpdater
                 subscriptionId,
                 buildId))
             {
-                ISubscriptionActor actor = SubscriptionActorFactory(new ActorId(subscriptionId));
-                await actor.UpdateAsync(buildId);
+                try
+                {
+                    ISubscriptionActor actor = SubscriptionActorFactory(new ActorId(subscriptionId));
+                    await actor.UpdateAsync(buildId);
+                }
+                catch (Exception e)
+                {
+                    Logger.LogError(e, "Failed to update subscription '{subscriptionId}' with build '{buildId}'");
+                }
             }
         }
     }

--- a/src/Maestro/Maestro.Contracts/IDependencyUpdater.cs
+++ b/src/Maestro/Maestro.Contracts/IDependencyUpdater.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ServiceFabric.Services.Remoting;
 
@@ -13,5 +14,12 @@ namespace Maestro.Contracts
         Task StartUpdateDependenciesAsync(int buildId, int channelId);
 
         Task StartSubscriptionUpdateAsync(Guid subscription);
+
+        /// <summary>
+        ///     Temporary method for debugging daily update issues
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task CheckDailySubscriptionsAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/SubscriptionsController.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Maestro.Contracts;
 using Maestro.Data;
@@ -132,6 +133,24 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
                 });
 
             return Accepted(new Subscription(subscription));
+        }
+
+        /// <summary>
+        ///   Trigger daily update
+        /// </summary>
+        /// <param name="id">The id of the <see cref="Subscription"/> to trigger.</param>
+        [HttpPost("triggerDaily")]
+        [SwaggerApiResponse(HttpStatusCode.Accepted, Description = "Trigger all subscriptions normally updated daily.")]
+        [ValidateModelState]
+        public virtual IActionResult TriggerDailyUpdate()
+        {
+            _queue.Post(
+                async () =>
+                {
+                    await _dependencyUpdater.CheckDailySubscriptionsAsync(CancellationToken.None);
+                });
+
+            return Accepted();
         }
 
         /// <summary>

--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/SubscriptionsController.cs
@@ -138,7 +138,6 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
         /// <summary>
         ///   Trigger daily update
         /// </summary>
-        /// <param name="id">The id of the <see cref="Subscription"/> to trigger.</param>
         [HttpPost("triggerDaily")]
         [SwaggerApiResponse(HttpStatusCode.Accepted, Description = "Trigger all subscriptions normally updated daily.")]
         [ValidateModelState]


### PR DESCRIPTION
Part workaround (add temporary REST api to trigger daily update)
Part catch on failure to update so a single failure during daily updates doesn't take down the others.

Also need to add more applicaiton logging because appinsights is dropping events.