### PR TITLE
Remove old updates when updating an existing PR with a build

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -724,6 +724,14 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
             PullRequest pullRequest = await darc.GetPullRequestAsync(pr.Url);
             string headBranch = pullRequest.HeadBranch;
 
+            // Update the list of contained subscriptions with the new subscription update.
+            // Replace all existing updates for the subscription id with the new update.
+            // This avoids a potential issue where we may update the last applied build id
+            // on the subscription to an older build id.
+            foreach ((UpdateAssetsParameters update, List<DependencyDetail> deps) update in requiredUpdates)
+            {
+                pr.ContainedSubscriptions.RemoveAll(s => s.SubscriptionId == update.update.SubscriptionId);
+            }
             pr.ContainedSubscriptions.AddRange(
                 requiredUpdates.Select(
                     u => new SubscriptionPullRequestUpdate


### PR DESCRIPTION
Failing to do so may lead to a case where we update the latest build id with the wrong data.
I'm not positive that this is the issue with the latest build id, but it is a potential source of issues