### PR TITLE
Reorganizing the way we invoke RunAsync

### DIFF
--- a/src/Maestro/DependencyUpdater/DependencyUpdater.cs
+++ b/src/Maestro/DependencyUpdater/DependencyUpdater.cs
@@ -128,7 +128,7 @@ namespace DependencyUpdater
             }
             catch (TaskCanceledException tcex) when (tcex.CancellationToken == cancellationToken)
             {
-                // ignore
+                return TimeSpan.MaxValue;
             }
             catch (Exception ex)
             {

--- a/src/Maestro/DependencyUpdater/DependencyUpdater.cs
+++ b/src/Maestro/DependencyUpdater/DependencyUpdater.cs
@@ -99,45 +99,43 @@ namespace DependencyUpdater
             return Task.CompletedTask;
         }
 
-        public async Task RunAsync(CancellationToken cancellationToken)
+        public async Task<TimeSpan> RunAsync(CancellationToken cancellationToken)
         {
             IReliableConcurrentQueue<DependencyUpdateItem> queue =
                 await StateManager.GetOrAddAsync<IReliableConcurrentQueue<DependencyUpdateItem>>("queue");
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                try
-                {
-                    using (ITransaction tx = StateManager.CreateTransaction())
-                    {
-                        ConditionalValue<DependencyUpdateItem> maybeItem = await queue.TryDequeueAsync(
-                            tx,
-                            cancellationToken);
-                        if (maybeItem.HasValue)
-                        {
-                            DependencyUpdateItem item = maybeItem.Value;
-                            using (Logger.BeginScope(
-                                "Processing dependency update for build {buildId} in channel {channelId}",
-                                item.BuildId,
-                                item.ChannelId))
-                            {
-                                await UpdateDependenciesAsync(item.BuildId, item.ChannelId);
-                            }
-                        }
 
-                        await tx.CommitAsync();
+            try
+            {
+                using (ITransaction tx = StateManager.CreateTransaction())
+                {
+                    ConditionalValue<DependencyUpdateItem> maybeItem = await queue.TryDequeueAsync(
+                        tx,
+                        cancellationToken);
+                    if (maybeItem.HasValue)
+                    {
+                        DependencyUpdateItem item = maybeItem.Value;
+                        using (Logger.BeginScope(
+                            "Processing dependency update for build {buildId} in channel {channelId}",
+                            item.BuildId,
+                            item.ChannelId))
+                        {
+                            await UpdateDependenciesAsync(item.BuildId, item.ChannelId);
+                        }
                     }
 
-                    await Task.Delay(1000, cancellationToken);
-                }
-                catch (TaskCanceledException tcex) when (tcex.CancellationToken == cancellationToken)
-                {
-                    // ignore
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "Processing queue messages");
+                    await tx.CommitAsync();
                 }
             }
+            catch (TaskCanceledException tcex) when (tcex.CancellationToken == cancellationToken)
+            {
+                // ignore
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Processing queue messages");
+            }
+            
+            return TimeSpan.FromSeconds(1);
         }
 
         /// <summary>

--- a/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
+++ b/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
@@ -90,7 +90,7 @@ namespace ReleasePipelineRunner
             }
             catch (TaskCanceledException tcex) when (tcex.CancellationToken == cancellationToken)
             {
-                // ignore
+                return TimeSpan.MaxValue;
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatefulService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatefulService.cs
@@ -103,6 +103,11 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
 
                     var shouldWaitFor = await impl.RunAsync(cancellationToken);
 
+                    if (shouldWaitFor.Equals(TimeSpan.MaxValue))
+                    {
+                        return;
+                    }
+
                     await Task.Delay(shouldWaitFor, cancellationToken);
                 }
             }

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatefulService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatefulService.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                 RunAsyncLoop(cancellationToken));
         }
 
-        private async Task RunSchedule(CancellationToken cancellationToken)
+        private async Task RunAsyncLoop(CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
             {
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
             }
         }
 
-        private async Task RunAsyncLoop(CancellationToken cancellationToken)
+        private async Task RunSchedule(CancellationToken cancellationToken)
         {
             using (ILifetimeScope scope = _container.BeginLifetimeScope(
                             builder => builder.RegisterInstance(StateManager).As<IReliableStateManager>()))

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatefulService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatefulService.cs
@@ -86,17 +86,39 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
 
         protected override async Task RunAsync(CancellationToken cancellationToken)
         {
+            await Task.WhenAll(RunSchedule(cancellationToken),
+                RunAsyncLoop(cancellationToken));
+        }
+
+        private async Task RunSchedule(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                using (ILifetimeScope scope = _container.BeginLifetimeScope(
+                                builder => builder.RegisterInstance(StateManager).As<IReliableStateManager>()))
+                {
+                    var impl = scope.Resolve<TServiceImplementation>();
+                    var telemetryClient = scope.Resolve<TelemetryClient>();
+                    var logger = scope.Resolve<ILogger<DelegatedStatefulService<TServiceImplementation>>>();
+
+                    var shouldWaitFor = await impl.RunAsync(cancellationToken);
+
+                    await Task.Delay(shouldWaitFor, cancellationToken);
+                }
+            }
+        }
+
+        private async Task RunAsyncLoop(CancellationToken cancellationToken)
+        {
             using (ILifetimeScope scope = _container.BeginLifetimeScope(
-                builder => { builder.RegisterInstance(StateManager).As<IReliableStateManager>(); }))
+                            builder => builder.RegisterInstance(StateManager).As<IReliableStateManager>()))
             {
                 var impl = scope.Resolve<TServiceImplementation>();
                 var telemetryClient = scope.Resolve<TelemetryClient>();
                 var logger = scope.Resolve<ILogger<DelegatedStatefulService<TServiceImplementation>>>();
 
-                await Task.WhenAll(
-                    impl.RunAsync(cancellationToken),
-                    ScheduledService.RunScheduleAsync(impl, telemetryClient, cancellationToken, logger));
+                await ScheduledService.RunScheduleAsync(impl, telemetryClient, cancellationToken, logger);
             }
         }
-    }
+     }
 }

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/IServiceImplementation.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/IServiceImplementation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,6 +10,6 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
 {
     public interface IServiceImplementation
     {
-        Task RunAsync(CancellationToken cancellationToken);
+        Task<TimeSpan> RunAsync(CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
The way BARContext is inserted into DependencyUpdater and ReleasePipelineRunner today is through IoC to [the class constructor](https://github.com/dotnet/arcade-services/blob/1454160d212e1ccb2e00cb2911a1315e6b893938/src/Maestro/DependencyUpdater/DependencyUpdater.cs#L46). The problem here is that the RunAsync methods of these services never return and therefore the BARContext object is never reloaded with external changes, which result in wrong behavior in some cases.

As per talk with @alexperovich the fix for now will be to make the RunAsync methods of these services to return the amount of time the caller should wait before calling RunAsync again. Therefore the method won't execute in an infinite loop anymore and the object it's contained will be recreated 'frequently'.