### PR TITLE
Fix several problems with BAR visualization

### DIFF
--- a/src/Maestro/Maestro.Data/BuildAssetRegistryContext.cs
+++ b/src/Maestro/Maestro.Data/BuildAssetRegistryContext.cs
@@ -303,6 +303,8 @@ FROM traverse;",
             List<BuildDependency> things = await edges.ToListAsync();
             var buildIds = new HashSet<int>(things.SelectMany(t => new[] { t.BuildId, t.DependentBuildId }));
 
+            buildIds.Add(buildId); // Make sure we always include the requested build, even if it has no edges.
+
             IQueryable<Build> builds = from build in Builds
                                        where buildIds.Contains(build.Id)
                                        select build;

--- a/src/Maestro/Maestro.Web/Pages/Index.cshtml
+++ b/src/Maestro/Maestro.Web/Pages/Index.cshtml
@@ -1,7 +1,7 @@
 @page
 @model Maestro.Web.Pages.IndexModel
+@using System.Web
 @using Maestro.Data
-@using Microsoft.AspNetCore.Http
 @using Microsoft.AspNetCore.Identity
 @{
     ViewBag.Title = "Index";
@@ -81,7 +81,7 @@
     <script type="text/javascript">
         window.applicationData = {
           brand: '@Html.Raw(ViewBag.Brand)',
-          userName: '@await GetUserNameAsync()',
+          userName: '@Html.Raw(HttpUtility.JavaScriptStringEncode(await GetUserNameAsync()))',
         };
     </script>
     @Model.GetStyleBundles()

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -83,7 +83,7 @@
           </div>
         </td>
         <td>
-          <a [routerLink]="['../..', node.build.gitHubRepository, node.build.id]">{{node.build.gitHubRepository}}</a>
+          <a [routerLink]="['../..', getRepo(node.build), node.build.id]">{{getRepo(node.build)}}</a>
         </td>
         <td>
           {{node.build.dateProduced | amTimeAgo}}

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.html
@@ -13,15 +13,28 @@
     <div class="flex-grow-1">
       <h4>{{build.gitHubRepository}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>
       <div>
-        <span>Loading Build Information From Azure Pipelines</span>
+        <span>Loading build information from Azure Pipelines</span>
         <div style="display:inline-block; vertical-align: middle;">
           <progress-ring width="50" height="50" color="#777"></progress-ring>
         </div>
       </div>
     </div>
   </ng-template>
+  <ng-template #errorBuildInfo>
+    <div class="flex-grow-0 mr-3" style="font-size: 6em">
+      <fa-icon class="text-warning" icon="exclamation-circle"></fa-icon>
+    </div>
+    <div class="flex-grow-1">
+      <h4>{{build.gitHubRepository}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>
+      <div>
+        <span class="text-warning">Error loading build information from Azure Pipelines</span>
+        <div style="display:inline-block; vertical-align: middle; width: 50px; height: 50px;">
+        </div>
+      </div>
+    </div>
+  </ng-template>
   <div class="d-flex flex-row p-3 header align-items-center">
-    <ng-container *stateful="let azDevInfo from azDevBuildInfo$; loadingTemplate: loadingBuildInfo;">
+    <ng-container *stateful="let azDevInfo from azDevBuildInfo$; loadingTemplate: loadingBuildInfo; errorTemplate: errorBuildInfo;">
       <div class="flex-grow-0 mr-3" style="font-size: 6em">
         <fa-icon class="text-info" icon="info-circle"
           *ngIf="!azDevInfo.isMostRecent && !azDevInfo.mostRecentFailureLink"></fa-icon>

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
@@ -10,6 +10,7 @@ import { Observable } from 'rxjs';
 import { BuildStatusService } from 'src/app/services/build-status.service';
 import { BuildStatus } from 'src/app/model/build-status';
 import { statefulSwitchMap, StatefulResult, statefulPipe } from 'src/stateful';
+import { WrappedError } from 'src/stateful/helpers';
 
 interface AzDevBuildInfo {
   isMostRecent: boolean;
@@ -49,7 +50,12 @@ export class BuildComponent implements OnInit, OnChanges {
     );
     this.build$ = data$.pipe(
       statefulPipe(
-        map(t => t.graph.builds[t.buildId]),
+        map(({graph, buildId}) => {
+          if (buildId in graph.builds) {
+            return graph.builds[buildId];
+          }
+          return new WrappedError(new Error("That build has no graph."));
+        })
       ),
     );
 

--- a/src/Maestro/maestro-angular/src/app/util/names.ts
+++ b/src/Maestro/maestro-angular/src/app/util/names.ts
@@ -1,3 +1,6 @@
 export function prettyRepository(repo: string): string {
+  if (!repo.includes("github.com")) {
+    return repo.split("/").slice(-1).join("/");
+  }
   return repo.split("/").slice(-2).join("/");
 }

--- a/src/Maestro/maestro-angular/src/app/widget/side-bar/side-bar.component.html
+++ b/src/Maestro/maestro-angular/src/app/widget/side-bar/side-bar.component.html
@@ -1,4 +1,4 @@
-<div>
+<div style="overflow-y: auto;">
   <ng-container *ngIf="channels$ | async as channels">
     <ng-container *ngFor="let channel of channels">
       <mc-side-bar-channel [channel]="channel"></mc-side-bar-channel>

--- a/src/Maestro/maestro-angular/src/styles.scss
+++ b/src/Maestro/maestro-angular/src/styles.scss
@@ -10,7 +10,7 @@
 @import "~bootstrap/scss/grid";
 @import "~bootstrap/scss/tables";
 @import "~bootstrap/scss/buttons";
-// @import "~bootstrap/scss/transitions";
+@import "~bootstrap/scss/transitions";
 @import "~bootstrap/scss/dropdown";
 // @import "~bootstrap/scss/button-group";
 // @import "~bootstrap/scss/input-group";


### PR DESCRIPTION
- Make Build Graph api always return the root build
- Make user name display properly for people with non-ascii characters in their names
- Include bootstrap transition styles for collapse elements
- Add error display for failures to load build info from AzDev
- Display AzDev repo uri in build dependency table if there is no github uri
- Properly determine "coherent" bit for builds that have a build number that isn't a parsable number
- Display only the last path segment of AzDev repo uris in the sidebar
- Allow the sidebar to scroll