### PR TITLE
Trigger dependency updates for builds added to channels through the R…

### DIFF
--- a/src/Maestro/ReleasePipelineRunner/Program.cs
+++ b/src/Maestro/ReleasePipelineRunner/Program.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Maestro.AzureDevOps;
+using Maestro.Contracts;
 using Maestro.Data;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
@@ -23,6 +24,7 @@ namespace ReleasePipelineRunner
                 host =>
                 {
                     host.RegisterStatefulService<ReleasePipelineRunner>("ReleasePipelineRunnerType");
+                    host.ConfigureContainer(builder => { builder.AddServiceFabricService<IDependencyUpdater>("fabric:/MaestroApplication/DependencyUpdater"); });
                     host.ConfigureServices(
                         services =>
                         {

--- a/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
+++ b/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
@@ -277,7 +277,7 @@ namespace ReleasePipelineRunner
 
                     if (buildChannelsToAdd.Count > 0)
                     {
-                        List<BuildChannel> addedBuildChannels = AddFinishedBuildChannelsIfNotPresent(buildChannelsToAdd);
+                        List<BuildChannel> addedBuildChannels = await AddFinishedBuildChannelsIfNotPresent(buildChannelsToAdd);
                         await TriggerDependencyUpdates(addedBuildChannels);
                     }
                     await tx.CommitAsync();
@@ -313,11 +313,11 @@ namespace ReleasePipelineRunner
             return new AzureDevOpsClient(accessToken, Logger, null);
         }
 
-        private List<BuildChannel> AddFinishedBuildChannelsIfNotPresent(HashSet<BuildChannel> buildChannelsToAdd)
+        private async Task<List<BuildChannel>> AddFinishedBuildChannelsIfNotPresent(HashSet<BuildChannel> buildChannelsToAdd)
         {
             var missingBuildChannels = buildChannelsToAdd.Where(x => !Context.BuildChannels.Any(y => y.ChannelId == x.ChannelId && y.BuildId == x.BuildId)).ToList();
             Context.BuildChannels.AddRange(missingBuildChannels);
-            Context.SaveChanges();
+            await Context.SaveChangesAsync();
             return missingBuildChannels;
         }
     }

--- a/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
+++ b/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
@@ -30,16 +30,19 @@ namespace ReleasePipelineRunner
         public ReleasePipelineRunner(
             IReliableStateManager stateManager,
             ILogger<ReleasePipelineRunner> logger,
-            BuildAssetRegistryContext context)
+            BuildAssetRegistryContext context,
+            IDependencyUpdater dependencyUpdater)
         {
             StateManager = stateManager;
             Logger = logger;
             Context = context;
+            DependencyUpdater = dependencyUpdater;
         }
 
         public IReliableStateManager StateManager { get; }
         public ILogger<ReleasePipelineRunner> Logger { get; }
         public BuildAssetRegistryContext Context { get; }
+        public IDependencyUpdater DependencyUpdater { get; }
 
         private const string RunningPipelineDictionaryName = "runningPipelines";
         private static HashSet<string> InProgressStatuses = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "notstarted", "scheduled", "queued", "inprogress" };
@@ -274,7 +277,8 @@ namespace ReleasePipelineRunner
 
                     if (buildChannelsToAdd.Count > 0)
                     {
-                        AddFinishedBuildChannelsIfNotPresent(buildChannelsToAdd);
+                        List<BuildChannel> addedBuildChannels = AddFinishedBuildChannelsIfNotPresent(buildChannelsToAdd);
+                        await TriggerDependencyUpdates(addedBuildChannels);
                     }
                     await tx.CommitAsync();
                 }
@@ -286,6 +290,14 @@ namespace ReleasePipelineRunner
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Processing finished releases");
+            }
+        }
+
+        private async Task TriggerDependencyUpdates(List<BuildChannel> addedBuildChannels)
+        {
+            foreach (BuildChannel buildChannel in addedBuildChannels)
+            {
+                await DependencyUpdater.StartUpdateDependenciesAsync(buildChannel.BuildId, buildChannel.ChannelId);
             }
         }
 
@@ -301,11 +313,12 @@ namespace ReleasePipelineRunner
             return new AzureDevOpsClient(accessToken, Logger, null);
         }
 
-        private void AddFinishedBuildChannelsIfNotPresent(HashSet<BuildChannel> buildChannelsToAdd)
+        private List<BuildChannel> AddFinishedBuildChannelsIfNotPresent(HashSet<BuildChannel> buildChannelsToAdd)
         {
             var missingBuildChannels = buildChannelsToAdd.Where(x => !Context.BuildChannels.Any(y => y.ChannelId == x.ChannelId && y.BuildId == x.BuildId)).ToList();
             Context.BuildChannels.AddRange(missingBuildChannels);
             Context.SaveChanges();
+            return missingBuildChannels;
         }
     }
 }

--- a/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
+++ b/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
@@ -297,6 +297,7 @@ namespace ReleasePipelineRunner
         {
             foreach (BuildChannel buildChannel in addedBuildChannels)
             {
+                Logger.LogInformation($"Calling DependencyUpdater to process dependency updates for build {buildChannel.BuildId} and channel {buildChannel.ChannelId}.");
                 await DependencyUpdater.StartUpdateDependenciesAsync(buildChannel.BuildId, buildChannel.ChannelId);
             }
         }


### PR DESCRIPTION
…eleasePipelineRunner

https://github.com/dotnet/arcade/issues/2308

So far I validated locally by checking that the call to StartDependencyUpdater plumbs through to the DependencyUpdater, adds an item to its internal queue, and calls UpdateDependenciesAsync with the build/channel combination.

Haven't been able to create a subscription from my local instance, so UpdateDependenciesAsync doesn't find a subscription for it, but at that point it's all up to the dependencyUpdater to do the right thing for the BuildChannel that it's checking.

Could use some feedback on how I glued the two services together @alexperovich

I still want to see if I can modify some of the scenario tests @mmitche mentioned so we are guarded from missing a bug like this again, but it might be OK to have that as a followup??