### PR TITLE
Update LICENSE.TXT to match Arcade.SDK MIT License

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,6 +1,8 @@
-MIT License
+The MIT License (MIT)
 
-Copyright (c) 2018 .NET Foundation
+*ignore-line*
+
+All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Maestro PR's are failing due to mismatch between Arcade-services LICENSE.TXT and Arcade SDK MIT License. I assume we want to follow Arcade license?

Failing maestro build: https://dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_build/results?buildId=130304