### PR TITLE
Improve the BAR visualization build and bundle size

### DIFF
--- a/src/Maestro/Maestro.Web/Pages/Index.cshtml.cs
+++ b/src/Maestro/Maestro.Web/Pages/Index.cshtml.cs
@@ -10,6 +10,7 @@ using System.Xml.XPath;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Newtonsoft.Json.Linq;
 
 namespace Maestro.Web.Pages
 {
@@ -29,22 +30,24 @@ namespace Maestro.Web.Pages
 
         public HtmlString GetStyleBundles()
         {
-            var angularGeneratedIndex = Path.Join(Environment.ContentRootPath, "angular-bundle.html");
-            var fileText = System.IO.File.ReadAllText(angularGeneratedIndex);
-            var firstLink = fileText.IndexOf("<link", StringComparison.Ordinal);
-            var endOfHead = fileText.IndexOf("</head>", StringComparison.Ordinal);
-            var links = fileText.Substring(firstLink, endOfHead - firstLink);
-            return new HtmlString(links);
+            var assetsJson = Path.Join(Environment.WebRootPath, "assets.json");
+            var assets = JObject.Parse(System.IO.File.ReadAllText(assetsJson));
+
+            var links = assets["styles"].ToObject<JArray>()
+                .Select(s => $"<link rel=\"stylesheet\" href=\"{s["file"]}\">");
+
+            return new HtmlString(string.Join("", links));
         }
 
         public HtmlString GetScriptBundles()
         {
-            var angularGeneratedIndex = Path.Join(Environment.ContentRootPath, "angular-bundle.html");
-            var fileText = System.IO.File.ReadAllText(angularGeneratedIndex);
-            var firstScript = fileText.IndexOf("<script", StringComparison.Ordinal);
-            var endOfBody = fileText.IndexOf("</body>", StringComparison.Ordinal);
-            var scripts = fileText.Substring(firstScript, endOfBody - firstScript);
-            return new HtmlString(scripts);
+            var assetsJson = Path.Join(Environment.WebRootPath, "assets.json");
+            var assets = JObject.Parse(System.IO.File.ReadAllText(assetsJson));
+
+            var scripts = assets["scripts"].ToObject<JArray>()
+                .Select(s => $"<script type=\"text/javascript\" src=\"{s["file"]}\"></script>");
+
+            return new HtmlString(string.Join("", scripts));
         }
     }
 }

--- a/src/Maestro/maestro-angular/angular.json
+++ b/src/Maestro/maestro-angular/angular.json
@@ -50,7 +50,7 @@
               "namedChunks": false,
               "aot": true,
               "extractLicenses": true,
-              "vendorChunk": false,
+              "vendorChunk": true,
               "buildOptimizer": true,
               "budgets": [
                 {

--- a/src/Maestro/maestro-angular/maestro-angular.proj
+++ b/src/Maestro/maestro-angular/maestro-angular.proj
@@ -37,6 +37,8 @@
     <Exec Command="npm run build -- --prod"
           WorkingDirectory="$(MSBuildProjectDirectory)"/>
     <Touch AlwaysCreate="true" Files="@(BuildOutput)"/>
+    <Message Text="##vso[artifact.upload containerfolder=bundle-report;artifactname=bundle-report.html;]$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(OutputPath)'))bundle-report.html"
+             Importance="High"/>
   </Target>
 
   <Target Name="Build"
@@ -52,11 +54,12 @@
         Include="$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(OutputPath)'))**\*"
         Exclude="$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(OutputPath)')).build-successful">
       </_OutputFile>
+      <_OutputFile Remove="@(_OutputFile)" Condition="'%(Filename)%(Extension)' == 'index.html'"/>
+      <_OutputFile Remove="@(_OutputFile)" Condition="'%(Filename)%(Extension)' == 'bundle-report.html'"/>
+      <_OutputFile Remove="@(_OutputFile)" Condition="'%(Filename)%(Extension)' == 'stats.json'"/>
       <CopyToPublishDirectoryItem
-        Include="@(_OutputFile)"
-        Condition="'%(Filename)%(Extension)' != 'favicon.ico'">
-        <TargetPath Condition="'%(Filename)%(Extension)' != 'index.html'">wwwroot\%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
-        <TargetPath Condition="'%(Filename)%(Extension)' == 'index.html'">angular-bundle.html</TargetPath>
+        Include="@(_OutputFile)">
+        <TargetPath>wwwroot\%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </CopyToPublishDirectoryItem>
     </ItemGroup>

--- a/src/Maestro/maestro-angular/package-lock.json
+++ b/src/Maestro/maestro-angular/package-lock.json
@@ -976,6 +976,12 @@
       "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
       "dev": true
     },
+    "acorn-walk": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+      "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+      "dev": true
+    },
     "adm-zip": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
@@ -1105,6 +1111,7 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -1558,6 +1565,18 @@
         "callsite": "1.0.0"
       }
     },
+    "bfj": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.1.tgz",
+      "integrity": "sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.1",
+        "check-types": "^7.3.0",
+        "hoopy": "^0.1.2",
+        "tryer": "^1.0.0"
+      }
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -1963,6 +1982,12 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "check-types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
+      "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==",
+      "dev": true
+    },
     "chokidar": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
@@ -2326,7 +2351,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -2568,6 +2594,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.0.0-alpha.27",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.27.tgz",
+      "integrity": "sha512-cqfVLS+346P/Mpj2RpDrBv0P4p2zZhWWvfY5fuWrXNR/K38HaAGEkeOwb47hIpQP9Jr/TIxjZ2/sNMQwdXuGMg=="
+    },
     "date-format": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
@@ -2722,7 +2753,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -2842,6 +2874,12 @@
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -2868,6 +2906,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "ejs": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
       "dev": true
     },
     "electron-to-chromium": {
@@ -3482,6 +3526,12 @@
         "minimatch": "^3.0.3"
       }
     },
+    "filesize": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+      "dev": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -3701,7 +3751,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4116,7 +4167,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4172,6 +4224,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4215,12 +4268,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4229,6 +4284,7 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -4241,6 +4297,7 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
+      "optional": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -4278,7 +4335,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "get-stream": {
       "version": "3.0.0",
@@ -4374,6 +4432,16 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
+    "gzip-size": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
+      "integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.1",
+        "pify": "^3.0.0"
+      }
+    },
     "handle-thing": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
@@ -4458,7 +4526,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -4522,6 +4591,12 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "hoopy": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -5178,7 +5253,8 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -5736,6 +5812,7 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -5748,7 +5825,8 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6023,7 +6101,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "map-visit": {
       "version": "1.0.0",
@@ -6301,11 +6380,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -6385,14 +6459,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
       "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
       "dev": true
-    },
-    "ngx-moment": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ngx-moment/-/ngx-moment-3.3.0.tgz",
-      "integrity": "sha512-6fpllpJqLfjRWboOhphgeEYt+rzIA9O29rG5QWCebRt2X0uNk4P93sLEb0S8lbDF0dEp2NOC3UOD+xoCVlJQhA==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
     },
     "nice-try": {
       "version": "1.0.5",
@@ -6657,6 +6723,7 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -6787,6 +6854,12 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
+    },
+    "opener": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+      "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+      "dev": true
     },
     "opn": {
       "version": "5.4.0",
@@ -7651,6 +7724,7 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -7662,6 +7736,7 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "pify": "^2.0.0",
@@ -7672,7 +7747,8 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7681,6 +7757,7 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -7691,6 +7768,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "path-exists": "^2.0.0",
             "pinkie-promise": "^2.0.0"
@@ -7701,6 +7779,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
+          "optional": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
@@ -8980,6 +9059,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-utf8": "^0.2.0"
       }
@@ -9420,6 +9500,12 @@
         "glob": "^7.1.2"
       }
     },
+    "tryer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
+      "dev": true
+    },
     "ts-node": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
@@ -9851,6 +9937,44 @@
           "requires": {
             "ajv": "^6.1.0",
             "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.1.0.tgz",
+      "integrity": "sha512-nyDyWEs7C6DZlgvu1pR1zzJfIWSiGPbtaByZr8q+Fd2xp70FuM/8ngCJzj3Er1TYRLSFmp1F1OInbEm4DZH8NA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.7",
+        "acorn-walk": "^6.1.1",
+        "bfj": "^6.1.1",
+        "chalk": "^2.4.1",
+        "commander": "^2.18.0",
+        "ejs": "^2.6.1",
+        "express": "^4.16.3",
+        "filesize": "^3.6.1",
+        "gzip-size": "^5.0.0",
+        "lodash": "^4.17.10",
+        "mkdirp": "^0.5.1",
+        "opener": "^1.5.1",
+        "ws": "^6.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "dev": true
+        },
+        "ws": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.0.tgz",
+          "integrity": "sha512-deZYUNlt2O4buFCa3t5bKLf8A7FPP/TVjwOeVNpw818Ma5nk4MLXls2eoEGS39o8119QIYxTrTDoPQ5B/gTD6w==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -10294,6 +10418,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }

--- a/src/Maestro/maestro-angular/package.json
+++ b/src/Maestro/maestro-angular/package.json
@@ -4,10 +4,11 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build --stats-json",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "postbuild": "node post-build.js && webpack-bundle-analyzer dist/maestro-angular/stats.json -m static -O -r dist/maestro-angular/bundle-report.html"
   },
   "private": true,
   "dependencies": {
@@ -26,8 +27,7 @@
     "@ng-bootstrap/ng-bootstrap": "^4.0.4",
     "bootstrap": "^4.3.1",
     "core-js": "^2.5.4",
-    "moment": "^2.24.0",
-    "ngx-moment": "^3.3.0",
+    "date-fns": "^2.0.0-alpha.27",
     "rxjs": "~6.3.3",
     "tslib": "^1.9.0",
     "zone.js": "~0.8.26"
@@ -37,9 +37,9 @@
     "@angular/cli": "~7.3.3",
     "@angular/compiler-cli": "~7.2.0",
     "@angular/language-service": "~7.2.0",
-    "@types/node": "~8.9.4",
     "@types/jasmine": "~2.8.8",
     "@types/jasminewd2": "~2.0.3",
+    "@types/node": "~8.9.4",
     "codelyzer": "~4.5.0",
     "jasmine-core": "~2.99.1",
     "jasmine-spec-reporter": "~4.2.1",
@@ -51,6 +51,7 @@
     "protractor": "~5.4.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.11.0",
-    "typescript": "~3.2.2"
+    "typescript": "~3.2.2",
+    "webpack-bundle-analyzer": "^3.1.0"
   }
 }

--- a/src/Maestro/maestro-angular/post-build.js
+++ b/src/Maestro/maestro-angular/post-build.js
@@ -1,0 +1,48 @@
+const path = require("path");
+const fs = require("fs");
+
+const outDir = path.join(__dirname, "dist/maestro-angular");
+const statsJson = path.join(outDir, "stats.json");
+const assetsJson = path.join(outDir, "assets.json");
+
+console.log(`READ ${statsJson}`);
+const stats = JSON.parse(fs.readFileSync(statsJson));
+
+
+const assetOrder = [
+  "runtime",
+  "es2015-polyfills",
+  "polyfills",
+  "vendor",
+  "main",
+];
+
+console.log(`WRITE ${assetsJson}`);
+const assets = {
+  "scripts": [],
+  "styles": [],
+};
+function addAsset(assetName, fileName) {
+  if (fileName.endsWith(".js")) {
+    assets.scripts.push({
+      name: assetName,
+      file: fileName,
+    });
+  } else {
+    assets.styles.push({
+      name: assetName,
+      file: fileName,
+    });
+  }
+}
+for (const assetName of assetOrder) {
+  const fileName = stats.assetsByChunkName[assetName];
+  delete stats.assetsByChunkName[assetName];
+  addAsset(assetName, fileName);
+}
+for (const asset of Object.keys(stats.assetsByChunkName)) {
+  const fileName = stats.assetsByChunkName[asset];
+  addAsset(asset, fileName);
+}
+fs.writeFileSync(assetsJson, JSON.stringify(assets, undefined, 2));
+

--- a/src/Maestro/maestro-angular/src/app/app.module.ts
+++ b/src/Maestro/maestro-angular/src/app/app.module.ts
@@ -25,7 +25,6 @@ import {
   faQuestionCircle as farQuestionCircle,
 } from "@fortawesome/free-regular-svg-icons";
 import { NgbCollapseModule, NgbModule } from "@ng-bootstrap/ng-bootstrap";
-import { MomentModule } from "ngx-moment";
 
 import { MaestroModule } from "src/maestro-client";
 import { StatefulModule } from "src/stateful";
@@ -42,6 +41,8 @@ import { RecentBuildComponent } from './page/recent-build/recent-build.component
 import { BuildGraphTableComponent } from './page/build-graph-table/build-graph-table.component';
 import { UriEncodePipe } from './uri-encode.pipe';
 import { SwitchComponent } from './widget/switch/switch.component';
+import { RelativeDatePipe } from './pipes/relative-date.pipe';
+import { TimeAgoPipe } from './pipes/time-ago.pipe';
 
 @NgModule({
   declarations: [
@@ -54,6 +55,8 @@ import { SwitchComponent } from './widget/switch/switch.component';
     BuildGraphTableComponent,
     UriEncodePipe,
     SwitchComponent,
+    RelativeDatePipe,
+    TimeAgoPipe,
   ],
   imports: [
     BrowserModule,
@@ -62,7 +65,6 @@ import { SwitchComponent } from './widget/switch/switch.component';
     FontAwesomeModule,
     BrowserAnimationsModule,
     NgbCollapseModule,
-    MomentModule,
     MaestroModule.forRoot(maestroOptions),
     StatefulModule,
     FormsModule,

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -90,7 +90,7 @@
         <a [routerLink]="['../..', getRepo(node.build), node.build.id]">{{getRepo(node.build)}}</a>
       </td>
       <td>
-        {{node.build.dateProduced | amTimeAgo}}
+        {{node.build.dateProduced | timeAgo}}
       </td>
       <td>
         <fa-icon icon="exclamation-circle" title="A newer build of this same repository is in the tree" *ngIf="!isCoherent(node)"></fa-icon>

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.html
@@ -62,7 +62,7 @@
         <h4>{{build.gitHubRepository}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>
         <div><a class="btn btn-sm btn-info" [href]="getCommitLink(build)" target="_blank">{{build.commit}} <fa-icon
               icon="external-link-alt"></fa-icon></a></div>
-        <div>{{build.dateProduced | amCalendar}}</div>
+        <div>{{build.dateProduced | relativeDate}}</div>
         <div>
           <span class="text-info" *ngIf="!azDevInfo.isMostRecent && !azDevInfo.mostRecentFailureLink">This is not the
             most recent successful

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnChanges } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { prettyRepository } from "src/app/util/names";
 import { map, shareReplay } from 'rxjs/operators';
-import moment from 'moment';
+import { isAfter, compareAsc, parseISO } from "date-fns";
 
 import { BuildGraph, Build } from 'src/maestro-client/models';
 import { MaestroService } from 'src/maestro-client';
@@ -38,13 +38,13 @@ export class BuildComponent implements OnInit, OnChanges {
     );
     this.graph$ = buildId$.pipe(
       statefulSwitchMap(buildId => {
-        return this.maestro.builds.getBuildGraphAsync(buildId);
+        return this.maestro.builds.getBuildGraphAsync({id: buildId});
       }),
       shareReplay(1),
     );
     this.build$ = buildId$.pipe(
       statefulSwitchMap(buildId => {
-        return this.maestro.builds.getBuildAsync(buildId);
+        return this.maestro.builds.getBuildAsync({id: buildId});
       }),
     );
 
@@ -89,13 +89,13 @@ export class BuildComponent implements OnInit, OnChanges {
             if (b.id === build.azureDevOpsBuildId) {
               return false;
             }
-            return moment(b.finishTime).isAfter(build.dateProduced);
+            return isAfter(parseISO(b.finishTime), build.dateProduced);
           }
 
           let isMostRecent: boolean;
           let mostRecentFailureLink: string | undefined;
 
-          const newerBuilds = builds.value.filter(isNewer).sort((l, r) => moment(l.finishTime).diff(moment(r.finishTime)));
+          const newerBuilds = builds.value.filter(isNewer).sort((l, r) => compareAsc(parseISO(l.finishTime), parseISO(r.finishTime)));
           if (!newerBuilds.length) {
             isMostRecent = true;
             mostRecentFailureLink = undefined;

--- a/src/Maestro/maestro-angular/src/app/page/recent-build/recent-build.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/recent-build/recent-build.component.ts
@@ -40,7 +40,10 @@ export class RecentBuildComponent implements OnInit {
           map(channels => channels.find(c => c.id === +channelId) as Channel),
         );
 
-        return this.maestro.builds.getLatestAsync(undefined, +channelId, undefined, undefined, undefined, undefined, repository).pipe(
+        return this.maestro.builds.getLatestAsync({
+          channelId: +channelId,
+          repository: repository,
+        }).pipe(
           map(b => [+channelId, repository, b] as [number, string, Build]),
         );
       }),

--- a/src/Maestro/maestro-angular/src/app/pipes/relative-date.pipe.spec.ts
+++ b/src/Maestro/maestro-angular/src/app/pipes/relative-date.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { RelativeDatePipe } from './relative-date.pipe';
+
+describe('RelativeDatePipe', () => {
+  it('create an instance', () => {
+    const pipe = new RelativeDatePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/Maestro/maestro-angular/src/app/pipes/relative-date.pipe.ts
+++ b/src/Maestro/maestro-angular/src/app/pipes/relative-date.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { formatRelative } from "date-fns";
+
+@Pipe({
+  name: 'relativeDate'
+})
+export class RelativeDatePipe implements PipeTransform {
+
+  transform(value: Date): any {
+    return formatRelative(value, new Date());
+  }
+
+}

--- a/src/Maestro/maestro-angular/src/app/pipes/time-ago.pipe.spec.ts
+++ b/src/Maestro/maestro-angular/src/app/pipes/time-ago.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { TimeAgoPipe } from './time-ago.pipe';
+
+describe('TimeAgoPipe', () => {
+  it('create an instance', () => {
+    const pipe = new TimeAgoPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/Maestro/maestro-angular/src/app/pipes/time-ago.pipe.ts
+++ b/src/Maestro/maestro-angular/src/app/pipes/time-ago.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { formatDistance } from 'date-fns';
+
+@Pipe({
+  name: 'timeAgo'
+})
+export class TimeAgoPipe implements PipeTransform {
+
+  transform(value: Date): any {
+    return formatDistance(value, new Date()) + " ago";
+  }
+
+}

--- a/src/Maestro/maestro-angular/src/app/services/channel.service.ts
+++ b/src/Maestro/maestro-angular/src/app/services/channel.service.ts
@@ -21,7 +21,7 @@ export class ChannelService {
   private channels$: Observable<Channel[]>;
 
   public constructor(private maestro: MaestroService) {
-    this.channels$ = maestro.channels.listChannelsAsync().pipe(
+    this.channels$ = maestro.channels.listChannelsAsync({}).pipe(
       shareReplay(1),
       map(channels => channels.filter(c => c.classification !== "test").sort(channelSorter)),
     );
@@ -32,6 +32,6 @@ export class ChannelService {
   }
 
   public getRepositories(channelId: number): Observable<DefaultChannel[]> {
-    return this.maestro.defaultChannels.listAsync(undefined, channelId);
+    return this.maestro.defaultChannels.listAsync({ channelId: channelId });
   }
 }

--- a/src/Maestro/maestro-angular/src/maestro-client/maestro.ts
+++ b/src/Maestro/maestro-angular/src/maestro-client/maestro.ts
@@ -2,7 +2,7 @@ import { NgModule, Injectable, Inject, InjectionToken } from "@angular/core";
 import { HttpClientModule, HttpClient, HttpHeaders, HttpParams } from "@angular/common/http";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
-import moment, { Moment } from "moment";
+import { parseISO } from "date-fns";
 
 import * as models from "./models";
 import { Helper } from "./helper";
@@ -80,7 +80,7 @@ export class MaestroService {
 })
 export class MaestroModule {
     public static defaultOptions: MaestroOptions = {
-        baseUrl: "http://localhost:8080/",
+        baseUrl: "https://maestro-prod.westus2.cloudapp.azure.com/",
         defaultHeaders: {},
     };
 
@@ -97,28 +97,36 @@ export class MaestroModule {
 export interface IAssetsApi {
 
     listAssetsAsync(
-        buildId?: number,
-        loadLocations?: boolean,
-        name?: string,
-        nonShipping?: boolean,
-        page?: number,
-        perPage?: number,
-        version?: string,
+        parameters: {
+            buildId?: number,
+            loadLocations?: boolean,
+            name?: string,
+            nonShipping?: boolean,
+            page?: number,
+            perPage?: number,
+            version?: string,
+        }
     ): Observable<models.Asset[]>;
 
     getAssetAsync(
-        id: number,
+        parameters: {
+            id: number,
+        }
     ): Observable<models.Asset>;
 
     addAssetLocationToAssetAsync(
-        assetId: number,
-        assetLocationType: models.AddAssetLocationToAssetAssetLocationType,
-        location: string,
+        parameters: {
+            assetId: number,
+            assetLocationType: models.AddAssetLocationToAssetAssetLocationType,
+            location: string,
+        }
     ): Observable<models.AssetLocation>;
 
     removeAssetLocationFromAssetAsync(
-        assetId: number,
-        assetLocationId: number,
+        parameters: {
+            assetId: number,
+            assetLocationId: number,
+        }
     ): Observable<void>;
 }
 
@@ -129,13 +137,23 @@ export class AssetsApiService implements IAssetsApi {
     }
 
     public listAssetsAsync(
-        buildId?: number,
-        loadLocations?: boolean,
-        name?: string,
-        nonShipping?: boolean,
-        page?: number,
-        perPage?: number,
-        version?: string,
+        {
+            buildId,
+            loadLocations,
+            name,
+            nonShipping,
+            page,
+            perPage,
+            version,
+        }: {
+            buildId?: number,
+            loadLocations?: boolean,
+            name?: string,
+            nonShipping?: boolean,
+            page?: number,
+            perPage?: number,
+            version?: string,
+        }
     ): Observable<models.Asset[]> {
         const apiVersion = "2019-01-16";
         let _path = this.options.baseUrl;
@@ -201,7 +219,11 @@ export class AssetsApiService implements IAssetsApi {
     }
 
     public getAssetAsync(
-        id: number,
+        {
+            id,
+        }: {
+            id: number,
+        }
     ): Observable<models.Asset> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -237,9 +259,15 @@ export class AssetsApiService implements IAssetsApi {
     }
 
     public addAssetLocationToAssetAsync(
-        assetId: number,
-        assetLocationType: models.AddAssetLocationToAssetAssetLocationType,
-        location: string,
+        {
+            assetId,
+            assetLocationType,
+            location,
+        }: {
+            assetId: number,
+            assetLocationType: models.AddAssetLocationToAssetAssetLocationType,
+            location: string,
+        }
     ): Observable<models.AssetLocation> {
         if (assetId === undefined) {
             throw new Error("Required parameter assetId is undefined.");
@@ -293,8 +321,13 @@ export class AssetsApiService implements IAssetsApi {
     }
 
     public removeAssetLocationFromAssetAsync(
-        assetId: number,
-        assetLocationId: number,
+        {
+            assetId,
+            assetLocationId,
+        }: {
+            assetId: number,
+            assetLocationId: number,
+        }
     ): Observable<void> {
         if (assetId === undefined) {
             throw new Error("Required parameter assetId is undefined.");
@@ -336,37 +369,47 @@ export class AssetsApiService implements IAssetsApi {
 export interface IBuildsApi {
 
     listBuildsAsync(
-        buildNumber?: string,
-        channelId?: number,
-        commit?: string,
-        loadCollections?: boolean,
-        notAfter?: Moment,
-        notBefore?: Moment,
-        page?: number,
-        perPage?: number,
-        repository?: string,
+        parameters: {
+            buildNumber?: string,
+            channelId?: number,
+            commit?: string,
+            loadCollections?: boolean,
+            notAfter?: Date,
+            notBefore?: Date,
+            page?: number,
+            perPage?: number,
+            repository?: string,
+        }
     ): Observable<models.Build[]>;
 
     createAsync(
-        body: models.BuildData,
+        parameters: {
+            body: models.BuildData,
+        }
     ): Observable<models.Build>;
 
     getBuildAsync(
-        id: number,
+        parameters: {
+            id: number,
+        }
     ): Observable<models.Build>;
 
     getBuildGraphAsync(
-        id: number,
+        parameters: {
+            id: number,
+        }
     ): Observable<models.BuildGraph>;
 
     getLatestAsync(
-        buildNumber?: string,
-        channelId?: number,
-        commit?: string,
-        loadCollections?: boolean,
-        notAfter?: Moment,
-        notBefore?: Moment,
-        repository?: string,
+        parameters: {
+            buildNumber?: string,
+            channelId?: number,
+            commit?: string,
+            loadCollections?: boolean,
+            notAfter?: Date,
+            notBefore?: Date,
+            repository?: string,
+        }
     ): Observable<models.Build>;
 }
 
@@ -377,15 +420,27 @@ export class BuildsApiService implements IBuildsApi {
     }
 
     public listBuildsAsync(
-        buildNumber?: string,
-        channelId?: number,
-        commit?: string,
-        loadCollections?: boolean,
-        notAfter?: Moment,
-        notBefore?: Moment,
-        page?: number,
-        perPage?: number,
-        repository?: string,
+        {
+            buildNumber,
+            channelId,
+            commit,
+            loadCollections,
+            notAfter,
+            notBefore,
+            page,
+            perPage,
+            repository,
+        }: {
+            buildNumber?: string,
+            channelId?: number,
+            commit?: string,
+            loadCollections?: boolean,
+            notAfter?: Date,
+            notBefore?: Date,
+            page?: number,
+            perPage?: number,
+            repository?: string,
+        }
     ): Observable<models.Build[]> {
         const apiVersion = "2019-01-16";
         let _path = this.options.baseUrl;
@@ -420,12 +475,12 @@ export class BuildsApiService implements IBuildsApi {
 
         if (notBefore)
         {
-            queryParameters = queryParameters.set("notBefore", notBefore.format());
+            queryParameters = queryParameters.set("notBefore", notBefore.toISOString());
         }
 
         if (notAfter)
         {
-            queryParameters = queryParameters.set("notAfter", notAfter.format());
+            queryParameters = queryParameters.set("notAfter", notAfter.toISOString());
         }
 
         if (loadCollections)
@@ -461,7 +516,11 @@ export class BuildsApiService implements IBuildsApi {
     }
 
     public createAsync(
-        body: models.BuildData,
+        {
+            body,
+        }: {
+            body: models.BuildData,
+        }
     ): Observable<models.Build> {
         if (body === undefined) {
             throw new Error("Required parameter body is undefined.");
@@ -497,7 +556,11 @@ export class BuildsApiService implements IBuildsApi {
     }
 
     public getBuildAsync(
-        id: number,
+        {
+            id,
+        }: {
+            id: number,
+        }
     ): Observable<models.Build> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -533,7 +596,11 @@ export class BuildsApiService implements IBuildsApi {
     }
 
     public getBuildGraphAsync(
-        id: number,
+        {
+            id,
+        }: {
+            id: number,
+        }
     ): Observable<models.BuildGraph> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -569,13 +636,23 @@ export class BuildsApiService implements IBuildsApi {
     }
 
     public getLatestAsync(
-        buildNumber?: string,
-        channelId?: number,
-        commit?: string,
-        loadCollections?: boolean,
-        notAfter?: Moment,
-        notBefore?: Moment,
-        repository?: string,
+        {
+            buildNumber,
+            channelId,
+            commit,
+            loadCollections,
+            notAfter,
+            notBefore,
+            repository,
+        }: {
+            buildNumber?: string,
+            channelId?: number,
+            commit?: string,
+            loadCollections?: boolean,
+            notAfter?: Date,
+            notBefore?: Date,
+            repository?: string,
+        }
     ): Observable<models.Build> {
         const apiVersion = "2019-01-16";
         let _path = this.options.baseUrl;
@@ -610,12 +687,12 @@ export class BuildsApiService implements IBuildsApi {
 
         if (notBefore)
         {
-            queryParameters = queryParameters.set("notBefore", notBefore.format());
+            queryParameters = queryParameters.set("notBefore", notBefore.toISOString());
         }
 
         if (notAfter)
         {
-            queryParameters = queryParameters.set("notAfter", notAfter.format());
+            queryParameters = queryParameters.set("notAfter", notAfter.toISOString());
         }
 
         if (loadCollections)
@@ -644,35 +721,49 @@ export class BuildsApiService implements IBuildsApi {
 export interface IChannelsApi {
 
     listChannelsAsync(
-        classification?: string,
+        parameters: {
+            classification?: string,
+        }
     ): Observable<models.Channel[]>;
 
     createChannelAsync(
-        classification: string,
-        name: string,
+        parameters: {
+            classification: string,
+            name: string,
+        }
     ): Observable<models.Channel>;
 
     getChannelAsync(
-        id: number,
+        parameters: {
+            id: number,
+        }
     ): Observable<models.Channel>;
 
     deleteChannelAsync(
-        id: number,
+        parameters: {
+            id: number,
+        }
     ): Observable<models.Channel>;
 
     addBuildToChannelAsync(
-        buildId: number,
-        channelId: number,
+        parameters: {
+            buildId: number,
+            channelId: number,
+        }
     ): Observable<void>;
 
     addPipelineToChannelAsync(
-        channelId: number,
-        pipelineId: number,
+        parameters: {
+            channelId: number,
+            pipelineId: number,
+        }
     ): Observable<void>;
 
     deletePipelineFromChannelAsync(
-        channelId: number,
-        pipelineId: number,
+        parameters: {
+            channelId: number,
+            pipelineId: number,
+        }
     ): Observable<void>;
 }
 
@@ -683,7 +774,11 @@ export class ChannelsApiService implements IChannelsApi {
     }
 
     public listChannelsAsync(
-        classification?: string,
+        {
+            classification,
+        }: {
+            classification?: string,
+        }
     ): Observable<models.Channel[]> {
         const apiVersion = "2019-01-16";
         let _path = this.options.baseUrl;
@@ -719,8 +814,13 @@ export class ChannelsApiService implements IChannelsApi {
     }
 
     public createChannelAsync(
-        classification: string,
-        name: string,
+        {
+            classification,
+            name,
+        }: {
+            classification: string,
+            name: string,
+        }
     ): Observable<models.Channel> {
         if (classification === undefined) {
             throw new Error("Required parameter classification is undefined.");
@@ -769,7 +869,11 @@ export class ChannelsApiService implements IChannelsApi {
     }
 
     public getChannelAsync(
-        id: number,
+        {
+            id,
+        }: {
+            id: number,
+        }
     ): Observable<models.Channel> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -805,7 +909,11 @@ export class ChannelsApiService implements IChannelsApi {
     }
 
     public deleteChannelAsync(
-        id: number,
+        {
+            id,
+        }: {
+            id: number,
+        }
     ): Observable<models.Channel> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -841,8 +949,13 @@ export class ChannelsApiService implements IChannelsApi {
     }
 
     public addBuildToChannelAsync(
-        buildId: number,
-        channelId: number,
+        {
+            buildId,
+            channelId,
+        }: {
+            buildId: number,
+            channelId: number,
+        }
     ): Observable<void> {
         if (buildId === undefined) {
             throw new Error("Required parameter buildId is undefined.");
@@ -881,8 +994,13 @@ export class ChannelsApiService implements IChannelsApi {
     }
 
     public addPipelineToChannelAsync(
-        channelId: number,
-        pipelineId: number,
+        {
+            channelId,
+            pipelineId,
+        }: {
+            channelId: number,
+            pipelineId: number,
+        }
     ): Observable<void> {
         if (channelId === undefined) {
             throw new Error("Required parameter channelId is undefined.");
@@ -921,8 +1039,13 @@ export class ChannelsApiService implements IChannelsApi {
     }
 
     public deletePipelineFromChannelAsync(
-        channelId: number,
-        pipelineId: number,
+        {
+            channelId,
+            pipelineId,
+        }: {
+            channelId: number,
+            pipelineId: number,
+        }
     ): Observable<void> {
         if (channelId === undefined) {
             throw new Error("Required parameter channelId is undefined.");
@@ -964,21 +1087,29 @@ export class ChannelsApiService implements IChannelsApi {
 export interface IDefaultChannelsApi {
 
     listAsync(
-        branch?: string,
-        channelId?: number,
-        repository?: string,
+        parameters: {
+            branch?: string,
+            channelId?: number,
+            repository?: string,
+        }
     ): Observable<models.DefaultChannel[]>;
 
     createAsync(
-        body: models.PostData,
+        parameters: {
+            body: models.PostData,
+        }
     ): Observable<void>;
 
     getAsync(
-        id: number,
+        parameters: {
+            id: number,
+        }
     ): Observable<models.DefaultChannel>;
 
     deleteAsync(
-        id: number,
+        parameters: {
+            id: number,
+        }
     ): Observable<void>;
 }
 
@@ -989,9 +1120,15 @@ export class DefaultChannelsApiService implements IDefaultChannelsApi {
     }
 
     public listAsync(
-        branch?: string,
-        channelId?: number,
-        repository?: string,
+        {
+            branch,
+            channelId,
+            repository,
+        }: {
+            branch?: string,
+            channelId?: number,
+            repository?: string,
+        }
     ): Observable<models.DefaultChannel[]> {
         const apiVersion = "2019-01-16";
         let _path = this.options.baseUrl;
@@ -1037,7 +1174,11 @@ export class DefaultChannelsApiService implements IDefaultChannelsApi {
     }
 
     public createAsync(
-        body: models.PostData,
+        {
+            body,
+        }: {
+            body: models.PostData,
+        }
     ): Observable<void> {
         if (body === undefined) {
             throw new Error("Required parameter body is undefined.");
@@ -1071,7 +1212,11 @@ export class DefaultChannelsApiService implements IDefaultChannelsApi {
     }
 
     public getAsync(
-        id: number,
+        {
+            id,
+        }: {
+            id: number,
+        }
     ): Observable<models.DefaultChannel> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -1107,7 +1252,11 @@ export class DefaultChannelsApiService implements IDefaultChannelsApi {
     }
 
     public deleteAsync(
-        id: number,
+        {
+            id,
+        }: {
+            id: number,
+        }
     ): Observable<void> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -1144,23 +1293,31 @@ export class DefaultChannelsApiService implements IDefaultChannelsApi {
 export interface IPipelinesApi {
 
     listAsync(
-        organization?: string,
-        pipelineIdentifier?: number,
-        project?: string,
+        parameters: {
+            organization?: string,
+            pipelineIdentifier?: number,
+            project?: string,
+        }
     ): Observable<models.ReleasePipeline[]>;
 
     createPipelineAsync(
-        organization: string,
-        pipelineIdentifier: number,
-        project: string,
+        parameters: {
+            organization: string,
+            pipelineIdentifier: number,
+            project: string,
+        }
     ): Observable<models.ReleasePipeline>;
 
     getPipelineAsync(
-        id: number,
+        parameters: {
+            id: number,
+        }
     ): Observable<models.ReleasePipeline>;
 
     deletePipelineAsync(
-        id: number,
+        parameters: {
+            id: number,
+        }
     ): Observable<models.ReleasePipeline>;
 }
 
@@ -1171,9 +1328,15 @@ export class PipelinesApiService implements IPipelinesApi {
     }
 
     public listAsync(
-        organization?: string,
-        pipelineIdentifier?: number,
-        project?: string,
+        {
+            organization,
+            pipelineIdentifier,
+            project,
+        }: {
+            organization?: string,
+            pipelineIdentifier?: number,
+            project?: string,
+        }
     ): Observable<models.ReleasePipeline[]> {
         const apiVersion = "2019-01-16";
         let _path = this.options.baseUrl;
@@ -1219,9 +1382,15 @@ export class PipelinesApiService implements IPipelinesApi {
     }
 
     public createPipelineAsync(
-        organization: string,
-        pipelineIdentifier: number,
-        project: string,
+        {
+            organization,
+            pipelineIdentifier,
+            project,
+        }: {
+            organization: string,
+            pipelineIdentifier: number,
+            project: string,
+        }
     ): Observable<models.ReleasePipeline> {
         if (organization === undefined) {
             throw new Error("Required parameter organization is undefined.");
@@ -1279,7 +1448,11 @@ export class PipelinesApiService implements IPipelinesApi {
     }
 
     public getPipelineAsync(
-        id: number,
+        {
+            id,
+        }: {
+            id: number,
+        }
     ): Observable<models.ReleasePipeline> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -1315,7 +1488,11 @@ export class PipelinesApiService implements IPipelinesApi {
     }
 
     public deletePipelineAsync(
-        id: number,
+        {
+            id,
+        }: {
+            id: number,
+        }
     ): Observable<models.ReleasePipeline> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -1354,27 +1531,35 @@ export class PipelinesApiService implements IPipelinesApi {
 export interface IRepositoryApi {
 
     getMergePoliciesAsync(
-        branch: string,
-        repository: string,
+        parameters: {
+            branch: string,
+            repository: string,
+        }
     ): Observable<models.MergePolicy[]>;
 
     setMergePoliciesAsync(
-        branch: string,
-        repository: string,
-        body?: models.MergePolicy[],
+        parameters: {
+            branch: string,
+            repository: string,
+            body?: models.MergePolicy[],
+        }
     ): Observable<void>;
 
     getHistoryAsync(
-        branch?: string,
-        page?: number,
-        perPage?: number,
-        repository?: string,
+        parameters: {
+            branch?: string,
+            page?: number,
+            perPage?: number,
+            repository?: string,
+        }
     ): Observable<models.RepositoryHistoryItem[]>;
 
     retryActionAsyncAsync(
-        branch: string,
-        repository: string,
-        timestamp: number,
+        parameters: {
+            branch: string,
+            repository: string,
+            timestamp: number,
+        }
     ): Observable<void>;
 }
 
@@ -1385,8 +1570,13 @@ export class RepositoryApiService implements IRepositoryApi {
     }
 
     public getMergePoliciesAsync(
-        branch: string,
-        repository: string,
+        {
+            branch,
+            repository,
+        }: {
+            branch: string,
+            repository: string,
+        }
     ): Observable<models.MergePolicy[]> {
         if (branch === undefined) {
             throw new Error("Required parameter branch is undefined.");
@@ -1435,9 +1625,15 @@ export class RepositoryApiService implements IRepositoryApi {
     }
 
     public setMergePoliciesAsync(
-        branch: string,
-        repository: string,
-        body?: models.MergePolicy[],
+        {
+            branch,
+            repository,
+            body,
+        }: {
+            branch: string,
+            repository: string,
+            body?: models.MergePolicy[],
+        }
     ): Observable<void> {
         if (branch === undefined) {
             throw new Error("Required parameter branch is undefined.");
@@ -1485,10 +1681,17 @@ export class RepositoryApiService implements IRepositoryApi {
     }
 
     public getHistoryAsync(
-        branch?: string,
-        page?: number,
-        perPage?: number,
-        repository?: string,
+        {
+            branch,
+            page,
+            perPage,
+            repository,
+        }: {
+            branch?: string,
+            page?: number,
+            perPage?: number,
+            repository?: string,
+        }
     ): Observable<models.RepositoryHistoryItem[]> {
         const apiVersion = "2019-01-16";
         let _path = this.options.baseUrl;
@@ -1539,9 +1742,15 @@ export class RepositoryApiService implements IRepositoryApi {
     }
 
     public retryActionAsyncAsync(
-        branch: string,
-        repository: string,
-        timestamp: number,
+        {
+            branch,
+            repository,
+            timestamp,
+        }: {
+            branch: string,
+            repository: string,
+            timestamp: number,
+        }
     ): Observable<void> {
         if (branch === undefined) {
             throw new Error("Required parameter branch is undefined.");
@@ -1596,42 +1805,61 @@ export class RepositoryApiService implements IRepositoryApi {
 export interface ISubscriptionsApi {
 
     listSubscriptionsAsync(
-        channelId?: number,
-        enabled?: boolean,
-        sourceRepository?: string,
-        targetRepository?: string,
+        parameters: {
+            channelId?: number,
+            enabled?: boolean,
+            sourceRepository?: string,
+            targetRepository?: string,
+        }
     ): Observable<models.Subscription[]>;
 
     createAsync(
-        body: models.SubscriptionData,
+        parameters: {
+            body: models.SubscriptionData,
+        }
     ): Observable<models.Subscription>;
 
     getSubscriptionAsync(
-        id: string,
+        parameters: {
+            id: string,
+        }
     ): Observable<models.Subscription>;
 
     deleteSubscriptionAsync(
-        id: string,
+        parameters: {
+            id: string,
+        }
     ): Observable<models.Subscription>;
 
     updateSubscriptionAsync(
-        id: string,
-        body?: models.SubscriptionUpdate,
+        parameters: {
+            id: string,
+            body?: models.SubscriptionUpdate,
+        }
     ): Observable<models.Subscription>;
 
     triggerSubscriptionAsync(
-        id: string,
+        parameters: {
+            id: string,
+        }
     ): Observable<models.Subscription>;
 
+    triggerDailyUpdateAsync(
+    ): Observable<void>;
+
     getSubscriptionHistoryAsync(
-        id: string,
-        page?: number,
-        perPage?: number,
+        parameters: {
+            id: string,
+            page?: number,
+            perPage?: number,
+        }
     ): Observable<models.SubscriptionHistoryItem[]>;
 
     retrySubscriptionActionAsyncAsync(
-        id: string,
-        timestamp: number,
+        parameters: {
+            id: string,
+            timestamp: number,
+        }
     ): Observable<void>;
 }
 
@@ -1642,10 +1870,17 @@ export class SubscriptionsApiService implements ISubscriptionsApi {
     }
 
     public listSubscriptionsAsync(
-        channelId?: number,
-        enabled?: boolean,
-        sourceRepository?: string,
-        targetRepository?: string,
+        {
+            channelId,
+            enabled,
+            sourceRepository,
+            targetRepository,
+        }: {
+            channelId?: number,
+            enabled?: boolean,
+            sourceRepository?: string,
+            targetRepository?: string,
+        }
     ): Observable<models.Subscription[]> {
         const apiVersion = "2019-01-16";
         let _path = this.options.baseUrl;
@@ -1696,7 +1931,11 @@ export class SubscriptionsApiService implements ISubscriptionsApi {
     }
 
     public createAsync(
-        body: models.SubscriptionData,
+        {
+            body,
+        }: {
+            body: models.SubscriptionData,
+        }
     ): Observable<models.Subscription> {
         if (body === undefined) {
             throw new Error("Required parameter body is undefined.");
@@ -1732,7 +1971,11 @@ export class SubscriptionsApiService implements ISubscriptionsApi {
     }
 
     public getSubscriptionAsync(
-        id: string,
+        {
+            id,
+        }: {
+            id: string,
+        }
     ): Observable<models.Subscription> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -1768,7 +2011,11 @@ export class SubscriptionsApiService implements ISubscriptionsApi {
     }
 
     public deleteSubscriptionAsync(
-        id: string,
+        {
+            id,
+        }: {
+            id: string,
+        }
     ): Observable<models.Subscription> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -1804,8 +2051,13 @@ export class SubscriptionsApiService implements ISubscriptionsApi {
     }
 
     public updateSubscriptionAsync(
-        id: string,
-        body?: models.SubscriptionUpdate,
+        {
+            id,
+            body,
+        }: {
+            id: string,
+            body?: models.SubscriptionUpdate,
+        }
     ): Observable<models.Subscription> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -1842,7 +2094,11 @@ export class SubscriptionsApiService implements ISubscriptionsApi {
     }
 
     public triggerSubscriptionAsync(
-        id: string,
+        {
+            id,
+        }: {
+            id: string,
+        }
     ): Observable<models.Subscription> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -1877,10 +2133,44 @@ export class SubscriptionsApiService implements ISubscriptionsApi {
 
     }
 
+    public triggerDailyUpdateAsync(
+    ): Observable<void> {
+        const apiVersion = "2019-01-16";
+        let _path = this.options.baseUrl;
+        if (_path.endsWith("/"))
+        {
+            _path = _path.slice(0, -1);
+        }
+        _path = _path + "/api/subscriptions/triggerDaily";
+
+        let queryParameters = new HttpParams();
+        let headerParameters = new HttpHeaders(this.options.defaultHeaders);
+
+        queryParameters = queryParameters.set("api-version", apiVersion);
+
+
+        return this.client.request(
+            "post",
+            _path,
+            {
+                headers: headerParameters,
+                params: queryParameters,
+                responseType: "text",
+            }
+        );
+
+    }
+
     public getSubscriptionHistoryAsync(
-        id: string,
-        page?: number,
-        perPage?: number,
+        {
+            id,
+            page,
+            perPage,
+        }: {
+            id: string,
+            page?: number,
+            perPage?: number,
+        }
     ): Observable<models.SubscriptionHistoryItem[]> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");
@@ -1926,8 +2216,13 @@ export class SubscriptionsApiService implements ISubscriptionsApi {
     }
 
     public retrySubscriptionActionAsyncAsync(
-        id: string,
-        timestamp: number,
+        {
+            id,
+            timestamp,
+        }: {
+            id: string,
+            timestamp: number,
+        }
     ): Observable<void> {
         if (id === undefined) {
             throw new Error("Required parameter id is undefined.");

--- a/src/Maestro/maestro-angular/src/maestro-client/models.ts
+++ b/src/Maestro/maestro-angular/src/maestro-client/models.ts
@@ -1,4 +1,4 @@
-import moment, { Moment } from "moment";
+import { parseISO } from "date-fns";
 
 import { Helper } from "./helper";
 
@@ -11,8 +11,13 @@ export enum AddAssetLocationToAssetAssetLocationType {
 
 export class ApiError {
     public constructor(
-        message?: string,
-        errors?: string[],
+        {
+            message,
+            errors,
+        }: {
+            message?: string,
+            errors?: string[],
+        }
     ) {
         this._message = message;
         this._errors = errors;
@@ -31,13 +36,10 @@ export class ApiError {
     }
 
     public static fromRawObject(value: any): ApiError {
-        let result = new ApiError(
-            value["message"] == null ? undefined : value["message"],
-            value["errors"] == null ? undefined : value["errors"].map((e: any) => e),
-        );
-        for (let key of Object.keys(value))
-        {
-        }
+        let result = new ApiError({
+            message: value["message"] == null ? undefined : value["message"] as any,
+            errors: value["errors"] == null ? undefined : value["errors"].map((e: any) => e) as any,
+        });
         return result;
     }
 
@@ -55,18 +57,27 @@ export class ApiError {
 
 export class Asset {
     public constructor(
-        id: number,
-        buildId: number,
-        nonShipping: boolean,
-        name?: string,
-        version?: string,
-        locations?: AssetLocation[],
+        {
+            id,
+            name,
+            version,
+            buildId,
+            nonShipping,
+            locations,
+        }: {
+            id: number,
+            name?: string,
+            version?: string,
+            buildId: number,
+            nonShipping: boolean,
+            locations?: AssetLocation[],
+        }
     ) {
         this._id = id;
-        this._buildId = buildId;
-        this._nonShipping = nonShipping;
         this._name = name;
         this._version = version;
+        this._buildId = buildId;
+        this._nonShipping = nonShipping;
         this._locations = locations;
     }
 
@@ -123,17 +134,14 @@ export class Asset {
     }
 
     public static fromRawObject(value: any): Asset {
-        let result = new Asset(
-            value["id"],
-            value["buildId"],
-            value["nonShipping"],
-            value["name"] == null ? undefined : value["name"],
-            value["version"] == null ? undefined : value["version"],
-            value["locations"] == null ? undefined : value["locations"].map((e: any) => AssetLocation.fromRawObject(e)),
-        );
-        for (let key of Object.keys(value))
-        {
-        }
+        let result = new Asset({
+            id: value["id"] == null ? undefined : value["id"] as any,
+            name: value["name"] == null ? undefined : value["name"] as any,
+            version: value["version"] == null ? undefined : value["version"] as any,
+            buildId: value["buildId"] == null ? undefined : value["buildId"] as any,
+            nonShipping: value["nonShipping"] == null ? undefined : value["nonShipping"] as any,
+            locations: value["locations"] == null ? undefined : value["locations"].map((e: any) => AssetLocation.fromRawObject(e)) as any,
+        });
         return result;
     }
 
@@ -157,9 +165,22 @@ export class Asset {
 
 export class AssetData {
     public constructor(
-        nonShipping: boolean,
+        {
+            name,
+            version,
+            nonShipping,
+            locations,
+        }: {
+            name?: string,
+            version?: string,
+            nonShipping: boolean,
+            locations?: AssetLocationData[],
+        }
     ) {
+        this._name = name;
+        this._version = version;
         this._nonShipping = nonShipping;
+        this._locations = locations;
     }
 
     private _name?: string;
@@ -209,27 +230,12 @@ export class AssetData {
     }
 
     public static fromRawObject(value: any): AssetData {
-        let result = new AssetData(
-            value["nonShipping"],
-        );
-        for (let key of Object.keys(value))
-        {
-            if (key === "name")
-            {
-                result._name = value[key];
-                continue;
-            }
-            if (key === "version")
-            {
-                result._version = value[key];
-                continue;
-            }
-            if (key === "locations")
-            {
-                result._locations = value[key].map((e: any) => AssetLocationData.fromRawObject(e));
-                continue;
-            }
-        }
+        let result = new AssetData({
+            name: value["name"] == null ? undefined : value["name"] as any,
+            version: value["version"] == null ? undefined : value["version"] as any,
+            nonShipping: value["nonShipping"] == null ? undefined : value["nonShipping"] as any,
+            locations: value["locations"] == null ? undefined : value["locations"].map((e: any) => AssetLocationData.fromRawObject(e)) as any,
+        });
         return result;
     }
 
@@ -251,13 +257,19 @@ export class AssetData {
 
 export class AssetLocation {
     public constructor(
-        id: number,
-        type: AssetLocationType,
-        location?: string,
+        {
+            id,
+            location,
+            type,
+        }: {
+            id: number,
+            location?: string,
+            type: AssetLocationType,
+        }
     ) {
         this._id = id;
-        this._type = type;
         this._location = location;
+        this._type = type;
     }
 
     private _id: number;
@@ -286,14 +298,11 @@ export class AssetLocation {
     }
 
     public static fromRawObject(value: any): AssetLocation {
-        let result = new AssetLocation(
-            value["id"],
-            value["type"],
-            value["location"] == null ? undefined : value["location"],
-        );
-        for (let key of Object.keys(value))
-        {
-        }
+        let result = new AssetLocation({
+            id: value["id"] == null ? undefined : value["id"] as any,
+            location: value["location"] == null ? undefined : value["location"] as any,
+            type: value["type"] == null ? undefined : value["type"] as any,
+        });
         return result;
     }
 
@@ -310,8 +319,15 @@ export class AssetLocation {
 
 export class AssetLocationData {
     public constructor(
-        type: AssetLocationDataType,
+        {
+            location,
+            type,
+        }: {
+            location?: string,
+            type: AssetLocationDataType,
+        }
     ) {
+        this._location = location;
         this._type = type;
     }
 
@@ -342,17 +358,10 @@ export class AssetLocationData {
     }
 
     public static fromRawObject(value: any): AssetLocationData {
-        let result = new AssetLocationData(
-            value["type"],
-        );
-        for (let key of Object.keys(value))
-        {
-            if (key === "location")
-            {
-                result._location = value[key];
-                continue;
-            }
-        }
+        let result = new AssetLocationData({
+            location: value["location"] == null ? undefined : value["location"] as any,
+            type: value["type"] == null ? undefined : value["type"] as any,
+        });
         return result;
     }
 
@@ -380,16 +389,55 @@ export enum AssetLocationType {
 
 export class Build {
     public constructor(
-        id: number,
-        dateProduced: Moment,
-        commit?: string,
-        channels?: Channel[],
-        assets?: Asset[],
-        dependencies?: BuildRef[],
+        {
+            id,
+            commit,
+            azureDevOpsBuildId,
+            azureDevOpsBuildDefinitionId,
+            azureDevOpsAccount,
+            azureDevOpsProject,
+            azureDevOpsBuildNumber,
+            azureDevOpsRepository,
+            azureDevOpsBranch,
+            gitHubRepository,
+            gitHubBranch,
+            publishUsingPipelines,
+            dateProduced,
+            channels,
+            assets,
+            dependencies,
+        }: {
+            id: number,
+            commit?: string,
+            azureDevOpsBuildId?: number,
+            azureDevOpsBuildDefinitionId?: number,
+            azureDevOpsAccount?: string,
+            azureDevOpsProject?: string,
+            azureDevOpsBuildNumber?: string,
+            azureDevOpsRepository?: string,
+            azureDevOpsBranch?: string,
+            gitHubRepository?: string,
+            gitHubBranch?: string,
+            publishUsingPipelines: boolean,
+            dateProduced: Date,
+            channels?: Channel[],
+            assets?: Asset[],
+            dependencies?: BuildRef[],
+        }
     ) {
         this._id = id;
-        this._dateProduced = dateProduced;
         this._commit = commit;
+        this._azureDevOpsBuildId = azureDevOpsBuildId;
+        this._azureDevOpsBuildDefinitionId = azureDevOpsBuildDefinitionId;
+        this._azureDevOpsAccount = azureDevOpsAccount;
+        this._azureDevOpsProject = azureDevOpsProject;
+        this._azureDevOpsBuildNumber = azureDevOpsBuildNumber;
+        this._azureDevOpsRepository = azureDevOpsRepository;
+        this._azureDevOpsBranch = azureDevOpsBranch;
+        this._gitHubRepository = gitHubRepository;
+        this._gitHubBranch = gitHubBranch;
+        this._publishUsingPipelines = publishUsingPipelines;
+        this._dateProduced = dateProduced;
         this._channels = channels;
         this._assets = assets;
         this._dependencies = dependencies;
@@ -497,9 +545,19 @@ export class Build {
         this._gitHubBranch = __value;
     }
 
-    private _dateProduced: Moment;
+    private _publishUsingPipelines: boolean;
 
-    public get dateProduced(): Moment {
+    public get publishUsingPipelines(): boolean {
+        return this._publishUsingPipelines;
+    }
+
+    public set publishUsingPipelines(__value: boolean) {
+        this._publishUsingPipelines = __value;
+    }
+
+    private _dateProduced: Date;
+
+    public get dateProduced(): Date {
         return this._dateProduced;
     }
 
@@ -524,67 +582,30 @@ export class Build {
     public isValid(): boolean {
         return (
             this._id !== undefined &&
+            this._publishUsingPipelines !== undefined &&
             this._dateProduced !== undefined
         );
     }
 
     public static fromRawObject(value: any): Build {
-        let result = new Build(
-            value["id"],
-            moment(value["dateProduced"]),
-            value["commit"] == null ? undefined : value["commit"],
-            value["channels"] == null ? undefined : value["channels"].map((e: any) => Channel.fromRawObject(e)),
-            value["assets"] == null ? undefined : value["assets"].map((e: any) => Asset.fromRawObject(e)),
-            value["dependencies"] == null ? undefined : value["dependencies"].map((e: any) => BuildRef.fromRawObject(e)),
-        );
-        for (let key of Object.keys(value))
-        {
-            if (key === "azureDevOpsBuildId")
-            {
-                result._azureDevOpsBuildId = value[key];
-                continue;
-            }
-            if (key === "azureDevOpsBuildDefinitionId")
-            {
-                result._azureDevOpsBuildDefinitionId = value[key];
-                continue;
-            }
-            if (key === "azureDevOpsAccount")
-            {
-                result._azureDevOpsAccount = value[key];
-                continue;
-            }
-            if (key === "azureDevOpsProject")
-            {
-                result._azureDevOpsProject = value[key];
-                continue;
-            }
-            if (key === "azureDevOpsBuildNumber")
-            {
-                result._azureDevOpsBuildNumber = value[key];
-                continue;
-            }
-            if (key === "azureDevOpsRepository")
-            {
-                result._azureDevOpsRepository = value[key];
-                continue;
-            }
-            if (key === "azureDevOpsBranch")
-            {
-                result._azureDevOpsBranch = value[key];
-                continue;
-            }
-            if (key === "gitHubRepository")
-            {
-                result._gitHubRepository = value[key];
-                continue;
-            }
-            if (key === "gitHubBranch")
-            {
-                result._gitHubBranch = value[key];
-                continue;
-            }
-        }
+        let result = new Build({
+            id: value["id"] == null ? undefined : value["id"] as any,
+            commit: value["commit"] == null ? undefined : value["commit"] as any,
+            azureDevOpsBuildId: value["azureDevOpsBuildId"] == null ? undefined : value["azureDevOpsBuildId"] as any,
+            azureDevOpsBuildDefinitionId: value["azureDevOpsBuildDefinitionId"] == null ? undefined : value["azureDevOpsBuildDefinitionId"] as any,
+            azureDevOpsAccount: value["azureDevOpsAccount"] == null ? undefined : value["azureDevOpsAccount"] as any,
+            azureDevOpsProject: value["azureDevOpsProject"] == null ? undefined : value["azureDevOpsProject"] as any,
+            azureDevOpsBuildNumber: value["azureDevOpsBuildNumber"] == null ? undefined : value["azureDevOpsBuildNumber"] as any,
+            azureDevOpsRepository: value["azureDevOpsRepository"] == null ? undefined : value["azureDevOpsRepository"] as any,
+            azureDevOpsBranch: value["azureDevOpsBranch"] == null ? undefined : value["azureDevOpsBranch"] as any,
+            gitHubRepository: value["gitHubRepository"] == null ? undefined : value["gitHubRepository"] as any,
+            gitHubBranch: value["gitHubBranch"] == null ? undefined : value["gitHubBranch"] as any,
+            publishUsingPipelines: value["publishUsingPipelines"] == null ? undefined : value["publishUsingPipelines"] as any,
+            dateProduced: value["dateProduced"] == null ? undefined : parseISO(value["dateProduced"]) as any,
+            channels: value["channels"] == null ? undefined : value["channels"].map((e: any) => Channel.fromRawObject(e)) as any,
+            assets: value["assets"] == null ? undefined : value["assets"].map((e: any) => Asset.fromRawObject(e)) as any,
+            dependencies: value["dependencies"] == null ? undefined : value["dependencies"].map((e: any) => BuildRef.fromRawObject(e)) as any,
+        });
         return result;
     }
 
@@ -621,7 +642,8 @@ export class Build {
         if (value._gitHubBranch) {
             result["gitHubBranch"] = value._gitHubBranch;
         }
-        result["dateProduced"] = value._dateProduced.format();
+        result["publishUsingPipelines"] = value._publishUsingPipelines;
+        result["dateProduced"] = value._dateProduced.toISOString();
         if (value._channels) {
             result["channels"] = value._channels.map((e: any) => Channel.toRawObject(e));
         }
@@ -637,19 +659,49 @@ export class Build {
 
 export class BuildData {
     public constructor(
-        commit: string,
-        azureDevOpsAccount: string,
-        azureDevOpsProject: string,
-        azureDevOpsBuildNumber: string,
-        azureDevOpsRepository: string,
-        azureDevOpsBranch: string,
+        {
+            commit,
+            assets,
+            dependencies,
+            azureDevOpsBuildId,
+            azureDevOpsBuildDefinitionId,
+            azureDevOpsAccount,
+            azureDevOpsProject,
+            azureDevOpsBuildNumber,
+            azureDevOpsRepository,
+            azureDevOpsBranch,
+            gitHubRepository,
+            gitHubBranch,
+            publishUsingPipelines,
+        }: {
+            commit: string,
+            assets?: AssetData[],
+            dependencies?: BuildRef[],
+            azureDevOpsBuildId?: number,
+            azureDevOpsBuildDefinitionId?: number,
+            azureDevOpsAccount: string,
+            azureDevOpsProject: string,
+            azureDevOpsBuildNumber: string,
+            azureDevOpsRepository: string,
+            azureDevOpsBranch: string,
+            gitHubRepository?: string,
+            gitHubBranch?: string,
+            publishUsingPipelines: boolean,
+        }
     ) {
         this._commit = commit;
+        this._assets = assets;
+        this._dependencies = dependencies;
+        this._azureDevOpsBuildId = azureDevOpsBuildId;
+        this._azureDevOpsBuildDefinitionId = azureDevOpsBuildDefinitionId;
         this._azureDevOpsAccount = azureDevOpsAccount;
         this._azureDevOpsProject = azureDevOpsProject;
         this._azureDevOpsBuildNumber = azureDevOpsBuildNumber;
         this._azureDevOpsRepository = azureDevOpsRepository;
         this._azureDevOpsBranch = azureDevOpsBranch;
+        this._gitHubRepository = gitHubRepository;
+        this._gitHubBranch = gitHubBranch;
+        this._publishUsingPipelines = publishUsingPipelines;
     }
 
     private _commit: string;
@@ -771,6 +823,16 @@ export class BuildData {
     public set gitHubBranch(__value: string | undefined) {
         this._gitHubBranch = __value;
     }
+
+    private _publishUsingPipelines: boolean;
+
+    public get publishUsingPipelines(): boolean {
+        return this._publishUsingPipelines;
+    }
+
+    public set publishUsingPipelines(__value: boolean) {
+        this._publishUsingPipelines = __value;
+    }
     
     public isValid(): boolean {
         return (
@@ -779,52 +841,27 @@ export class BuildData {
             this._azureDevOpsProject !== undefined &&
             this._azureDevOpsBuildNumber !== undefined &&
             this._azureDevOpsRepository !== undefined &&
-            this._azureDevOpsBranch !== undefined
+            this._azureDevOpsBranch !== undefined &&
+            this._publishUsingPipelines !== undefined
         );
     }
 
     public static fromRawObject(value: any): BuildData {
-        let result = new BuildData(
-            value["commit"],
-            value["azureDevOpsAccount"],
-            value["azureDevOpsProject"],
-            value["azureDevOpsBuildNumber"],
-            value["azureDevOpsRepository"],
-            value["azureDevOpsBranch"],
-        );
-        for (let key of Object.keys(value))
-        {
-            if (key === "assets")
-            {
-                result._assets = value[key].map((e: any) => AssetData.fromRawObject(e));
-                continue;
-            }
-            if (key === "dependencies")
-            {
-                result._dependencies = value[key].map((e: any) => BuildRef.fromRawObject(e));
-                continue;
-            }
-            if (key === "azureDevOpsBuildId")
-            {
-                result._azureDevOpsBuildId = value[key];
-                continue;
-            }
-            if (key === "azureDevOpsBuildDefinitionId")
-            {
-                result._azureDevOpsBuildDefinitionId = value[key];
-                continue;
-            }
-            if (key === "gitHubRepository")
-            {
-                result._gitHubRepository = value[key];
-                continue;
-            }
-            if (key === "gitHubBranch")
-            {
-                result._gitHubBranch = value[key];
-                continue;
-            }
-        }
+        let result = new BuildData({
+            commit: value["commit"] == null ? undefined : value["commit"] as any,
+            assets: value["assets"] == null ? undefined : value["assets"].map((e: any) => AssetData.fromRawObject(e)) as any,
+            dependencies: value["dependencies"] == null ? undefined : value["dependencies"].map((e: any) => BuildRef.fromRawObject(e)) as any,
+            azureDevOpsBuildId: value["azureDevOpsBuildId"] == null ? undefined : value["azureDevOpsBuildId"] as any,
+            azureDevOpsBuildDefinitionId: value["azureDevOpsBuildDefinitionId"] == null ? undefined : value["azureDevOpsBuildDefinitionId"] as any,
+            azureDevOpsAccount: value["azureDevOpsAccount"] == null ? undefined : value["azureDevOpsAccount"] as any,
+            azureDevOpsProject: value["azureDevOpsProject"] == null ? undefined : value["azureDevOpsProject"] as any,
+            azureDevOpsBuildNumber: value["azureDevOpsBuildNumber"] == null ? undefined : value["azureDevOpsBuildNumber"] as any,
+            azureDevOpsRepository: value["azureDevOpsRepository"] == null ? undefined : value["azureDevOpsRepository"] as any,
+            azureDevOpsBranch: value["azureDevOpsBranch"] == null ? undefined : value["azureDevOpsBranch"] as any,
+            gitHubRepository: value["gitHubRepository"] == null ? undefined : value["gitHubRepository"] as any,
+            gitHubBranch: value["gitHubBranch"] == null ? undefined : value["gitHubBranch"] as any,
+            publishUsingPipelines: value["publishUsingPipelines"] == null ? undefined : value["publishUsingPipelines"] as any,
+        });
         return result;
     }
 
@@ -854,13 +891,18 @@ export class BuildData {
         if (value._gitHubBranch) {
             result["gitHubBranch"] = value._gitHubBranch;
         }
+        result["publishUsingPipelines"] = value._publishUsingPipelines;
         return result;
     }
 }
 
 export class BuildGraph {
     public constructor(
-        builds: Record<string, Build>,
+        {
+            builds,
+        }: {
+            builds: Record<string, Build>,
+        }
     ) {
         this._builds = builds;
     }
@@ -878,12 +920,9 @@ export class BuildGraph {
     }
 
     public static fromRawObject(value: any): BuildGraph {
-        let result = new BuildGraph(
-            Helper.mapValues(value["builds"], (v: any) => Build.fromRawObject(v)),
-        );
-        for (let key of Object.keys(value))
-        {
-        }
+        let result = new BuildGraph({
+            builds: value["builds"] == null ? undefined : Helper.mapValues(value["builds"], (v: any) => Build.fromRawObject(v)) as any,
+        });
         return result;
     }
 
@@ -896,8 +935,13 @@ export class BuildGraph {
 
 export class BuildRef {
     public constructor(
-        buildId: number,
-        isProduct: boolean,
+        {
+            buildId,
+            isProduct,
+        }: {
+            buildId: number,
+            isProduct: boolean,
+        }
     ) {
         this._buildId = buildId;
         this._isProduct = isProduct;
@@ -923,13 +967,10 @@ export class BuildRef {
     }
 
     public static fromRawObject(value: any): BuildRef {
-        let result = new BuildRef(
-            value["buildId"],
-            value["isProduct"],
-        );
-        for (let key of Object.keys(value))
-        {
-        }
+        let result = new BuildRef({
+            buildId: value["buildId"] == null ? undefined : value["buildId"] as any,
+            isProduct: value["isProduct"] == null ? undefined : value["isProduct"] as any,
+        });
         return result;
     }
 
@@ -943,10 +984,17 @@ export class BuildRef {
 
 export class Channel {
     public constructor(
-        id: number,
-        name?: string,
-        classification?: string,
-        releasePipelines?: ReleasePipeline[],
+        {
+            id,
+            name,
+            classification,
+            releasePipelines,
+        }: {
+            id: number,
+            name?: string,
+            classification?: string,
+            releasePipelines?: ReleasePipeline[],
+        }
     ) {
         this._id = id;
         this._name = name;
@@ -985,15 +1033,12 @@ export class Channel {
     }
 
     public static fromRawObject(value: any): Channel {
-        let result = new Channel(
-            value["id"],
-            value["name"] == null ? undefined : value["name"],
-            value["classification"] == null ? undefined : value["classification"],
-            value["releasePipelines"] == null ? undefined : value["releasePipelines"].map((e: any) => ReleasePipeline.fromRawObject(e)),
-        );
-        for (let key of Object.keys(value))
-        {
-        }
+        let result = new Channel({
+            id: value["id"] == null ? undefined : value["id"] as any,
+            name: value["name"] == null ? undefined : value["name"] as any,
+            classification: value["classification"] == null ? undefined : value["classification"] as any,
+            releasePipelines: value["releasePipelines"] == null ? undefined : value["releasePipelines"].map((e: any) => ReleasePipeline.fromRawObject(e)) as any,
+        });
         return result;
     }
 
@@ -1015,11 +1060,22 @@ export class Channel {
 
 export class DefaultChannel {
     public constructor(
-        id: number,
-        repository: string,
+        {
+            id,
+            repository,
+            branch,
+            channel,
+        }: {
+            id: number,
+            repository: string,
+            branch?: string,
+            channel?: Channel,
+        }
     ) {
         this._id = id;
         this._repository = repository;
+        this._branch = branch;
+        this._channel = channel;
     }
 
     private _id: number;
@@ -1070,23 +1126,12 @@ export class DefaultChannel {
     }
 
     public static fromRawObject(value: any): DefaultChannel {
-        let result = new DefaultChannel(
-            value["id"],
-            value["repository"],
-        );
-        for (let key of Object.keys(value))
-        {
-            if (key === "branch")
-            {
-                result._branch = value[key];
-                continue;
-            }
-            if (key === "channel")
-            {
-                result._channel = Channel.fromRawObject(value[key]);
-                continue;
-            }
-        }
+        let result = new DefaultChannel({
+            id: value["id"] == null ? undefined : value["id"] as any,
+            repository: value["repository"] == null ? undefined : value["repository"] as any,
+            branch: value["branch"] == null ? undefined : value["branch"] as any,
+            channel: value["channel"] == null ? undefined : Channel.fromRawObject(value["channel"]) as any,
+        });
         return result;
     }
 
@@ -1106,7 +1151,16 @@ export class DefaultChannel {
 
 export class MergePolicy {
     public constructor(
+        {
+            name,
+            properties,
+        }: {
+            name?: string,
+            properties?: Record<string, any>,
+        }
     ) {
+        this._name = name;
+        this._properties = properties;
     }
 
     private _name?: string;
@@ -1130,21 +1184,10 @@ export class MergePolicy {
     }
 
     public static fromRawObject(value: any): MergePolicy {
-        let result = new MergePolicy(
-        );
-        for (let key of Object.keys(value))
-        {
-            if (key === "name")
-            {
-                result._name = value[key];
-                continue;
-            }
-            if (key === "properties")
-            {
-                result._properties = Helper.mapValues(value[key], (v: any) => v);
-                continue;
-            }
-        }
+        let result = new MergePolicy({
+            name: value["name"] == null ? undefined : value["name"] as any,
+            properties: value["properties"] == null ? undefined : Helper.mapValues(value["properties"], (v: any) => v) as any,
+        });
         return result;
     }
 
@@ -1162,9 +1205,15 @@ export class MergePolicy {
 
 export class PostData {
     public constructor(
-        repository: string,
-        branch: string,
-        channelId: number,
+        {
+            repository,
+            branch,
+            channelId,
+        }: {
+            repository: string,
+            branch: string,
+            channelId: number,
+        }
     ) {
         this._repository = repository;
         this._branch = branch;
@@ -1210,14 +1259,11 @@ export class PostData {
     }
 
     public static fromRawObject(value: any): PostData {
-        let result = new PostData(
-            value["repository"],
-            value["branch"],
-            value["channelId"],
-        );
-        for (let key of Object.keys(value))
-        {
-        }
+        let result = new PostData({
+            repository: value["repository"] == null ? undefined : value["repository"] as any,
+            branch: value["branch"] == null ? undefined : value["branch"] as any,
+            channelId: value["channelId"] == null ? undefined : value["channelId"] as any,
+        });
         return result;
     }
 
@@ -1232,11 +1278,22 @@ export class PostData {
 
 export class ReleasePipeline {
     public constructor(
-        id: number,
-        pipelineIdentifier: number,
+        {
+            id,
+            pipelineIdentifier,
+            organization,
+            project,
+        }: {
+            id: number,
+            pipelineIdentifier: number,
+            organization?: string,
+            project?: string,
+        }
     ) {
         this._id = id;
         this._pipelineIdentifier = pipelineIdentifier;
+        this._organization = organization;
+        this._project = project;
     }
 
     private _id: number;
@@ -1287,23 +1344,12 @@ export class ReleasePipeline {
     }
 
     public static fromRawObject(value: any): ReleasePipeline {
-        let result = new ReleasePipeline(
-            value["id"],
-            value["pipelineIdentifier"],
-        );
-        for (let key of Object.keys(value))
-        {
-            if (key === "organization")
-            {
-                result._organization = value[key];
-                continue;
-            }
-            if (key === "project")
-            {
-                result._project = value[key];
-                continue;
-            }
-        }
+        let result = new ReleasePipeline({
+            id: value["id"] == null ? undefined : value["id"] as any,
+            pipelineIdentifier: value["pipelineIdentifier"] == null ? undefined : value["pipelineIdentifier"] as any,
+            organization: value["organization"] == null ? undefined : value["organization"] as any,
+            project: value["project"] == null ? undefined : value["project"] as any,
+        });
         return result;
     }
 
@@ -1323,19 +1369,29 @@ export class ReleasePipeline {
 
 export class RepositoryHistoryItem {
     public constructor(
-        timestamp: Moment,
-        success: boolean,
-        repositoryName?: string,
-        branchName?: string,
-        errorMessage?: string,
-        action?: string,
-        retryUrl?: string,
+        {
+            repositoryName,
+            branchName,
+            timestamp,
+            errorMessage,
+            success,
+            action,
+            retryUrl,
+        }: {
+            repositoryName?: string,
+            branchName?: string,
+            timestamp: Date,
+            errorMessage?: string,
+            success: boolean,
+            action?: string,
+            retryUrl?: string,
+        }
     ) {
-        this._timestamp = timestamp;
-        this._success = success;
         this._repositoryName = repositoryName;
         this._branchName = branchName;
+        this._timestamp = timestamp;
         this._errorMessage = errorMessage;
+        this._success = success;
         this._action = action;
         this._retryUrl = retryUrl;
     }
@@ -1352,9 +1408,9 @@ export class RepositoryHistoryItem {
         return this._branchName;
     }
 
-    private _timestamp: Moment;
+    private _timestamp: Date;
 
-    public get timestamp(): Moment {
+    public get timestamp(): Date {
         return this._timestamp;
     }
 
@@ -1390,18 +1446,15 @@ export class RepositoryHistoryItem {
     }
 
     public static fromRawObject(value: any): RepositoryHistoryItem {
-        let result = new RepositoryHistoryItem(
-            moment(value["timestamp"]),
-            value["success"],
-            value["repositoryName"] == null ? undefined : value["repositoryName"],
-            value["branchName"] == null ? undefined : value["branchName"],
-            value["errorMessage"] == null ? undefined : value["errorMessage"],
-            value["action"] == null ? undefined : value["action"],
-            value["retryUrl"] == null ? undefined : value["retryUrl"],
-        );
-        for (let key of Object.keys(value))
-        {
-        }
+        let result = new RepositoryHistoryItem({
+            repositoryName: value["repositoryName"] == null ? undefined : value["repositoryName"] as any,
+            branchName: value["branchName"] == null ? undefined : value["branchName"] as any,
+            timestamp: value["timestamp"] == null ? undefined : parseISO(value["timestamp"]) as any,
+            errorMessage: value["errorMessage"] == null ? undefined : value["errorMessage"] as any,
+            success: value["success"] == null ? undefined : value["success"] as any,
+            action: value["action"] == null ? undefined : value["action"] as any,
+            retryUrl: value["retryUrl"] == null ? undefined : value["retryUrl"] as any,
+        });
         return result;
     }
 
@@ -1413,7 +1466,7 @@ export class RepositoryHistoryItem {
         if (value._branchName) {
             result["branchName"] = value._branchName;
         }
-        result["timestamp"] = value._timestamp.format();
+        result["timestamp"] = value._timestamp.toISOString();
         if (value._errorMessage) {
             result["errorMessage"] = value._errorMessage;
         }
@@ -1430,17 +1483,34 @@ export class RepositoryHistoryItem {
 
 export class Subscription {
     public constructor(
-        id: string,
-        enabled: boolean,
-        sourceRepository?: string,
-        targetRepository?: string,
-        targetBranch?: string,
+        {
+            id,
+            channel,
+            sourceRepository,
+            targetRepository,
+            targetBranch,
+            policy,
+            lastAppliedBuild,
+            enabled,
+        }: {
+            id: string,
+            channel?: Channel,
+            sourceRepository?: string,
+            targetRepository?: string,
+            targetBranch?: string,
+            policy?: SubscriptionPolicy,
+            lastAppliedBuild?: Build,
+            enabled: boolean,
+        }
     ) {
         this._id = id;
-        this._enabled = enabled;
+        this._channel = channel;
         this._sourceRepository = sourceRepository;
         this._targetRepository = targetRepository;
         this._targetBranch = targetBranch;
+        this._policy = policy;
+        this._lastAppliedBuild = lastAppliedBuild;
+        this._enabled = enabled;
     }
 
     private _id: string;
@@ -1511,31 +1581,16 @@ export class Subscription {
     }
 
     public static fromRawObject(value: any): Subscription {
-        let result = new Subscription(
-            value["id"],
-            value["enabled"],
-            value["sourceRepository"] == null ? undefined : value["sourceRepository"],
-            value["targetRepository"] == null ? undefined : value["targetRepository"],
-            value["targetBranch"] == null ? undefined : value["targetBranch"],
-        );
-        for (let key of Object.keys(value))
-        {
-            if (key === "channel")
-            {
-                result._channel = Channel.fromRawObject(value[key]);
-                continue;
-            }
-            if (key === "policy")
-            {
-                result._policy = SubscriptionPolicy.fromRawObject(value[key]);
-                continue;
-            }
-            if (key === "lastAppliedBuild")
-            {
-                result._lastAppliedBuild = Build.fromRawObject(value[key]);
-                continue;
-            }
-        }
+        let result = new Subscription({
+            id: value["id"] == null ? undefined : value["id"] as any,
+            channel: value["channel"] == null ? undefined : Channel.fromRawObject(value["channel"]) as any,
+            sourceRepository: value["sourceRepository"] == null ? undefined : value["sourceRepository"] as any,
+            targetRepository: value["targetRepository"] == null ? undefined : value["targetRepository"] as any,
+            targetBranch: value["targetBranch"] == null ? undefined : value["targetBranch"] as any,
+            policy: value["policy"] == null ? undefined : SubscriptionPolicy.fromRawObject(value["policy"]) as any,
+            lastAppliedBuild: value["lastAppliedBuild"] == null ? undefined : Build.fromRawObject(value["lastAppliedBuild"]) as any,
+            enabled: value["enabled"] == null ? undefined : value["enabled"] as any,
+        });
         return result;
     }
 
@@ -1567,16 +1622,27 @@ export class Subscription {
 
 export class SubscriptionData {
     public constructor(
-        channelName: string,
-        sourceRepository: string,
-        targetRepository: string,
-        targetBranch: string,
-        policy: SubscriptionPolicy,
+        {
+            channelName,
+            sourceRepository,
+            targetRepository,
+            targetBranch,
+            enabled,
+            policy,
+        }: {
+            channelName: string,
+            sourceRepository: string,
+            targetRepository: string,
+            targetBranch: string,
+            enabled?: boolean,
+            policy: SubscriptionPolicy,
+        }
     ) {
         this._channelName = channelName;
         this._sourceRepository = sourceRepository;
         this._targetRepository = targetRepository;
         this._targetBranch = targetBranch;
+        this._enabled = enabled;
         this._policy = policy;
     }
 
@@ -1651,21 +1717,14 @@ export class SubscriptionData {
     }
 
     public static fromRawObject(value: any): SubscriptionData {
-        let result = new SubscriptionData(
-            value["channelName"],
-            value["sourceRepository"],
-            value["targetRepository"],
-            value["targetBranch"],
-            SubscriptionPolicy.fromRawObject(value["policy"]),
-        );
-        for (let key of Object.keys(value))
-        {
-            if (key === "enabled")
-            {
-                result._enabled = value[key];
-                continue;
-            }
-        }
+        let result = new SubscriptionData({
+            channelName: value["channelName"] == null ? undefined : value["channelName"] as any,
+            sourceRepository: value["sourceRepository"] == null ? undefined : value["sourceRepository"] as any,
+            targetRepository: value["targetRepository"] == null ? undefined : value["targetRepository"] as any,
+            targetBranch: value["targetBranch"] == null ? undefined : value["targetBranch"] as any,
+            enabled: value["enabled"] == null ? undefined : value["enabled"] as any,
+            policy: value["policy"] == null ? undefined : SubscriptionPolicy.fromRawObject(value["policy"]) as any,
+        });
         return result;
     }
 
@@ -1685,24 +1744,33 @@ export class SubscriptionData {
 
 export class SubscriptionHistoryItem {
     public constructor(
-        timestamp: Moment,
-        success: boolean,
-        subscriptionId: string,
-        errorMessage?: string,
-        action?: string,
-        retryUrl?: string,
+        {
+            timestamp,
+            errorMessage,
+            success,
+            subscriptionId,
+            action,
+            retryUrl,
+        }: {
+            timestamp: Date,
+            errorMessage?: string,
+            success: boolean,
+            subscriptionId: string,
+            action?: string,
+            retryUrl?: string,
+        }
     ) {
         this._timestamp = timestamp;
+        this._errorMessage = errorMessage;
         this._success = success;
         this._subscriptionId = subscriptionId;
-        this._errorMessage = errorMessage;
         this._action = action;
         this._retryUrl = retryUrl;
     }
 
-    private _timestamp: Moment;
+    private _timestamp: Date;
 
-    public get timestamp(): Moment {
+    public get timestamp(): Date {
         return this._timestamp;
     }
 
@@ -1745,23 +1813,20 @@ export class SubscriptionHistoryItem {
     }
 
     public static fromRawObject(value: any): SubscriptionHistoryItem {
-        let result = new SubscriptionHistoryItem(
-            moment(value["timestamp"]),
-            value["success"],
-            value["subscriptionId"],
-            value["errorMessage"] == null ? undefined : value["errorMessage"],
-            value["action"] == null ? undefined : value["action"],
-            value["retryUrl"] == null ? undefined : value["retryUrl"],
-        );
-        for (let key of Object.keys(value))
-        {
-        }
+        let result = new SubscriptionHistoryItem({
+            timestamp: value["timestamp"] == null ? undefined : parseISO(value["timestamp"]) as any,
+            errorMessage: value["errorMessage"] == null ? undefined : value["errorMessage"] as any,
+            success: value["success"] == null ? undefined : value["success"] as any,
+            subscriptionId: value["subscriptionId"] == null ? undefined : value["subscriptionId"] as any,
+            action: value["action"] == null ? undefined : value["action"] as any,
+            retryUrl: value["retryUrl"] == null ? undefined : value["retryUrl"] as any,
+        });
         return result;
     }
 
     public static toRawObject(value: SubscriptionHistoryItem): any {
         let result: any = {};
-        result["timestamp"] = value._timestamp.format();
+        result["timestamp"] = value._timestamp.toISOString();
         if (value._errorMessage) {
             result["errorMessage"] = value._errorMessage;
         }
@@ -1779,11 +1844,19 @@ export class SubscriptionHistoryItem {
 
 export class SubscriptionPolicy {
     public constructor(
-        batchable: boolean,
-        updateFrequency: SubscriptionPolicyUpdateFrequency,
+        {
+            batchable,
+            updateFrequency,
+            mergePolicies,
+        }: {
+            batchable: boolean,
+            updateFrequency: SubscriptionPolicyUpdateFrequency,
+            mergePolicies?: MergePolicy[],
+        }
     ) {
         this._batchable = batchable;
         this._updateFrequency = updateFrequency;
+        this._mergePolicies = mergePolicies;
     }
 
     private _batchable: boolean;
@@ -1824,18 +1897,11 @@ export class SubscriptionPolicy {
     }
 
     public static fromRawObject(value: any): SubscriptionPolicy {
-        let result = new SubscriptionPolicy(
-            value["batchable"],
-            value["updateFrequency"],
-        );
-        for (let key of Object.keys(value))
-        {
-            if (key === "mergePolicies")
-            {
-                result._mergePolicies = value[key].map((e: any) => MergePolicy.fromRawObject(e));
-                continue;
-            }
-        }
+        let result = new SubscriptionPolicy({
+            batchable: value["batchable"] == null ? undefined : value["batchable"] as any,
+            updateFrequency: value["updateFrequency"] == null ? undefined : value["updateFrequency"] as any,
+            mergePolicies: value["mergePolicies"] == null ? undefined : value["mergePolicies"].map((e: any) => MergePolicy.fromRawObject(e)) as any,
+        });
         return result;
     }
 
@@ -1858,7 +1924,22 @@ export enum SubscriptionPolicyUpdateFrequency {
 
 export class SubscriptionUpdate {
     public constructor(
+        {
+            channelName,
+            sourceRepository,
+            policy,
+            enabled,
+        }: {
+            channelName?: string,
+            sourceRepository?: string,
+            policy?: SubscriptionPolicy,
+            enabled?: boolean,
+        }
     ) {
+        this._channelName = channelName;
+        this._sourceRepository = sourceRepository;
+        this._policy = policy;
+        this._enabled = enabled;
     }
 
     private _channelName?: string;
@@ -1902,31 +1983,12 @@ export class SubscriptionUpdate {
     }
 
     public static fromRawObject(value: any): SubscriptionUpdate {
-        let result = new SubscriptionUpdate(
-        );
-        for (let key of Object.keys(value))
-        {
-            if (key === "channelName")
-            {
-                result._channelName = value[key];
-                continue;
-            }
-            if (key === "sourceRepository")
-            {
-                result._sourceRepository = value[key];
-                continue;
-            }
-            if (key === "policy")
-            {
-                result._policy = SubscriptionPolicy.fromRawObject(value[key]);
-                continue;
-            }
-            if (key === "enabled")
-            {
-                result._enabled = value[key];
-                continue;
-            }
-        }
+        let result = new SubscriptionUpdate({
+            channelName: value["channelName"] == null ? undefined : value["channelName"] as any,
+            sourceRepository: value["sourceRepository"] == null ? undefined : value["sourceRepository"] as any,
+            policy: value["policy"] == null ? undefined : SubscriptionPolicy.fromRawObject(value["policy"]) as any,
+            enabled: value["enabled"] == null ? undefined : value["enabled"] as any,
+        });
         return result;
     }
 


### PR DESCRIPTION
- Add node postbuild steps to produce stats and a bundle report file
- Publish the bundle-report file as a build artifact
- Remove moment and replace it with date-fns reducing the vendor bundle size by ~30%, taking gzipped size from 219 KB to 146KB
- Adjust angular generated code to produce parameter objects for methods, rather than multiple parameters.