### PR TITLE
Handle repos with a '.' in the name

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyGraphOperation.cs
@@ -335,7 +335,9 @@ namespace Microsoft.DotNet.Darc.Operations
 
         private string CalculateGraphVizNodeName(DependencyGraphNode node)
         {
-            return GetSimpleRepoName(node.RepoUri).Replace("-", "") + node.Commit;
+            return GetSimpleRepoName(node.RepoUri)
+                .Replace(".", "")
+                .Replace("-", "") + node.Commit;
         }
 
         /// <summary>


### PR DESCRIPTION
Currently we fail to produce the graph image if there are repo names which include a '.' in the name sucha as "nuget.client".