### PR TITLE
Add general purpose retry and retry for a couple cases

### DIFF
--- a/src/Maestro/Maestro.GitHub/GitHubTokenProvider.cs
+++ b/src/Maestro/Maestro.GitHub/GitHubTokenProvider.cs
@@ -1,32 +1,44 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading.Tasks;
 using GitHubJwt;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Octokit;
+using System.Net;
+using System.Threading.Tasks;
 
 namespace Maestro.GitHub
 {
     public class GitHubTokenProvider : IGitHubTokenProvider
     {
         private readonly IOptions<GitHubTokenProviderOptions> _options;
+        public ILogger<GitHubTokenProvider> _logger;
 
-        public GitHubTokenProvider(IOptions<GitHubTokenProviderOptions> options)
+        public GitHubTokenProvider(IOptions<GitHubTokenProviderOptions> options,
+                                   ILogger<GitHubTokenProvider> logger)
         {
             _options = options;
+            _logger = logger;
         }
 
         public GitHubTokenProviderOptions Options => _options.Value;
 
         public async Task<string> GetTokenForInstallation(long installationId)
         {
-            string jwt = GetAppToken();
-            var product = new ProductHeaderValue(Options.ApplicationName, Options.ApplicationVersion);
-            var appClient = new GitHubClient(product) {Credentials = new Credentials(jwt, AuthenticationType.Bearer)};
-            AccessToken token = await appClient.GitHubApps.CreateInstallationToken(installationId);
-            return token.Token;
+            return await ExponentialRetry.RetryAsync(
+                async () =>
+                {
+                    string jwt = GetAppToken();
+                    var product = new ProductHeaderValue(Options.ApplicationName, Options.ApplicationVersion);
+                    var appClient = new Octokit.GitHubClient(product) { Credentials = new Credentials(jwt, AuthenticationType.Bearer) };
+                    AccessToken token = await appClient.GitHubApps.CreateInstallationToken(installationId);
+                    return token.Token;
+                },
+                ex => _logger.LogError(ex, $"Failed to get a github token for installation id {installationId}, retrying"),
+                ex => ex is ApiException && ((ApiException)ex).StatusCode == HttpStatusCode.InternalServerError);
         }
 
         private string GetAppToken()

--- a/src/Maestro/Maestro.GitHub/Maestro.GitHub.csproj
+++ b/src/Maestro/Maestro.GitHub/Maestro.GitHub.csproj
@@ -8,9 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubJwt" Version="0.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
     <PackageReference Include="Octokit" Version="0.32.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.DotNet.Darc\src\DarcLib\Microsoft.DotNet.DarcLib.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -406,7 +406,7 @@ namespace Microsoft.DotNet.DarcLib
                             Blob blob = await ExponentialRetry.RetryAsync(
                                 async () => await Client.Git.Blob.Get(owner, repo, treeItem.Sha),
                                 ex => _logger.LogError(ex, $"Failed to get blob at sha {treeItem.Sha}"),
-                                ex => ex is ApiException apiex && apiex.StatusCode == HttpStatusCode.InternalServerError;
+                                ex => ex is ApiException apiex && apiex.StatusCode == HttpStatusCode.InternalServerError);
 
                             ContentEncoding encoding;
                             switch (blob.Encoding.Value)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -406,7 +406,7 @@ namespace Microsoft.DotNet.DarcLib
                             Blob blob = await ExponentialRetry.RetryAsync(
                                 async () => await Client.Git.Blob.Get(owner, repo, treeItem.Sha),
                                 ex => _logger.LogError(ex, $"Failed to get blob at sha {treeItem.Sha}"),
-                                ex => ex is ApiException && ((ApiException)ex).StatusCode == HttpStatusCode.InternalServerError);
+                                ex => ex is ApiException apiex && apiex.StatusCode == HttpStatusCode.InternalServerError;
 
                             ContentEncoding encoding;
                             switch (blob.Encoding.Value)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/ExponentialRetry.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/ExponentialRetry.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.DarcLib
     {
         private static readonly Random Randomizer = new Random();
 
-        private const int RetryCount = 15;
+        private const int RetryCount = 10;
 
         private const double RetryBackOffFactor = 1.3;
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/ExponentialRetry.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/ExponentialRetry.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.DarcLib
+{
+    public class ExponentialRetry
+    {
+        private static readonly Random Randomizer = new Random();
+
+        private const int RetryCount = 15;
+
+        private const double RetryBackOffFactor = 1.3;
+
+        private static int GetRetryDelay(int attempt)
+        {
+            var factor = RetryBackOffFactor;
+            var min = (int)(Math.Pow(factor, attempt) * 1000);
+            var max = (int)(Math.Pow(factor, attempt + 1) * 1000);
+            return Randomizer.Next(min, max);
+        }
+
+        /// <summary>
+        ///     Perform an action with exponential retry.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="function"></param>
+        /// <param name="logRetry"></param>
+        /// <param name="isRetryable"></param>
+        /// <returns></returns>
+        public static async Task<T> RetryAsync<T>(Func<Task<T>> function, Action<Exception> logRetry, Func<Exception, bool> isRetryable)
+        {
+            var attempt = 0;
+            var maxAttempt = RetryCount;
+            while (true)
+            {
+                try
+                {
+                    return await function();
+                }
+                catch (Exception ex) when (isRetryable(ex))
+                {
+                    if (attempt >= maxAttempt)
+                    {
+                        throw;
+                    }
+
+                    logRetry(ex);
+                }
+                await Task.Delay(GetRetryDelay(attempt));
+                attempt++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a general purpose retry method (same as one from Helix API).
Use this in a couple cases to test it out and see whether the pattern works. We have seen quite a few 500 errors coming from github, and this should help. If it works I'll widen the usage out to the other Octokit calls