### PR TITLE
Track failed actions in appinsights

### DIFF
--- a/src/Maestro/SubscriptionActorService/ActionRunner/ActionRunner.cs
+++ b/src/Maestro/SubscriptionActorService/ActionRunner/ActionRunner.cs
@@ -98,6 +98,8 @@ namespace SubscriptionActorService
                 }
                 catch (Exception displayable) when (IsDisplayableException(displayable))
                 {
+                    string message = $"Non-fatal error processing action: {displayable.Message}";
+                    Logger.LogError(displayable, message);
                     await target.TrackFailedAction(
                         actionMessage,
                         displayable.Message,


### PR DESCRIPTION
While there are plenty of non-fatal (and expected) errors in the failed actions, I'd like to have a single place to look for them while we push for a more stable Maestro.