### PR TITLE
Fix more bugs in BAR Visualization

### DIFF
--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -43,8 +43,10 @@
 </ng-template>
 <table class="table table-sm table-hover mb-0">
   <thead>
-    <th style="min-width: 0">
-      <span style="float: right; cursor: help;" [ngbPopover]="popContent" popoverTitle="Help" placement="right"><fa-icon [icon]="['far', 'question-circle']"></fa-icon></span>
+    <th style="min-width: 0" class="graph-icon">
+      <span style="cursor: help;" [ngbPopover]="popContent" popoverTitle="Help" placement="right">
+        <fa-icon [icon]="['far', 'question-circle']"></fa-icon>
+      </span>
     </th>
     <th>Repository</th>
     <th>Date Produced</th>
@@ -59,33 +61,26 @@
       [ngClass]="{'table-warning': !isCoherent(node)}"
       (mouseenter)="hover(node.build.id)"
       (mouseleave)="hover(undefined)">
-      <td style="width: 2em; text-align: center"
-          (click)="node.isFocused && toggleLock()">
-        <div style="display: inline-block">
-          <span *ngIf="node.isFocused; else first">
+      <td (click)="node.isFocused && toggleLock()" class="graph-icon">
+        <div>
+          <span [style.visibility]="node.state == 'locked' ? 'visible' : 'hidden'">
             <fa-icon icon="lock" *ngIf="node.isLocked" title="locked"></fa-icon>
+          </span>
+          <span [style.visibility]="node.state == 'unlocked' ? 'visible' : 'hidden'">
             <fa-icon icon="lock-open" *ngIf="!node.isLocked" title="unlocked"></fa-icon>
           </span>
-          <ng-template #first>
-            <span *ngIf="node.isSameRepository; else second" class="text-danger">
-              <fa-icon icon="exclamation-triangle" title="conflicting build"></fa-icon>
-            </span>
-          </ng-template>
-          <ng-template #second>
-            <span *ngIf="node.isAncestor; else third">
-              <fa-icon icon="ellipsis-v" title="ancestor"></fa-icon>
-            </span>
-          </ng-template>
-          <ng-template #third>
-            <span *ngIf="node.isParent; else fourth">
-              <fa-icon icon="angle-up" title="parent"></fa-icon>
-            </span>
-          </ng-template>
-          <ng-template #fourth>
-            <span *ngIf="node.isDependent">
-              <fa-icon icon="angle-right" title="child"></fa-icon>
-            </span>
-          </ng-template>
+          <span [style.visibility]="node.state == 'conflict' ? 'visible' : 'hidden'" class="text-danger">
+            <fa-icon icon="exclamation-triangle" title="conflicting build"></fa-icon>
+          </span>
+          <span [style.visibility]="node.state == 'ancestor' ? 'visible' : 'hidden'">
+            <fa-icon icon="ellipsis-v" title="ancestor"></fa-icon>
+          </span>
+          <span [style.visibility]="node.state == 'parent' ? 'visible' : 'hidden'">
+            <fa-icon icon="angle-up" title="parent"></fa-icon>
+          </span>
+          <span [style.visibility]="node.state == 'child' ? 'visible' : 'hidden'">
+            <fa-icon icon="angle-right" title="child"></fa-icon>
+          </span>
         </div>
       </td>
       <td>

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.scss
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.scss
@@ -1,0 +1,17 @@
+.graph-icon {
+  width: 1.5rem;
+  text-align: center;
+  div {
+    display: inline-block;
+    position: relative;
+    width: 1.5rem;
+    height: 1.5rem;
+    span {
+      left: 50%;
+      margin-left: (-1rem / 2);
+      width: 1rem;
+      height: 1rem;
+      position: absolute;
+    }
+  }
+}

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.html
@@ -11,7 +11,7 @@
       <fa-icon class="text-info" icon="question-circle"></fa-icon>
     </div>
     <div class="flex-grow-1">
-      <h4>{{build.gitHubRepository}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>
+      <h4>{{getRepo(build)}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>
       <div>
         <span>Loading build information from Azure Pipelines</span>
         <div style="display:inline-block; vertical-align: middle;">
@@ -25,7 +25,7 @@
       <fa-icon class="text-warning" icon="exclamation-circle"></fa-icon>
     </div>
     <div class="flex-grow-1">
-      <h4>{{build.gitHubRepository}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>
+      <h4>{{getRepo(build)}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>
       <div>
         <span class="text-warning" *ngIf="!haveAzDevInfo(build)">
           Cannot lookup build in Azure Pipelines. Missing required data. Update to the latest Arcade SDK to collect this data.
@@ -59,7 +59,7 @@
             </a>
           </div>
         </div>
-        <h4>{{build.gitHubRepository}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>
+        <h4>{{getRepo(build)}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>
         <div><a class="btn btn-sm btn-info" [href]="getCommitLink(build)" target="_blank">{{build.commit}} <fa-icon
               icon="external-link-alt"></fa-icon></a></div>
         <div>{{build.dateProduced | relativeDate}}</div>

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
@@ -123,6 +123,10 @@ export class BuildComponent implements OnInit, OnChanges {
 
   public getBuildLink = getBuildLink;
 
+  public getRepo(build: Build) {
+    return build.gitHubRepository || build.azureDevOpsRepository;
+  }
+
   public getBuildLinkFromAzdo(account: string, project: string, buildId: number): string {
     return `https://dev.azure.com` +
       `/${account}` +

--- a/src/Maestro/maestro-angular/src/helpers.ts
+++ b/src/Maestro/maestro-angular/src/helpers.ts
@@ -24,6 +24,17 @@ export function topologicalSort<TNode, TKey>(nodes: TNode[], getChildren: (node:
   const sorted: TNode[] = [];
   const toProcess: TNode[] = nodes.filter(node => !hasIncommingEdges(node));
   while (toProcess.length) {
+    toProcess.sort((a, b) => {
+      const ak = getKey(a);
+      const bk = getKey(b);
+      if (ak < bk) {
+        return -1;
+      }
+      if (ak > bk) {
+        return 1;
+      }
+      return 0;
+    })
     const n = toProcess.pop() as TNode; // can't be undefined
     log("processing: " + getKey(n))
     sorted.push(n);


### PR DESCRIPTION
- topologicalSort now orders nodes by node keys where possible while still maintaining the topological ordering
- Repository url on top of the build page now shows the azDev repo url if there isn't a github one
- Prevent recalculation of layout when hovering rows in the dependency graph table by changing visibility of the icons, rather than using ngIf to show the correct icon