### PR TITLE
Implement repo uberclone.

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
@@ -1,14 +1,15 @@
-using CSharpx;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations
@@ -28,26 +29,16 @@ namespace Microsoft.DotNet.Darc.Operations
             {
                 EnsureOptionsCompatibility(_options);
                 RemoteFactory remoteFactory = new RemoteFactory(_options);
-                HashSet<StrippedDependency> seenDependencies = new HashSet<StrippedDependency>();
 
-                if (_options.Local)
+                if (string.IsNullOrWhiteSpace(_options.RepoUri))
                 {
                     Local local = new Local(Logger);
                     IEnumerable<DependencyDetail>  rootDependencies = await local.GetDependenciesAsync();
 
                     foreach (DependencyDetail dep in rootDependencies)
                     {
-                        StrippedDependency seen = new StrippedDependency(dep);
-                        if (seenDependencies.Contains(seen))
-                        {
-                            Logger.LogDebug($"Local dependency {dep.RepoUri}@{dep.Commit} already processed.  Skipping...");
-                        }
-                        else
-                        {
-                            seenDependencies.Add(seen);
-                            Logger.LogInformation($"Found local dependency {dep.RepoUri}@{dep.Commit}.  Starting deep clone...");
-                            await CloneRemoteRepoAndDependencies(remoteFactory, _options.ReposFolder, dep.RepoUri, dep.Commit, _options.IncludeToolset, Logger);
-                        }
+                        Logger.LogInformation($"Found local dependency {dep.RepoUri}@{dep.Commit}.  Starting deep clone...");
+                        await CloneRemoteRepoAndDependencies(remoteFactory, _options.ReposFolder, dep.RepoUri, dep.Commit, _options.IncludeToolset, Logger);
                     }
                 }
                 else
@@ -121,23 +112,11 @@ namespace Microsoft.DotNet.Darc.Operations
 
         private static void EnsureOptionsCompatibility(CloneCommandLineOptions options)
         {
-            if (options.Local)
+
+            if ((string.IsNullOrWhiteSpace(options.RepoUri) && !string.IsNullOrWhiteSpace(options.Version)) ||
+                (!string.IsNullOrWhiteSpace(options.RepoUri) && string.IsNullOrWhiteSpace(options.Version)))
             {
-                if (!string.IsNullOrWhiteSpace(options.RepoUri) || !string.IsNullOrWhiteSpace(options.Version))
-                {
-                    throw new ArgumentException($"If using the local Version.Details.xml to determine repos to clone, repo-uri and version are not applicable.");
-                }
-            }
-            else
-            {
-                if (string.IsNullOrWhiteSpace(options.RepoUri))
-                {
-                    throw new ArgumentException($"If not using a local Version.Details.xml, the repo to start the clone at must be specified.");
-                }
-                if (string.IsNullOrWhiteSpace(options.Version))
-                {
-                    throw new ArgumentException($"If not using a local Version.Details.xml, the version to start the clone at must be specified.");
-                }
+                throw new ArgumentException($"Either specify both repo and version to clone a specific remote repo, or neither to clone all dependencies from this repo.");
             }
 
             if (string.IsNullOrWhiteSpace(options.ReposFolder))
@@ -166,39 +145,6 @@ namespace Microsoft.DotNet.Darc.Operations
                 return dependencies.Where(dependency => dependency.Type != DependencyType.Toolset);
             }
             return dependencies;
-        }
-
-        private class StrippedDependency
-        {
-            internal string RepoUri { get; set; }
-            internal string Commit { get; set; }
-
-            internal StrippedDependency(DependencyDetail d)
-            {
-                this.RepoUri = d.RepoUri;
-                this.Commit = d.Commit;
-            }
-
-            internal StrippedDependency(string repoUri, string commit)
-            {
-                this.RepoUri = repoUri;
-                this.Commit = commit;
-            }
-
-            public override bool Equals(object obj)
-            {
-                StrippedDependency other = obj as StrippedDependency;
-                if (other == null)
-                {
-                    return false;
-                }
-                return this.RepoUri == other.RepoUri && this.Commit == other.Commit;
-            }
-
-            public override int GetHashCode()
-            {
-                return this.RepoUri.GetHashCode() ^ this.Commit.GetHashCode();
-            }
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 {
                     logger.LogInformation($"Remote repo {repoUri}@{commit} has no dependencies.  Cloning shallowly into {repoPath}");
                     IRemote repoRemote = await remoteFactory.GetRemoteAsync(repoUri, logger);
-                    await repoRemote.CloneAsync(repoUri, commit, repoPath);
+                    repoRemote.Clone(repoUri, commit, repoPath);
                 }
                 return;
             }
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 {
                     logger.LogInformation($"Cloning {repo.RepoUri}@{repo.Commit} into {repoPath}");
                     IRemote repoRemote = await remoteFactory.GetRemoteAsync(repo.RepoUri, logger);
-                    await repoRemote.CloneAsync(repo.RepoUri, repo.Commit, repoPath);
+                    repoRemote.Clone(repo.RepoUri, repo.Commit, repoPath);
                 }
             }
         }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
@@ -1,0 +1,160 @@
+using CSharpx;
+using Microsoft.DotNet.Darc.Helpers;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Darc.Operations
+{
+    internal class CloneOperation : Operation
+    {
+        CloneCommandLineOptions _options;
+
+        public CloneOperation(CloneCommandLineOptions options) : base(options)
+        {
+            _options = options;
+        }
+
+        public override async Task<int> ExecuteAsync()
+        {
+            try
+            {
+                // use a queue to accumulate dependencies as we go
+                Queue<StrippedDependency> dependenciesToClone = new Queue<StrippedDependency>();
+                // use a set to keep track of whether we've seen dependencies before, otherwise we get trapped in circular dependencies
+                HashSet<StrippedDependency> seenDependencies = new HashSet<StrippedDependency>();
+                RemoteFactory remoteFactory = new RemoteFactory(_options);
+                
+                if (string.IsNullOrWhiteSpace(_options.ReposFolder))
+                {
+                    _options.ReposFolder = Environment.CurrentDirectory;
+                }
+
+                if (!Directory.Exists(_options.ReposFolder))
+                {
+                    Directory.CreateDirectory(_options.ReposFolder);
+                }
+
+                // Start with the root repo we were asked to clone
+                dependenciesToClone.Enqueue(new StrippedDependency(_options.RepoUri, _options.Version));
+                
+                while (dependenciesToClone.Any())
+                {
+                    StrippedDependency repo = dependenciesToClone.Dequeue();
+                    string repoPath = GetRepoDirectory(_options.ReposFolder, repo.RepoUri, repo.Commit);
+                    if (Directory.Exists(repoPath))
+                    {
+                        Logger.LogDebug($"Repo path {repoPath} already exists, assuming we cloned already and skipping");
+                    }
+                    else
+                    {
+                        Logger.LogInformation($"Cloning {repo.RepoUri}@{repo.Commit} into {repoPath}");
+                        IRemote repoRemote = await remoteFactory.GetRemoteAsync(repo.RepoUri, Logger);
+                        await repoRemote.CloneAsync(repo.RepoUri, repo.Commit, repoPath);
+                    }
+
+                    Logger.LogDebug($"Starting to look for dependencies in {repoPath}");
+                    Local local = new Local(Logger, repoPath);
+
+                    try
+                    {
+                        IEnumerable<DependencyDetail> deps = await local.GetDependenciesAsync();
+                        IEnumerable<DependencyDetail> filteredDeps = FilterToolsetDependencies(deps);
+                        Logger.LogDebug($"Got {deps.Count()} dependencies and filtered to {filteredDeps.Count()} dependencies");
+                        filteredDeps.ForEach((d) => {
+                            // arcade depends on previous versions of itself to build, so this would go on forever
+                            if (d.RepoUri == repo.RepoUri)
+                            {
+                                Logger.LogDebug($"Skipping self-dependency in {repo.RepoUri} ({repo.Commit} => {d.Commit})");
+                            }
+                            else
+                            {
+                                StrippedDependency stripped = new StrippedDependency(d);
+                                if (!seenDependencies.Contains(stripped))
+                                {
+                                    Logger.LogDebug($"Adding new dependency {stripped.RepoUri}@{stripped.Commit}");
+                                    seenDependencies.Add(stripped);
+                                    dependenciesToClone.Enqueue(stripped);
+                                }
+                            }
+                        });
+                    }
+                    catch (DirectoryNotFoundException)
+                    {
+                        Logger.LogWarning($"Repo {repoPath} appears to have no '/eng' directory at commit {repo.Commit}.  Dependency chain is broken here.");
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        Logger.LogWarning($"Repo {repoPath} appears to have no '/eng/Version.Details.xml' file at commit {repo.Commit}.  Dependency chain is broken here.");
+                    }
+
+                    Logger.LogDebug($"Now have {dependenciesToClone.Count} dependencies to consider");
+                }
+
+
+                return Constants.SuccessCode;
+            }
+            catch (Exception exc)
+            {
+                Logger.LogError(exc, "Something failed while cloning.");
+                return Constants.ErrorCode;
+            }
+        }
+
+        private string GetRepoDirectory(string reposFolder, string repoUri, string commit)
+        {
+            // commit could actually be a branch or tag, make it filename-safe
+            commit = commit.Replace('/', '-').Replace('\\', '-').Replace('?', '-').Replace('*', '-').Replace(':', '-').Replace('|', '-').Replace('"', '-').Replace('<', '-').Replace('>', '-');
+            return Path.Combine(reposFolder, $"{repoUri.Substring(repoUri.LastIndexOf("/") + 1)}.{commit}");
+        }
+
+        private IEnumerable<DependencyDetail> FilterToolsetDependencies(IEnumerable<DependencyDetail> dependencies)
+        {
+            if (!_options.IncludeToolset)
+            {
+                Console.WriteLine($"Removing toolset dependencies...");
+                return dependencies.Where(dependency => dependency.Type != DependencyType.Toolset);
+            }
+            return dependencies;
+        }
+
+        private class StrippedDependency
+        {
+            internal string RepoUri { get; set; }
+            internal string Commit { get; set; }
+
+            internal StrippedDependency(DependencyDetail d)
+            {
+                this.RepoUri = d.RepoUri;
+                this.Commit = d.Commit;
+            }
+
+            internal StrippedDependency(string repoUri, string commit)
+            {
+                this.RepoUri = repoUri;
+                this.Commit = commit;
+            }
+
+            public override bool Equals(object obj)
+            {
+                StrippedDependency other = obj as StrippedDependency;
+                if (other == null)
+                {
+                    return false;
+                }
+                return this.RepoUri == other.RepoUri && this.Commit == other.Commit;
+            }
+
+            public override int GetHashCode()
+            {
+                return this.RepoUri.GetHashCode() ^ this.Commit.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/CloneCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/CloneCommandLineOptions.cs
@@ -10,10 +10,13 @@ namespace Microsoft.DotNet.Darc.Options
 
     internal class CloneCommandLineOptions : CommandLineOptions
     {
-        [Option("repo", Required = true, HelpText = "Remote repository to start the clone operation at.")]
+        [Option('l', "local", HelpText = "Clone all repos that this local repository declares a reference on.")]
+        public bool Local { get; set; }
+
+        [Option("repo", HelpText = "Remote repository to start the clone operation at.")]
         public string RepoUri { get; set; }
 
-        [Option('v', "version", Required = true, HelpText = "Branch, commit or tag to start at in the remote repository.")]
+        [Option('v', "version", HelpText = "Branch, commit or tag to start at in the remote repository.")]
         public string Version { get; set; }
 
         [Option("repos-folder", HelpText = @"Full path to folder where all the repos will be cloned to. i.e. C:\repos.  Default: current directory.")]

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/CloneCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/CloneCommandLineOptions.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using CommandLine;
+using Microsoft.DotNet.Darc.Operations;
+
+namespace Microsoft.DotNet.Darc.Options
+{
+    [Verb("clone", HelpText = "clone a remote repo and all of its dependency repos")]
+
+    internal class CloneCommandLineOptions : CommandLineOptions
+    {
+        [Option("repo", Required = true, HelpText = "Remote repository to start the clone operation at.")]
+        public string RepoUri { get; set; }
+
+        [Option('v', "version", Required = true, HelpText = "Branch, commit or tag to start at in the remote repository.")]
+        public string Version { get; set; }
+
+        [Option("repos-folder", HelpText = @"Full path to folder where all the repos will be cloned to. i.e. C:\repos.  Default: current directory.")]
+        public string ReposFolder { get; set; }
+
+        [Option("include-toolset", HelpText = "Include toolset dependencies.")]
+        public bool IncludeToolset { get; set; }
+
+        public override Operation GetOperation()
+        {
+            return new CloneOperation(this);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/CloneCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/CloneCommandLineOptions.cs
@@ -1,6 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using CommandLine;
 using Microsoft.DotNet.Darc.Operations;
 
@@ -10,13 +11,10 @@ namespace Microsoft.DotNet.Darc.Options
 
     internal class CloneCommandLineOptions : CommandLineOptions
     {
-        [Option('l', "local", HelpText = "Clone all repos that this local repository declares a reference on.")]
-        public bool Local { get; set; }
-
-        [Option("repo", HelpText = "Remote repository to start the clone operation at.")]
+        [Option("repo", HelpText = "Remote repository to start the clone operation at.  If none specified, clone all that the current repo depends on.")]
         public string RepoUri { get; set; }
 
-        [Option('v', "version", HelpText = "Branch, commit or tag to start at in the remote repository.")]
+        [Option('v', "version", HelpText = "Branch, commit or tag to start at in the remote repository.  Required if repo is specified.")]
         public string Version { get; set; }
 
         [Option("repos-folder", HelpText = @"Full path to folder where all the repos will be cloned to. i.e. C:\repos.  Default: current directory.")]

--- a/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
@@ -56,6 +56,7 @@ namespace Microsoft.DotNet.Darc
                     typeof(AddSubscriptionCommandLineOptions),
                     typeof(AddBuildToChannelCommandLineOptions),
                     typeof(AuthenticateCommandLineOptions),
+                    typeof(CloneCommandLineOptions),
                     typeof(DeleteChannelCommandLineOptions),
                     typeof(DeleteDefaultChannelCommandLineOptions),
                     typeof(DeleteSubscriptionCommandLineOptions),

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -1047,9 +1047,9 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="commit">Branch, tag, or commit to checkout</param>
         /// <param name="targetDirectory">Directory to clone into</param>
         /// <returns></returns>
-        public Task CloneAsync(string repoUri, string commit, string targetDirectory)
+        public void Clone(string repoUri, string commit, string targetDirectory)
         {
-            return this.CloneAsync(repoUri, commit, targetDirectory, _logger, _personalAccessToken);
+            this.Clone(repoUri, commit, targetDirectory, _logger, _personalAccessToken);
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -1039,5 +1039,17 @@ namespace Microsoft.DotNet.DarcLib
 
             return repoUri;
         }
+
+        /// <summary>
+        ///     Clone a remote repository.
+        /// </summary>
+        /// <param name="repoUri">Repository uri to clone</param>
+        /// <param name="commit">Branch, tag, or commit to checkout</param>
+        /// <param name="targetDirectory">Directory to clone into</param>
+        /// <returns></returns>
+        public Task CloneAsync(string repoUri, string commit, string targetDirectory)
+        {
+            return this.CloneAsync(repoUri, commit, targetDirectory, _logger, _personalAccessToken);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -845,6 +845,19 @@ namespace Microsoft.DotNet.DarcLib
         }
 
         /// <summary>
+        ///     Clone a remote repo
+        /// </summary>
+        /// <param name="repoUri">Repository to clone</param>
+        /// <param name="commit">Branch, commit, or tag to checkout</param>
+        /// <param name="targetDirectory">Directory to clone to</param>
+        /// <returns></returns>
+        public async Task CloneAsync(string repoUri, string commit, string targetDirectory)
+        {
+            CheckForValidGitClient();
+            await _gitClient.CloneAsync(repoUri, commit, targetDirectory);
+        }
+
+        /// <summary>
         ///     Called prior to operations requiring the BAR.  Throws if a bar client isn't available.
         /// </summary>
         private void CheckForValidBarClient()

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -851,10 +851,10 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="commit">Branch, commit, or tag to checkout</param>
         /// <param name="targetDirectory">Directory to clone to</param>
         /// <returns></returns>
-        public async Task CloneAsync(string repoUri, string commit, string targetDirectory)
+        public void Clone(string repoUri, string commit, string targetDirectory)
         {
             CheckForValidGitClient();
-            await _gitClient.CloneAsync(repoUri, commit, targetDirectory);
+            _gitClient.Clone(repoUri, commit, targetDirectory);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -821,5 +821,17 @@ namespace Microsoft.DotNet.DarcLib
                 return GitDiff.UnknownDiff();
             }
         }
+
+        /// <summary>
+        ///     Clone a remote repository.
+        /// </summary>
+        /// <param name="repoUri">Repository uri to clone</param>
+        /// <param name="commit">Commit, branch, or tag to checkout</param>
+        /// <param name="targetDirectory">Directory to clone into</param>
+        /// <returns></returns>
+        public async Task CloneAsync(string repoUri, string commit, string targetDirectory)
+        {
+            await this.CloneAsync(repoUri, commit, targetDirectory, _logger, Client.Credentials.Password);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -829,9 +829,9 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="commit">Commit, branch, or tag to checkout</param>
         /// <param name="targetDirectory">Directory to clone into</param>
         /// <returns></returns>
-        public async Task CloneAsync(string repoUri, string commit, string targetDirectory)
+        public void Clone(string repoUri, string commit, string targetDirectory)
         {
-            await this.CloneAsync(repoUri, commit, targetDirectory, _logger, Client.Credentials.Password);
+            this.Clone(repoUri, commit, targetDirectory, _logger, Client.Credentials.Password);
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -138,6 +138,15 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="targetVersion">Target version</param>
         /// <returns>Diff information</returns>
         Task<GitDiff> GitDiffAsync(string repoUri, string baseVersion, string targetVersion);
+
+        /// <summary>
+        ///     Clone a remote repository.
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <param name="commit">Branch, commit, or tag to checkout</param>
+        /// <param name="targetDirectory">Directory to clone to</param>
+        /// <returns></returns>
+        Task CloneAsync(string repoUri, string commit, string targetDirectory);
     }
 
     public class PullRequest

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="commit">Branch, commit, or tag to checkout</param>
         /// <param name="targetDirectory">Directory to clone to</param>
         /// <returns></returns>
-        Task CloneAsync(string repoUri, string commit, string targetDirectory);
+        void Clone(string repoUri, string commit, string targetDirectory);
     }
 
     public class PullRequest

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -323,7 +323,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="commit">Branch, commit, or tag to checkout</param>
         /// <param name="targetDirectory">Directory to clone the repo to</param>
         /// <returns></returns>
-        Task CloneAsync(string repoUri, string commit, string targetDirectory);
+        void Clone(string repoUri, string commit, string targetDirectory);
 
         #endregion
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -316,6 +316,15 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns>Latest commit</returns>
         Task<string> GetLatestCommitAsync(string repoUri, string branch);
 
+        /// <summary>
+        ///     Clone a remote repo.
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <param name="commit">Branch, commit, or tag to checkout</param>
+        /// <param name="targetDirectory">Directory to clone the repo to</param>
+        /// <returns></returns>
+        Task CloneAsync(string repoUri, string commit, string targetDirectory);
+
         #endregion
 
         #region Build/Asset Operations

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -256,5 +256,10 @@ namespace Microsoft.DotNet.DarcLib
         {
             throw new NotImplementedException();
         }
+
+        public Task CloneAsync(string repoUri, string commit, string targetDirectory)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -257,7 +257,7 @@ namespace Microsoft.DotNet.DarcLib
             throw new NotImplementedException();
         }
 
-        public Task CloneAsync(string repoUri, string commit, string targetDirectory)
+        public void Clone(string repoUri, string commit, string targetDirectory)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="commit">Branch, commit, or tag to checkout</param>
         /// <param name="targetDirectory">Target directory to clone to</param>
         /// <returns></returns>
-        protected async Task CloneAsync(string repoUri, string commit, string targetDirectory, ILogger _logger, string pat)
+        protected void Clone(string repoUri, string commit, string targetDirectory, ILogger _logger, string pat)
         {
             string dotnetMaestro = "dotnet-maestro";
             using (_logger.BeginScope("Cloning {repoUri} to {targetDirectory}", repoUri, targetDirectory))

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
@@ -183,8 +183,6 @@ namespace Microsoft.DotNet.DarcLib
                 }
                 catch (Exception exc)
                 {
-                    // This was originally a DarcException. Making it an actual Exception so we get to see in AppInsights if something failed while
-                    // commiting the changes
                     throw new Exception($"Something went wrong when cloning repo {repoUri} at {commit} into {targetDirectory}", exc);
                 }
             }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
@@ -143,6 +143,53 @@ namespace Microsoft.DotNet.DarcLib
             }
         }
 
+        /// <summary>
+        ///     Clone a remote git repo.
+        /// </summary>
+        /// <param name="repoUri">Repository uri to clone</param>
+        /// <param name="commit">Branch, commit, or tag to checkout</param>
+        /// <param name="targetDirectory">Target directory to clone to</param>
+        /// <returns></returns>
+        protected async Task CloneAsync(string repoUri, string commit, string targetDirectory, ILogger _logger, string pat)
+        {
+            string dotnetMaestro = "dotnet-maestro";
+            using (_logger.BeginScope("Cloning {repoUri} to {targetDirectory}", repoUri, targetDirectory))
+            {
+                try
+                {
+                    _logger.LogDebug($"Cloning {repoUri} to {targetDirectory}");
+                    string repoPath = LibGit2Sharp.Repository.Clone(
+                        repoUri,
+                        targetDirectory,
+                        new LibGit2Sharp.CloneOptions
+                        {
+                            Checkout = false,
+                            CredentialsProvider = (url, user, cred) =>
+                            new LibGit2Sharp.UsernamePasswordCredentials
+                            {
+                                // The PAT is actually the only thing that matters here, the username
+                                // will be ignored.
+                                Username = dotnetMaestro,
+                                Password = pat
+                            }
+                        });
+
+                    _logger.LogDebug($"Reading local repo from {repoPath}");
+                    using (LibGit2Sharp.Repository localRepo = new LibGit2Sharp.Repository(repoPath))
+                    {
+                        _logger.LogDebug($"Checking out {commit} in {repoPath}");
+                        LibGit2Sharp.Commands.Checkout(localRepo, commit);
+                    }
+                }
+                catch (Exception exc)
+                {
+                    // This was originally a DarcException. Making it an actual Exception so we get to see in AppInsights if something failed while
+                    // commiting the changes
+                    throw new Exception($"Something went wrong when cloning repo {repoUri} at {commit} into {targetDirectory}", exc);
+                }
+            }
+        }
+
         private byte[] GetUtf8ContentBytes(string content, ContentEncoding encoding)
         {
             switch (encoding)


### PR DESCRIPTION
This adds a new darc verb, `clone`, that will either clone a specified remote repo and all repos in its dependency graph, or look at a local Version.Details.xml and clone all repos in it and all repos in their dependency graph.  It will put all the repos in the same directory with the format `{name}.{sha}`.