### PR TITLE
Cache assets for already found builds

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -146,6 +146,8 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 return null;
             }
 
+            // Commonly, if a repository has a dependency on an asset from a build, more dependencies will be to that same build
+            // lets fetch all assets from that build to save time later.
             var build = await client.Builds.GetBuildAsync(buildId.Value, cancellationToken);
             foreach (var asset in build.Assets)
             {


### PR DESCRIPTION
This change adds a cache containing all assets for found builds to avoid hitting the api a lot.