### PR TITLE
Add x-ms-paginated to swagger doc

### DIFF
--- a/src/Maestro/Maestro.Web/Startup.Api.cs
+++ b/src/Maestro/Maestro.Web/Startup.Api.cs
@@ -84,6 +84,7 @@ namespace Maestro.Web
                             var paginated = ctx.MethodInfo.GetCustomAttribute<PaginatedAttribute>();
                             if (paginated != null)
                             {
+                                // Add an extension that tells the client generator that this operation is paged with first,prev,next,last urls in the Link header.
                                 op.Extensions["x-ms-paginated"] = new
                                 {
                                     page = paginated.PageParameterName,

--- a/src/Maestro/Maestro.Web/Startup.cs
+++ b/src/Maestro/Maestro.Web/Startup.cs
@@ -257,7 +257,7 @@ namespace Maestro.Web
                 // Redirect api requests to prod when running locally outside of service fabric
                 // This is for the `ng serve` local debugging case for the website
                 app.MapWhen(
-                    ctx => IsGet(ctx) && ctx.Request.Path.StartsWithSegments("/api"),
+                    ctx => IsGet(ctx) && ctx.Request.Path.StartsWithSegments("/api") && ctx.Request.Path != "/api/swagger.json",
                     a =>
                     {
                         a.Run(ApiRedirectHandler);


### PR DESCRIPTION
- Also use references for enum definitions to preserve the enum names defined in the code.