### PR TITLE
Pass channel classification to release pipeline

### DIFF
--- a/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
+++ b/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
@@ -177,7 +177,7 @@ namespace ReleasePipelineRunner
 
                     pipeDef = await azdoClient.AddArtifactSourceAsync(organization, project, pipeDef, azdoBuild);
 
-                    int releaseId = await azdoClient.StartNewReleaseAsync(organization, project, pipeDef, build.Id);
+                    int releaseId = await azdoClient.StartNewReleaseAsync(organization, project, pipeDef, build.Id, channel.Classification);
 
                     var item = new ReleasePipelineStatusItem(releaseId, channelId, organization, project);
                     releaseList.Add(item);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -931,9 +931,11 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="accountName">Azure DevOps account name</param>
         /// <param name="projectName">Project name</param>
         /// <param name="releaseDefinition">Release definition to be updated</param>
-        public async Task<int> StartNewReleaseAsync(string accountName, string projectName, AzureDevOpsReleaseDefinition releaseDefinition, int barBuildId)
+        /// <param name="barBuildId">BAR BuildID to be passed as variable to the pipeline</param>
+        /// <param name="channelClassification">BAR Channel Classification to be passed as variable to the pipeline</param>
+        public async Task<int> StartNewReleaseAsync(string accountName, string projectName, AzureDevOpsReleaseDefinition releaseDefinition, int barBuildId, string channelClassification = null)
         {
-            var body = $"{{ \"definitionId\": {releaseDefinition.Id}, \"variables\": {{ \"BARBuildId\": {{ \"value\": \"{barBuildId}\" }} }} }}";
+            var body = $"{{ \"definitionId\": {releaseDefinition.Id}, \"variables\": {{ \"BARBuildId\": {{ \"value\": \"{barBuildId}\" }}, \"ChannelClassification\": {{ \"value\": \"{channelClassification}\" }} }} }}";
 
             JObject content = await this.ExecuteAzureDevOpsAPIRequestAsync(
                 HttpMethod.Post,


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/2370

Passing this information to the release pipeline so that it'll be able to make decisions using it.