### PR TITLE
Fix dependency name comparison

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -578,7 +578,7 @@ namespace Microsoft.DotNet.DarcLib
             foreach (AssetData asset in assets)
             {
                 DependencyDetail matchingDependencyByName =
-                    dependencies.FirstOrDefault(d => d.Name.Equals(asset.Name, StringComparison.Ordinal) &&
+                    dependencies.FirstOrDefault(d => d.Name.Equals(asset.Name, StringComparison.OrdinalIgnoreCase) &&
                                                      string.IsNullOrEmpty(d.CoherentParentDependencyName));
 
                 if (matchingDependencyByName == null)

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
@@ -83,6 +83,7 @@ namespace Microsoft.DotNet.Darc.Tests
         ///     Test that a simple set of non-coherency updates works.
         ///     
         ///     depB is tied to depA and should not move.
+        ///     depA should have its case-corrected.
         /// </summary>
         [Fact]
         public async Task CoherencyUpdateTests3()
@@ -95,7 +96,7 @@ namespace Microsoft.DotNet.Darc.Tests
 
             List<AssetData> assets = new List<AssetData>()
             {
-                new AssetData(false) { Name = "depA", Version = "v2"},
+                new AssetData(false) { Name = "depa", Version = "v2"},
                 new AssetData(false) { Name = "depB", Version = "v5"}
             };
 
@@ -107,6 +108,7 @@ namespace Microsoft.DotNet.Darc.Tests
             {
                 Assert.Equal(depA, u.From);
                 Assert.Equal("v2", u.To.Version);
+                Assert.Equal("depa", u.To.Name);
             });
         }
 


### PR DESCRIPTION
Should be case insensitive.  Fix the tests so that they will catch this.