### PR TITLE
Retry on anything higher than 500

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -406,7 +406,7 @@ namespace Microsoft.DotNet.DarcLib
                             Blob blob = await ExponentialRetry.RetryAsync(
                                 async () => await Client.Git.Blob.Get(owner, repo, treeItem.Sha),
                                 ex => _logger.LogError(ex, $"Failed to get blob at sha {treeItem.Sha}"),
-                                ex => ex is ApiException apiex && apiex.StatusCode == HttpStatusCode.InternalServerError);
+                                ex => ex is ApiException apiex && apiex.StatusCode >= HttpStatusCode.InternalServerError);
 
                             ContentEncoding encoding;
                             switch (blob.Encoding.Value)


### PR DESCRIPTION
We are seeing APIExceptions with a "Server Error" message during this operation. Expanding to grabbing anything higher to 500 in case what they are actually sending over is one of the other flavors of 5XX