### PR TITLE
Some fixes for anonymous uberclone and additional options.

### DIFF
--- a/src/Maestro/tests/Scenarios/all.ps1
+++ b/src/Maestro/tests/Scenarios/all.ps1
@@ -15,6 +15,7 @@ $testScripts = (
     'azdoflow-nonbatched-all-checks-successful.ps1',
     # 'azdoflow-nonbatched-require-checks.ps1',
     'channels.ps1',
+    'clone.ps1',
     'default-channels.ps1',
     'githubflow-batched.ps1',
     'githubflow-nonbatched.ps1',

--- a/src/Maestro/tests/Scenarios/clone.ps1
+++ b/src/Maestro/tests/Scenarios/clone.ps1
@@ -1,0 +1,236 @@
+param(
+    [string]$maestroInstallation,
+    [string]$darcVersion,
+    [string]$maestroBearerToken,
+    [string]$githubPAT,
+    [string]$githubUser,
+    [string]$azdoPAT
+)
+
+$githubTestOrg = "dotnet"
+
+function Check-GitDir {
+param([string]$gitDirPath)
+
+    ("hooks", "info", "logs", "objects", "refs") | % {
+        $folderPath = Join-Path $gitDirFolder $_
+        if (-Not (Test-Path $folderPath -PathType Container)) {
+            throw "'$gitDirPath' does not appear to be a valid .gitdir: missing folder '$_'"
+        }
+    }
+    ("config", "description", "FETCH_HEAD", "HEAD", "index") | % {
+        $filePath = Join-Path $gitDirFolder $_
+        if (-Not (Test-Path $filePath -PathType Leaf)) {
+            throw "'$gitDirPath' does not appear to be a valid .gitdir: missing file '$_'"
+        }
+    }
+}
+
+function Check-Expected {
+param(
+    [Tuple[string,string][]]$repos,
+    [string[]]$masterRepos,
+    [string[]]$gitDirs
+)
+    foreach ($rName in $repos.Keys) {
+        $rPath = Join-Path $reposFolder $rName
+        if (-Not (Test-Path $rPath -PathType Container)) {
+            throw "Expected cloned repo '$rName' but not found at '$rPath'"
+        }
+        $versionDetailsPath = Join-Path (Join-Path $rPath "eng") "Version.Details.xml"
+        if (Test-Path $versionDetailsPath -PathType Leaf) {
+            $h = Get-FileHash -Algorithm SHA256 $versionDetailsPath
+            if ($h.Hash -ine $repos[$rName]) {
+                throw "Expected $versionDetailsPath to have hash '$($repos[$rName])', actual hash '$($h.Hash)'"
+            }
+        }
+        else {
+            if ($repos[$rName] -ne "") {
+                throw "Expected a '$versionDetailsPath' but it is missing"
+            }
+        }
+    }
+
+    foreach ($r in $masterRepos) {
+        $rPath = Join-Path $reposFolder $r
+        if (-Not (Test-Path $rPath -PathType Container)) {
+            throw "Expected cloned master repo '$r' but not found at '$rPath'"
+        }
+        $gitRedirectPath = Join-Path $rPath ".git"
+        $expectedGitDir = Join-Path $gitDirFolder $r
+        $expectedRedirect = "gitdir: $expectedGitDir.git"
+        $actualRedirect = Get-Content $gitRedirectPath
+        if ($actualRedirect -ine $expectedRedirect) {
+            throw "Expected '$rPath' to have a .gitdir redirect of '$expectedRedirect', actual '$actualRedirect'"
+        }
+    }
+
+    $actualRepos = Get-ChildItem $reposFolder -Directory | ? { $_.Name.Contains(".") }
+    $actualMasterRepos = Get-ChildItem $reposFolder -Directory | ? { -Not $_.Name.Contains(".") }
+
+    foreach ($r in $actualRepos) {
+        $found = $false
+        $repos | % {
+            if ($_.Item1 -ieq $r) {
+                $found = $true
+            }
+        }
+        if (-Not $found) {
+            throw "Found unexpected repo folder '$($r.FullName)'"
+        }
+    }
+
+    foreach ($r in $actualMasterRepos) {
+        $found = $false
+        $masterRepos | % {
+            if ($_ -ieq $r.Name) {
+                $found = $true
+            }
+        }
+        if (-Not $found) {
+            throw "Found unexpected master repo folder '$($r.FullName)'"
+        }
+    }
+
+    foreach ($gd in $gitDirs) {
+        $gdPath = Join-Path $gitDirFolder $gd
+        if (-Not (Test-Path $gdPath -PathType Container)) {
+            throw "Expected a .gitdir for '$gd' but not found at '$gdPath'"
+        }
+    }
+
+    $actualGitDirs = Get-ChildItem $gitDirFolder -Directory
+
+    foreach ($gd in $actualGitDirs) {
+        if (-Not $gitDirs.Contains($gd.Name)) {
+            throw "Found unexpected .gitdir '$($gd.FullName)'"
+        }
+        Check-GitDir $gd.FullName
+    }
+}
+
+try {
+    Write-Host
+    Write-Host "Uberclone"
+    Write-Host
+
+    # Import common tooling and prep for tests
+    . $PSScriptRoot/common.ps1
+
+    $sourceRepoName = "core-sdk"
+    $sourceRepoVersion = "v3.0.100-preview4-011223"
+    $reposFolder = Join-Path $testRoot "cloned-repos"
+    $gitDirFolder = Join-Path $testRoot "git-dirs"
+    # these repos are not currently clonable for us due to auth
+    $reposToIgnore = "https://dev.azure.com/dnceng/internal/_git/dotnet-optimization;https://dev.azure.com/devdiv/DevDiv/_git/DotNet-Trusted;https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Trusted"
+    # these repos have file names that are too long on Windows for the temp folder
+    $reposToIgnore += ";https://github.com/aspnet/AspNetCore;https://github.com/aspnet/AspNetCore-Tooling;https://github.com/dotnet/core-setup;https://github.com/dotnet/templating;https://github.com/dotnet/sdk;https://github.com/Microsoft/visualfsharp;https://github.com/dotnet/roslyn;https://github.com/NuGet/NuGet.Client;https://github.com/dotnet/corefx"
+
+    Write-Host "parameters: sourceRepoName=$sourceRepoName, sourceRepoVersion=$sourceRepoVersion, reposFolder=$reposFolder, gitDirFolder=$gitDirFolder, reposToIgnore='$reposToIgnore'"
+
+    Write-Host "Running tests..."
+    Write-Host
+
+    $sourceRepoUri = Get-Github-RepoUri $sourceRepoName
+    
+    Write-Host "Cloning repo $sourceRepoUri at $sourceRepoVersion with depth 2 and include-toolset=false"
+    try { Darc-Command clone --repo $sourceRepoUri --version `'$sourceRepoVersion`' --git-dir-folder `'$gitDirFolder`' --ignore-repos `'$reposToIgnore`' --repos-folder `'$reposFolder`' --depth 2 } catch {}
+
+    $expectedRepos = @(
+        [Tuple]::Create("cli.204f425b6f061d0b8a01faf46f762ecf71436f68",                     "E9C194F021B0E91C9494B16FB6EAA52CC443E865BE5D33EFB6303232A0D80005"),
+        [Tuple]::Create("cliCommandLineParser.0e89c2116ad28e404ba56c14d1c3f938caa25a01",    "B0FC3EAC54CFDAB2152FCFF78D922AE39F3F1BC8D0985DDCAFC4A2AB86725F93"),
+        [Tuple]::Create("core-sdk.v3.0.100-preview4-011223",                                "6171BB338C8BF8F5C9CE2E84585F102599B407F632FDCFC5D5FD273920E4E0B4"),
+        [Tuple]::Create("msbuild.d004974104fde202e633b3c97e0ece3287aa62f9",                 "CA5E91071DFF9F288C3FBA198AFD4594C020941602E0F4340B835FD40918FE45"),
+        [Tuple]::Create("roslyn.01f3eb103049e2c93e0516c7d50908031deaca74",                  "44EE060FD57300CDB28EBC1C1098CB282162742DEA0E94D07E18130C93BA3B67"),
+        [Tuple]::Create("sdk.814b7898f9908a88f62706331cf56f1ecc9745eb",                     "535F2D732EDBE41846985CB192C70220CE2871B55D21C8B2EEDC09D558F5BD12"),
+        [Tuple]::Create("standard.8ef5ada20b5343b0cb9e7fd577341426dab76cd8",                "13DA5AFE54625E18EF6F5A8A4A4155F8237EE5FDD2AEC554D38819C74BFE5397"),
+        [Tuple]::Create("toolset.3165b2579582b6b44aef768c01c3cc9ff4f0bc17",                 "105E3D6CDCDFAA8FD4C1FBFBE0CAA49308EDCD4E45BD982900C53CAE3E29D79C"),
+        [Tuple]::Create("websdk.b55d4f4cf22bee7ec9a2ca5f49d54ebf6ee67e83",                  "68DF74EB53B1B1465FD48D0B16AF40DBD23E0E024BED967543C3B011EF0CA883"),
+        [Tuple]::Create("winforms.b1ee29b8b8e14c1200adff02847391dde471d0d2",                "B081A500DAB904994907F9A213E05B7B0765F87A02607D138023548EE67AECF9"),
+        [Tuple]::Create("wpf.d378b1ec6b8555c52b7da1c40ffc0784cb0f5cad",                     "C934F80C5FA37ECB54B555C76571BF0A7A49587F3DA5E8AD9A6E09A0A4740DB7")
+    )
+
+    $expectedMasterRepos = @(
+        "cli",
+        "cliCommandLineParser",
+        "core-sdk",
+        "msbuild"
+        "standard",
+        "toolset",
+        "websdk",
+        "winforms",
+        "wpf"
+    )
+
+    $expectedGitDirs = @(
+        "cli.git",
+        "cliCommandLineParser.git",
+        "core-sdk.git",
+        "msbuild.git",
+        "standard.git",
+        "toolset.git",
+        "websdk.git",
+        "winforms.git",
+        "wpf.git"
+    )
+
+    Check-Expected $expectedRepos $expectedMasterRepos $expectedGitDirs
+
+    # more repos with file names that are too long
+    $reposToIgnore += ";https://github.com/dotnet/arcade"
+
+    Write-Host "Cloning repo $sourceRepoUri at $sourceRepoVersion with depth 4 and include-toolset=true"
+    try { Darc-Command clone --repo `'$sourceRepoUri`' --version `'$sourceRepoVersion`' --git-dir-folder `'$gitDirFolder`' --ignore-repos `'$reposToIgnore`' --repos-folder `'$reposFolder`' --depth 4 --include-toolset } catch {}
+
+    $expectedRepos = @(
+        [Tuple]::Create("cli.204f425b6f061d0b8a01faf46f762ecf71436f68",                     "E9C194F021B0E91C9494B16FB6EAA52CC443E865BE5D33EFB6303232A0D80005"),
+        [Tuple]::Create("cliCommandLineParser.0e89c2116ad28e404ba56c14d1c3f938caa25a01",    "B0FC3EAC54CFDAB2152FCFF78D922AE39F3F1BC8D0985DDCAFC4A2AB86725F93"),
+        [Tuple]::Create("core-sdk.v3.0.100-preview4-011223",                                "6171BB338C8BF8F5C9CE2E84585F102599B407F632FDCFC5D5FD273920E4E0B4"),
+        [Tuple]::Create("coreclr.9562c551f391635ce81869aabc84f894c2846be8",                 "2D0D4BE57A2EBAB8FADA391C1EA90ED71EC5CFD6441B3AF34B0A43FCC3CB0979"),
+        [Tuple]::Create("coreclr.991817d90827b206ab25e74e7a5bd326a7e86ad4",                 "7101B4BEDC4783B7DD4F3449E12130FAF43CB65A49809ECE970CD8D2978A63C0"),
+        [Tuple]::Create("coreclr.aea7846fc71591739e47c65c0632007bff1cc4a4",                 "C5B777C8948A439375FBB0C216919592BBB036CA4A9BFFEFB428739904172F69"),
+        [Tuple]::Create("coreclr.d833cacabd67150fe3a2405845429a0ba1b72c12",                 "2D0D4BE57A2EBAB8FADA391C1EA90ED71EC5CFD6441B3AF34B0A43FCC3CB0979"),
+        [Tuple]::Create("msbuild.d004974104fde202e633b3c97e0ece3287aa62f9",                 "CA5E91071DFF9F288C3FBA198AFD4594C020941602E0F4340B835FD40918FE45"),
+        [Tuple]::Create("sdk.814b7898f9908a88f62706331cf56f1ecc9745eb",                     "535F2D732EDBE41846985CB192C70220CE2871B55D21C8B2EEDC09D558F5BD12"),
+        [Tuple]::Create("standard.31a38c14c8a4d06ea59c67706fe4399c1f14368f",                "3A79469090374A4386754F5B331255775ADA567751585798ECB64B1B5687493B"),
+        [Tuple]::Create("standard.8ef5ada20b5343b0cb9e7fd577341426dab76cd8",                "13DA5AFE54625E18EF6F5A8A4A4155F8237EE5FDD2AEC554D38819C74BFE5397"),
+        [Tuple]::Create("standard.a652c72dd650656e8284eb8cfb95cb9965a2e75e",                "8A9BCA3A645635931CAB5DC2EEB246F7029BF1D4DDECFF29E5DD6E6E7B4F62A7"),
+        [Tuple]::Create("toolset.3165b2579582b6b44aef768c01c3cc9ff4f0bc17",                 "105E3D6CDCDFAA8FD4C1FBFBE0CAA49308EDCD4E45BD982900C53CAE3E29D79C"),
+        [Tuple]::Create("websdk.b55d4f4cf22bee7ec9a2ca5f49d54ebf6ee67e83",                  "68DF74EB53B1B1465FD48D0B16AF40DBD23E0E024BED967543C3B011EF0CA883"),
+        [Tuple]::Create("winforms.b1ee29b8b8e14c1200adff02847391dde471d0d2",                "B081A500DAB904994907F9A213E05B7B0765F87A02607D138023548EE67AECF9"),
+        [Tuple]::Create("wpf.d378b1ec6b8555c52b7da1c40ffc0784cb0f5cad",                     "C934F80C5FA37ECB54B555C76571BF0A7A49587F3DA5E8AD9A6E09A0A4740DB7")
+    )
+
+    $expectedMasterRepos = @(
+        "cli",
+        "cliCommandLineParser",
+        "core-sdk",
+        "coreclr",
+        "msbuild",
+        "standard",
+        "toolset",
+        "websdk",
+        "winforms",
+        "wpf"
+    )
+
+    $expectedGitDirs = @(
+        "cli.git",
+        "cliCommandLineParser.git",
+        "core-sdk.git",
+        "coreclr.git",
+        "msbuild.git",
+        "standard.git",
+        "toolset.git",
+        "websdk.git",
+        "winforms.git",
+        "wpf.git"
+    )
+
+    Check-Expected -repos $expectedRepos -masterRepos $expectedMasterRepos -gitDirs $expectedGitDirs
+
+    Write-Host "Test passed"
+
+} finally {
+    Teardown
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
@@ -140,15 +140,7 @@ namespace Microsoft.DotNet.Darc.Operations
                                     accumulatedDependencies.Add(stripped);
                                 }
                             }
-                            // delete the .gitdir redirect to orphan the repo.
-                            // we want to do this because otherwise all of these folder will show as dirty in Git,
-                            // and any operations on them will affect the master copy and all the others, which
-                            // could be confusing.
-                            string repoGitRedirectPath = Path.Combine(repoPath, ".git");
-                            if (File.Exists(repoGitRedirectPath))
-                            {
-                                File.Delete(repoGitRedirectPath);
-                            }
+			    Logger.LogDebug($"done looking for dependencies in {repoPath} at {repo.Commit}");
                         }
                         catch (DirectoryNotFoundException)
                         {
@@ -158,8 +150,23 @@ namespace Microsoft.DotNet.Darc.Operations
                         {
                             Logger.LogWarning($"Repo {repoPath} appears to have no '/eng/Version.Details.xml' file at commit {repo.Commit}.  Dependency chain is broken here.");
                         }
-
-                        Logger.LogDebug($"Now have {dependenciesToClone.Count} dependencies to consider");
+                        finally
+                        {
+                            // delete the .gitdir redirect to orphan the repo.
+                            // we want to do this because otherwise all of these folder will show as dirty in Git,
+                            // and any operations on them will affect the master copy and all the others, which
+                            // could be confusing.
+                            string repoGitRedirectPath = Path.Combine(repoPath, ".git");
+                            if (File.Exists(repoGitRedirectPath))
+                            {
+                                Logger.LogDebug($"Deleting .gitdir redirect {repoGitRedirectPath}");
+                                File.Delete(repoGitRedirectPath);
+                            }
+                            else
+                            {
+                                Logger.LogDebug($"No .gitdir redirect found at {repoGitRedirectPath}");
+                            }
+                        }
                     }   // end inner while(dependenciesToClone.Any())
 
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
@@ -110,6 +110,10 @@ namespace Microsoft.DotNet.Darc.Operations
                                 {
                                     Logger.LogDebug($"Skipping ignored repo {d.RepoUri} (at {d.Commit})");
                                 }
+                                else if (string.IsNullOrWhiteSpace(d.Commit))
+                                {
+                                    Logger.LogWarning($"Skipping dependency from {repo.RepoUri}@{repo.Commit} to {d.RepoUri}: Missing commit.");
+                                }
                                 else
                                 {
                                     StrippedDependency stripped = new StrippedDependency(d);
@@ -197,6 +201,11 @@ namespace Microsoft.DotNet.Darc.Operations
 
         private static string GetRepoDirectory(string reposFolder, string repoUri, string commit)
         {
+            if (repoUri.EndsWith(".git"))
+            {
+                repoUri = repoUri.Substring(0, repoUri.Length - ".git".Length);
+            }
+
             // commit could actually be a branch or tag, make it filename-safe
             commit = commit.Replace('/', '-').Replace('\\', '-').Replace('?', '-').Replace('*', '-').Replace(':', '-').Replace('|', '-').Replace('"', '-').Replace('<', '-').Replace('>', '-');
             return Path.Combine(reposFolder, $"{repoUri.Substring(repoUri.LastIndexOf("/") + 1)}.{commit}");
@@ -209,12 +218,20 @@ namespace Microsoft.DotNet.Darc.Operations
                 return null;
             }
 
-            // commit could actually be a branch or tag, make it filename-safe
+            if (repoUri.EndsWith(".git"))
+            {
+                repoUri = repoUri.Substring(0, repoUri.Length - ".git".Length);
+            }
+
             return Path.Combine(gitDirParent, $"{repoUri.Substring(repoUri.LastIndexOf("/") + 1)}.git");
         }
 
         private static string GetMasterGitRepoPath(string reposFolder, string repoUri)
         {
+            if (repoUri.EndsWith(".git"))
+            {
+                repoUri = repoUri.Substring(0, repoUri.Length - ".git".Length);
+            }
             return Path.Combine(reposFolder, $"{repoUri.Substring(repoUri.LastIndexOf("/") + 1)}");
         }
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 if (string.IsNullOrWhiteSpace(_options.RepoUri))
                 {
                     Local local = new Local(Logger);
-                    IEnumerable<DependencyDetail>  rootDependencies = await local.GetDependenciesAsync(reposToIgnore: _options.IgnoredRepos);
+                    IEnumerable<DependencyDetail>  rootDependencies = await local.GetDependenciesAsync();
                     IEnumerable<StrippedDependency> stripped = rootDependencies.Select(d => new StrippedDependency(d));
                     stripped.ForEach((s) => accumulatedDependencies.Add(s));
                     stripped.ForEach((s) => seenDependencies.Add(s));
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Darc.Operations
                         Local local = new Local(Logger, repoPath);
                         try
                         {
-                            IEnumerable<DependencyDetail> deps = await local.GetDependenciesAsync(reposToIgnore: _options.IgnoredRepos);
+                            IEnumerable<DependencyDetail> deps = await local.GetDependenciesAsync();
                             IEnumerable<DependencyDetail> filteredDeps = FilterToolsetDependencies(deps, _options.IncludeToolset);
                             Logger.LogDebug($"Got {deps.Count()} dependencies and filtered to {filteredDeps.Count()} dependencies");
                             filteredDeps.ForEach((d) =>
@@ -91,6 +91,10 @@ namespace Microsoft.DotNet.Darc.Operations
                                 if (d.RepoUri == repo.RepoUri)
                                 {
                                     Logger.LogDebug($"Skipping self-dependency in {repo.RepoUri} ({repo.Commit} => {d.Commit})");
+                                }
+                                else if (_options.IgnoredRepos.Any(r => r.Equals(d.RepoUri, StringComparison.OrdinalIgnoreCase)))
+                                {
+                                    Logger.LogDebug($"Skipping ignored repo {d.RepoUri} (at {d.Commit})");
                                 }
                                 else
                                 {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/CloneCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/CloneCommandLineOptions.cs
@@ -4,10 +4,11 @@
 
 using CommandLine;
 using Microsoft.DotNet.Darc.Operations;
+using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Darc.Options
 {
-    [Verb("clone", HelpText = "clone a remote repo and all of its dependency repos")]
+    [Verb("clone", HelpText = "Clone a remote repo and all of its dependency repos")]
 
     internal class CloneCommandLineOptions : CommandLineOptions
     {
@@ -17,11 +18,20 @@ namespace Microsoft.DotNet.Darc.Options
         [Option('v', "version", HelpText = "Branch, commit or tag to start at in the remote repository.  Required if repo is specified.")]
         public string Version { get; set; }
 
-        [Option("repos-folder", HelpText = @"Full path to folder where all the repos will be cloned to. i.e. C:\repos.  Default: current directory.")]
+        [Option("repos-folder", HelpText = @"Full path to folder where all the repos will be cloned to, e.g. C:\repos.  Default: current directory.")]
         public string ReposFolder { get; set; }
+
+        [Option("git-dir-folder", HelpText = @"Advanced: Full path to folder where .git folders will be stored, e.g. C:\myrepos\.git\modules.  Default: each repo's folder.")]
+        public string GitDirFolder { get; set; }
 
         [Option("include-toolset", HelpText = "Include toolset dependencies.")]
         public bool IncludeToolset { get; set; }
+
+        [Option("ignore-repos", Separator = ';', HelpText = "Semicolon-separated list of repo URIs to ignore.  e.g. 'https://dev.azure.com/devdiv/DevDiv/_git/DotNet-Trusted;https://github.com/dotnet/arcade-services'")]
+        public IEnumerable<string> IgnoredRepos { get; set; }
+
+        [Option('d', "depth", Default = uint.MaxValue, HelpText = "Depth to clone the repos to.  Defaults to infinite.")]
+        public uint CloneDepth { get; set; }
 
         public override Operation GetOperation()
         {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -1164,5 +1164,14 @@ namespace Microsoft.DotNet.DarcLib
         {
             this.Clone(repoUri, commit, targetDirectory, _logger, _personalAccessToken, gitDirectory);
         }
+
+        /// <summary>
+        ///     Does not apply to remote repositories.
+        /// </summary>
+        /// <param name="commit">Ignored</param>
+        public void Checkout(string repoPath, string commit)
+        {
+            throw new NotImplementedException($"Cannot checkout a remote repo.");
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -1169,7 +1169,7 @@ namespace Microsoft.DotNet.DarcLib
         ///     Does not apply to remote repositories.
         /// </summary>
         /// <param name="commit">Ignored</param>
-        public void Checkout(string repoPath, string commit)
+        public void Checkout(string repoPath, string commit, bool force)
         {
             throw new NotImplementedException($"Cannot checkout a remote repo.");
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -1158,10 +1158,11 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="repoUri">Repository uri to clone</param>
         /// <param name="commit">Branch, tag, or commit to checkout</param>
         /// <param name="targetDirectory">Directory to clone into</param>
+        /// <param name="gitDirectory">Location for the .git directory, or null for default</param>
         /// <returns></returns>
-        public void Clone(string repoUri, string commit, string targetDirectory)
+        public void Clone(string repoUri, string commit, string targetDirectory, string gitDirectory = null)
         {
-            this.Clone(repoUri, commit, targetDirectory, _logger, _personalAccessToken);
+            this.Clone(repoUri, commit, targetDirectory, _logger, _personalAccessToken, gitDirectory);
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -110,12 +110,10 @@ namespace Microsoft.DotNet.DarcLib
         ///     Gets the local dependencies
         /// </summary>
         /// <returns></returns>
-        public async Task<IEnumerable<DependencyDetail>> GetDependenciesAsync(string name = null, bool includePinned = true, IEnumerable<string> reposToIgnore = null)
+        public async Task<IEnumerable<DependencyDetail>> GetDependenciesAsync(string name = null, bool includePinned = true)
         {
-            reposToIgnore = reposToIgnore ?? Enumerable.Empty<string>();
             return (await _fileManager.ParseVersionDetailsXmlAsync(_repo, null, includePinned)).Where(
-                dependency => (string.IsNullOrEmpty(name) || dependency.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
-                           && !reposToIgnore.Any(r => dependency.RepoUri.Equals(r, StringComparison.OrdinalIgnoreCase)));
+                dependency => string.IsNullOrEmpty(name) || dependency.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -133,5 +133,14 @@ namespace Microsoft.DotNet.DarcLib
         {
             return _fileManager.ParseVersionDetailsXml(fileContents, includePinned);
         }
+
+        /// <summary>
+        /// Checkout the local repo to a given state.
+        /// </summary>
+        /// <param name="commit">Tag, branch, or commit to checkout</param>
+        public void Checkout(string commit)
+        {
+            _gitClient.Checkout(_repo, commit);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -138,9 +138,9 @@ namespace Microsoft.DotNet.DarcLib
         /// Checkout the local repo to a given state.
         /// </summary>
         /// <param name="commit">Tag, branch, or commit to checkout</param>
-        public void Checkout(string commit)
+        public void Checkout(string commit, bool force = false)
         {
-            _gitClient.Checkout(_repo, commit);
+            _gitClient.Checkout(_repo, commit, force);
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -110,10 +110,12 @@ namespace Microsoft.DotNet.DarcLib
         ///     Gets the local dependencies
         /// </summary>
         /// <returns></returns>
-        public async Task<IEnumerable<DependencyDetail>> GetDependenciesAsync(string name = null, bool includePinned = true)
+        public async Task<IEnumerable<DependencyDetail>> GetDependenciesAsync(string name = null, bool includePinned = true, IEnumerable<string> reposToIgnore = null)
         {
+            reposToIgnore = reposToIgnore ?? Enumerable.Empty<string>();
             return (await _fileManager.ParseVersionDetailsXmlAsync(_repo, null, includePinned)).Where(
-                dependency => string.IsNullOrEmpty(name) || dependency.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+                dependency => (string.IsNullOrEmpty(name) || dependency.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                           && !reposToIgnore.Any(r => dependency.RepoUri.Equals(r, StringComparison.OrdinalIgnoreCase)));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -933,11 +933,12 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="repoUri">Repository to clone</param>
         /// <param name="commit">Branch, commit, or tag to checkout</param>
         /// <param name="targetDirectory">Directory to clone to</param>
+        /// <param name="gitDirectory">Location for the .git directory</param>
         /// <returns></returns>
-        public void Clone(string repoUri, string commit, string targetDirectory)
+        public void Clone(string repoUri, string commit, string targetDirectory, string gitDirectory = null)
         {
             CheckForValidGitClient();
-            _gitClient.Clone(repoUri, commit, targetDirectory);
+            _gitClient.Clone(repoUri, commit, targetDirectory, gitDirectory);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -871,5 +871,14 @@ namespace Microsoft.DotNet.DarcLib
         {
             this.Clone(repoUri, commit, targetDirectory, _logger, Client.Credentials.Password, gitDirectory);
         }
+
+        /// <summary>
+        ///     Does not apply to remote repositories.
+        /// </summary>
+        /// <param name="commit">Ignored</param>
+        public void Checkout(string repoPath, string commit)
+        {
+            throw new NotImplementedException($"Cannot checkout a remote repo.");
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -865,10 +865,11 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="repoUri">Repository uri to clone</param>
         /// <param name="commit">Commit, branch, or tag to checkout</param>
         /// <param name="targetDirectory">Directory to clone into</param>
+        /// <param name="gitDirectory">Location for the .git directory, or null for default</param>
         /// <returns></returns>
-        public void Clone(string repoUri, string commit, string targetDirectory)
+        public void Clone(string repoUri, string commit, string targetDirectory, string gitDirectory = null)
         {
-            this.Clone(repoUri, commit, targetDirectory, _logger, Client.Credentials.Password);
+            this.Clone(repoUri, commit, targetDirectory, _logger, Client.Credentials.Password, gitDirectory);
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -876,7 +876,7 @@ namespace Microsoft.DotNet.DarcLib
         ///     Does not apply to remote repositories.
         /// </summary>
         /// <param name="commit">Ignored</param>
-        public void Checkout(string repoPath, string commit)
+        public void Checkout(string repoPath, string commit, bool force)
         {
             throw new NotImplementedException($"Cannot checkout a remote repo.");
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -152,8 +152,9 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="repoUri">Repository uri</param>
         /// <param name="commit">Branch, commit, or tag to checkout</param>
         /// <param name="targetDirectory">Directory to clone to</param>
+        /// <param name="gitDirectory">Location for .git directory, or null for default</param>
         /// <returns></returns>
-        void Clone(string repoUri, string commit, string targetDirectory);
+        void Clone(string repoUri, string commit, string targetDirectory, string gitDirectory);
     }
 
     public class PullRequest

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -159,8 +159,10 @@ namespace Microsoft.DotNet.DarcLib
         /// <summary>
         ///     Checkout the repository to a given state.
         /// </summary>
+        /// <param name="repoPath">Path to the local repository</param>
         /// <param name="commit">Tag, branch, or commit to checkout</param>
-        void Checkout(string repoPath, string commit);
+        /// <param name="force">True to force the checkout (loses work)</param>
+        void Checkout(string repoPath, string commit, bool force);
     }
 
     public class PullRequest

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -155,6 +155,12 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="gitDirectory">Location for .git directory, or null for default</param>
         /// <returns></returns>
         void Clone(string repoUri, string commit, string targetDirectory, string gitDirectory);
+
+        /// <summary>
+        ///     Checkout the repository to a given state.
+        /// </summary>
+        /// <param name="commit">Tag, branch, or commit to checkout</param>
+        void Checkout(string repoPath, string commit);
     }
 
     public class PullRequest

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/ILocal.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/ILocal.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.DarcLib
         ///     Checkout the specified tag, branch, or commit.
         /// </summary>
         /// <param name="commit">Tag, branch, or commit to checkout</param>
-        void Checkout(string commit);
+        /// <param name="force">True to force checkout (can lose work)</param>
+        void Checkout(string commit, bool force);
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/ILocal.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/ILocal.cs
@@ -15,5 +15,11 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         /// <returns>Async task</returns>
         Task<bool> Verify();
+
+        /// <summary>
+        ///     Checkout the specified tag, branch, or commit.
+        /// </summary>
+        /// <param name="commit">Tag, branch, or commit to checkout</param>
+        void Checkout(string commit);
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -340,8 +340,9 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="repoUri">Repository uri</param>
         /// <param name="commit">Branch, commit, or tag to checkout</param>
         /// <param name="targetDirectory">Directory to clone the repo to</param>
+        /// <param name="gitDirParent">Location for the .git directory, or null for default</param>
         /// <returns></returns>
-        void Clone(string repoUri, string commit, string targetDirectory);
+        void Clone(string repoUri, string commit, string targetDirectory, string gitDirectory);
 
         #endregion
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -423,6 +423,16 @@ namespace Microsoft.DotNet.DarcLib
                             CleanRepoAndSubmodules(subRepo, log);
                         }
                     }
+
+                    if (File.Exists(subRepoGitFilePath))
+                    {
+                        log.LogDebug($"Deleting {subRepoGitFilePath} to orphan submodule {sub.Name}");
+                        File.Delete(subRepoGitFilePath);
+                    }
+                    else
+                    {
+                        log.LogDebug($"{sub.Name} doesn't have a .gitdir redirect at {subRepoGitFilePath}, skipping delete");
+                    }
                 }
             }
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -280,7 +280,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="commit">Tag, branch, or commit to checkout.</param>
         public void Checkout(string repoDir, string commit, bool force = false)
         {
-            using (_logger.BeginScope("Checking out {commit}", commit))
+            using (_logger.BeginScope("Checking out {commit}", commit ?? "default commit"))
             {
                 LibGit2Sharp.CheckoutOptions checkoutOptions = new LibGit2Sharp.CheckoutOptions
                 {
@@ -288,11 +288,16 @@ namespace Microsoft.DotNet.DarcLib
                 };
                 try
                 {
-                    _logger.LogDebug($"Checking out {commit}");
+                    _logger.LogDebug($"Checking out {commit ?? "default commit"}");
 
                     _logger.LogDebug($"Reading local repo from {repoDir}");
                     using (LibGit2Sharp.Repository localRepo = new LibGit2Sharp.Repository(repoDir))
                     {
+                        if (commit == null)
+                        {
+                            commit = localRepo.Head.Reference.TargetIdentifier;
+                            _logger.LogInformation($"Repo {localRepo.Info.WorkingDirectory} default commit to checkout is {commit}");
+                        }
                         try
                         {
                             _logger.LogDebug($"Attempting to check out {commit} in {repoDir}");

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -282,6 +282,7 @@ namespace Microsoft.DotNet.DarcLib
         {
             using (_logger.BeginScope("Checking out {commit}", commit ?? "default commit"))
             {
+                _logger.LogDebug($"Checking out {commit}", commit ?? "default commit");
                 LibGit2Sharp.CheckoutOptions checkoutOptions = new LibGit2Sharp.CheckoutOptions
                 {
                     CheckoutModifiers = force ? LibGit2Sharp.CheckoutModifiers.Force : LibGit2Sharp.CheckoutModifiers.None,
@@ -365,6 +366,7 @@ namespace Microsoft.DotNet.DarcLib
         {
             using (log.BeginScope($"Beginning clean of {repo.Info.WorkingDirectory} and {repo.Submodules.Count()} submodules"))
             {
+                log.LogDebug($"Beginning clean of {repo.Info.WorkingDirectory} and {repo.Submodules.Count()} submodules");
                 LibGit2Sharp.StatusOptions options = new LibGit2Sharp.StatusOptions
                 {
                     IncludeUntracked = true,
@@ -412,9 +414,11 @@ namespace Microsoft.DotNet.DarcLib
 
                     using (log.BeginScope($"Beginning clean of submodule {sub.Name}"))
                     {
+                        log.LogDebug($"Beginning clean of submodule {sub.Name} in {subRepoPath}");
                         using (LibGit2Sharp.Repository subRepo = new LibGit2Sharp.Repository(subRepoPath))
                         {
-                            subRepo.Reset(LibGit2Sharp.ResetMode.Hard, subRepo.Commits.Single(c => c.Sha == sub.HeadCommitId.Sha));
+                            log.LogDebug($"Resetting {sub.Name} to {sub.HeadCommitId.Sha}");
+                            subRepo.Reset(LibGit2Sharp.ResetMode.Hard, subRepo.Commits.QueryBy(new LibGit2Sharp.CommitFilter { IncludeReachableFrom = subRepo.Refs }).Single(c => c.Sha == sub.HeadCommitId.Sha));
                             log.LogDebug($"Done resetting {subRepoPath}, checking submodules");
                             CleanRepoAndSubmodules(subRepo, log);
                         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -262,7 +262,7 @@ namespace Microsoft.DotNet.DarcLib
             throw new NotImplementedException();
         }
 
-        public void Clone(string repoUri, string commit, string targetDirectory)
+        public void Clone(string repoUri, string commit, string targetDirectory, string gitDirectory)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -404,6 +404,7 @@ namespace Microsoft.DotNet.DarcLib
                             LibGit2Sharp.Submodule masterSubModule = masterRepo.Submodules.Single(s => s.Name == sub.Name);
                             string masterSubPath = Path.Combine(repo.Info.Path, "modules", masterSubModule.Path);
                             log.LogDebug($"Writing .gitdir redirect {masterSubPath} to {subRepoGitFilePath}");
+                            Directory.CreateDirectory(Path.GetDirectoryName(subRepoGitFilePath));
                             File.WriteAllText(subRepoGitFilePath, $"gitdir: {masterSubPath}");
                         }
                     }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -266,5 +266,31 @@ namespace Microsoft.DotNet.DarcLib
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        ///     Checkout the repo to the specified state.
+        /// </summary>
+        /// <param name="commit">Tag, branch, or commit to checkout.</param>
+        public void Checkout(string repoDir, string commit)
+        {
+            using (_logger.BeginScope("Checking out {commit}", commit))
+            {
+                try
+                {
+                    _logger.LogDebug($"Checking out {commit}");
+
+                    _logger.LogDebug($"Reading local repo from {repoDir}");
+                    using (LibGit2Sharp.Repository localRepo = new LibGit2Sharp.Repository(repoDir))
+                    {
+                        _logger.LogDebug($"Checking out {commit} in {repoDir}");
+                        LibGit2Sharp.Commands.Checkout(localRepo, commit);
+                    }
+                }
+                catch (Exception exc)
+                {
+                    throw new Exception($"Something went wrong when checkout out {commit} in {repoDir}", exc);
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
@@ -250,7 +250,7 @@ namespace Microsoft.DotNet.DarcLib
                 using (LibGit2Sharp.Repository subRepo = new LibGit2Sharp.Repository(subRepoPath))
                 {
                     log.LogDebug($"Resetting {sub.Name} to {sub.HeadCommitId.Sha}");
-                    subRepo.Reset(LibGit2Sharp.ResetMode.Hard, subRepo.Commits.Single(c => c.Sha == sub.HeadCommitId.Sha));
+                    subRepo.Reset(LibGit2Sharp.ResetMode.Hard, subRepo.Commits.QueryBy(new LibGit2Sharp.CommitFilter { IncludeReachableFrom = subRepo.Refs }).Single(c => c.Sha == sub.HeadCommitId.Sha));
                     CheckoutSubmodules(subRepo, submoduleCloneOptions, absoluteGitDirPath, log);
                 }
             }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
@@ -248,10 +248,41 @@ namespace Microsoft.DotNet.DarcLib
                     s.SetLength(s.Position);
                 }
 
+                // The worktree is stored in the .gitdir/config file, so we have to change it
+                // to get it to check out to the correct place.
+                LibGit2Sharp.ConfigurationEntry<string> oldWorkTree = null;
+                using (LibGit2Sharp.Repository subRepo = new LibGit2Sharp.Repository(subRepoPath))
+                {
+                    oldWorkTree = subRepo.Config.Get<string>("core.worktree");
+                    if (oldWorkTree != null)
+                    {
+                        log.LogDebug($"{subRepoPath} old worktree is {oldWorkTree.Value}, setting to {subRepoPath}");
+                        subRepo.Config.Set("core.worktree", subRepoPath);
+                    }
+                    else
+                    {
+                        log.LogDebug($"{subRepoPath} has default worktree, leaving unchanged");
+                    }
+                }
+
                 using (LibGit2Sharp.Repository subRepo = new LibGit2Sharp.Repository(subRepoPath))
                 {
                     log.LogDebug($"Resetting {sub.Name} to {sub.HeadCommitId.Sha}");
                     subRepo.Reset(LibGit2Sharp.ResetMode.Hard, subRepo.Commits.QueryBy(new LibGit2Sharp.CommitFilter { IncludeReachableFrom = subRepo.Refs }).Single(c => c.Sha == sub.HeadCommitId.Sha));
+
+                    // Now we reset the worktree back so that when we can initialize a Repository
+                    // from it, instead of having to figure out which hash of the repo was most recently checked out.
+                    if (oldWorkTree != null)
+                    {
+                        log.LogDebug($"resetting {subRepoPath} worktree to {oldWorkTree.Value}");
+                        subRepo.Config.Set("core.worktree", oldWorkTree.Value);
+                    }
+                    else
+                    {
+                        log.LogDebug($"leaving {subRepoPath} worktree as default");
+                    }
+
+                    log.LogDebug($"Done checking out {subRepoPath}, checking submodules");
                     CheckoutSubmodules(subRepo, submoduleCloneOptions, absoluteGitDirPath, log);
                 }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
@@ -177,6 +177,11 @@ namespace Microsoft.DotNet.DarcLib
                         targetDirectory,
                         cloneOptions);
 
+                    LibGit2Sharp.CheckoutOptions checkoutOptions = new LibGit2Sharp.CheckoutOptions
+                    {
+                        CheckoutModifiers = LibGit2Sharp.CheckoutModifiers.Force,
+                    };
+
                     _logger.LogDebug($"Reading local repo from {repoPath}");
                     using (LibGit2Sharp.Repository localRepo = new LibGit2Sharp.Repository(repoPath))
                     {
@@ -188,14 +193,14 @@ namespace Microsoft.DotNet.DarcLib
                         try
                         {
                             _logger.LogDebug($"Attempting to checkout {commit} as commit in {localRepo.Info.WorkingDirectory}");
-                            LibGit2Sharp.Commands.Checkout(localRepo, commit);
+                            LibGit2Sharp.Commands.Checkout(localRepo, commit, checkoutOptions);
                         }
                         catch
                         {
                             _logger.LogDebug($"Failed to checkout {commit} as commit, trying to resolve");
                             string resolvedReference = ParseReference(localRepo, commit, _logger);
                             _logger.LogDebug($"Resolved {commit} to {resolvedReference ?? "<invalid>"} in {localRepo.Info.WorkingDirectory}, attempting checkout");
-                            LibGit2Sharp.Commands.Checkout(localRepo, resolvedReference);
+                            LibGit2Sharp.Commands.Checkout(localRepo, resolvedReference, checkoutOptions);
                         }
                     }
                     // LibGit2Sharp doesn't support a --git-dir equivalent yet (https://github.com/libgit2/libgit2sharp/issues/1467), so we do this manually

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
@@ -238,6 +238,8 @@ namespace Microsoft.DotNet.DarcLib
                 using (StreamWriter w = new StreamWriter(s))
                 {
                     w.Write($"gitdir: {relocatedGitDirPath}");
+                    w.Flush();
+                    s.SetLength(s.Position);
                 }
 
                 using (LibGit2Sharp.Repository subRepo = new LibGit2Sharp.Repository(subRepoPath))


### PR DESCRIPTION
- Fix clone operation to work without a real PAT.
  - Instead of hitting the GitHub API to get the dependency graph, clone the repo then get the dependencies locally.
  - Remove unneeded BAR dependency.
- Add two options for limiting the uberclone: depth limit and ignored repos.
- Add one option for relocating `.git` directories (to simulate the way submodules work in regular git).