### PR TITLE
Add prototype tree view for builds

### DIFF
--- a/src/Maestro/maestro-angular/src/app/app.module.ts
+++ b/src/Maestro/maestro-angular/src/app/app.module.ts
@@ -44,6 +44,10 @@ import { TimeAgoComponent } from './widget/time-ago/time-ago.component';
 import { RelativeDateComponent } from './widget/relative-date/relative-date.component';
 import { CommitLinkPipe } from './pipes/commit-link.pipe';
 import { BuildLinkPipe } from './pipes/build-link.pipe';
+import { TreeViewModule } from 'src/tree-view';
+import { BuildGraphTreeComponent } from './page/build-graph-tree/build-graph-tree.component';
+import { RepoNamePipe } from './pipes/repo-name.pipe';
+import { GetRepositoryNamePipe } from './pipes/get-repository-name.pipe';
 
 @NgModule({
   declarations: [
@@ -59,6 +63,9 @@ import { BuildLinkPipe } from './pipes/build-link.pipe';
     RelativeDateComponent,
     CommitLinkPipe,
     BuildLinkPipe,
+    BuildGraphTreeComponent,
+    RepoNamePipe,
+    GetRepositoryNamePipe,
   ],
   imports: [
     BrowserModule,
@@ -70,6 +77,7 @@ import { BuildLinkPipe } from './pipes/build-link.pipe';
     MaestroModule.forRoot(maestroOptions),
     StatefulModule,
     FormsModule,
+    TreeViewModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-tree/build-graph-tree.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-tree/build-graph-tree.component.html
@@ -1,0 +1,12 @@
+<tree-view [data]="tree">
+  <ng-template let-build>
+    <span [ngClass]="{'text-danger': !build.coherent}">
+      Build
+      <a target="_blank" [href]="build | buildLink">{{build.azureDevOpsBuildNumber}}</a>
+      of
+      <a [routerLink]="['../..', build | getRepositoryName, build.id]">{{build | getRepositoryName | repoName}}</a>@<a target="_blank" [href]="build | commitLink">{{build.commit | slice:0:7}}</a>
+      produced
+      <mc-time-ago [value]="build.dateProduced"></mc-time-ago>
+    </span>
+  </ng-template>
+</tree-view>

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-tree/build-graph-tree.component.spec.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-tree/build-graph-tree.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BuildGraphTreeComponent } from './build-graph-tree.component';
+
+describe('BuildGraphTreeComponent', () => {
+  let component: BuildGraphTreeComponent;
+  let fixture: ComponentFixture<BuildGraphTreeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ BuildGraphTreeComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BuildGraphTreeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-tree/build-graph-tree.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-tree/build-graph-tree.component.ts
@@ -1,0 +1,62 @@
+import { Component, Input, OnChanges } from '@angular/core';
+import { BuildGraph, Build } from 'src/maestro-client/models';
+import { TreeNode } from 'src/tree-view';
+import { compareDesc } from 'date-fns';
+import { GetRepositoryNamePipe } from 'src/app/pipes/get-repository-name.pipe';
+
+function toTree(build: Build, builds: Record<string, Build>, includeToolsets: boolean, root: boolean): TreeNode {
+  const childBuilds = build.dependencies &&
+    build.dependencies.filter(ref => includeToolsets || ref.isProduct)
+      .map(ref => builds[ref.buildId]);
+  return {
+    data: build,
+    children: childBuilds && childBuilds.map(b => toTree(b, builds, includeToolsets, false)),
+    startOpen: root,
+  };
+}
+
+@Component({
+  selector: 'mc-build-graph-tree',
+  templateUrl: './build-graph-tree.component.html',
+  styleUrls: ['./build-graph-tree.component.scss'],
+})
+export class BuildGraphTreeComponent implements OnChanges {
+
+  @Input() public rootId?: number;
+  @Input() public graph?: BuildGraph;
+  @Input() public includeToolsets?: boolean;
+
+  public tree?: TreeNode[];
+
+  constructor() { }
+
+  ngOnChanges() {
+    if (this.graph && this.rootId) {
+      const builds: (Build & {coherent?: boolean;})[] = Object.values(this.graph.builds).sort((l, r) => compareDesc(l.dateProduced, r.dateProduced));
+      const foundRepos: Record<string, Build> = {};
+      for (const build of builds) {
+        const repo = GetRepositoryNamePipe.prototype.transform.call(undefined, build);
+        if (repo)  {
+          if (repo in foundRepos) {
+            build.coherent = foundRepos[repo] === build;
+          } else {
+            foundRepos[repo] = build;
+            build.coherent = true;
+          }
+        }
+      }
+
+      const buildMap: Record<string, Build> = {};
+      for (const build of builds) {
+        buildMap[build.id] = build;
+      }
+
+      const rootBuild = buildMap[this.rootId];
+      this.tree = [toTree(rootBuild, buildMap, !!this.includeToolsets, true)];
+    }
+    else {
+      this.tree = undefined;
+    }
+  }
+
+}

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.html
@@ -93,7 +93,20 @@
           </span>
         </div>
         <ng-container *stateful="let graph from graph$; loadingTemplate: loadingData">
-          <mc-build-graph-table [graph]="graph" [includeToolsets]="includeToolsets"></mc-build-graph-table>
+          <ul class="nav nav-tabs">
+            <li class="nav-item">
+              <a (click)="view = 'graph'" style="cursor: pointer;" class="nav-link" [ngClass]="{active: view == 'graph'}">Graph</a>
+            </li>
+            <li class="nav-item">
+              <a (click)="view = 'tree'" style="cursor: pointer;" class="nav-link" [ngClass]="{active: view == 'tree'}">Tree</a>
+            </li>
+          </ul>
+          <ng-container *ngIf="view == 'graph'">
+            <mc-build-graph-table [graph]="graph" [includeToolsets]="includeToolsets"></mc-build-graph-table>
+          </ng-container>
+          <ng-container *ngIf="view == 'tree'">
+            <mc-build-graph-tree [graph]="graph" [includeToolsets]="includeToolsets" [rootId]="build.id"></mc-build-graph-tree>
+          </ng-container>
         </ng-container>
         <ng-template #loadingData>
           <progress-ring [style]="{ 'width.px': 150, 'height.px': 150 }"></progress-ring>

--- a/src/Maestro/maestro-angular/src/app/pipes/get-repository-name.pipe.spec.ts
+++ b/src/Maestro/maestro-angular/src/app/pipes/get-repository-name.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { GetRepositoryNamePipe } from './get-repository-name.pipe';
+
+describe('GetRepositoryNamePipe', () => {
+  it('create an instance', () => {
+    const pipe = new GetRepositoryNamePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/Maestro/maestro-angular/src/app/pipes/get-repository-name.pipe.ts
+++ b/src/Maestro/maestro-angular/src/app/pipes/get-repository-name.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Build } from 'src/maestro-client/models';
+
+@Pipe({
+  name: 'getRepositoryName'
+})
+export class GetRepositoryNamePipe implements PipeTransform {
+  transform(build: Build): string | undefined {
+    return build.gitHubRepository || build.azureDevOpsRepository;
+  }
+}

--- a/src/Maestro/maestro-angular/src/app/pipes/repo-name.pipe.spec.ts
+++ b/src/Maestro/maestro-angular/src/app/pipes/repo-name.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { RepoNamePipe } from './repo-name.pipe';
+
+describe('RepoNamePipe', () => {
+  it('create an instance', () => {
+    const pipe = new RepoNamePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/Maestro/maestro-angular/src/app/pipes/repo-name.pipe.ts
+++ b/src/Maestro/maestro-angular/src/app/pipes/repo-name.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'repoName'
+})
+export class RepoNamePipe implements PipeTransform {
+
+  transform(repo: string): string | undefined {
+    if (!repo) {
+      return;
+    }
+    if (!repo.includes("github.com")) {
+      return repo.split("/").slice(-1).join("/");
+    }
+    return repo.split("/").slice(-2).join("/");
+  }
+
+}

--- a/src/Maestro/maestro-angular/src/app/util/names.ts
+++ b/src/Maestro/maestro-angular/src/app/util/names.ts
@@ -1,6 +1,0 @@
-export function prettyRepository(repo: string): string {
-  if (!repo.includes("github.com")) {
-    return repo.split("/").slice(-1).join("/");
-  }
-  return repo.split("/").slice(-2).join("/");
-}

--- a/src/Maestro/maestro-angular/src/app/widget/side-bar-channel/side-bar-channel.component.html
+++ b/src/Maestro/maestro-angular/src/app/widget/side-bar-channel/side-bar-channel.component.html
@@ -20,7 +20,7 @@
       <div class="list-group list-group-flush">
         <a class="list-group-item" *ngFor="let branch of branches" [routerLink]="['/', channel.id, branch.repository]"
           routerLinkActive="active">
-          {{trimName(branch.repository)}}
+          {{branch.repository | repoName}}
         </a>
         <div class="list-group-item" *ngIf="!branches.length">
           No repositories avaliable.

--- a/src/Maestro/maestro-angular/src/app/widget/side-bar-channel/side-bar-channel.component.ts
+++ b/src/Maestro/maestro-angular/src/app/widget/side-bar-channel/side-bar-channel.component.ts
@@ -3,7 +3,6 @@ import { NavigationEnd, Router } from "@angular/router";
 import { Observable, SubscriptionLike, of } from "rxjs";
 import { filter, map, switchMap, concat, shareReplay, tap } from "rxjs/operators";
 
-import { prettyRepository } from "../../util/names";
 import { Channel, DefaultChannel } from 'src/maestro-client/models';
 import { ChannelService } from 'src/app/services/channel.service';
 import { statefulSwitchMap, StatefulResult, statefulPipe } from 'src/stateful';
@@ -44,8 +43,6 @@ export class SideBarChannelComponent implements OnInit, OnDestroy {
   public isCollapsed = true;
 
   public branches$!: Observable<StatefulResult<DefaultChannel[]>>;
-
-  public trimName = prettyRepository;
 
   private routeSubscription?: SubscriptionLike;
 

--- a/src/Maestro/maestro-angular/src/tree-view/definitions.ts
+++ b/src/Maestro/maestro-angular/src/tree-view/definitions.ts
@@ -1,0 +1,15 @@
+import { Observable } from "rxjs";
+
+export interface StaticTreeNode {
+  data: any;
+  startOpen?: boolean;
+  children?: TreeNode[];
+}
+
+export interface DynamicTreeNode {
+  data: any;
+  startOpen?: boolean;
+  children$: () => Observable<TreeNode[]>;
+}
+
+export type TreeNode = StaticTreeNode | DynamicTreeNode;

--- a/src/Maestro/maestro-angular/src/tree-view/index.ts
+++ b/src/Maestro/maestro-angular/src/tree-view/index.ts
@@ -1,0 +1,3 @@
+export { TreeViewModule } from "./tree-view.module";
+export { StaticTreeNode, DynamicTreeNode, TreeNode } from "./definitions";
+

--- a/src/Maestro/maestro-angular/src/tree-view/tree-node-list/tree-node-list.component.html
+++ b/src/Maestro/maestro-angular/src/tree-view/tree-node-list/tree-node-list.component.html
@@ -1,0 +1,3 @@
+<div class="list list-group">
+  <tree-node *ngFor="let node of data" [data]="node" [nodeTemplate]="nodeTemplate"></tree-node>
+</div>

--- a/src/Maestro/maestro-angular/src/tree-view/tree-node-list/tree-node-list.component.scss
+++ b/src/Maestro/maestro-angular/src/tree-view/tree-node-list/tree-node-list.component.scss
@@ -1,0 +1,9 @@
+.list {
+  display: block;
+  list-style-type: disc;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+
+  padding-left: 0;
+  margin-bottom: 0;
+}

--- a/src/Maestro/maestro-angular/src/tree-view/tree-node-list/tree-node-list.component.spec.ts
+++ b/src/Maestro/maestro-angular/src/tree-view/tree-node-list/tree-node-list.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TreeNodeListComponent } from './tree-node-list.component';
+
+describe('TreeNodeListComponent', () => {
+  let component: TreeNodeListComponent;
+  let fixture: ComponentFixture<TreeNodeListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TreeNodeListComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TreeNodeListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Maestro/maestro-angular/src/tree-view/tree-node-list/tree-node-list.component.ts
+++ b/src/Maestro/maestro-angular/src/tree-view/tree-node-list/tree-node-list.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input, TemplateRef } from '@angular/core';
+import { TreeNode } from '../definitions';
+
+@Component({
+  selector: 'tree-node-list',
+  templateUrl: './tree-node-list.component.html',
+  styleUrls: ['./tree-node-list.component.scss']
+})
+export class TreeNodeListComponent {
+  @Input() public nodeTemplate?: TemplateRef<any>;
+  @Input() public data?: TreeNode[];
+}

--- a/src/Maestro/maestro-angular/src/tree-view/tree-node/tree-node.component.html
+++ b/src/Maestro/maestro-angular/src/tree-view/tree-node/tree-node.component.html
@@ -1,0 +1,29 @@
+<div class="node list-group-item">
+  <div class="d-flex flex-row">
+    <div>
+      <div class="expander" (click)="open = !open" [style.visibility]="hasChildren ? 'visible' : 'hidden'">
+        <fa-icon [icon]="open ? faAngleDown : faAngleRight" [fixedWidth]="true"></fa-icon>
+      </div>
+    </div>
+    <div class="d-flex flex-column">
+      <div class="data">
+        <ng-container *ngIf="nodeTemplate">
+          <ng-container *ngTemplateOutlet="nodeTemplate; context: {$implicit: data?.data}"></ng-container>
+        </ng-container>
+        <ng-container *ngIf="!nodeTemplate">
+          {{data?.data}}
+        </ng-container>
+      </div>
+      <div class="children" *ngIf="open" @expandCollapse>
+        <ng-container *stateful="let children from children$; loadingTemplate: childrenLoading">
+          <tree-node-list [data]="children" [nodeTemplate]="nodeTemplate"></tree-node-list>
+        </ng-container>
+        <ng-template #childrenLoading>
+          <div style="margin: auto;">
+            <progress-ring width="24" height="24"></progress-ring>
+          </div>
+        </ng-template>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/Maestro/maestro-angular/src/tree-view/tree-node/tree-node.component.scss
+++ b/src/Maestro/maestro-angular/src/tree-view/tree-node/tree-node.component.scss
@@ -1,0 +1,23 @@
+.node {
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+
+  .expander, .data {
+    margin: 0.25rem 0.5rem;
+  }
+
+  .expander {
+    cursor: pointer;
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .data {
+    margin-left: 0;
+  }
+}
+
+.children {
+
+}

--- a/src/Maestro/maestro-angular/src/tree-view/tree-node/tree-node.component.spec.ts
+++ b/src/Maestro/maestro-angular/src/tree-view/tree-node/tree-node.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TreeNodeComponent } from './tree-node.component';
+
+describe('TreeNodeComponent', () => {
+  let component: TreeNodeComponent;
+  let fixture: ComponentFixture<TreeNodeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TreeNodeComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TreeNodeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Maestro/maestro-angular/src/tree-view/tree-node/tree-node.component.ts
+++ b/src/Maestro/maestro-angular/src/tree-view/tree-node/tree-node.component.ts
@@ -1,0 +1,68 @@
+import { Component, OnInit, Input, OnChanges, TemplateRef } from '@angular/core';
+import { TreeNode } from '../definitions';
+import {
+  faAngleDown,
+  faAngleRight,
+} from "@fortawesome/free-solid-svg-icons";
+import { Observable, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { statefulSwitchMap, statefulPipe, StatefulResult } from 'src/stateful';
+import { trigger, transition, style, animate } from '@angular/animations';
+
+@Component({
+  selector: 'tree-node',
+  templateUrl: './tree-node.component.html',
+  styleUrls: ['./tree-node.component.scss'],
+  animations: [
+    trigger("expandCollapse", [
+      transition(":enter", [
+        style({ height: 0 }),
+        animate("400ms ease-out", style({ height: "*" })),
+      ]),
+      transition(":leave", [
+        style({ height: "*" }),
+        animate("400ms ease-in", style({ height: 0 })),
+      ]),
+    ]),
+  ]
+})
+export class TreeNodeComponent implements OnChanges {
+  faAngleDown = faAngleDown;
+  faAngleRight = faAngleRight;
+
+  @Input() public nodeTemplate?: TemplateRef<any>;
+  @Input() public data?: TreeNode;
+
+  public hasChildren: boolean = false;
+  public open: boolean = false;
+  public children$?: Observable<StatefulResult<TreeNode[]>>;
+
+  constructor() { }
+
+  ngOnChanges() {
+    if (this.data) {
+      if ('children' in this.data && this.data.children) {
+        this.open = !!this.data.startOpen;
+        this.hasChildren = this.data.children && !!this.data.children.length;
+        this.children$ = of(this.data.children);
+        return;
+      } else if ('children$' in this.data) {
+        this.open = !!this.data.startOpen;
+        this.hasChildren = true;
+        this.children$ = of(this.data.children$).pipe(
+          statefulSwitchMap(fn => fn()),
+          statefulPipe(
+            tap(c => {
+              this.hasChildren = c && !!c.length;
+            }),
+          ),
+        );
+        return;
+      }
+    }
+    this.hasChildren = false;
+    this.open = false;
+    this.children$ = undefined;
+  }
+
+}

--- a/src/Maestro/maestro-angular/src/tree-view/tree-view.module.ts
+++ b/src/Maestro/maestro-angular/src/tree-view/tree-view.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
+
+import { TreeViewComponent } from './tree-view/tree-view.component';
+import { TreeNodeComponent } from './tree-node/tree-node.component';
+import { TreeNodeListComponent } from './tree-node-list/tree-node-list.component';
+import { StatefulModule } from 'src/stateful';
+
+@NgModule({
+  declarations: [TreeViewComponent, TreeNodeComponent, TreeNodeListComponent],
+  imports: [
+    CommonModule,
+    FontAwesomeModule,
+    StatefulModule,
+  ],
+  exports: [TreeViewComponent, TreeNodeListComponent]
+})
+export class TreeViewModule { }

--- a/src/Maestro/maestro-angular/src/tree-view/tree-view/tree-view.component.html
+++ b/src/Maestro/maestro-angular/src/tree-view/tree-view/tree-view.component.html
@@ -1,0 +1,1 @@
+<tree-node-list [data]="data" [nodeTemplate]="nodeTemplate"></tree-node-list>

--- a/src/Maestro/maestro-angular/src/tree-view/tree-view/tree-view.component.spec.ts
+++ b/src/Maestro/maestro-angular/src/tree-view/tree-view/tree-view.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TreeViewComponent } from './tree-view.component';
+
+describe('TreeViewComponent', () => {
+  let component: TreeViewComponent;
+  let fixture: ComponentFixture<TreeViewComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TreeViewComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TreeViewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Maestro/maestro-angular/src/tree-view/tree-view/tree-view.component.ts
+++ b/src/Maestro/maestro-angular/src/tree-view/tree-view/tree-view.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit, Input, ContentChild, TemplateRef } from '@angular/core';
+import { TreeNode } from '../definitions';
+
+@Component({
+  selector: 'tree-view',
+  templateUrl: './tree-view.component.html',
+  styleUrls: ['./tree-view.component.scss']
+})
+export class TreeViewComponent implements OnInit {
+  @ContentChild(TemplateRef) public nodeTemplate?: TemplateRef<any>;
+  @Input() public data?: TreeNode[];
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}


### PR DESCRIPTION
This change adds a tree view as an option for the build dependency view.

![image](https://user-images.githubusercontent.com/10565410/56168708-cd8cd900-5f90-11e9-8727-ab5f05b85d60.png)
