### PR TITLE
Some scenario test script refactoring

### DIFF
--- a/src/Maestro/tests/Scenarios/azdoflow-nonbatched.ps1
+++ b/src/Maestro/tests/Scenarios/azdoflow-nonbatched.ps1
@@ -39,14 +39,12 @@ try {
 
     $sourceRepoUri = Get-AzDO-RepoUri $sourceRepoName
     $targetRepoUri = Get-AzDO-RepoUri $targetRepoName
-    
+
     Write-Host "Creating a test channel '$testChannelName'"
     Darc-Add-Channel $testChannelName "test"
-    $channelsToDelete += $testChannelName
 
     Write-Host "Adding a subscription from $sourceRepoName to $targetRepoName"
     $subscriptionId = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $sourceRepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch
-    $subscriptionsToDelete += $subscriptionId
 
     Write-Host "Set up build for intake into target repository"
     # Create a build for the source repo
@@ -74,75 +72,29 @@ try {
     # Commit and push
     Git-Command $targetRepoName commit -am `"Add dependencies.`"
     Git-Command $targetRepoName push origin HEAD
-    $azdoBranchesToDelete += @{ branch = $targetBranch; repo = $targetRepoName}
+    $global:azdoBranchesToDelete += @{ branch = $targetBranch; repo = $targetRepoName}
 
     Write-Host "Trigger the dependency update"
     # Trigger the subscription
     Trigger-Subscription $subscriptionId
 
+    $expectedDependencies =@(
+        "Name:    Foo"
+        "Version: 1.1.0",
+        "Repo:    $sourceRepoUri",
+        "Commit:  $sourceCommit",
+        "Type:    Product",
+        "",
+        "Name:    Bar",
+        "Version: 2.1.0",
+        "Repo:    $sourceRepoUri",
+        "Commit:  $sourceCommit",
+        "Type:    Product",
+        ""
+    )
+
     Write-Host "Waiting on PR to be opened in $targetRepoUri"
-    # Check that the PR was created properly. poll azdo 
-    $tries = 10
-    $success = $false
-    while ($tries-- -gt 0) {
-        Write-Host "Checking for PRs, ${tries} tries remaining"
-        $pullRequests = Get-AzDO-PullRequests $targetRepoName $targetBranch
-        if ($pullRequests.count -gt 0) {
-            # Find and verify PR info
-            if ($pullRequests.count -ne 1) {
-                throw "Unexpected number of pull requests open $($pullRequests.count)."
-            }
-            $pullRequest = $pullRequests.value[0]
-            $pullRequestBaseBranch = $pullRequest.sourceRefName.Replace('refs/heads/','')
-            $azdoBranchesToDelete += @{ branch = $pullRequestBaseBranch; repo = $targetRepoName}
-            $azdoPRsToClose += @{ number = $pullRequest.pullRequestId; repo = $targetRepoName }
-
-            $expectedPRTitle = "[$targetBranch] Update dependencies from $azdoAccount/$azdoProject/$sourceRepoName"
-            if ($pullRequest.title -ne $expectedPRTitle) {
-                throw "Expected PR title to be $expectedPRTitle, was $($pullrequest.title)"
-            }
-            
-            # Check out the merge commit sha, then use darc to get and verify the
-            # dependencies
-            Git-Command $targetRepoName fetch
-            Git-Command $targetRepoName checkout $pullRequestBaseBranch
-
-            try {
-                Push-Location -Path $(Get-Repo-Location $targetRepoName)
-                $dependencies = Darc-Command get-dependencies
-                $expectedDependencies =@(
-                    "Name:    Foo"
-                    "Version: 1.1.0",
-                    "Repo:    $sourceRepoUri",
-                    "Commit:  $sourceCommit",
-                    "Type:    Product",
-                    "",
-                    "Name:    Bar",
-                    "Version: 2.1.0",
-                    "Repo:    $sourceRepoUri",
-                    "Commit:  $sourceCommit",
-                    "Type:    Product",
-                    ""
-                )
-                if ($dependencies.Count -ne $expectedDependencies.Count) {
-                    Write-Error "Expected $($expectedDependencies.Count) dependencies, Actual $($dependencies.Count) dependencies."
-                    throw "PR did not have expected dependency updates."
-                }
-                for ($i = 0; $i -lt $expectedDependencies.Count; $i++) {
-                    if ($dependencies[$i] -notmatch $expectedDependencies[$i]) {
-                        Write-Error "Dependencies Line $i not matched`nExpected $($expectedDependencies[$i])`nActual $($dependencies[$i])"
-                        throw "PR did not have expected dependency updates."
-                    }
-                }
-            } finally {
-                Pop-Location
-            }
-
-            $success = $true
-            break
-        }
-        Start-Sleep 60
-    }
+    $success = Check-AzDO-PullRequest $targetRepoName $targetBranch $expectedDependencies
 
     if (!$success) {
         throw "Pull request failed to open."

--- a/src/Maestro/tests/Scenarios/channels.ps1
+++ b/src/Maestro/tests/Scenarios/channels.ps1
@@ -22,7 +22,7 @@ try {
     
     # Add a new channel
     Write-Host "Creating channel '$newChannelName'"
-    Darc-Command add-channel --name `'$newChannelName`' --classification 'test'
+    Darc-Add-Channel $newChannelName 'test'
 
     # Get the channel and make sure it's there
     Write-Host "Checking that '$newChannelName' exists"
@@ -38,7 +38,7 @@ try {
 
     # Get the channel and make sure it's no longer there
     $channels = Darc-Command get-channels
-    if ($channels.Contains($newChannelName)) {
+    if ($channels -and $channels.Contains($newChannelName)) {
         throw "Cannot delete '$newChannelName' after creating it"
     }
 

--- a/src/Maestro/tests/Scenarios/default-channels.ps1
+++ b/src/Maestro/tests/Scenarios/default-channels.ps1
@@ -42,8 +42,6 @@ try {
     try { Darc-Delete-Channel $testChannel2Name } catch {}
     Darc-Add-Channel $testChannel1Name "test"
     Darc-Add-Channel $testChannel2Name "test"
-    $channelsToDelete += $testChannel1Name
-    $channelsToDelete += $testChannel2Name
 
     # Adding default channels'
     Write-Host "Creating default channels"
@@ -51,14 +49,12 @@ try {
     try { Darc-Delete-Default-Channel $testChannel2Name $repoUri $branchName } catch {}
     Darc-Add-Default-Channel $testChannel1Name $repoUri $branchName
     Darc-Add-Default-Channel $testChannel2Name $repoUri $branchName
-    $defaultChannelsToDelete += @{ channel = $testChannel1Name; repo = $repoUri; branch = $branchName }
-    $defaultChannelsToDelete += @{ channel = $testChannel2Name; repo = $repoUri; branch = $branchName }
 
     Write-Host "Set up build for intake into target repository"
     
     # Create a build for the source repo
     $buildId = New-Build -repository $repoUri -branch $branchName -commit $commit -buildNumber $buildNumber -assets $assets
-    
+
     # Look up the build and ensure that the channels were added
 
     $buildInfo = Get-Build $buildId

--- a/src/Maestro/tests/Scenarios/githubflow-nonbatched.ps1
+++ b/src/Maestro/tests/Scenarios/githubflow-nonbatched.ps1
@@ -44,11 +44,9 @@ try {
     Write-Host "Creating a test channel '$testChannelName'"
     try { Darc-Command delete-channel --name `'$testChannelName`' } catch {}
     Darc-Add-Channel $testChannelName "test"
-    $channelsToDelete += $testChannelName
 
     Write-Host "Adding a subscription from $sourceRepoName to $targetRepoName"
     $subscriptionId = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $sourceRepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch
-    $subscriptionsToDelete += $subscriptionId
 
     Write-Host "Set up build for intake into target repository"
     # Create a build for the source repo
@@ -76,77 +74,29 @@ try {
     # Commit and push
     Git-Command $targetRepoName commit -am `"Add dependencies.`"
     Git-Command $targetRepoName push origin HEAD
-    $githubBranchesToDelete += @{ branch = $targetBranch; repo = $targetRepoName}
+    $global:githubBranchesToDelete += @{ branch = $targetBranch; repo = $targetRepoName}
 
     Write-Host "Trigger the dependency update"
     # Trigger the subscription
     Trigger-Subscription $subscriptionId
 
     Write-Host "Waiting on PR to be opened in $targetRepoUri"
-    # Check that the PR was created properly. poll github 
-    $tries = 10
-    $success = $false
-    while ($tries-- -gt 0) {
-        Write-Host "Checking for PRs, ${tries} tries remaining"
-        $pullRequest = Get-GitHub-PullRequests $targetRepoName $targetBranch
-        if ($pullRequest) {
-            # Find and verify PR info
-            if ($pullRequest.Count -ne 1) {
-                throw "Unexpected number of pull requests opened."
-            }
-            $pullRequest = $pullRequest[0]
 
-            $pullRequestBaseBranch = $pullRequest.head.ref
-            $githubBranchesToDelete += @{ branch = $pullRequestBaseBranch; repo = $targetRepoName}
-            $gitHubPRsToClose += @{ number = $pullRequest.number; repo = $targetRepoName }
-
-            $expectedPRTitle = "[$targetBranch] Update dependencies from $githubTestOrg/$sourceRepoName"
-            if ($pullRequest.title -ne $expectedPRTitle) {
-                throw "Expected PR title to be $expectedPRTitle, was $($pullRequest.title)"
-            }
-            
-            # Check out the merge commit sha, then use darc to get and verify the
-            # dependencies
-            Git-Command $targetRepoName fetch
-            Git-Command $targetRepoName checkout $pullRequestBaseBranch
-
-            try {
-                Push-Location -Path $(Get-Repo-Location $targetRepoName)
-                $dependencies = Darc-Command get-dependencies
-                $expectedDependencies =@(
-                    "Name:    Foo"
-                    "Version: 1.1.0",
-                    "Repo:    $sourceRepoUri",
-                    "Commit:  $sourceCommit",
-                    "Type:    Product",
-                    "",
-                    "Name:    Bar",
-                    "Version: 2.1.0",
-                    "Repo:    $sourceRepoUri",
-                    "Commit:  $sourceCommit",
-                    "Type:    Product",
-                    ""
-                )
-
-                if ($dependencies.Count -ne $expectedDependencies.Count) {
-                    Write-Error "Expected $($expectedDependencies.Count) dependencies, Actual $($dependencies.Count) dependencies."
-                    throw "PR did not have expected dependency updates."
-                }
-                for ($i = 0; $i -lt $expectedDependencies.Count; $i++) {
-                    if ($dependencies[$i] -notmatch $expectedDependencies[$i]) {
-                        Write-Error "Dependencies Line $i not matched`nExpected $($expectedDependencies[$i])`nActual $($dependencies[$i])"
-                        throw "PR did not have expected dependency updates."
-                    }
-                }
-            } finally {
-                Pop-Location
-            }
-
-            $success = $true
-            break
-        }
-        Start-Sleep 60
-    }
+    $expectedDependencies =@(
+        "Name:    Foo"
+        "Version: 1.1.0",
+        "Repo:    $sourceRepoUri",
+        "Commit:  $sourceCommit",
+        "Type:    Product",
+        "",
+        "Name:    Bar",
+        "Version: 2.1.0",
+        "Repo:    $sourceRepoUri",
+        "Commit:  $sourceCommit",
+        "Type:    Product",
+        ""
+    )
+    $success = Check-Github-PullRequest $targetRepoName $targetBranch $expectedDependencies
 
     if (!$success) {
         throw "Pull request failed to open."

--- a/src/Maestro/tests/Scenarios/githubflow-release-pipeline-nonbatched.ps1
+++ b/src/Maestro/tests/Scenarios/githubflow-release-pipeline-nonbatched.ps1
@@ -45,17 +45,14 @@ try {
     Write-Host "Creating test channel"
     try { Darc-Delete-Channel $testChannelName } catch {}
     Darc-Add-Channel $testChannelName "test"
-    $channelsToDelete += $testChannelName
 
     Write-Host "Creating test pipeline"
     $pipelineId = Create-Pipeline $testReleasePipelineId
-    $pipelinesToDelete += $pipelineId
     Write-Host "Created Pipeline $pipelineId"
 
     Write-Host "Adding test release pipeline mapping to test channel"
     Add-Pipeline-To-Channel $testChannelName $pipelineId
     Write-Host "Associated test release pipeline $pipelineId to test channel"
-    $channelPipelinesToDelete[$testChannelName] += $pipelineId
 
     Write-Host "Creating default channel"
     try { Darc-Delete-Default-Channel $testChannelName $sourceRepoUri $sourceBranch } catch {}


### PR DESCRIPTION
First stab at https://github.com/dotnet/arcade/issues/2484

* Test scripts now mostly don't have to worry about managing which resources to delete.
* Fix azure devops api version
* Move PR checks for AzDO and Github to their own functions, so future test scripts can just call that instead of duplicating the code.