### PR TITLE
Use evaluations API for Azure DevOps auto merge

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/AzureDevOps/AzureDevOpsCheckState.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/AzureDevOps/AzureDevOpsCheckState.cs
@@ -7,11 +7,10 @@ namespace Microsoft.DotNet.DarcLib
     public enum AzureDevOpsCheckState
     {
         None,
-        Pending,
-        Error,
-        Failed,
-        Succeeded,
-        NotApplicable,
-        NotSet
+        Queued,
+        Broken,
+        Rejected,
+        Approved,
+        Running
     }
 }


### PR DESCRIPTION
fixes https://github.com/dotnet/arcade/issues/1715

Validated this with these Test prs:

* https://dev.azure.com/dnceng/internal/_git/maestro-test2/pullrequest/983?_a=overview (policy bypassed because "Not all comments resolved" policy was set to be ignored by the subscription)
* https://dev.azure.com/dnceng/internal/_git/maestro-test2/pullrequest/984?_a=overview (policy not bypassed, all required policies were successful)
* https://dev.azure.com/dnceng/internal/_git/maestro-test2/pullrequest/968?_a=overview (Policy not bypassed, the work items linked policy was ignored, and is not required)
* https://dev.azure.com/dnceng/internal/_git/maestro-test2/pullrequest/960?_a=overview (PR was not auto merged due to no checks)
* https://dev.azure.com/dnceng/internal/_git/maestro-test2/pullrequest/986?_a=overview (PR was not merged, pending checks)

Still working on e2e tests for this. Sending this early since there is desire to have this in for P5 snap on 4/22, and I'm comfortable with the manual validation I've done so far. Will finish up the e2e tests for this scenario as a followup if I don't get to finish them by tomorrow, as our deployment window is limited to tomorrow 4/18.
