### PR TITLE
Change the page title and name based on route navigation

### DIFF
--- a/src/Maestro/maestro-angular/src/app/app-routing.module.ts
+++ b/src/Maestro/maestro-angular/src/app/app-routing.module.ts
@@ -3,11 +3,19 @@ import { RouterModule, Routes } from "@angular/router";
 
 import { MainComponent } from "./page/main/main.component";
 import { BuildComponent } from "src/app/page/build/build.component";
+import { ChannelResolverService } from './resolvers/channel-resolver.service';
+import { BuildResolverService } from './resolvers/build-resolver.service';
+import { toTitleCase } from 'src/helpers';
+import { RepoNamePipe } from './pipes/repo-name.pipe';
 
 const routes: Routes = [
   {
     path: "",
     component: MainComponent,
+    data: {
+      title: "Index",
+      name: "Index",
+    },
   },
   {
     path: ":channelId/:repository",
@@ -22,6 +30,22 @@ const routes: Routes = [
   {
     path: ":channelId/:repository/:buildId/:tabName",
     component: BuildComponent,
+    data: {
+      title(params: any, data: any) {
+        const repo = RepoNamePipe.prototype.transform(params.repository);
+        if (data.build === "latest") {
+          return `Latest Build of ${repo} in ${data.channel.name} - ${toTitleCase(params.tabName)}`;
+        }
+        return `Build ${data.build.azureDevOpsBuildNumber} of ${repo} in ${data.channel.name} - ${toTitleCase(params.tabName)}`;
+      },
+      name(params: any) {
+        return `Build - ${toTitleCase(params.tabName)}`;
+      },
+    },
+    resolve: {
+      channel: ChannelResolverService,
+      build: BuildResolverService,
+    },
   },
 ];
 

--- a/src/Maestro/maestro-angular/src/app/app.module.ts
+++ b/src/Maestro/maestro-angular/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, APP_INITIALIZER } from "@angular/core";
+import { NgModule, APP_INITIALIZER, Injector, Type } from "@angular/core";
 import { BrowserModule } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { FormsModule } from '@angular/forms';
@@ -51,6 +51,20 @@ import { RepoNamePipe } from './pipes/repo-name.pipe';
 import { GetRepositoryNamePipe } from './pipes/get-repository-name.pipe';
 import { AssetTableComponent } from './page/asset-table/asset-table.component';
 import { ApplicationInsightsService } from './services/application-insights.service';
+import { RouterEventHandlerService } from './services/router-event-handler.service';
+
+export function initializer(type: Type<{start: () => any}>) {
+  return {
+    provide: APP_INITIALIZER,
+    useFactory(injector: Injector) {
+      return () => {
+        return injector.get(type).start();
+      };
+    },
+    deps: [Injector],
+    multi: true,
+  };
+}
 
 @NgModule({
   declarations: [
@@ -85,12 +99,8 @@ import { ApplicationInsightsService } from './services/application-insights.serv
     NgxPaginationModule,
   ],
   providers: [
-    {
-      provide: APP_INITIALIZER, // register an APP_INITIALIZER that resolves the application insights service
-      useFactory: () => () => {},
-      deps: [ApplicationInsightsService],
-      multi: true,
-    }
+    initializer(ApplicationInsightsService),
+    initializer(RouterEventHandlerService),
   ],
   bootstrap: [AppComponent],
 })

--- a/src/Maestro/maestro-angular/src/app/resolvers/build-resolver.service.spec.ts
+++ b/src/Maestro/maestro-angular/src/app/resolvers/build-resolver.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { BuildResolverService } from './build-resolver.service';
+
+describe('BuildResolverService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: BuildResolverService = TestBed.get(BuildResolverService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/Maestro/maestro-angular/src/app/resolvers/build-resolver.service.ts
+++ b/src/Maestro/maestro-angular/src/app/resolvers/build-resolver.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { Build } from 'src/maestro-client/models';
+import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { BuildService } from '../services/build.service';
+import { switchMap } from 'rxjs/operators';
+import { StatefulResult } from 'src/stateful';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BuildResolverService implements Resolve<StatefulResult<Build> | "latest" | undefined> {
+
+  constructor(private buildService: BuildService) { }
+
+  resolve(route: ActivatedRouteSnapshot): Observable<StatefulResult<Build> | "latest" | undefined> {
+    const buildId = route.paramMap.get("buildId");
+    const channelId = route.paramMap.get("channelId");
+    const repository = route.paramMap.get("repository");
+
+    if(buildId && channelId && repository) {
+      if (buildId === "latest") {
+        return of("latest");
+      }
+
+      return of(buildId).pipe(
+        switchMap(id => this.buildService.getBuild(+id)),
+      );
+    }
+
+    return of(undefined);
+  }
+}

--- a/src/Maestro/maestro-angular/src/app/resolvers/channel-resolver.service.spec.ts
+++ b/src/Maestro/maestro-angular/src/app/resolvers/channel-resolver.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ChannelResolverService } from './channel-resolver.service';
+
+describe('ChannelResolverService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: ChannelResolverService = TestBed.get(ChannelResolverService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/Maestro/maestro-angular/src/app/resolvers/channel-resolver.service.ts
+++ b/src/Maestro/maestro-angular/src/app/resolvers/channel-resolver.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { Channel } from 'src/maestro-client/models';
+import { Observable, of } from 'rxjs';
+import { ChannelService } from '../services/channel.service';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ChannelResolverService implements Resolve<Channel | undefined> {
+  constructor(private channelService: ChannelService) { }
+
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Channel | undefined> {
+    const channelId = route.paramMap.get("channelId");
+    if (channelId) {
+      console.log(`resolving channel ${channelId}`);
+      return this.channelService.getChannels().pipe(
+        map(channels => channels.find(c => c.id === +channelId)),
+      );
+    }
+    return of(undefined);
+  }
+}

--- a/src/Maestro/maestro-angular/src/app/services/application-insights.service.ts
+++ b/src/Maestro/maestro-angular/src/app/services/application-insights.service.ts
@@ -14,29 +14,9 @@ export class ApplicationInsightsService extends ApplicationInsights {
       },
     });
     this.loadAppInsights();
-
-
-    this.router.events.subscribe(this.handleRouteChange.bind(this));
   }
 
-  getRouteProperties() {
-    const params: Record<string, string> = {};
-    let node: ActivatedRouteSnapshot | null = this.router.routerState.snapshot.root;
-    while (node) {
-      for (const k of Object.keys(node.params)) {
-        params["route-" + k] = node.params[k];
-      }
-      node = node.firstChild;
-    }
-    return params;
-  }
-
-  handleRouteChange(event: Event) {
-    if (event instanceof NavigationEnd) {
-      this.trackPageView({
-        uri: event.urlAfterRedirects,
-        properties: this.getRouteProperties(),
-      });
-    }
+  public start() {
+    // nothing needed
   }
 }

--- a/src/Maestro/maestro-angular/src/app/services/router-event-handler.service.spec.ts
+++ b/src/Maestro/maestro-angular/src/app/services/router-event-handler.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { RouterEventHandlerService } from './router-event-handler.service';
+
+describe('RouterEventHandlerService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: RouterEventHandlerService = TestBed.get(RouterEventHandlerService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/Maestro/maestro-angular/src/app/services/router-event-handler.service.ts
+++ b/src/Maestro/maestro-angular/src/app/services/router-event-handler.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@angular/core';
+import { Router, Event, NavigationEnd, ActivatedRouteSnapshot } from '@angular/router';
+import { Title } from '@angular/platform-browser';
+import { ApplicationInsightsService } from './application-insights.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RouterEventHandlerService {
+
+  constructor(private router: Router, private ai: ApplicationInsightsService, private title: Title) { }
+
+  public start() {
+    this.router.events.subscribe(this.handleRouterEvent.bind(this));
+  }
+
+  getRouteData() {
+    const params: Record<string, string> = {};
+    const data: Record<string, any> = {};
+    let node: ActivatedRouteSnapshot | null = this.router.routerState.snapshot.root;
+    while (node) {
+      for (const k of Object.keys(node.params)) {
+        params[k] = node.params[k];
+      }
+      for (const k of Object.keys(node.data)) {
+        data[k] = node.data[k];
+      }
+      node = node.firstChild;
+    }
+    return {params, data};
+  }
+
+  formatTitle({params, data}: ReturnType<typeof RouterEventHandlerService.prototype.getRouteData>): string {
+    if (data.title) {
+      if (typeof data.title === "string") {
+        return data.title;
+      }
+      return data.title(params, data);
+    }
+    return "Nowhere";
+  }
+
+  formatName({params, data}: ReturnType<typeof RouterEventHandlerService.prototype.getRouteData>): string {
+    if (data.name) {
+      if (typeof data.name === "string") {
+        return data.name;
+      }
+      return data.name(params, data);
+    }
+    return "Unknown";
+  }
+
+  handleRouterEvent(event: Event) {
+    if(event instanceof NavigationEnd) {
+      const routeData = this.getRouteData();
+      const properties: Record<string, string> = {};
+      for (const k of Object.keys(routeData.params)) {
+        properties["route-" + k] = routeData.params[k];
+      }
+
+      this.title.setTitle(this.formatTitle(routeData) + " - Maestro++");
+      this.ai.trackPageView({
+        uri: event.urlAfterRedirects,
+        properties: properties,
+        name: this.formatName(routeData),
+      });
+    }
+  }
+}

--- a/src/Maestro/maestro-angular/src/helpers.ts
+++ b/src/Maestro/maestro-angular/src/helpers.ts
@@ -87,3 +87,7 @@ export function onThe(time: "minute" | "hour" | "day") {
 export function tapLog<T>(message: string) {
   return tap<T>(v => console.log(message, v));
 }
+
+export function toTitleCase(value: string): string {
+  return value.slice(0, 1).toUpperCase() + value.slice(1);
+}


### PR DESCRIPTION
This change adds support for updating the page title and the name reported to application insights for every route navigation.