### PR TITLE
Finding incoherencies based on build ID rather than build number

### DIFF
--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
@@ -51,17 +51,6 @@ function getRepo(build: Build) {
   return build.gitHubRepository || build.azureDevOpsRepository;
 }
 
-function buildNumber(b : Build): number | string {
-  let result: number | string = 0;
-  if (b.azureDevOpsBuildNumber) {
-    result = +b.azureDevOpsBuildNumber;
-    if (isNaN(result)) {
-      result = b.azureDevOpsBuildNumber;
-    }
-  }
-  return result;
-}
-
 function isToolset(build: Build, graph: BuildGraph) {
   // A build is a "toolset" if it has at least one dependency pointing to it,
   // and all dependencies pointing to it are toolset dependencies
@@ -93,8 +82,8 @@ function sortBuilds(graph: BuildGraph): BuildData[] {
   let result = sortedBuilds.map<BuildData>(build => {
       const sameRepo = sortedBuilds.filter(b => getRepo(b) === getRepo(build));
       const sameRepoProducts = sameRepo.filter(b => !isToolset(b, graph));
-      const coherentWithAll = sameRepo.every(b => buildNumber(b) <= buildNumber(build));
-      const coherentWithProducts = sameRepoProducts.every(b => buildNumber(b) <= buildNumber(build));
+      const coherentWithAll = sameRepo.every(b => b.id <= build.id);
+      const coherentWithProducts = sameRepoProducts.every(b => b.id <= build.id);
       return {
         build: build,
         coherent: {


### PR DESCRIPTION
Since we were trying to find incoherencies based on AzDO version numbers, we were running into issues when the values would be compared numerically. For example: 
20190422.23 version number IS larger than 20190422.5, but not when compared numerically (nearly a quarter is smaller than a half). So, we need to compare the values on build ID, which is inserted into the database in order, so we should not run into issues there. 