### PR TITLE
Fix scenario tests break and add darcPackageSource parameter

### DIFF
--- a/src/Maestro/tests/Scenarios/all.ps1
+++ b/src/Maestro/tests/Scenarios/all.ps1
@@ -3,7 +3,8 @@ param(
     [string]$darcVersion,
     [string]$maestroBearerToken,
     [string]$githubPAT,
-    [string]$azdoPAT
+    [string]$azdoPAT,
+    [string]$darcPackageSource
 )
 
 $testScripts = (

--- a/src/Maestro/tests/Scenarios/azdoflow-nonbatched.ps1
+++ b/src/Maestro/tests/Scenarios/azdoflow-nonbatched.ps1
@@ -79,17 +79,19 @@ try {
     Trigger-Subscription $subscriptionId
 
     $expectedDependencies =@(
-        "Name:    Foo"
-        "Version: 1.1.0",
-        "Repo:    $sourceRepoUri",
-        "Commit:  $sourceCommit",
-        "Type:    Product",
+        "Name:             Foo"
+        "Version:          1.1.0",
+        "Repo:             $sourceRepoUri",
+        "Commit:           $sourceCommit",
+        "Type:             Product",
+        "Pinned:           False",
         "",
-        "Name:    Bar",
-        "Version: 2.1.0",
-        "Repo:    $sourceRepoUri",
-        "Commit:  $sourceCommit",
-        "Type:    Product",
+        "Name:             Bar",
+        "Version:          2.1.0",
+        "Repo:             $sourceRepoUri",
+        "Commit:           $sourceCommit",
+        "Type:             Product",
+        "Pinned:           False",
         ""
     )
 

--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -9,7 +9,7 @@
 [string]$azdoAccount = if (-not $azdoAccount) { "dnceng" } else { $azdoAccount }
 [string]$azdoProject = if (-not $azdoProject) { "internal" } else { $azdoProject }
 [string]$azdoApiVersion = if (-not $azdoApiVersion) { "5.0-preview.1" } else { $azdoApiVersion }
-[string]$darcPackageSource = ""
+[string]$darcPackageSource = if (-not $darcPackageSource) {""} else { $darcPackageSource } 
 [string]$barApiVersion = "2019-01-16"
 $global:gitHubPRsToClose = @()
 $global:githubBranchesToDelete = @()

--- a/src/Maestro/tests/Scenarios/githubflow-nonbatched-with-coherency.ps1
+++ b/src/Maestro/tests/Scenarios/githubflow-nonbatched-with-coherency.ps1
@@ -106,23 +106,27 @@ try {
     Trigger-Subscription $subscriptionId
 
     $expectedDependencies =@(
-        "Name:    Foo"
-        "Version: 1.1.0",
-        "Repo:    $parentSourceRepoUri",
-        "Commit:  $parentSourceCommit",
-        "Type:    Product",
+        "Name:             Foo"
+        "Version:          1.1.0",
+        "Repo:             $parentSourceRepoUri",
+        "Commit:           $parentSourceCommit",
+        "Type:             Product",
+        "Pinned:           False",
         "",
-        "Name:    Bar",
-        "Version: 2.1.0",
-        "Repo:    $parentSourceRepoUri",
-        "Commit:  $parentSourceCommit",
-        "Type:    Product",
+        "Name:             Bar",
+        "Version:          2.1.0",
+        "Repo:             $parentSourceRepoUri",
+        "Commit:           $parentSourceCommit",
+        "Type:             Product",
+        "Pinned:           False",
         "",
-        "Name:    Baz",
-        "Version: 1.3.0",
-        "Repo:    $childSourceRepoUri",
-        "Commit:  $childSourceCommit",
-        "Type:    Product",
+        "Name:             Baz",
+        "Version:          1.3.0",
+        "Repo:             $childSourceRepoUri",
+        "Commit:           $childSourceCommit",
+        "Type:             Product",
+        "Pinned:           False",
+        "Coherent Parent:  Foo"
         ""
     )
 

--- a/src/Maestro/tests/Scenarios/githubflow-nonbatched.ps1
+++ b/src/Maestro/tests/Scenarios/githubflow-nonbatched.ps1
@@ -83,19 +83,22 @@ try {
     Write-Host "Waiting on PR to be opened in $targetRepoUri"
 
     $expectedDependencies =@(
-        "Name:    Foo"
-        "Version: 1.1.0",
-        "Repo:    $sourceRepoUri",
-        "Commit:  $sourceCommit",
-        "Type:    Product",
+        "Name:             Foo"
+        "Version:          1.1.0",
+        "Repo:             $sourceRepoUri",
+        "Commit:           $sourceCommit",
+        "Type:             Product",
+        "Pinned:           False",
         "",
-        "Name:    Bar",
-        "Version: 2.1.0",
-        "Repo:    $sourceRepoUri",
-        "Commit:  $sourceCommit",
-        "Type:    Product",
+        "Name:             Bar",
+        "Version:          2.1.0",
+        "Repo:             $sourceRepoUri",
+        "Commit:           $sourceCommit",
+        "Type:             Product",
+        "Pinned:           False",
         ""
     )
+
     $success = Check-Github-PullRequest $sourceRepoName $targetRepoName $targetBranch $expectedDependencies
 
     if (!$success) {

--- a/src/Maestro/tests/Scenarios/githubflow-release-pipeline-nonbatched.ps1
+++ b/src/Maestro/tests/Scenarios/githubflow-release-pipeline-nonbatched.ps1
@@ -117,17 +117,19 @@ try {
     }
 
     $expectedDependencies =@(
-    "Name:    Foo"
-    "Version: 1.1.0",
-    "Repo:    $sourceRepoUri",
-    "Commit:  $sourceCommit",
-    "Type:    Product",
+    "Name:             Foo"
+    "Version:          1.1.0",
+    "Repo:             $sourceRepoUri",
+    "Commit:           $sourceCommit",
+    "Type:             Product",
+    "Pinned:           False"
     "",
-    "Name:    Bar",
-    "Version: 2.1.0",
-    "Repo:    $sourceRepoUri",
-    "Commit:  $sourceCommit",
-    "Type:    Product",
+    "Name:             Bar",
+    "Version:          2.1.0",
+    "Repo:             $sourceRepoUri",
+    "Commit:           $sourceCommit",
+    "Type:             Product",
+    "Pinned:           False"
     ""
     )
 


### PR DESCRIPTION
As of https://github.com/dotnet/arcade-services/pull/374 the format returned by `darc get-dependencies` changed, and that broke the assertions in the scenario tests.

Also adding an optional parameter that will be passed during deployments to add a local source for Darc installation so that we can install the correct Darc version without having to wait for it to be published in the feeds.