### PR TITLE
Enable batchable subscriptions in add-subscription

### DIFF
--- a/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
+++ b/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
@@ -40,7 +40,8 @@ namespace SubscriptionActorService
             throw new NotImplementedException();
         }
 
-        public Task<Subscription> CreateSubscriptionAsync(string channelName, string sourceRepo, string targetRepo, string targetBranch, string updateFrequency, List<MergePolicy> mergePolicies)
+        public Task<Subscription> CreateSubscriptionAsync(string channelName, string sourceRepo, string targetRepo, string targetBranch,
+            string updateFrequency, bool batchable, List<MergePolicy> mergePolicies)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/AddSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/AddSubscriptionPopUp.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
         public string TargetBranch => _yamlData.TargetBranch;
         public string UpdateFrequency => _yamlData.UpdateFrequency;
         public List<MergePolicy> MergePolicies => _yamlData.GetMergePolicies();
+        public bool Batchable => _yamlData.Batchable;
 
         public AddSubscriptionPopUp(string path,
                                     ILogger logger,
@@ -32,6 +33,7 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
                                     string targetRepository,
                                     string targetBranch,
                                     string updateFrequency,
+                                    bool batchable,
                                     List<MergePolicy> mergePolicies,
                                     IEnumerable<string> suggestedChannels,
                                     IEnumerable<string> suggestedRepositories,
@@ -47,6 +49,7 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
                 TargetRepository = GetCurrentSettingForDisplay(targetRepository, "<required>", false),
                 TargetBranch = GetCurrentSettingForDisplay(targetBranch, "<required>", false),
                 UpdateFrequency = GetCurrentSettingForDisplay(updateFrequency, $"<'{string.Join("', '", Constants.AvailableFrequencies)}'>", false),
+                Batchable = batchable
             };
             _yamlData.SetMergePolicies(mergePolicies);
 
@@ -60,7 +63,8 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
                 new Line("Use this form to create a new subscription.", true),
                 new Line("A subscription maps a build of a source repository that has been applied to a specific channel", true),
                 new Line("onto a specific branch in a target repository.  The subscription has a trigger (update frequency)", true),
-                new Line("and merge policy.  For additional information about subscriptions, please see", true),
+                new Line("and merge policy. If a subscription is batchable, no merge policy should be provided.", true),
+                new Line("For additional information about subscriptions, please see", true),
                 new Line("https://github.com/dotnet/arcade/blob/master/Documentation/BranchesChannelsAndSubscriptions.md", true),
                 new Line("", true),
                 new Line("Fill out the following form.  Suggested values for fields are shown below.", true),
@@ -145,6 +149,8 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
                 return Constants.ErrorCode;
             }
 
+            _yamlData.Batchable = outputYamlData.Batchable;
+
             _yamlData.UpdateFrequency = ParseSetting(outputYamlData.UpdateFrequency, _yamlData.UpdateFrequency, false);
             if (string.IsNullOrEmpty(_yamlData.UpdateFrequency) || 
                 !Constants.AvailableFrequencies.Contains(_yamlData.UpdateFrequency, StringComparer.OrdinalIgnoreCase))
@@ -169,17 +175,26 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
             public const string targetBranchElement = "Target Branch";
             public const string updateFrequencyElement = "Update Frequency";
             public const string mergePolicyElement = "Merge Policies";
+            public const string batchableElement = "Batchable";
 
             [YamlMember(Alias = channelElement, ApplyNamingConventions = false)]
             public string Channel { get; set; }
+
             [YamlMember(Alias = sourceRepoElement, ApplyNamingConventions = false)]
             public string SourceRepository { get; set; }
+
             [YamlMember(Alias = targetRepoElement, ApplyNamingConventions = false)]
             public string TargetRepository { get; set; }
+
             [YamlMember(Alias = targetBranchElement, ApplyNamingConventions = false)]
             public string TargetBranch { get; set; }
+
             [YamlMember(Alias = updateFrequencyElement, ApplyNamingConventions = false)]
             public string UpdateFrequency { get; set; }
+
+            [YamlMember(Alias = batchableElement, ApplyNamingConventions = false)]
+            public bool Batchable { get; set; }
+
             [YamlMember(Alias = mergePolicyElement, ApplyNamingConventions = false)]
             public List<MergePolicyData> MergePolicies { get; set; }
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetSubscriptionsOperation.cs
@@ -59,10 +59,10 @@ namespace Microsoft.DotNet.Darc.Operations
                     {
                         mergePolicies = await remote.GetRepositoryMergePoliciesAsync(subscription.TargetRepository, subscription.TargetBranch);
                     }
-                    if (subscription.Policy.MergePolicies.Any())
+                    if (mergePolicies.Any())
                     {
                         Console.WriteLine($"  - Merge Policies:");
-                        foreach (var mergePolicy in subscription.Policy.MergePolicies)
+                        foreach (MergePolicy mergePolicy in mergePolicies)
                         {
                             Console.WriteLine($"    {mergePolicy.Name}");
                             if (mergePolicy.Properties != null)

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddSubscriptionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddSubscriptionCommandLineOptions.cs
@@ -26,6 +26,9 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("update-frequency", HelpText = "Frequency of updates. Valid values are: 'none', 'everyDay', or 'everyBuild'.")]
         public string UpdateFrequency { get; set; }
 
+        [Option("batchable", HelpText = "Make subscription batchable.")]
+        public bool Batchable { get; set; }
+
         [Option("all-checks-passed", HelpText = "PR is automatically merged if there is at least one checks and all are passed. " +
             "Optionally provide a comma separated list of ignored check with --ignore-checks.")]
         public bool AllChecksSuccessfulMergePolicy { get; set; }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -174,6 +174,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="targetRepo">URL of target repository where updates should be made</param>
         /// <param name="targetBranch">Name of target branch where updates should be made</param>
         /// <param name="updateFrequency">Frequency of updates, can be 'none', 'everyBuild' or 'everyDay'</param>
+        /// <param name="batchable">Is subscription batchable</param>
         /// <param name="mergePolicies">
         ///     Dictionary of merge policies. Each merge policy is a name of a policy with an associated blob
         ///     of metadata
@@ -185,6 +186,7 @@ namespace Microsoft.DotNet.DarcLib
             string targetRepo,
             string targetBranch,
             string updateFrequency,
+            bool batchable,
             List<MergePolicy> mergePolicies)
         {
             CheckForValidBarClient();
@@ -194,6 +196,7 @@ namespace Microsoft.DotNet.DarcLib
                 targetRepo,
                 targetBranch,
                 updateFrequency,
+                batchable,
                 mergePolicies);
         }
 
@@ -215,7 +218,7 @@ namespace Microsoft.DotNet.DarcLib
         ///     Delete a subscription by id
         /// </summary>
         /// <param name="subscriptionId">Id of subscription to delete</param>
-        /// <returns>Information on deleted subscriptio</returns>
+        /// <returns>Information on deleted subscription</returns>
         public async Task<Subscription> DeleteSubscriptionAsync(string subscriptionId)
         {
             CheckForValidBarClient();

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
@@ -37,6 +37,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="targetRepo">Target repository URI.</param>
         /// <param name="targetBranch">Target branch in <paramref name="targetRepo"/></param>
         /// <param name="updateFrequency">Frequency of update.  'none', 'everyDay', or 'everyBuild'.</param>
+        /// <param name="batchable">Is subscription batchable.</param>
         /// <param name="mergePolicies">Set of auto-merge policies.</param>
         /// <returns>Newly created subscription.</returns>
         Task<Subscription> CreateSubscriptionAsync(
@@ -45,6 +46,7 @@ namespace Microsoft.DotNet.DarcLib
             string targetRepo,
             string targetBranch,
             string updateFrequency,
+            bool batchable,
             List<MergePolicy> mergePolicies);
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -118,6 +118,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="targetRepo">Target repository URI.</param>
         /// <param name="targetBranch">Target branch in <paramref name="targetRepo"/></param>
         /// <param name="updateFrequency">Frequency of update.  'none', 'everyDay', or 'everyBuild'.</param>
+        /// <param name="batchable">If true, the subscription is batchable</param>
         /// <param name="mergePolicies">Set of auto-merge policies.</param>
         /// <returns>Newly created subscription.</returns>
         Task<Subscription> CreateSubscriptionAsync(
@@ -126,6 +127,7 @@ namespace Microsoft.DotNet.DarcLib
             string targetRepo,
             string targetBranch,
             string updateFrequency,
+            bool batchable,
             List<MergePolicy> mergePolicies);
 
         /// <summary>


### PR DESCRIPTION
- Add a way to batch subscriptions in add-subscription.
- Fix a few bugs related to dumping of subscriptions info (null ref when merge policies were not present on batchable subscriptions)