### PR TITLE
Fix release pipeline runner artifact source manipulation

### DIFF
--- a/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
+++ b/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
@@ -174,9 +174,8 @@ namespace ReleasePipelineRunner
                     Logger.LogInformation($"Going to create a release using pipeline {organization}/{project}/{pipelineId}");
 
                     AzureDevOpsReleaseDefinition pipeDef = await azdoClient.GetReleaseDefinitionAsync(organization, project, pipelineId);
-                    pipeDef = await azdoClient.RemoveAllArtifactSourcesAsync(organization, project, pipeDef);
 
-                    pipeDef = await azdoClient.AddArtifactSourceAsync(organization, project, pipeDef, azdoBuild);
+                    pipeDef = await azdoClient.AdjustReleasePipelineArtifactSource(organization, project, pipeDef, azdoBuild);
 
                     int releaseId = await azdoClient.StartNewReleaseAsync(organization, project, pipeDef, build.Id);
 

--- a/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
+++ b/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
@@ -175,7 +175,7 @@ namespace ReleasePipelineRunner
 
                     AzureDevOpsReleaseDefinition pipeDef = await azdoClient.GetReleaseDefinitionAsync(organization, project, pipelineId);
 
-                    pipeDef = await azdoClient.AdjustReleasePipelineArtifactSource(organization, project, pipeDef, azdoBuild);
+                    pipeDef = await azdoClient.AdjustReleasePipelineArtifactSourceAsync(organization, project, pipeDef, azdoBuild);
 
                     int releaseId = await azdoClient.StartNewReleaseAsync(organization, project, pipeDef, build.Id);
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -871,16 +871,21 @@ namespace Microsoft.DotNet.DarcLib
         }
 
         /// <summary>
-        ///     If the release pipeline doesn't have an artifact source a new one is added.
-        ///     If the pipeline has a single artifact source the artifact definition is adjusted as needed.
-        ///     If the pipeline has more than one source an error is thrown.
+        ///   If the release pipeline doesn't have an artifact source a new one is added.
+        ///   If the pipeline has a single artifact source the artifact definition is adjusted as needed.
+        ///   If the pipeline has more than one source an error is thrown.
+        ///     
+        ///   The artifact source added (or the adjustment) has the following properties:
+        ///     - Alias: PrimaryArtifact
+        ///     - Type: Single Build
+        ///     - Version: Specific
         /// </summary>
         /// <param name="accountName">Azure DevOps account name</param>
         /// <param name="projectName">Project name</param>
         /// <param name="releaseDefinition">Release definition to be updated</param>
         /// <param name="build">Build which should be added as source of the release definition.</param>
         /// <returns>AzureDevOpsReleaseDefinition</returns>
-        public async Task<AzureDevOpsReleaseDefinition> AdjustReleasePipelineArtifactSource(string accountName, string projectName, AzureDevOpsReleaseDefinition releaseDefinition, AzureDevOpsBuild build)
+        public async Task<AzureDevOpsReleaseDefinition> AdjustReleasePipelineArtifactSourceAsync(string accountName, string projectName, AzureDevOpsReleaseDefinition releaseDefinition, AzureDevOpsBuild build)
         {
             if (releaseDefinition.Artifacts == null || releaseDefinition.Artifacts.Count() == 0)
             {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -893,7 +893,7 @@ namespace Microsoft.DotNet.DarcLib
                         {
                             Definition = new AzureDevOpsIdNamePair()
                             {
-                                Id = build.Definition.Id.ToString(),
+                                Id = build.Definition.Id,
                                 Name = build.Definition.Name
                             },
                             DefaultVersionType = new AzureDevOpsIdNamePair()
@@ -908,7 +908,7 @@ namespace Microsoft.DotNet.DarcLib
                             },
                             Project = new AzureDevOpsIdNamePair()
                             {
-                                Id = build.Project.Id.ToString(),
+                                Id = build.Project.Id,
                                 Name = build.Project.Name
                             }
                         }
@@ -919,13 +919,13 @@ namespace Microsoft.DotNet.DarcLib
             {
                 var definitionReference = releaseDefinition.Artifacts[0].DefinitionReference;
 
-                definitionReference.Definition.Id = build.Definition.Id.ToString();
+                definitionReference.Definition.Id = build.Definition.Id;
                 definitionReference.Definition.Name = build.Definition.Name;
 
                 definitionReference.DefaultVersionSpecific.Id = build.Id.ToString();
                 definitionReference.DefaultVersionSpecific.Name = build.BuildNumber;
 
-                definitionReference.Project.Id = build.Project.Id.ToString();
+                definitionReference.Project.Id = build.Project.Id;
                 definitionReference.Project.Name = build.Project.Name;
 
                 if (!releaseDefinition.Artifacts[0].Alias.Equals("PrimaryArtifact"))


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/2334

Instead of removing the artifact everytime, let's just patch the existing one in case one exist or otherwise add one if no one exist.