### PR TITLE
Functionality to show only root and immediate dependency builds by default, and toggle to show all dependencies

### DIFF
--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -72,7 +72,7 @@
   </thead>
   <tbody @noop>
     <ng-container *ngFor="let node of sortedBuilds; trackBy getBuildId">
-    <tr *ngIf="includeToolsets || !node.isToolset"
+    <tr *ngIf="(includeToolsets || !node.isToolset) && (showAllDependencies || node.isRootOrImmediateDependency)"
       @insertRemove
       [ngClass]="{'table-danger': !isCoherent(node), 'table-warning': hasIncoherentDependencies(node)}"
       (mouseenter)="hover(node.build.id)"
@@ -112,9 +112,9 @@
         {{node.build.azureDevOpsBuildNumber}}
       </td>
       <td class="text-monospace">
+        <fa-icon [icon]="!isCoherent(node) ? 'exclamation-circle' : 'exclamation-triangle'" 
+        [style.visibility]="(!isCoherent(node) || hasIncoherentDependencies(node)) ? 'visible' : 'hidden'"></fa-icon>
         <a *ngIf="(node.build | commitLink) as link; else noCommitLink" [href]="link" target="_blank">
-            <fa-icon [icon]="!isCoherent(node) ? 'exclamation-circle' : 'exclamation-triangle'" 
-            [style.visibility]="(!isCoherent(node) || hasIncoherentDependencies(node)) ? 'visible' : 'hidden'"></fa-icon>
           {{node.build.commit | slice:0:7}}
           <fa-icon icon="external-link-alt"></fa-icon>
         </a>

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
@@ -112,10 +112,13 @@ function sortBuilds(graph: BuildGraph): BuildData[] {
     {
       for (const dependecy of result[0].build.dependencies)
       {
-        let dep = result.find(d => d.build.id == dependecy.buildId);
-        if(dep)
+        if(dependecy)
         {
-          dep.isRootOrImmediateDependency = true;
+          let dep = result.find(d => d.build.id == dependecy.buildId);
+          if(dep)
+          {
+            dep.isRootOrImmediateDependency = true;
+          }
         }
       }
     }

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
@@ -108,12 +108,15 @@ function sortBuilds(graph: BuildGraph): BuildData[] {
   if(result[0].build.dependencies)
   {
     result[0].isRootOrImmediateDependency = true;
-    for (const dependecy of result[0].build.dependencies)
+    if(result[0].build.dependencies)
     {
-      let dep = result.find(d => d.build.id == dependecy.buildId);
-      if(dep)
+      for (const dependecy of result[0].build.dependencies)
       {
-        dep.isRootOrImmediateDependency = true;
+        let dep = result.find(d => d.build.id == dependecy.buildId);
+        if(dep)
+        {
+          dep.isRootOrImmediateDependency = true;
+        }
       }
     }
   }

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
@@ -105,17 +105,20 @@ function sortBuilds(graph: BuildGraph): BuildData[] {
 
   result = result.reverse();
 
-  if(result[0].build.dependencies)
+  if (result && result[0] && result[0].build)
   {
     result[0].isRootOrImmediateDependency = true;
-    for (const dependecy of result[0].build.dependencies)
+    if (result[0].build.dependencies)
     {
-      if(dependecy)
+      for (const dependecy of result[0].build.dependencies!)
       {
-        let dep = result.find(d => d.build.id == dependecy.buildId);
-        if(dep)
+        if (dependecy)
         {
-          dep.isRootOrImmediateDependency = true;
+          let dep = result.find(d => d.build.id == dependecy.buildId);
+          if (dep)
+          {
+            dep.isRootOrImmediateDependency = true;
+          }
         }
       }
     }

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
@@ -108,17 +108,14 @@ function sortBuilds(graph: BuildGraph): BuildData[] {
   if(result[0].build.dependencies)
   {
     result[0].isRootOrImmediateDependency = true;
-    if(result[0].build.dependencies)
+    for (const dependecy of result[0].build.dependencies)
     {
-      for (const dependecy of result[0].build.dependencies)
+      if(dependecy)
       {
-        if(dependecy)
+        let dep = result.find(d => d.build.id == dependecy.buildId);
+        if(dep)
         {
-          let dep = result.find(d => d.build.id == dependecy.buildId);
-          if(dep)
-          {
-            dep.isRootOrImmediateDependency = true;
-          }
+          dep.isRootOrImmediateDependency = true;
         }
       }
     }

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.html
@@ -94,7 +94,7 @@
           <span class="form-check float-right">
             <mc-switch [style]="" [(value)]="showAllDependencies"></mc-switch>
             <label class="form-check-label">
-              Show All Dependencies
+              Show Sub-Dependencies
             </label>
           </span>
         </div>

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.html
@@ -91,6 +91,12 @@
               Include Toolsets
             </label>
           </span>
+          <span class="form-check float-right">
+            <mc-switch [style]="" [(value)]="showAllDependencies"></mc-switch>
+            <label class="form-check-label">
+              Show All Dependencies
+            </label>
+          </span>
         </div>
         <ng-container *stateful="let graph from graph$; loadingTemplate: loadingData">
           <ul class="nav nav-tabs">
@@ -103,7 +109,7 @@
           </ul>
           <ng-container *ngIf="view$ | async as view">
             <ng-container *ngIf="view == 'graph'">
-              <mc-build-graph-table [graph]="graph" [includeToolsets]="includeToolsets"></mc-build-graph-table>
+              <mc-build-graph-table [graph]="graph" [includeToolsets]="includeToolsets" [showAllDependencies]="showAllDependencies"></mc-build-graph-table>
             </ng-container>
             <ng-container *ngIf="view == 'tree'">
               <mc-build-graph-tree [graph]="graph" [includeToolsets]="includeToolsets" [rootId]="build.id"></mc-build-graph-tree>

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
@@ -51,6 +51,7 @@ export class BuildComponent implements OnInit, OnChanges {
   public azDevBuildInfo$!: Observable<StatefulResult<AzDevBuildInfo>>;
 
   public includeToolsets: boolean = false;
+  public showAllDependencies: boolean = false;
 
   public neverToastNewBuilds: boolean = false;
 


### PR DESCRIPTION
Changes: 
* Added toggle to build page to show all dependencies. Default is set to off. 
* Shows or hides non-immediate dependencies depending on the toggle. 

Minor fix: 
* Moved exclamation icon outside of SHA link. 