### PR TITLE
Use agent workFolder if running under vsts

### DIFF
--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -22,7 +22,7 @@ $global:pipelinesToDelete = @()
 $global:channelPipelinesToDelete = @{}
 
 # Get a temporary directory for a test root. Use the agent work folder if running under azdo, use the temp path if not.
-$testRootBase = if ($env:AGENT_WORKFOLDER ) { $env:AGENT_WORKFOLDER } else { $([System.IO.Path]::GetTempPath()) }
+$testRootBase = if ($env:AGENT_WORKFOLDER) { $env:AGENT_WORKFOLDER } else { $([System.IO.Path]::GetTempPath()) }
 $testRoot = Join-Path -Path $testRootBase -ChildPath $([System.IO.Path]::GetRandomFileName())
 New-Item -Path $testRoot -ItemType Directory | Out-Null
 

--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -21,8 +21,9 @@ $global:defaultChannelsToDelete = @()
 $global:pipelinesToDelete = @()
 $global:channelPipelinesToDelete = @{}
 
-# Get a temporary directory for a test root
-$testRoot = Join-Path -Path $([System.IO.Path]::GetTempPath()) -ChildPath $([System.IO.Path]::GetRandomFileName())
+# Get a temporary directory for a test root. Use the agent work folder if running under azdo, use the temp path if not.
+$testRootBase = if ($env:AGENT_WORKFOLDER ) { $env:AGENT_WORKFOLDER } else { $([System.IO.Path]::GetTempPath()) }
+$testRoot = Join-Path -Path $testRootBase -ChildPath $([System.IO.Path]::GetRandomFileName())
 New-Item -Path $testRoot -ItemType Directory | Out-Null
 
 $darcTool = ""


### PR DESCRIPTION
One of the tests is failing due to max path issues because the temp path in the machine is too long. Use the agent workfolder as the test root to see if that's enough to get the test working