### PR TITLE
Don't move a build if the release failed

### DIFF
--- a/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
+++ b/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
@@ -293,13 +293,14 @@ namespace ReleasePipelineRunner
                                     BuildId = buildId,
                                     ChannelId = channelId
                                 });
-                                await runningPipelines.TryRemoveAsync(tx, buildId);
                             }
                             else
                             {
                                 Logger.LogError($"One or more release environments of build {buildId} failed. Build id {buildId}" +
                                     $"was not added to channel {channelId}");
                             }
+
+                            await runningPipelines.TryRemoveAsync(tx, buildId);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/arcade/issues/2737

Basically do not move a build to a channel if there were environments in the release that failed