### PR TITLE
Workaround for MAX_PATH issues on Windows

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LibGit2SharpHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LibGit2SharpHelpers.cs
@@ -33,9 +33,12 @@ namespace Microsoft.DotNet.DarcLib.Helpers
                 log.LogDebug($"Trying safe checkout of {repo.Info.WorkingDirectory} at {commit}");
                 Commands.Checkout(repo, commit, options);
             }
-            catch (Exception e) when (e is InvalidSpecificationException || e is NameConflictException || e is LibGit2SharpException)
+            catch (Exception e) when (e is InvalidSpecificationException
+                                   || e is NameConflictException
+                                   || e is LibGit2SharpException)
             {
-                log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
+                log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()})." + 
+                                "  Attempting to checkout by individual files.");
                 SafeCheckoutByIndividualFiles(repo, commit, options, log);
             }
             catch
@@ -50,9 +53,12 @@ namespace Microsoft.DotNet.DarcLib.Helpers
                         log.LogDebug($"Trying checkout of {repo.Info.WorkingDirectory} at {resolvedReference}");
                         Commands.Checkout(repo, resolvedReference, options);
                     }
-                    catch (Exception e) when (e is InvalidSpecificationException || e is NameConflictException || e is LibGit2SharpException)
+                    catch (Exception e) when (e is InvalidSpecificationException
+                                           || e is NameConflictException
+                                           || e is LibGit2SharpException)
                     {
-                        log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
+                        log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()})." + 
+                                        "  Attempting to checkout by individual files.");
                         SafeCheckoutByIndividualFiles(repo, resolvedReference, options, log);
                     }
                 }
@@ -83,7 +89,12 @@ namespace Microsoft.DotNet.DarcLib.Helpers
         /// <param name="commit">The commit we are trying to checkout at.  This should be resolved already if it needs to be (i.e. normal whole-repo checkout failed)</param>
         /// <param name="options">Options for checkout - mostly used to force checkout</param>
         /// <param name="log">Logger</param>
-        private static void SafeCheckoutTreeByIndividualFiles(Repository repo, Tree tree, string treePath, string commit, CheckoutOptions options, ILogger log)
+        private static void SafeCheckoutTreeByIndividualFiles(Repository repo,
+                                                              Tree tree,
+                                                              string treePath,
+                                                              string commit,
+                                                              CheckoutOptions options,
+                                                              ILogger log)
         {
             foreach (TreeEntry f in tree)
             {
@@ -91,7 +102,9 @@ namespace Microsoft.DotNet.DarcLib.Helpers
                 {
                     repo.CheckoutPaths(commit, new[] { Path.Combine(treePath, f.Path) }, options);
                 }
-                catch (Exception e) when (e is InvalidSpecificationException || e is NameConflictException || e is LibGit2SharpException)
+                catch (Exception e) when (e is InvalidSpecificationException
+                                       || e is NameConflictException
+                                       || e is LibGit2SharpException)
                 {
                     log.LogWarning($"Failed to checkout {Path.Combine(treePath, f.Path)} in {repo.Info.WorkingDirectory} at {commit}, skipping.  Exception: {e.ToString()}");
                     if (f.TargetType == TreeEntryTargetType.Tree)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LibGit2SharpHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LibGit2SharpHelpers.cs
@@ -1,0 +1,140 @@
+using LibGit2Sharp;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.DotNet.DarcLib.Helpers
+{
+    internal static class LibGit2SharpHelpers
+    {
+        /// <summary>
+        /// This function works around a couple common issues when checking out files in LibGit2Sharp.
+        /// 1. First attempt a normal whole-repo checkout at the specified treeish.
+        /// 2. This could fail for two reasons: long path names on Windows, or the treeish not being resolved on any platform.
+        /// 3. If the exception is one of the ones we know LibGit2Sharp to throw for max path issues, we try to checkout files individually.
+        ///     1. Get the root tree.
+        ///     2. For each item in the tree, try to check it out.
+        ///     3. If that fails and the item is also a tree, recurse on #2.
+        /// 4. Otherwise, assume that the treeish specified needs to be resolved.  Resolve it, then...
+        /// 5. Attempt a normal whole-repo checkout at the resolved treeish.
+        /// 6. If this fails with one of the exception types linked to MAX_PATH issues, do #3 with the resolved treeish.
+        /// This will still fail if the specified treeish doesn't resolve, or if checkout fails for any other reason than MAX_PATH.
+        /// </summary>
+        /// <param name="repo">Repo to check out the files from</param>
+        /// <param name="commit">Commit, tag, or branch to checkout the files at</param>
+        /// <param name="options">Checkout options - mostly whether to force</param>
+        /// <param name="log">Logger</param>
+        internal static void SafeCheckout(Repository repo, string commit, CheckoutOptions options, ILogger log)
+        {
+            try
+            {
+                log.LogDebug($"Trying safe checkout of {repo.Info.WorkingDirectory} at {commit}");
+                Commands.Checkout(repo, commit, options);
+            }
+            catch (Exception e) when (e is InvalidSpecificationException || e is NameConflictException || e is LibGit2SharpException)
+            {
+                log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
+                SafeCheckoutByIndividualFiles(repo, commit, options, log);
+            }
+            catch
+            {
+                log.LogDebug($"Couldn't checkout {commit} as a commit.  Attempting to resolve as a treeish.");
+                string resolvedReference = ParseReference(repo, commit, log);
+                if (resolvedReference != null)
+                {
+                    log.LogDebug($"Resolved {commit} to {resolvedReference}, attempting to check out");
+                    try
+                    {
+                        log.LogDebug($"Trying checkout of {repo.Info.WorkingDirectory} at {resolvedReference}");
+                        Commands.Checkout(repo, resolvedReference, options);
+                    }
+                    catch (Exception e) when (e is InvalidSpecificationException || e is NameConflictException || e is LibGit2SharpException)
+                    {
+                        log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
+                        SafeCheckoutByIndividualFiles(repo, resolvedReference, options, log);
+                    }
+                }
+                else
+                {
+                    log.LogError($"Couldn't resolve {commit} as a commit or treeish.  Checkout of {repo.Info.WorkingDirectory} failed.");
+                    throw new ArgumentException($"Couldn't resolve {commit} as a commit or treeish.  Checkout of {repo.Info.WorkingDirectory} failed.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// This is just a base function to recurse from.
+        /// </summary>
+        private static void SafeCheckoutByIndividualFiles(Repository repo, string commit, CheckoutOptions options, ILogger log)
+        {
+            log.LogDebug($"Beginning individual file checkout for {repo.Info.WorkingDirectory} at {commit}");
+            SafeCheckoutTreeByIndividualFiles(repo, repo.Lookup(commit).Peel<Tree>(), "", commit, options, log);
+
+        }
+
+        /// <summary>
+        /// Checkout a tree, and if it fails, recursively attempt to checkout all of its members.
+        /// </summary>
+        /// <param name="repo">The repo to check files out in</param>
+        /// <param name="tree">The current tree we're looking at (starts at root)</param>
+        /// <param name="treePath">The built-up path of the tree we are currently recursively in</param>
+        /// <param name="commit">The commit we are trying to checkout at.  This should be resolved already if it needs to be (i.e. normal whole-repo checkout failed)</param>
+        /// <param name="options">Options for checkout - mostly used to force checkout</param>
+        /// <param name="log">Logger</param>
+        private static void SafeCheckoutTreeByIndividualFiles(Repository repo, Tree tree, string treePath, string commit, CheckoutOptions options, ILogger log)
+        {
+            foreach (TreeEntry f in tree)
+            {
+                try
+                {
+                    repo.CheckoutPaths(commit, new[] { Path.Combine(treePath, f.Path) }, options);
+                }
+                catch (Exception e) when (e is InvalidSpecificationException || e is NameConflictException || e is LibGit2SharpException)
+                {
+                    log.LogWarning($"Failed to checkout {Path.Combine(treePath, f.Path)} in {repo.Info.WorkingDirectory} at {commit}, skipping.  Exception: {e.ToString()}");
+                    if (f.TargetType == TreeEntryTargetType.Tree)
+                    {
+                        SafeCheckoutTreeByIndividualFiles(repo, f.Target.Peel<Tree>(), Path.Combine(treePath, f.Path), commit, options, log);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resolve a treeish in a repo's context.  This is sometimes needed for, e.g. a local branch name being supplied instead of a repo-context branch name.
+        /// </summary>
+        /// <param name="repo">The repo to resolve the treeish in</param>
+        /// <param name="treeish">The treeish to resolve</param>
+        /// <param name="log">Logger</param>
+        /// <returns>A resolved treeish, or null if one could not be found</returns>
+        private static string ParseReference(Repository repo, string treeish, ILogger log)
+        {
+            Reference reference = null;
+            GitObject dummy;
+            try
+            {
+                repo.RevParse(treeish, out reference, out dummy);
+            }
+            catch
+            {
+                // nothing we can do
+            }
+            log.LogDebug($"Parsed {treeish} to mean {reference?.TargetIdentifier ?? "<invalid>"}");
+            if (reference == null)
+            {
+                try
+                {
+                    repo.RevParse($"origin/{treeish}", out reference, out dummy);
+                }
+                catch
+                {
+                    // nothing we can do
+                }
+                log.LogDebug($"Parsed origin/{treeish} to mean {reference?.TargetIdentifier ?? "<invalid>"}");
+            }
+            return reference?.TargetIdentifier;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -495,15 +495,25 @@ namespace Microsoft.DotNet.DarcLib
         private static void SafeCheckoutByIndividualFiles(LibGit2Sharp.Repository repo, string commit, LibGit2Sharp.CheckoutOptions options, ILogger log)
         {
             log.LogDebug($"Beginning individual file checkout for {repo.Info.WorkingDirectory} at {commit}");
-            foreach (LibGit2Sharp.IndexEntry f in repo.Index)
+            SafeCheckoutTreeByIndividualFiles(repo, repo.Lookup(commit).Peel<LibGit2Sharp.Tree>(), "", commit, options, log);
+
+        }
+
+        private static void SafeCheckoutTreeByIndividualFiles(LibGit2Sharp.Repository repo, LibGit2Sharp.Tree tree, string treePath, string commit, LibGit2Sharp.CheckoutOptions options, ILogger log)
+        {
+            foreach (LibGit2Sharp.TreeEntry f in tree)
             {
                 try
                 {
-                    repo.CheckoutPaths(commit, new[] { f.Path }, options);
+                    repo.CheckoutPaths(commit, new[] { Path.Combine(treePath, f.Path) }, options);
                 }
                 catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException)
                 {
-                    log.LogWarning($"Failed to checkout {f.Path} in {repo.Info.WorkingDirectory} at {commit}, skipping.  Exception: {e.ToString()}");
+                    log.LogWarning($"Failed to checkout {Path.Combine(treePath, f.Path)} in {repo.Info.WorkingDirectory} at {commit}, skipping.  Exception: {e.ToString()}");
+                    if (f.TargetType == LibGit2Sharp.TreeEntryTargetType.Tree)
+                    {
+                        SafeCheckoutTreeByIndividualFiles(repo, f.Target.Peel<LibGit2Sharp.Tree>(), Path.Combine(treePath, f.Path), commit, options, log);
+                    }
                 }
             }
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -461,9 +461,9 @@ namespace Microsoft.DotNet.DarcLib
                 log.LogDebug($"Trying safe checkout of {repo.Info.WorkingDirectory} at {commit}");
                 LibGit2Sharp.Commands.Checkout(repo, commit, options);
             }
-            catch (LibGit2Sharp.InvalidSpecificationException)
+            catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException)
             {
-                log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations.  Attempting to checkout by individual files.");
+                log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
                 SafeCheckoutByIndividualFiles(repo, commit, options, log);
             }
             catch
@@ -478,9 +478,9 @@ namespace Microsoft.DotNet.DarcLib
                         log.LogDebug($"Trying checkout of {repo.Info.WorkingDirectory} at {resolvedReference}");
                         LibGit2Sharp.Commands.Checkout(repo, resolvedReference, options);
                     }
-                    catch (LibGit2Sharp.InvalidSpecificationException)
+                    catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException)
                     {
-                        log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations.  Attempting to checkout by individual files.");
+                        log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
                         SafeCheckoutByIndividualFiles(repo, resolvedReference, options, log);
                     }
                 }
@@ -501,9 +501,9 @@ namespace Microsoft.DotNet.DarcLib
                 {
                     repo.CheckoutPaths(commit, new[] { f.Path }, options);
                 }
-                catch (LibGit2Sharp.InvalidSpecificationException)
+                catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException)
                 {
-                    log.LogWarning($"Failed to checkout {f.Path} in {repo.Info.WorkingDirectory} at {commit}, skipping.");
+                    log.LogWarning($"Failed to checkout {f.Path} in {repo.Info.WorkingDirectory} at {commit}, skipping.  Exception: {e.ToString()}");
                 }
             }
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -461,7 +461,7 @@ namespace Microsoft.DotNet.DarcLib
                 log.LogDebug($"Trying safe checkout of {repo.Info.WorkingDirectory} at {commit}");
                 LibGit2Sharp.Commands.Checkout(repo, commit, options);
             }
-            catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException)
+            catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException || e is LibGit2Sharp.LibGit2SharpException)
             {
                 log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
                 SafeCheckoutByIndividualFiles(repo, commit, options, log);
@@ -478,7 +478,7 @@ namespace Microsoft.DotNet.DarcLib
                         log.LogDebug($"Trying checkout of {repo.Info.WorkingDirectory} at {resolvedReference}");
                         LibGit2Sharp.Commands.Checkout(repo, resolvedReference, options);
                     }
-                    catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException)
+                    catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException || e is LibGit2Sharp.LibGit2SharpException)
                     {
                         log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
                         SafeCheckoutByIndividualFiles(repo, resolvedReference, options, log);
@@ -507,7 +507,7 @@ namespace Microsoft.DotNet.DarcLib
                 {
                     repo.CheckoutPaths(commit, new[] { Path.Combine(treePath, f.Path) }, options);
                 }
-                catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException)
+                catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException || e is LibGit2Sharp.LibGit2SharpException)
                 {
                     log.LogWarning($"Failed to checkout {Path.Combine(treePath, f.Path)} in {repo.Info.WorkingDirectory} at {commit}, skipping.  Exception: {e.ToString()}");
                     if (f.TargetType == LibGit2Sharp.TreeEntryTargetType.Tree)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
@@ -295,9 +295,9 @@ namespace Microsoft.DotNet.DarcLib
                 log.LogDebug($"Trying safe checkout of {repo.Info.WorkingDirectory} at {commit}");
                 LibGit2Sharp.Commands.Checkout(repo, commit, options);
             }
-            catch (LibGit2Sharp.InvalidSpecificationException)
+            catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException)
             {
-                log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations.  Attempting to checkout by individual files.");
+                log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
                 SafeCheckoutByIndividualFiles(repo, commit, options, log);
             }
             catch
@@ -312,9 +312,9 @@ namespace Microsoft.DotNet.DarcLib
                         log.LogDebug($"Trying checkout of {repo.Info.WorkingDirectory} at {resolvedReference}");
                         LibGit2Sharp.Commands.Checkout(repo, resolvedReference, options);
                     }
-                    catch (LibGit2Sharp.InvalidSpecificationException)
+                    catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException)
                     {
-                        log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations.  Attempting to checkout by individual files.");
+                        log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
                         SafeCheckoutByIndividualFiles(repo, resolvedReference, options, log);
                     }
                 }
@@ -335,9 +335,9 @@ namespace Microsoft.DotNet.DarcLib
                 {
                     repo.CheckoutPaths(commit, new[] { f.Path }, options);
                 }
-                catch (LibGit2Sharp.InvalidSpecificationException)
+                catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException)
                 {
-                    log.LogWarning($"Failed to checkout {f.Path} in {repo.Info.WorkingDirectory} at {commit}, skipping.");
+                    log.LogWarning($"Failed to checkout {f.Path} in {repo.Info.WorkingDirectory} at {commit}, skipping.  Exception: {e.ToString()}");
                 }
             }
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
@@ -295,7 +295,7 @@ namespace Microsoft.DotNet.DarcLib
                 log.LogDebug($"Trying safe checkout of {repo.Info.WorkingDirectory} at {commit}");
                 LibGit2Sharp.Commands.Checkout(repo, commit, options);
             }
-            catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException)
+            catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException || e is LibGit2Sharp.LibGit2SharpException)
             {
                 log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
                 SafeCheckoutByIndividualFiles(repo, commit, options, log);
@@ -312,7 +312,7 @@ namespace Microsoft.DotNet.DarcLib
                         log.LogDebug($"Trying checkout of {repo.Info.WorkingDirectory} at {resolvedReference}");
                         LibGit2Sharp.Commands.Checkout(repo, resolvedReference, options);
                     }
-                    catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException)
+                    catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException || e is LibGit2Sharp.LibGit2SharpException)
                     {
                         log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
                         SafeCheckoutByIndividualFiles(repo, resolvedReference, options, log);
@@ -341,7 +341,7 @@ namespace Microsoft.DotNet.DarcLib
                 {
                     repo.CheckoutPaths(commit, new[] { Path.Combine(treePath, f.Path) }, options);
                 }
-                catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException)
+                catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException || e is LibGit2Sharp.LibGit2SharpException)
                 {
                     log.LogWarning($"Failed to checkout {Path.Combine(treePath, f.Path)} in {repo.Info.WorkingDirectory} at {commit}, skipping.  Exception: {e.ToString()}");
                     if (f.TargetType == LibGit2Sharp.TreeEntryTargetType.Tree)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -191,7 +192,7 @@ namespace Microsoft.DotNet.DarcLib
                             _logger.LogInformation($"Repo {localRepo.Info.WorkingDirectory} has no commit to clone at, assuming it's {commit}");
                         }
                         _logger.LogDebug($"Attempting to checkout {commit} as commit in {localRepo.Info.WorkingDirectory}");
-                        SafeCheckout(localRepo, commit, checkoutOptions, _logger);
+                        LibGit2SharpHelpers.SafeCheckout(localRepo, commit, checkoutOptions, _logger);
                     }
                     // LibGit2Sharp doesn't support a --git-dir equivalent yet (https://github.com/libgit2/libgit2sharp/issues/1467), so we do this manually
                     if (gitDirectory != null)
@@ -286,98 +287,6 @@ namespace Microsoft.DotNet.DarcLib
                     log.LogDebug($"{sub.Name} doesn't have a .gitdir redirect at {subRepoGitFilePath}, skipping delete");
                 }
             }
-        }
-
-        private static void SafeCheckout(LibGit2Sharp.Repository repo, string commit, LibGit2Sharp.CheckoutOptions options, ILogger log)
-        {
-            try
-            {
-                log.LogDebug($"Trying safe checkout of {repo.Info.WorkingDirectory} at {commit}");
-                LibGit2Sharp.Commands.Checkout(repo, commit, options);
-            }
-            catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException || e is LibGit2Sharp.LibGit2SharpException)
-            {
-                log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
-                SafeCheckoutByIndividualFiles(repo, commit, options, log);
-            }
-            catch
-            {
-                log.LogDebug($"Couldn't checkout {commit} as a commit after fetch.  Attempting to resolve as a treeish.");
-                string resolvedReference = ParseReference(repo, commit, log);
-                if (resolvedReference != null)
-                {
-                    log.LogDebug($"Resolved {commit} to {resolvedReference}, attempting to check out");
-                    try
-                    {
-                        log.LogDebug($"Trying checkout of {repo.Info.WorkingDirectory} at {resolvedReference}");
-                        LibGit2Sharp.Commands.Checkout(repo, resolvedReference, options);
-                    }
-                    catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException || e is LibGit2Sharp.LibGit2SharpException)
-                    {
-                        log.LogWarning($"Couldn't check out one or more files, possibly due to path length limitations ({e.ToString()}).  Attempting to checkout by individual files.");
-                        SafeCheckoutByIndividualFiles(repo, resolvedReference, options, log);
-                    }
-                }
-                else
-                {
-                    log.LogError($"Couldn't resolve {commit} as a commit or treeish.  Checkout of {repo.Info.WorkingDirectory} failed.");
-                    throw new ArgumentException($"Couldn't resolve {commit} as a commit or treeish.  Checkout of {repo.Info.WorkingDirectory} failed.");
-                }
-            }
-        }
-
-        private static void SafeCheckoutByIndividualFiles(LibGit2Sharp.Repository repo, string commit, LibGit2Sharp.CheckoutOptions options, ILogger log)
-        {
-            log.LogDebug($"Beginning individual file checkout for {repo.Info.WorkingDirectory} at {commit}");
-            SafeCheckoutTreeByIndividualFiles(repo, repo.Lookup(commit).Peel<LibGit2Sharp.Tree>(), "", commit, options, log);
-
-        }
-
-        private static void SafeCheckoutTreeByIndividualFiles(LibGit2Sharp.Repository repo, LibGit2Sharp.Tree tree, string treePath, string commit, LibGit2Sharp.CheckoutOptions options, ILogger log)
-        {
-            foreach (LibGit2Sharp.TreeEntry f in tree)
-            {
-                try
-                {
-                    repo.CheckoutPaths(commit, new[] { Path.Combine(treePath, f.Path) }, options);
-                }
-                catch (Exception e) when (e is LibGit2Sharp.InvalidSpecificationException || e is LibGit2Sharp.NameConflictException || e is LibGit2Sharp.LibGit2SharpException)
-                {
-                    log.LogWarning($"Failed to checkout {Path.Combine(treePath, f.Path)} in {repo.Info.WorkingDirectory} at {commit}, skipping.  Exception: {e.ToString()}");
-                    if (f.TargetType == LibGit2Sharp.TreeEntryTargetType.Tree)
-                    {
-                        SafeCheckoutTreeByIndividualFiles(repo, f.Target.Peel<LibGit2Sharp.Tree>(), Path.Combine(treePath, f.Path), commit, options, log);
-                    }
-                }
-            }
-        }
-
-        private static string ParseReference(LibGit2Sharp.Repository repo, string treeish, ILogger log)
-        {
-            LibGit2Sharp.Reference reference = null;
-            LibGit2Sharp.GitObject dummy;
-            try
-            {
-                repo.RevParse(treeish, out reference, out dummy);
-            }
-            catch
-            {
-                // nothing we can do
-            }
-            log.LogDebug($"Parsed {treeish} to mean {reference?.TargetIdentifier ?? "<invalid>"}");
-            if (reference == null)
-            {
-                try
-                {
-                    repo.RevParse($"origin/{treeish}", out reference, out dummy);
-                }
-                catch
-                {
-                    // nothing we can do
-                }
-                log.LogDebug($"Parsed origin/{treeish} to mean {reference?.TargetIdentifier ?? "<invalid>"}");
-            }
-            return reference?.TargetIdentifier;
         }
 
         private byte[] GetUtf8ContentBytes(string content, ContentEncoding encoding)


### PR DESCRIPTION
A few repos have extremely long file names for testing (AspNetCore, core-setup, and F#).  Unlike the Git command line, LibGit2Sharp does not attempt to mitigate MAX_PATH issues when checking out entire commits.  This change makes it so that if checking out the whole commit fails, we will instead check out individual files and just skip the ones that have paths that are too long.

There is some slight risk in that we will no longer catch if an actual source file cannot be checked out due to MAX_PATH.  We will emit a warning and the build will likely fail in that case.