### PR TITLE
Add merge policy to batched subscription tests

### DIFF
--- a/src/Maestro/tests/Scenarios/azdoflow-batched.ps1
+++ b/src/Maestro/tests/Scenarios/azdoflow-batched.ps1
@@ -55,10 +55,10 @@ try {
     Darc-Add-Channel $testChannelName "test"
 
     Write-Host "Adding a subscription from $source1RepoName to $targetRepoName"
-    $subscription1Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source1RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable
+    $subscription1Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source1RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable --standard-automerge
 
     Write-Host "Adding a subscription from $source2RepoName to $targetRepoName"
-    $subscription2Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source2RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable
+    $subscription2Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source2RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable --standard-automerge
 
     Write-Host "Set up build2 for intake into target repository"
     # Create a build for the first source repo

--- a/src/Maestro/tests/Scenarios/githubflow-batched.ps1
+++ b/src/Maestro/tests/Scenarios/githubflow-batched.ps1
@@ -54,10 +54,10 @@ try {
     Darc-Add-Channel $testChannelName "test"
 
     Write-Host "Adding a subscription from $source1RepoName to $targetRepoName"
-    $subscription1Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source1RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable
+    $subscription1Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source1RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable --standard-automerge
 
     Write-Host "Adding a subscription from $source2RepoName to $targetRepoName"
-    $subscription2Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source2RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable
+    $subscription2Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source2RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable --standard-automerge
 
     Write-Host "Set up build2 for intake into target repository"
     # Create a build for the first source repo


### PR DESCRIPTION
The new warning when adding a batched subscription w/o merge policy is messing with the way we check if a subscription was created in the tests.

