### PR TITLE
fix batched scenario tests (this time for real)

### DIFF
--- a/src/Maestro/tests/Scenarios/azdoflow-batched.ps1
+++ b/src/Maestro/tests/Scenarios/azdoflow-batched.ps1
@@ -55,10 +55,10 @@ try {
     Darc-Add-Channel $testChannelName "test"
 
     Write-Host "Adding a subscription from $source1RepoName to $targetRepoName"
-    $subscription1Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source1RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable --standard-automerge
+    $subscription1Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source1RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable
 
     Write-Host "Adding a subscription from $source2RepoName to $targetRepoName"
-    $subscription2Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source2RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable --standard-automerge
+    $subscription2Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source2RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable
 
     Write-Host "Set up build2 for intake into target repository"
     # Create a build for the first source repo
@@ -102,28 +102,28 @@ try {
     $expectedDependencies =@(
         "Name:             Foo"
         "Version:          1.1.0",
-        "Repo:             $sourceRepo1Uri",
+        "Repo:             $source1RepoUri",
         "Commit:           $sourceCommit",
         "Type:             Product",
         "Pinned:           False",
         "",
         "Name:             Bar",
         "Version:          2.1.0",
-        "Repo:             $sourceRepo1Uri",
+        "Repo:             $source1RepoUri",
         "Commit:           $sourceCommit",
         "Type:             Product",
         "Pinned:           False",
         "",
         "Name:             Pizza",
         "Version:          3.1.0",
-        "Repo:             $sourceRepo2Uri",
+        "Repo:             $source2RepoUri",
         "Commit:           $sourceCommit",
         "Type:             Product",
         "Pinned:           False",
         "",
         "Name:             Hamburger",
         "Version:          4.1.0",
-        "Repo:             $sourceRepo2Uri",
+        "Repo:             $source2RepoUri",
         "Commit:           $sourceCommit",
         "Type:             Product",
         "Pinned:           False",

--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -221,9 +221,9 @@ function Darc-Disable-Default-Channel($channelName, $repoUri, $branch) {
 function Darc-Add-Subscription() {
     $darcParams = "add-subscription $args -q"
     $output = Darc-Command-Impl $darcParams
-    
-    if ($output -match "Successfully created new subscription with id '([a-f0-9-]+)'") {
-        $subscriptionId = $matches[1]
+    $subscriptionIdString = $output -match "Successfully created new subscription with id '([a-f0-9-]+)'"
+    if ($subscriptionIdString -and $subscriptionIdString[0] -match "'([a-f0-9-]+)'") {
+        $subscriptionId = $Matches[0].replace("'", "")
         if (-not $subscriptionId) {
             throw "Failed to extract subscription id"
         }

--- a/src/Maestro/tests/Scenarios/githubflow-batched.ps1
+++ b/src/Maestro/tests/Scenarios/githubflow-batched.ps1
@@ -54,10 +54,10 @@ try {
     Darc-Add-Channel $testChannelName "test"
 
     Write-Host "Adding a subscription from $source1RepoName to $targetRepoName"
-    $subscription1Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source1RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable --standard-automerge
+    $subscription1Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source1RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable
 
     Write-Host "Adding a subscription from $source2RepoName to $targetRepoName"
-    $subscription2Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source2RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable --standard-automerge
+    $subscription2Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source2RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable
 
     Write-Host "Set up build2 for intake into target repository"
     # Create a build for the first source repo


### PR DESCRIPTION
The response to the batched subscription generation is now an object, which changes the behavior of the -match operator in Powershell. First extract the line, and then extract the sub id.

