### PR TITLE
Stop leaking github branches during scenario tests

### DIFF
--- a/src/Maestro/tests/Scenarios/azdoflow-batched.ps1
+++ b/src/Maestro/tests/Scenarios/azdoflow-batched.ps1
@@ -60,12 +60,13 @@ try {
     Write-Host "Adding a subscription from $source2RepoName to $targetRepoName"
     $subscription2Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source2RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable
 
-    Write-Host "Set up build2 for intake into target repository"
+    Write-Host "Set up build1 for intake into target repository"
     # Create a build for the first source repo
     $build1Id = New-Build -repository $source1RepoUri -branch $sourceBranch -commit $sourceCommit -buildNumber $sourceBuildNumber -assets $source1Assets
     # Add the build to the target channel
     Add-Build-To-Channel $build1Id $testChannelName
 
+    Write-Host "Set up build2 for intake into target repository"
     # Create a build for the second  source repo
     $build2Id = New-Build -repository $source2RepoUri -branch $sourceBranch -commit $sourceCommit -buildNumber $sourceBuildNumber -assets $source2Assets
     # Add the build to the target channel

--- a/src/Maestro/tests/Scenarios/githubflow-batched.ps1
+++ b/src/Maestro/tests/Scenarios/githubflow-batched.ps1
@@ -59,12 +59,13 @@ try {
     Write-Host "Adding a subscription from $source2RepoName to $targetRepoName"
     $subscription2Id = Darc-Add-Subscription --channel `'$testChannelName`' --source-repo $source2RepoUri --target-repo $targetRepoUri --update-frequency none --target-branch $targetBranch --batchable
 
-    Write-Host "Set up build2 for intake into target repository"
+    Write-Host "Set up build1 for intake into target repository"
     # Create a build for the first source repo
     $build1Id = New-Build -repository $source1RepoUri -branch $sourceBranch -commit $sourceCommit -buildNumber $sourceBuildNumber -assets $source1Assets
     # Add the build to the target channel
     Add-Build-To-Channel $build1Id $testChannelName
 
+    Write-Host "Set up build2 for intake into target repository"
     # Create a build for the second  source repo
     $build2Id = New-Build -repository $source2RepoUri -branch $sourceBranch -commit $sourceCommit -buildNumber $sourceBuildNumber -assets $source2Assets
     # Add the build to the target channel
@@ -91,7 +92,7 @@ try {
     # Commit and push
     Git-Command $targetRepoName commit -am `"Add dependencies.`"
     Git-Command $targetRepoName push origin HEAD
-    $global:azdoBranchesToDelete += @{ branch = $targetBranch; repo = $targetRepoName}
+    $global:githubBranchesToDelete += @{ branch = $targetBranch; repo = $targetRepoName}
 
     Write-Host "Trigger the dependency update"
     # Trigger the subscriptions


### PR DESCRIPTION
* The github-batched tests were leaving github branches behind due to a typo.

* Some logging fixes during the tests.