### PR TITLE
Use the new right type for ApplicationInsightsLoggerOptions

### DIFF
--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/FixedApplicationInsigthtsLoggerProvider/FixedApplicationInsightsLoggerFactoryExtensions.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/FixedApplicationInsigthtsLoggerProvider/FixedApplicationInsightsLoggerFactoryExtensions.cs
@@ -27,7 +27,8 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                 provider => new FixedApplicationInsightsLoggerProvider(
                     provider.GetRequiredService<TelemetryClient>(),
                     filter,
-                    provider.GetRequiredService<IOptions<ApplicationInsightsLoggerOptions>>()));
+                    provider.GetRequiredService<IOptions<
+                        Microsoft.ApplicationInsights.AspNetCore.Logging.ApplicationInsightsLoggerOptions>>()));
             return builder;
         }
     }

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/FixedApplicationInsigthtsLoggerProvider/FixedApplicationInsightsLoggerFactoryExtensions.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/FixedApplicationInsigthtsLoggerProvider/FixedApplicationInsightsLoggerFactoryExtensions.cs
@@ -28,7 +28,9 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                     provider.GetRequiredService<TelemetryClient>(),
                     filter,
                     provider.GetRequiredService<IOptions<
+#pragma warning disable CS0618 // Type or member is obsolete
                         Microsoft.ApplicationInsights.AspNetCore.Logging.ApplicationInsightsLoggerOptions>>()));
+#pragma warning restore CS0618 // Type or member is obsolete
             return builder;
         }
     }

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/FixedApplicationInsigthtsLoggerProvider/FixedApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/FixedApplicationInsigthtsLoggerProvider/FixedApplicationInsightsLoggerProvider.cs
@@ -5,7 +5,7 @@
 using System;
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.ApplicationInsights;
+using Microsoft.ApplicationInsights.AspNetCore.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.DotNet.ServiceFabric.ServiceHost

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/FixedApplicationInsigthtsLoggerProvider/FixedApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/FixedApplicationInsigthtsLoggerProvider/FixedApplicationInsightsLoggerProvider.cs
@@ -19,7 +19,9 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
         public FixedApplicationInsightsLoggerProvider(
             TelemetryClient telemetryClient,
             Func<string, LogLevel, bool> filter,
+#pragma warning disable CS0618 // Type or member is obsolete
             IOptions<ApplicationInsightsLoggerOptions> options)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             _telemetryClient = telemetryClient;
             // OFC the ApplicationInsights stuff is all internal so we can't inherit any of it

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Microsoft.DotNet.ServiceFabric.ServiceHost.csproj
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Microsoft.DotNet.ServiceFabric.ServiceHost.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks>$(NetFxTfm);netcoreapp2.1</TargetFrameworks>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <LangVersion>7.1</LangVersion>
-    <NoWarn>$(NoWarn);612;618</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Microsoft.DotNet.ServiceFabric.ServiceHost.csproj
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Microsoft.DotNet.ServiceFabric.ServiceHost.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(NetFxTfm);netcoreapp2.1</TargetFrameworks>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <LangVersion>7.1</LangVersion>
+    <NoWarn>$(NoWarn);612;618</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I believe this fixes the current deployment failure.

The type for the ApplicationInsightsLoggerOptions changed in the internal API we are using.

@alexperovich Could you link to the issue where we're going to change the way we set up App Insights for the service so we can clean this up?

As a heads up, this type is marked as obsolete, but I don't believe it's worth spending more time debugging this failure if this change unblocks the service deployment.