### PR TITLE
Remove extra space in PR title now that we insert a space before every Repo name

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -558,7 +558,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                 // or we'll list out the number of repos that are involved.
                 // Start building up the list. If we reach a max length, then backtrack and
                 // just note the number of input subscriptions.
-                string baseTitle = $"[{targetBranch}] Update dependencies from ";
+                string baseTitle = $"[{targetBranch}] Update dependencies from";
                 StringBuilder titleBuilder = new StringBuilder(baseTitle);
                 bool prefixComma = false;
                 const int maxTitleLength = 80;
@@ -578,7 +578,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                     }
                     else
                     {
-                        titleBuilder.Append($" {repoNameForTitle}");
+                        titleBuilder.Append(" " + repoNameForTitle);
                     }
                 }
 

--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -521,7 +521,7 @@ function Check-NonBatched-AzDO-PullRequest($sourceRepoName, $targetRepoName, $ta
 }
 
 function Check-Batched-AzDO-PullRequest($sourceRepoCount, $targetRepoName, $targetBranch, $expectedDependencies) {
-    $expectedPRTitle = "[$targetBranch] Update dependencies from  $sourceRepoCount repositories"
+    $expectedPRTitle = "[$targetBranch] Update dependencies from $sourceRepoCount repositories"
     return Check-AzDO-PullRequest $expectedPRTitle $targetRepoName $targetBranch $expectedDependencies $false
 }
 
@@ -722,7 +722,7 @@ function Check-NonBatched-Github-PullRequest($sourceRepoName, $targetRepoName, $
 }
 
 function Check-Batched-Github-PullRequest($sourceRepoCount, $targetRepoName, $targetBranch, $expectedDependencies) {
-    $expectedPRTitle = "[$targetBranch] Update dependencies from  $sourceRepoCount repositories"
+    $expectedPRTitle = "[$targetBranch] Update dependencies from $sourceRepoCount repositories"
     return Check-Github-PullRequest $expectedPRTitle $targetRepoName $targetBranch $expectedDependencies $false
 }
 


### PR DESCRIPTION
Fixes an extra space before the first repo name introduced in #445