### PR TITLE
Update LibGit2Sharp to 0.26.0.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
     <CommandLineParserVersion>2.2.1</CommandLineParserVersion>
     <CredentialManagementVersion>1.0.2</CredentialManagementVersion>
     <HandlebarsNetVersion>1.9.5</HandlebarsNetVersion>
-    <LibGit2SharpVersion>0.25.2</LibGit2SharpVersion>
+    <LibGit2SharpVersion>0.26.0</LibGit2SharpVersion>
     <log4netVersion>2.0.8</log4netVersion>
     <SystemNetHttpVersion>4.3.3</SystemNetHttpVersion>
     <MicrosoftAzureKeyVaultVersion>3.0.3</MicrosoftAzureKeyVaultVersion>

--- a/src/Maestro/Maestro.MergePolicies/Maestro.MergePolicies.csproj
+++ b/src/Maestro/Maestro.MergePolicies/Maestro.MergePolicies.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
+    <PackageReference Include="LibGit2Sharp" Version="$(LibGit2SharpVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>

--- a/src/Maestro/SubscriptionActorService/SubscriptionActorService.csproj
+++ b/src/Maestro/SubscriptionActorService/SubscriptionActorService.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
+    <PackageReference Include="LibGit2Sharp" Version="$(LibGit2SharpVersion)" />
     <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.664" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
@@ -19,7 +19,7 @@
   
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="$(CommandLineParserVersion)" />
-    <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
+    <PackageReference Include="LibGit2Sharp" Version="$(LibGit2SharpVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
+    <PackageReference Include="LibGit2Sharp" Version="$(LibGit2SharpVersion)" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="$(MicrosoftAzureKeyVaultVersion)" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
+    <PackageReference Include="LibGit2Sharp" Version="$(LibGit2SharpVersion)" />
     <PackageReference Include="Moq" Version="4.8.2" />
   </ItemGroup>
 


### PR DESCRIPTION
This version includes a fix for Ubuntu 18.04 not having libcurl3.