### PR TITLE
Include darc managed feeds as part of dependency update PRs

### DIFF
--- a/src/Maestro/Maestro.Contracts/Asset.cs
+++ b/src/Maestro/Maestro.Contracts/Asset.cs
@@ -14,5 +14,8 @@ namespace Maestro.Contracts
 
         [DataMember]
         public string Version { get; set; }
+
+        [DataMember]
+        public string[] Locations { get; set; }
     }
 }

--- a/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
+++ b/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
@@ -168,8 +168,11 @@ namespace SubscriptionActorService
             return builds.Select(b => ToClientModelBuild(b));
         }
 
-        public async Task<IEnumerable<Asset>> GetAssetsAsync(string name = null,
-            string version = null, int? buildId = null, bool? nonShipping = null)
+        public async Task<IEnumerable<Asset>> GetAssetsAsync(
+            string name = null,
+            string version = null,
+            int? buildId = null,
+            bool? nonShipping = null)
         {
             IQueryable<Maestro.Data.Models.Asset> assets = _context.Assets;
             if (name != null)
@@ -194,7 +197,6 @@ namespace SubscriptionActorService
                 .ToListAsync();
 
             return assetList.Select(a => ToClientModelAsset(a));
-
         }
 
         private AssetLocation ToClientAssetLocation(Maestro.Data.Models.AssetLocation other)
@@ -204,8 +206,13 @@ namespace SubscriptionActorService
 
         private Asset ToClientModelAsset(Maestro.Data.Models.Asset other)
         {
-            return new Asset(other.Id, other.BuildId, other.NonShipping,
-                other.Name, other.Version, other.Locations?.Select(l => ToClientAssetLocation(l)).ToImmutableList());
+            return new Asset(
+                other.Id,
+                other.BuildId,
+                other.NonShipping,
+                other.Name,
+                other.Version,
+                other.Locations?.Select(l => ToClientAssetLocation(l)).ToImmutableList());
         }
 
         private Build ToClientModelBuild(Maestro.Data.Models.Build other)

--- a/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
@@ -85,7 +85,7 @@ namespace SubscriptionActorService.Tests
             DarcRemotes[TargetRepo]
                 .Verify(r => r.GetRequiredNonCoherencyUpdatesAsync(SourceRepo, NewCommit, Capture.In(assets), Capture.In(dependencies)));
             DarcRemotes[TargetRepo]
-                .Verify(r => r.GetDependenciesAsync(TargetRepo, TargetBranch, null));
+                .Verify(r => r.GetDependenciesAsync(TargetRepo, TargetBranch, null, false));
             DarcRemotes[TargetRepo]
                 .Verify(r => r.GetRequiredCoherencyUpdatesAsync(Capture.In(dependencies), RemoteFactory.Object));
             assets.Should()

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -968,7 +968,6 @@ namespace Microsoft.DotNet.DarcLib
             return dependencies;
         }
 
-
         /// <summary>
         ///     Clone a remote repo
         /// </summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -949,6 +949,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="repoUri">Repository to get dependencies from</param>
         /// <param name="branchOrCommit">Commit to get dependencies at</param>
         /// <param name="name">Optional name of specific dependency to get information on</param>
+        /// <param name="loadAssetLocations">Optional switch to include the asset locations</param>
         /// <returns>Matching dependency information.</returns>
         public async Task<IEnumerable<DependencyDetail>> GetDependenciesAsync(string repoUri,
                                                                               string branchOrCommit,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileContentContainer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileContentContainer.cs
@@ -14,13 +14,16 @@ namespace Microsoft.DotNet.DarcLib
 
         public GitFile GlobalJson { get; set; }
 
+        public GitFile NugetConfig { get; set; }
+
         public List<GitFile> GetFilesToCommit()
         {
             var gitHubCommitsMap = new List<GitFile>
             {
                 VersionDetailsXml,
                 VersionProps,
-                GlobalJson
+                GlobalJson,
+                NugetConfig
             };
 
             return gitHubCommitsMap;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -260,7 +260,6 @@ namespace Microsoft.DotNet.DarcLib
             var unmanagedSources = GetPackageSources(nugetConfig, f => !IsMaestroMagedFeed(f));
             var managedSources = GetManagedPackageSources(maestroManagedFeeds).OrderByDescending(t => t.feed).ToList();
 
-
             // Reconstruct the PackageSources section with the feeds
             XmlNode packageSourcesNode = nugetConfig.SelectSingleNode("//configuration/packageSources");
             if (packageSourcesNode == null)
@@ -274,7 +273,6 @@ namespace Microsoft.DotNet.DarcLib
             packageSourcesNode.AppendChild(nugetConfig.CreateComment(
                 "Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below."));
             AppendToPackageSources(nugetConfig, packageSourcesNode, managedSources);
-
             packageSourcesNode.AppendChild(nugetConfig.CreateComment(
                 "End: Package sources managed by Dependency Flow automation. Do not edit the sources above."));
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -931,7 +931,7 @@ namespace Microsoft.DotNet.DarcLib
             {
                 var parsedFeed = ParseMaestroManagedFeed(feed);
 
-                string key = $"darc-{parsedFeed.repoName}-{parsedFeed.type}-{parsedFeed.sha.Substring(0, 7)}";
+                string key = $"darc-{parsedFeed.type}-{parsedFeed.repoName}-{parsedFeed.sha.Substring(0, 7)}";
                 if (!string.IsNullOrEmpty(parsedFeed.subVersion))
                 {
                     key += "-" + parsedFeed.subVersion;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -2,12 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml;
 
@@ -17,6 +21,11 @@ namespace Microsoft.DotNet.DarcLib
     {
         private readonly IGitRepo _gitClient;
         private readonly ILogger _logger;
+
+        // Matches package feeds like
+        // https://dnceng.pkgs.visualstudio.com/public/_packaging/darc-pub-arcade-fd8184c3fcde81eb27ca4c061c6e171f418d753f-1
+        private const string ManagedFeedPattern =
+            @"https://(\w+).pkgs.visualstudio.com/(public/){0,1}_packaging/darc-(int|pub)-(.+?)-([A-Fa-f0-9]{40})-?(\d*)";
 
         public GitFileManager(IGitRepo gitRepo, ILogger logger)
         {
@@ -57,6 +66,16 @@ namespace Microsoft.DotNet.DarcLib
             return JObject.Parse(fileContent);
         }
 
+        public XmlDocument ReadNugetConfigAsync(string fileContent)
+        {
+            return ReadXmlFile(fileContent);
+        }
+
+        public async Task<XmlDocument> ReadNugetConfigAsync(string repoUri, string branch)
+        {
+            return await ReadXmlFileAsync(VersionFiles.NugetConfig, repoUri, branch);
+        }
+
         public IEnumerable<DependencyDetail> ParseVersionDetailsXml(string fileContents, bool includePinned = true)
         {
             _logger.LogInformation($"Getting a collection of dependencies from '{VersionFiles.VersionDetailsXml}'...");
@@ -80,7 +99,6 @@ namespace Microsoft.DotNet.DarcLib
                     $"Getting a collection of dependencies from '{VersionFiles.VersionDetailsXml}' in repo '{repoUri}'...");
             }
 
-            var dependencyDetails = new List<DependencyDetail>();
             XmlDocument document = await ReadVersionDetailsXmlAsync(repoUri, branch);
 
             return GetDependencyDetails(document, includePinned: includePinned);
@@ -131,25 +149,31 @@ namespace Microsoft.DotNet.DarcLib
             attribute.Value = value;
         }
 
-        private static void SetElement(XmlDocument document, XmlNode node, string name, string value)
+        private static XmlNode SetElement(XmlDocument document, XmlNode node, string name, string value = null, bool replace = true)
         {
             XmlNode element = node.SelectSingleNode(name);
-            if (element == null)
+            if (element == null || !replace)
             {
                 element = node.AppendChild(document.CreateElement(name));
             }
 
-            element.InnerText = value;
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                element.InnerText = value;
+            }
+            return element;
         }
 
         public async Task<GitFileContentContainer> UpdateDependencyFiles(
             IEnumerable<DependencyDetail> itemsToUpdate,
             string repoUri,
-            string branch)
+            string branch,
+            IEnumerable<DependencyDetail> oldDependencies = null)
         {
             XmlDocument versionDetails = await ReadVersionDetailsXmlAsync(repoUri, branch);
             XmlDocument versionProps = await ReadVersionPropsAsync(repoUri, branch);
             JObject globalJson = await ReadGlobalJsonAsync(repoUri, branch);
+            XmlDocument nugetConfig = await ReadNugetConfigAsync(repoUri, branch);
 
             foreach (DependencyDetail itemToUpdate in itemsToUpdate)
             {
@@ -194,14 +218,68 @@ namespace Microsoft.DotNet.DarcLib
                 UpdateVersionFiles(versionProps, globalJson, itemToUpdate);
             }
 
+            // Combine the two sets of dependencies. If an asset is present in the itemsToUpdate,
+            // prefer that one over the old dependencies
+            Dictionary<String, HashSet<string>> itemsToUpdateLocations = GetAssetLocationMapping(itemsToUpdate);
+
+            if (oldDependencies != null)
+            {
+                foreach (DependencyDetail dependency in oldDependencies)
+                {
+                    if (!itemsToUpdateLocations.ContainsKey(dependency.Name) && dependency.Locations != null)
+                    {
+                        itemsToUpdateLocations.Add(dependency.Name, new HashSet<string>(dependency.Locations));
+                    }
+                }
+            }
+
+            // At this point we only care about the Maestro managed locations for the assets. 
+            // Flatten the dictionary into a set that has all the managed feeds
+            HashSet<string> managedFeeds = FlattenLocations(itemsToUpdateLocations, IsManagedFeed);
+
+            var updatedNugetConfig = UpdatePackageSources(nugetConfig, managedFeeds);
+
             var fileContainer = new GitFileContentContainer
             {
                 GlobalJson = new GitFile(VersionFiles.GlobalJson, globalJson),
                 VersionDetailsXml = new GitFile(VersionFiles.VersionDetailsXml, versionDetails),
-                VersionProps = new GitFile(VersionFiles.VersionProps, versionProps)
+                VersionProps = new GitFile(VersionFiles.VersionProps, versionProps),
+                NugetConfig = new GitFile(VersionFiles.NugetConfig, updatedNugetConfig)
             };
 
             return fileContainer;
+        }
+
+        private bool IsManagedFeed(string feed)
+        {
+            return Regex.IsMatch(feed, ManagedFeedPattern);
+        }
+
+        private XmlDocument UpdatePackageSources(XmlDocument nugetConfig, HashSet<string> managedFeeds)
+        {
+            var unmanagedSources = GetPackageSources(nugetConfig, f => !IsManagedFeed(f));
+            var allSources = GetManagedPackageSources(managedFeeds).OrderByDescending(t => t.feed).ToList();
+
+            // Place unmanaged sources below the managed ones.
+            allSources.AddRange(unmanagedSources);
+
+            // Reconstruct the PackageSources section with the feeds
+            XmlNode packageSourcesNode = nugetConfig.SelectSingleNode("//configuration/packageSources");
+            if (packageSourcesNode == null)
+            {
+                _logger.LogError("Did not find a <packageSources> element in NuGet.config");
+                return nugetConfig;
+            }
+            packageSourcesNode.RemoveAll();
+            SetElement(nugetConfig, packageSourcesNode, "clear");
+
+            foreach ((string key, string feed) in allSources)
+            {
+                XmlNode addNode = SetElement(nugetConfig, packageSourcesNode, VersionFiles.AddElement, replace: false);
+                SetAttribute(nugetConfig, addNode, VersionFiles.KeyAttributeName, key);
+                SetAttribute(nugetConfig, addNode, VersionFiles.ValueAttributeName, feed);
+            }
+            return nugetConfig;
         }
 
         public async Task AddDependencyToVersionDetailsAsync(
@@ -454,6 +532,7 @@ namespace Microsoft.DotNet.DarcLib
                     }
                 }
             }
+
 
             // Update the global json too, even if there was an element in the props file, in case
             // it was listed in both
@@ -734,7 +813,7 @@ namespace Microsoft.DotNet.DarcLib
             return Task.FromResult(result);
         }
 
-        private IEnumerable<DependencyDetail> GetDependencyDetails(XmlDocument document, string branch = null, bool includePinned = true)
+        private IEnumerable<DependencyDetail> GetDependencyDetails(XmlDocument document, bool includePinned = true)
         {
             List<DependencyDetail> dependencyDetails = new List<DependencyDetail>();
 
@@ -805,6 +884,97 @@ namespace Microsoft.DotNet.DarcLib
             }
 
             return dependencyDetails.Where(d => !d.Pinned);
+        }
+
+        private HashSet<string> FlattenLocations(Dictionary<string, HashSet<string>> assetLocationMap, Func<string, bool> filter = null)
+        {
+            HashSet<string> managedFeeds = new HashSet<string>();
+
+            foreach (HashSet<string> locations in assetLocationMap.Values)
+            {
+                IEnumerable<string> filteredLocations = filter != null ?
+                    locations.Where(filter) :
+                    locations;
+
+                managedFeeds.UnionWith(filteredLocations);
+            }
+            return managedFeeds;
+        }
+
+        private List<(string key, string feed)> GetPackageSources(XmlDocument nugetConfig, Func<string, bool> filter = null)
+        {
+            var sources = new List<(string key, string feed)>();
+            XmlNodeList nodes = nugetConfig.SelectNodes("//configuration/packageSources/add");
+            foreach (XmlNode node in nodes)
+            {
+                if (node.NodeType != XmlNodeType.Comment && node.NodeType != XmlNodeType.Whitespace)
+                {
+                    var keyContent = node.Attributes["key"]?.Value;
+                    var valueContent = node.Attributes["value"]?.Value;
+                    if (keyContent != null && valueContent != null)
+                    {
+                        if (filter != null && !filter(valueContent))
+                        {
+                            continue;
+                        }
+                        sources.Add((keyContent, valueContent));
+                    }
+                }
+            }
+            return sources;
+        }
+
+        private List<(string key, string feed)> GetManagedPackageSources(HashSet<string> feeds)
+        {
+            var sources = new List<(string key, string feed)>();
+
+            foreach (string feed in feeds)
+            {
+                var parsedFeed = ParseManagedPackageFeed(feed);
+
+                string key = $"darc-{parsedFeed.repoName}-{parsedFeed.sha.Substring(0, 7)}";
+                if (!string.IsNullOrEmpty(parsedFeed.subVersion))
+                {
+                    key += "-" + parsedFeed.subVersion;
+                }
+                sources.Add((key, feed));
+            }
+            return sources;
+        }
+
+        private (string org, string repoName, string sha, string subVersion) ParseManagedPackageFeed(string feed)
+        {
+            var match = Regex.Match(feed, ManagedFeedPattern);
+            if (match.Success)
+            {
+                string org = match.Groups[1].Value;
+                string repo = match.Groups[4].Value;
+                string sha = match.Groups[5].Value;
+                string subVersion = match.Groups[6].Value;
+                return (org, repo, sha, subVersion);
+            }
+            else
+            {
+                _logger.LogError($"Unable to parse feed { feed } as a darc managed feed");
+                throw new ArgumentException($"feed { feed } is not a valid darc managed feed");
+            }
+        }
+
+        private Dictionary<string, HashSet<string>> GetAssetLocationMapping(IEnumerable<DependencyDetail> dependencies)
+        {
+            var assetLocationMappings = new Dictionary<string, HashSet<string>>();
+
+            foreach (var dependency in dependencies)
+            {
+                if (!assetLocationMappings.ContainsKey(dependency.Name))
+                {
+                    assetLocationMappings[dependency.Name] = new HashSet<string>();
+                }
+
+                assetLocationMappings[dependency.Name].UnionWith(dependency.Locations ?? Enumerable.Empty<string>());
+            }
+
+            return assetLocationMappings;
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -931,7 +931,7 @@ namespace Microsoft.DotNet.DarcLib
             {
                 var parsedFeed = ParseMaestroManagedFeed(feed);
 
-                string key = $"darc-{parsedFeed.repoName}-{parsedFeed.sha.Substring(0, 7)}";
+                string key = $"darc-{parsedFeed.repoName}-{parsedFeed.type}-{parsedFeed.sha.Substring(0, 7)}";
                 if (!string.IsNullOrEmpty(parsedFeed.subVersion))
                 {
                     key += "-" + parsedFeed.subVersion;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
@@ -25,6 +25,10 @@ namespace Microsoft.DotNet.DarcLib
         public const string VersionAttributeName = "Version";
         public const string CoherentParentAttributeName = "CoherentParentDependency";
         public const string PinnedAttributeName = "Pinned";
+        public const string NugetConfig = "NuGet.config";
+        public const string AddElement = "add";
+        public const string KeyAttributeName = "key";
+        public const string ValueAttributeName = "value";
 
         private static string GetVersionPropsElementBaseName(string dependencyName)
         {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -243,8 +243,9 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="repoUri">Repository to get dependencies from</param>
         /// <param name="branchOrCommit">Commit to get dependencies at</param>
         /// <param name="name">Optional name of specific dependency to get information on</param>
+        /// <param name="loadLocations">Optional switch to populate dependency locations from BAR</param>
         /// <returns>Matching dependency information.</returns>
-        Task<IEnumerable<DependencyDetail>> GetDependenciesAsync(string repoUri, string branchOrCommit, string name = null);
+        Task<IEnumerable<DependencyDetail>> GetDependenciesAsync(string repoUri, string branchOrCommit, string name = null, bool loadLocations = false);
 
         /// <summary>
         ///     Given a repo and branch, determine what updates are required to satisfy

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyDetail.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyDetail.cs
@@ -2,11 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.Maestro.Client.Models;
+using System.Collections;
+using System.Collections.Generic;
+
 namespace Microsoft.DotNet.DarcLib
 {
     public class DependencyDetail
     {
-        public DependencyDetail() { }
+        public DependencyDetail()
+        {
+            Locations = new List<string>();
+        }
+
         public DependencyDetail(DependencyDetail other)
         {
             Name = other.Name;
@@ -16,6 +24,7 @@ namespace Microsoft.DotNet.DarcLib
             Pinned = other.Pinned;
             Type = other.Type;
             CoherentParentDependencyName = other.CoherentParentDependencyName;
+            Locations = other.Locations;
         }
 
         public string Name { get; set; }
@@ -81,5 +90,10 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         /// 
         public string CoherentParentDependencyName { get; set; }
+
+        /// <summary>
+        /// Asset locations for the dependency
+        /// </summary>
+        public IEnumerable<string> Locations { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
@@ -475,7 +475,7 @@ namespace Microsoft.DotNet.Darc.Tests
         private void RepoHasDependencies(Mock<IRemote> dependencyGraphRemoteMock, 
             string repo, string commit, List<DependencyDetail> dependencies)
         {
-            dependencyGraphRemoteMock.Setup(m => m.GetDependenciesAsync(repo, commit, null)).ReturnsAsync(dependencies);
+            dependencyGraphRemoteMock.Setup(m => m.GetDependenciesAsync(repo, commit, null, false)).ReturnsAsync(dependencies);
         }
 
         private void BuildProducesAssets(Mock<IBarClient> barClientMock, string repo,

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -734,6 +734,9 @@
     <None Update="inputs\emptyversions1\input\global.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="inputs\EmptyVersions1\input\NuGet.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="inputs\emptyversions1\output\eng\Version.Details.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -750,6 +753,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="inputs\EmptyVersions2\input\global.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="inputs\EmptyVersions2\input\NuGet.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="inputs\EmptyVersions2\output\eng\Version.Details.xml">
@@ -770,6 +776,9 @@
     <None Update="inputs\SupportAlternateVersionPropertyFormats1\input\global.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="inputs\SupportAlternateVersionPropertyFormats1\input\NuGet.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="inputs\SupportAlternateVersionPropertyFormats1\output\eng\Version.Details.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -786,6 +795,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="inputs\SupportAlternateVersionPropertyFormats2\input\global.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="inputs\SupportAlternateVersionPropertyFormats2\input\NuGet.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="inputs\SupportAlternateVersionPropertyFormats2\output\eng\Version.Details.xml">
@@ -806,6 +818,9 @@
     <None Update="inputs\UpdateArcadeDependency1\input\global.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="inputs\UpdateArcadeDependency1\input\NuGet.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="inputs\UpdateArcadeDependency1\output\eng\Version.Details.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -822,6 +837,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="inputs\UpdateArcadeDependency2\input\global.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="inputs\UpdateArcadeDependency2\input\NuGet.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="inputs\UpdateArcadeDependency2\output\eng\Version.Details.xml">
@@ -842,6 +860,9 @@
     <None Update="inputs\UpdateDependencies1\input\global.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="inputs\UpdateDependencies1\input\NuGet.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="inputs\UpdateDependencies1\output\eng\Version.Details.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -851,6 +872,12 @@
     <None Update="inputs\UpdateDependencies1\output\global.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="inputs\UpdateDependencies3\input\NuGet.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="inputs\UpdateDependencies4\input\NuGet.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="inputs\UpdateDependencies5\input\eng\Version.Details.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -858,6 +885,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="inputs\UpdateDependencies5\input\global.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="inputs\UpdateDependencies5\input\NuGet.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="inputs\UpdateDependencies5\output\eng\Version.Details.xml">

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/EmptyVersions1/input/NuGet.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/EmptyVersions1/input/NuGet.config
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration/>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/EmptyVersions2/input/NuGet.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/EmptyVersions2/input/NuGet.config
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration/>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/SupportAlternateVersionPropertyFormats1/input/NuGet.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/SupportAlternateVersionPropertyFormats1/input/NuGet.config
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration/>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/SupportAlternateVersionPropertyFormats2/input/NuGet.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/SupportAlternateVersionPropertyFormats2/input/NuGet.config
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration/>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependency1/input/NuGet.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependency1/input/NuGet.config
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration/>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependency2/input/NuGet.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependency2/input/NuGet.config
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration/>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateDependencies1/input/NuGet.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateDependencies1/input/NuGet.config
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration/>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateDependencies3/input/NuGet.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateDependencies3/input/NuGet.config
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration/>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateDependencies4/input/NuGet.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateDependencies4/input/NuGet.config
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration/>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateDependencies5/input/NuGet.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateDependencies5/input/NuGet.config
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration/>


### PR DESCRIPTION
dotnet/arcade#2174

Flow feeds into NuGet.config when we find an asset that is located in one of the package feeds that are automatically created by the publishing process.

Validation:

https://github.com/maestro-auth-test/maestro-test2/pull/618/files added feed https://dnceng.pkgs.visualstudio.com/public/_packaging/darc-pub-arcade-fd8184c3fcde81eb27ca4c061c6e171f418d753f for dependencies foo and bar.

https://github.com/maestro-auth-test/maestro-test2/pull/619 removed the feed from the first PR, and added two additional ones for the new package locations for the newer versions of foo and bar.

https://github.com/maestro-auth-test/maestro-test2/pull/620 the new build only produced packages foo and baz (new) the PR adds the feeds for the new assets, and leaves the feed for the existing bar dependency alone.
