### PR TITLE
Fix Publish to BAR ##VSO output syntax

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -97,10 +97,10 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
                         var defaultChannelsStr = string.Join(",", defaultChannels.Select(x => x.Channel.Id));
 
-                        Console.WriteLine($"##vso[task.setvariable variable=BARBuildId;isOutput=true;]{recordedBuild.Id}");
-                        Console.WriteLine($"##vso[task.setvariable variable=DefaultChannels;isOutput=true;]{defaultChannelsStr}");
-                        Console.WriteLine($"##vso[task.setvariable variable=IsStableBuild;isOutput=true;]{IsStableBuild(finalBuild)}");
-                        Console.WriteLine($"##vso[task.setvariable variable=IsInternalBuild;isOutput=true;]{recordedBuild.GitHubRepository == null && recordedBuild.GitHubBranch == null}");
+                        Console.WriteLine($"##vso[task.setvariable variable=BARBuildId]{recordedBuild.Id}");
+                        Console.WriteLine($"##vso[task.setvariable variable=DefaultChannels]{defaultChannelsStr}");
+                        Console.WriteLine($"##vso[task.setvariable variable=IsStableBuild]{IsStableBuild(finalBuild)}");
+                        Console.WriteLine($"##vso[task.setvariable variable=IsInternalBuild]{recordedBuild.GitHubRepository == null && recordedBuild.GitHubBranch == null}");
                     }
                 }
             }


### PR DESCRIPTION
As it turns out if we add this attribute (isOutput) to the command it makes the variable visible to other **jobs** but the variable isn't accessible to other **steps** in the same job that created the variable...