### PR TITLE
Trigger release on Partially successful builds

### DIFF
--- a/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
+++ b/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
@@ -139,7 +139,8 @@ namespace ReleasePipelineRunner
 
         private async Task HandleCompletedBuild(ReleasePipelineRunnerItem item, AzureDevOpsBuild azdoBuild, CancellationToken cancellationToken)
         {
-            if (azdoBuild.Result.Equals("succeeded", StringComparison.OrdinalIgnoreCase))
+            if (azdoBuild.Result.Equals("succeeded", StringComparison.OrdinalIgnoreCase) ||
+                azdoBuild.Result.Equals("partiallySucceeded", StringComparison.OrdinalIgnoreCase))
             {
                 using (Logger.BeginScope(
                     $"Triggering release pipelines associated with channel {item.ChannelId} for build {item.BuildId}.",


### PR DESCRIPTION
dotnet/arcade#3136

Azure DevOps returns a different status for partially successful builds. Add this new status to the ones that trigger a release pipeline.