### PR TITLE
Remove creation of IsInternalBuild azdo variable

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -100,7 +100,6 @@ namespace Microsoft.DotNet.Maestro.Tasks
                         Console.WriteLine($"##vso[task.setvariable variable=BARBuildId]{recordedBuild.Id}");
                         Console.WriteLine($"##vso[task.setvariable variable=DefaultChannels]{defaultChannelsStr}");
                         Console.WriteLine($"##vso[task.setvariable variable=IsStableBuild]{IsStableBuild(finalBuild)}");
-                        Console.WriteLine($"##vso[task.setvariable variable=IsInternalBuild]{recordedBuild.GitHubRepository == null && recordedBuild.GitHubBranch == null}");
                     }
                 }
             }


### PR DESCRIPTION
We changed our approach to this to instead check if the branch name contains the "internal" word. Therefore we can do that comparison using AzDO predefined variables.