### PR TITLE
Add fetch when safe checkout fails.

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/CloneOperation.cs
@@ -140,7 +140,7 @@ namespace Microsoft.DotNet.Darc.Operations
                                     accumulatedDependencies.Add(stripped);
                                 }
                             }
-			    Logger.LogDebug($"done looking for dependencies in {repoPath} at {repo.Commit}");
+                            Logger.LogDebug($"done looking for dependencies in {repoPath} at {repo.Commit}");
                         }
                         catch (DirectoryNotFoundException)
                         {
@@ -228,6 +228,8 @@ namespace Microsoft.DotNet.Darc.Operations
             {
                 await HandleMasterCopyWithDefaultGitDir(remoteFactory, repoUrl, masterGitRepoPath, masterRepoGitDirPath, log);
             }
+            Local local = new Local(log, masterGitRepoPath);
+            local.AddRemoteIfMissing(masterGitRepoPath, repoUrl);
         }
 
         private static async Task HandleMasterCopyWithDefaultGitDir(RemoteFactory remoteFactory, string repoUrl, string masterGitRepoPath, string masterRepoGitDirPath, ILogger log)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -1177,5 +1177,15 @@ namespace Microsoft.DotNet.DarcLib
         {
             throw new NotImplementedException($"Cannot checkout a remote repo.");
         }
+
+        /// <summary>
+        ///     Does not apply to remote repositories.
+        /// </summary>
+        /// <param name="repoDir">Ignored</param>
+        /// <param name="repoUrl">Ignored</param>
+        public void AddRemoteIfMissing(string repoDir, string repoUrl)
+        {
+            throw new NotImplementedException("Cannot add a remote to a remote repo.");
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -142,5 +142,15 @@ namespace Microsoft.DotNet.DarcLib
         {
             _gitClient.Checkout(_repo, commit, force);
         }
+
+        /// <summary>
+        /// Add a remote to the local repo if it does not already exist, and attempt to fetch new commits.
+        /// </summary>
+        /// <param name="repoDir">The directory of the local repo</param>
+        /// <param name="repoUrl">The remote URL to add</param>
+        public void AddRemoteIfMissing(string repoDir, string repoUrl)
+        {
+            _gitClient.AddRemoteIfMissing(repoDir, repoUrl);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -882,5 +882,15 @@ namespace Microsoft.DotNet.DarcLib
         {
             throw new NotImplementedException($"Cannot checkout a remote repo.");
         }
+
+        /// <summary>
+        ///     Does not apply to remote repositories.
+        /// </summary>
+        /// <param name="repoDir">Ignored</param>
+        /// <param name="repoUrl">Ignored</param>
+        public void AddRemoteIfMissing(string repoDir, string repoUrl)
+        {
+            throw new NotImplementedException($"Cannot add a remote to a remote repo.");
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -163,6 +163,13 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="commit">Tag, branch, or commit to checkout</param>
         /// <param name="force">True to force the checkout (loses work)</param>
         void Checkout(string repoPath, string commit, bool force);
+
+        /// <summary>
+        ///     Add a remote to local repo if it does not already exist, and attempt to fetch commits.
+        /// </summary>
+        /// <param name="repoDir">The local repo directory</param>
+        /// <param name="repoUrl">The remote URL to add</param>
+        void AddRemoteIfMissing(string repoDir, string repoUrl);
     }
 
     public class PullRequest

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using LibGit2Sharp;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
 
@@ -472,7 +471,7 @@ namespace Microsoft.DotNet.DarcLib
                 string remoteName = Guid.NewGuid().ToString();
                 repo.Network.Remotes.Add(remoteName, repoUrl);
                 _logger.LogDebug($"Fetching new commits from {repoUrl} into {repoDir}");
-                Commands.Fetch(repo, remoteName, new[] { $"+refs/heads/*:refs/remotes/{remoteName}/*" }, new FetchOptions(), $"Fetching {repoUrl} into {repoDir}");
+                LibGit2Sharp.Commands.Fetch(repo, remoteName, new[] { $"+refs/heads/*:refs/remotes/{remoteName}/*" }, new LibGit2Sharp.FetchOptions(), $"Fetching {repoUrl} into {repoDir}");
             }
         }
     }


### PR DESCRIPTION
When I added the safe checkout for long files names, I introduced a bug where we treat all failures as long file name failures and so we never fetch to see if a commit is available in the source repository.  This change makes it so we fetch and attempt a commit checkout again before attempting a file-by-file checkout.

Recommend appending `?w=1` to the diff for review.

Fixes #440.