### PR TITLE
Fix blob feed regex

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -23,14 +23,14 @@ namespace Microsoft.DotNet.DarcLib
         private readonly ILogger _logger;
 
         // Matches package feeds like
-        // https://dnceng.pkgs.visualstudio.com/public/_packaging/darc-pub-arcade-fd8184c3fcde81eb27ca4c061c6e171f418d753f-1
+        // https://dnceng.pkgs.visualstudio.com/public/_packaging/darc-pub-arcade-fd8184c3fcde81eb27ca4c061c6e171f418d753f-1/nuget/v3/index.json
         private const string MaestroManagedFeedPattern =
             @"https://(?<organization>\w+).pkgs.visualstudio.com/(public/){0,1}_packaging/darc-(?<type>(int|pub))-(?<repository>.+?)-(?<sha>[A-Fa-f0-9]{7,40})-?(?<subversion>\d*)/nuget/v\d+/index.json";
 
         // Matches package feeds like
-        // https://dotnet-feed-internal.azurewebsites.net/container/dotnet-core-internal/sig/dsdfasdfasdf234234s/se/2020-02-02/darc-int-dotnet-arcade-services-babababababe-08/nuget/v3/index.json
+        // https://dotnet-feed-internal.azurewebsites.net/container/dotnet-core-internal/sig/dsdfasdfasdf234234s/se/2020-02-02/darc-int-dotnet-arcade-services-babababababe-08/index.json
         private const string AzureStorageProxyFeedPattern =
-            @"https://([a-z-]+).azurewebsites.net/container/([^/]+)/sig/\w+/se/([0-9]{4}-[0-9]{2}-[0-9]{2})/darc-(?<type>int)-(?<repository>.+?)-(?<sha>[A-Fa-f0-9]{7,40})-?(?<subversion>\d*)/nuget/v\d+/index.json";
+            @"https://([a-z-]+).azurewebsites.net/container/([^/]+)/sig/\w+/se/([0-9]{4}-[0-9]{2}-[0-9]{2})/darc-(?<type>int)-(?<repository>.+?)-(?<sha>[A-Fa-f0-9]{7,40})-?(?<subversion>\d*)/index.json";
 
         public GitFileManager(IGitRepo gitRepo, ILogger logger)
         {


### PR DESCRIPTION
Another change for https://github.com/dotnet/arcade/issues/3220

The blob feeds look slightly different, and don't include the `nuget/v<version>` portion.

Validated that with this change the blob feeds actually flow to NuGet.config, as seen here: https://dnceng.visualstudio.com/internal/_git/dotnet-arcade-validation/pullrequest/2035?_a=files&path=%2FNuGet.config