### PR TITLE
Respect file mode during darc update-dependencies

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LibGit2SharpHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LibGit2SharpHelpers.cs
@@ -91,6 +91,25 @@ namespace Microsoft.DotNet.DarcLib.Helpers
             }
         }
 
+        /// <summary>
+        /// Adds a file to the repo's index respecting the original file's mode.
+        /// </summary>
+        /// <param name="repo">Repo to add the files to</param>
+        /// <param name="file">Original GitFile to add</param>
+        /// <param name="fullPath">Final path for the file to be added</param>
+        /// <param name="log">Logger</param>
+        internal static void AddFileToIndex(Repository repo, GitFile file, string fullPath, ILogger log)
+        {
+            var fileMode = (Mode)Convert.ToInt32(file.Mode, 8);
+            if (!Enum.IsDefined(typeof(Mode), fileMode) || fileMode == Mode.Nonexistent)
+            {
+                log.LogInformation($"Could not detect file mode {file.Mode} for file {file.FilePath}. Assigning non-executable mode.");
+                fileMode = Mode.NonExecutableFile;
+            }
+            Blob fileBlob = repo.ObjectDatabase.CreateBlob(fullPath);
+            repo.Index.Add(fileBlob, file.FilePath, fileMode);
+        }
+
         private static void FetchRepo(Repository repo, ILogger log)
         {
             foreach (LibGit2Sharp.Remote remote in repo.Network.Remotes)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -149,45 +149,59 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns></returns>
         public async Task CommitFilesAsync(List<GitFile> filesToCommit, string repoUri, string branch, string commitMessage)
         {
-            foreach (GitFile file in filesToCommit.Where(f => f.Operation != GitFileOperation.Delete))
+            string repoDir = LocalHelpers.GetRootDir(_logger);
+            try
             {
-                switch (file.Operation)
+                using (LibGit2Sharp.Repository localRepo = new LibGit2Sharp.Repository(repoDir))
                 {
-                    case GitFileOperation.Add:
-                        string parentDirectory = Directory.GetParent(file.FilePath).FullName;
+                    foreach (GitFile file in filesToCommit.Where(f => f.Operation != GitFileOperation.Delete))
+                    {
+                        switch (file.Operation)
+                        {
+                            case GitFileOperation.Add:
+                                string parentDirectory = Directory.GetParent(file.FilePath).FullName;
 
-                        if (!Directory.Exists(parentDirectory))
-                        {
-                            Directory.CreateDirectory(parentDirectory);
-                        }
+                                if (!Directory.Exists(parentDirectory))
+                                {
+                                    Directory.CreateDirectory(parentDirectory);
+                                }
 
-                        string fullPath = Path.Combine(repoUri, file.FilePath);
-                        using (var streamWriter = new StreamWriter(fullPath))
-                        {
-                            string finalContent;
-                            switch (file.ContentEncoding)
-                            {
-                                case ContentEncoding.Utf8:
-                                    finalContent = file.Content;
-                                    break;
-                                case ContentEncoding.Base64:
-                                    byte[] bytes = Convert.FromBase64String(file.Content);
-                                    finalContent = Encoding.UTF8.GetString(bytes);
-                                    break;
-                                default:
-                                    throw new DarcException($"Unknown file content encoding {file.ContentEncoding}");
-                            }
-                            finalContent = NormalizeLineEndings(fullPath, finalContent);
-                            await streamWriter.WriteAsync(finalContent);
+                                string fullPath = Path.Combine(repoUri, file.FilePath);
+                                using (var streamWriter = new StreamWriter(fullPath))
+                                {
+                                    string finalContent;
+                                    switch (file.ContentEncoding)
+                                    {
+                                        case ContentEncoding.Utf8:
+                                            finalContent = file.Content;
+                                            break;
+                                        case ContentEncoding.Base64:
+                                            byte[] bytes = Convert.FromBase64String(file.Content);
+                                            finalContent = Encoding.UTF8.GetString(bytes);
+                                            break;
+                                        default:
+                                            throw new DarcException($"Unknown file content encoding {file.ContentEncoding}");
+                                    }
+                                    finalContent = NormalizeLineEndings(fullPath, finalContent);
+                                    await streamWriter.WriteAsync(finalContent);
+
+                                    LibGit2SharpHelpers.AddFileToIndex(localRepo, file, fullPath, _logger);
+                                }
+                                break;
+                            case GitFileOperation.Delete:
+                                if (File.Exists(file.FilePath))
+                                {
+                                    File.Delete(file.FilePath);
+                                }
+                                break;
                         }
-                        break;
-                    case GitFileOperation.Delete:
-                        if (File.Exists(file.FilePath))
-                        {
-                            File.Delete(file.FilePath);
-                        }
-                        break;
+                    }
+                    LibGit2Sharp.Commands.Stage(localRepo, filesToCommit.Select(f => f.FilePath));
                 }
+            }
+            catch (Exception exc)
+            {
+                throw new Exception($"Something went wrong when checking out {repoUri} in {repoDir}", exc);
             }
         }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -201,7 +201,7 @@ namespace Microsoft.DotNet.DarcLib
             }
             catch (Exception exc)
             {
-                throw new Exception($"Something went wrong when checking out {repoUri} in {repoDir}", exc);
+                throw new DarcException($"Something went wrong when checking out {repoUri} in {repoDir}", exc);
             }
         }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
@@ -85,15 +85,8 @@ namespace Microsoft.DotNet.DarcLib
                                     byte[] contentBytes = GetUtf8ContentBytes(file.Content, file.ContentEncoding);
                                     await stream.WriteAsync(contentBytes, 0, contentBytes.Length);
                                 }
-                                LibGit2Sharp.Blob fileBlob = localRepo.ObjectDatabase.CreateBlob(filePath);
 
-                                var fileMode = (LibGit2Sharp.Mode)Convert.ToInt32(file.Mode, 8);
-                                if (!Enum.IsDefined(typeof(LibGit2Sharp.Mode), fileMode) || fileMode == LibGit2Sharp.Mode.Nonexistent)
-                                {
-                                    _logger.LogInformation($"Could not detect file mode {file.Mode} for file {file.FilePath}. Assigning non-executable mode.");
-                                    fileMode = LibGit2Sharp.Mode.NonExecutableFile;
-                                }
-                                localRepo.Index.Add(fileBlob, file.FilePath, fileMode);
+                                LibGit2SharpHelpers.AddFileToIndex(localRepo, file, filePath, _logger);
                             }
                             else
                             {


### PR DESCRIPTION
Final part of https://github.com/dotnet/arcade/issues/2862

We now stage the files that we update during `update-dependencies`, and we respect the file mode of the file from the original repo:

Validated:

Before:
![image](https://user-images.githubusercontent.com/23242101/61233691-f898dd00-a6e5-11e9-97cf-9070ca5f8229.png)

After running `darc update-dependencies --channel ".Net tools - latest"`

![image](https://user-images.githubusercontent.com/23242101/61233879-70ff9e00-a6e6-11e9-9d01-1bad250e64d6.png)


(100755) is the executable-file mode.