### PR TITLE
Add logging when getting a remote

### DIFF
--- a/src/Maestro/Maestro.GitHub/GitHubTokenProvider.cs
+++ b/src/Maestro/Maestro.GitHub/GitHubTokenProvider.cs
@@ -33,10 +33,10 @@ namespace Maestro.GitHub
 
         public async Task<string> GetTokenForInstallation(long installationId)
         {
-            if (TryGetCachedToken(installationId, out string cachedToken))
+            if (TryGetCachedToken(installationId, out AccessToken cachedToken))
             {
                 _logger.LogInformation($"Cached token obtained for GitHub installation {installationId}. Expires at {cachedToken.ExpiresAt}.");
-                return cachedToken;
+                return cachedToken.Token;
             }
 
             return await ExponentialRetry.RetryAsync(
@@ -66,7 +66,7 @@ namespace Maestro.GitHub
             return generator.CreateEncodedJwtToken();
         }
 
-        private bool TryGetCachedToken(long installationId, out string cachedToken)
+        private bool TryGetCachedToken(long installationId, out AccessToken cachedToken)
         {
             cachedToken = null;
 
@@ -84,7 +84,7 @@ namespace Maestro.GitHub
                 return false;
             }
 
-            cachedToken = token.Token;
+            cachedToken = token;
             return true;
         }
 

--- a/src/Maestro/Maestro.GitHub/GitHubTokenProvider.cs
+++ b/src/Maestro/Maestro.GitHub/GitHubTokenProvider.cs
@@ -35,6 +35,7 @@ namespace Maestro.GitHub
                     var product = new ProductHeaderValue(Options.ApplicationName, Options.ApplicationVersion);
                     var appClient = new Octokit.GitHubClient(product) { Credentials = new Credentials(jwt, AuthenticationType.Bearer) };
                     AccessToken token = await appClient.GitHubApps.CreateInstallationToken(installationId);
+                    _logger.LogInformation($"New token obtained for GitHub installation {installationId}. Expires at {token.ExpiresAt}.");
                     return token.Token;
                 },
                 ex => _logger.LogError(ex, $"Failed to get a github token for installation id {installationId}, retrying"),

--- a/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
+++ b/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
@@ -40,42 +40,45 @@ namespace SubscriptionActorService
 
         public async Task<IRemote> GetRemoteAsync(string repoUrl, ILogger logger)
         {
-            // Normalize the url with the AzDO client prior to attempting to
-            // get a token. When we do coherency updates we build a repo graph and
-            // may end up traversing links to classic azdo uris.
-            string normalizedUrl = AzureDevOpsClient.NormalizeUrl(repoUrl);
-            Uri normalizedRepoUri = new Uri(normalizedUrl);
-            // Look up the setting for where the repo root should be held.  Default to empty,
-            // which will use the temp directory.
-            string temporaryRepositoryRoot = Configuration.GetValue<string>("DarcTemporaryRepoRoot", null);
-            if (string.IsNullOrEmpty(temporaryRepositoryRoot))
+            using (logger.BeginScope($"Getting remote for repo {repoUrl}."))
             {
-                temporaryRepositoryRoot = Path.GetTempPath();
+                // Normalize the url with the AzDO client prior to attempting to
+                // get a token. When we do coherency updates we build a repo graph and
+                // may end up traversing links to classic azdo uris.
+                string normalizedUrl = AzureDevOpsClient.NormalizeUrl(repoUrl);
+                Uri normalizedRepoUri = new Uri(normalizedUrl);
+                // Look up the setting for where the repo root should be held.  Default to empty,
+                // which will use the temp directory.
+                string temporaryRepositoryRoot = Configuration.GetValue<string>("DarcTemporaryRepoRoot", null);
+                if (string.IsNullOrEmpty(temporaryRepositoryRoot))
+                {
+                    temporaryRepositoryRoot = Path.GetTempPath();
+                }
+                IGitRepo gitClient;
+
+                long installationId = await Context.GetInstallationId(normalizedUrl);
+
+                switch (normalizedRepoUri.Host)
+                {
+                    case "github.com":
+                        if (installationId == default)
+                        {
+                            throw new SubscriptionException($"No installation is avaliable for repository '{normalizedUrl}'");
+                        }
+
+                        gitClient = new GitHubClient(await GitHubTokenProvider.GetTokenForInstallation(installationId),
+                            logger, temporaryRepositoryRoot);
+                        break;
+                    case "dev.azure.com":
+                        gitClient = new AzureDevOpsClient(await AzureDevOpsTokenProvider.GetTokenForRepository(normalizedUrl),
+                            logger, temporaryRepositoryRoot);
+                        break;
+                    default:
+                        throw new NotImplementedException($"Unknown repo url type {normalizedUrl}");
+                };
+
+                return new Remote(gitClient, new MaestroBarClient(Context), logger);
             }
-            IGitRepo gitClient;
-
-            long installationId = await Context.GetInstallationId(normalizedUrl);
-
-            switch (normalizedRepoUri.Host)
-            {
-                case "github.com":
-                    if (installationId == default)
-                    {
-                        throw new SubscriptionException($"No installation is avaliable for repository '{normalizedUrl}'");
-                    }
-
-                    gitClient = new GitHubClient(await GitHubTokenProvider.GetTokenForInstallation(installationId),
-                        logger, temporaryRepositoryRoot);
-                    break;
-                case "dev.azure.com":
-                    gitClient = new AzureDevOpsClient(await AzureDevOpsTokenProvider.GetTokenForRepository(normalizedUrl),
-                        logger, temporaryRepositoryRoot);
-                    break;
-                default:
-                    throw new NotImplementedException($"Unknown repo url type {normalizedUrl}");
-            };
-
-            return new Remote(gitClient, new MaestroBarClient(Context), logger);
         }
     }
 }


### PR DESCRIPTION
Need a little clearer marker as to when we are getting/refreshing the remote to diagnose the Octokit exceptions.