### PR TITLE
Up timeout and add token caching

### DIFF
--- a/src/Maestro/DependencyUpdater/DependencyUpdater.cs
+++ b/src/Maestro/DependencyUpdater/DependencyUpdater.cs
@@ -241,7 +241,7 @@ namespace DependencyUpdater
                 }
                 catch (Exception e)
                 {
-                    Logger.LogError(e, "Failed to update subscription '{subscriptionId}' with build '{buildId}'");
+                    Logger.LogError(e, $"Failed to update subscription '{subscriptionId}' with build '{buildId}'");
                 }
             }
         }

--- a/src/Maestro/Maestro.AzureDevOps/AzureDevOpsTokenProvider.cs
+++ b/src/Maestro/Maestro.AzureDevOps/AzureDevOpsTokenProvider.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Extensions.Options;
 using System;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Maestro.AzureDevOps

--- a/src/Maestro/Maestro.GitHub/GitHubTokenProvider.cs
+++ b/src/Maestro/Maestro.GitHub/GitHubTokenProvider.cs
@@ -7,6 +7,8 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Octokit;
+using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -15,6 +17,7 @@ namespace Maestro.GitHub
     public class GitHubTokenProvider : IGitHubTokenProvider
     {
         private readonly IOptions<GitHubTokenProviderOptions> _options;
+        private readonly Dictionary<long, AccessToken> _tokenCache;
         public ILogger<GitHubTokenProvider> _logger;
 
         public GitHubTokenProvider(IOptions<GitHubTokenProviderOptions> options,
@@ -22,12 +25,18 @@ namespace Maestro.GitHub
         {
             _options = options;
             _logger = logger;
+            _tokenCache = new Dictionary<long, AccessToken>();
         }
 
         public GitHubTokenProviderOptions Options => _options.Value;
 
         public async Task<string> GetTokenForInstallation(long installationId)
         {
+            if (TryGetCachedToken(installationId, out string cachedToken))
+            {
+                return cachedToken;
+            }
+
             return await ExponentialRetry.RetryAsync(
                 async () =>
                 {
@@ -35,6 +44,7 @@ namespace Maestro.GitHub
                     var product = new ProductHeaderValue(Options.ApplicationName, Options.ApplicationVersion);
                     var appClient = new Octokit.GitHubClient(product) { Credentials = new Credentials(jwt, AuthenticationType.Bearer) };
                     AccessToken token = await appClient.GitHubApps.CreateInstallationToken(installationId);
+                    UpdateTokenCache(installationId, token);
                     return token.Token;
                 },
                 ex => _logger.LogError(ex, $"Failed to get a github token for installation id {installationId}, retrying"),
@@ -51,6 +61,40 @@ namespace Maestro.GitHub
                     ExpirationSeconds = 600
                 });
             return generator.CreateEncodedJwtToken();
+        }
+
+        private bool TryGetCachedToken(long installationId, out string cachedToken)
+        {
+            cachedToken = null;
+
+            if (!_tokenCache.ContainsKey(installationId))
+            {
+                return false;
+            }
+
+            AccessToken token = _tokenCache[installationId];
+
+            // If the cached token will expire in less than 15 minutes we won't use it and let GetTokenForInstallation generate a new one
+            // and update the cache
+            if (DateTimeOffset.Now.Subtract(token.ExpiresAt).TotalMinutes < 15)
+            {
+                return false;
+            }
+
+            cachedToken = token.Token;
+            return true;
+        }
+
+        private void UpdateTokenCache(long installationId, AccessToken accessToken)
+        {
+            if (_tokenCache.ContainsKey(installationId))
+            {
+                _tokenCache[installationId] = accessToken;
+            }
+            else
+            {
+                _tokenCache.Add(installationId, accessToken);
+            }
         }
     }
 }

--- a/src/Maestro/SubscriptionActorService/PackageRoot/Config/Settings.xml
+++ b/src/Maestro/SubscriptionActorService/PackageRoot/Config/Settings.xml
@@ -15,7 +15,10 @@
     <Parameter Name="CredentialType" Value="None" />
   </Section>
   <Section Name="TransportSettings">
-    <Parameter Name="OperationTimeoutInSeconds" Value="900" />
+    <!-- Default OperationTimeout is 5 minutes which for some of the operations like publishing files into a branch
+         is not enough. We first changed it to 10 minutes but turned out that was not enough for some repos, changing to
+         20 now so we are safe (the longest we've seen process take is 12 minutes) -->
+    <Parameter Name="OperationTimeoutInSeconds" Value="1200" />
   </Section>
   <!-- The content will be generated during build -->
 </Settings>

--- a/src/Maestro/SubscriptionActorService/PackageRoot/Config/Settings.xml
+++ b/src/Maestro/SubscriptionActorService/PackageRoot/Config/Settings.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Section Name="SubscriptionActorServiceReplicatorConfig">
     <Parameter Name="ReplicatorEndpoint" Value="SubscriptionActorServiceReplicatorEndpoint" />
@@ -15,7 +15,7 @@
     <Parameter Name="CredentialType" Value="None" />
   </Section>
   <Section Name="TransportSettings">
-    <Parameter Name="OperationTimeoutInSeconds" Value="600" />
+    <Parameter Name="OperationTimeoutInSeconds" Value="900" />
   </Section>
   <!-- The content will be generated during build -->
 </Settings>


### PR DESCRIPTION
To solve https://github.com/dotnet/core-eng/issues/6946 we analyzed using a CancellationToken that we would cancel once we hit a timeout but after looking at all places we'd need to change we decided to just up the `OperationTimeout` so mono operations are able to complete.

This also includes caching of the GH access token which helps alleviate the "Bad Credentials" error we are seeing since we'll use tokens that we're created some time before not just immediately before (in most cases)