### PR TITLE
Replace nullable boolean logic with enums

### DIFF
--- a/src/Maestro/SubscriptionActorService/MergePolicyCheckResult.cs
+++ b/src/Maestro/SubscriptionActorService/MergePolicyCheckResult.cs
@@ -6,10 +6,10 @@ namespace SubscriptionActorService
 {
     public enum MergePolicyCheckResult
     {
-        NoPolicies,
-        PendingPolicies,
-        FailedPolicies,
-        FailedToMerge,
-        Merged,
+        NoPolicies = 0,
+        PendingPolicies = 1,
+        FailedPolicies = 2,
+        FailedToMerge = 3,
+        Merged = 4,
     }
 }

--- a/src/Maestro/SubscriptionActorService/MergePolicyCheckResult.cs
+++ b/src/Maestro/SubscriptionActorService/MergePolicyCheckResult.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace SubscriptionActorService
+{
+    public enum MergePolicyCheckResult
+    {
+        NoPolicies,
+        PendingPolicies,
+        FailedPolicies,
+        FailedToMerge,
+        Merged,
+    }
+}

--- a/src/Maestro/SubscriptionActorService/PackageRoot/Config/Settings.xml
+++ b/src/Maestro/SubscriptionActorService/PackageRoot/Config/Settings.xml
@@ -1,6 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Section Name="SubscriptionActorServiceReplicatorConfig">
+    <!-- Default OperationTimeout is 5 minutes which for some of the operations like publishing files into a branch
+         is not enough. We first changed it to 10 minutes but turned out that was not enough for some repos, changing to
+         20 now so we are safe (the longest we've seen process take is 12 minutes) -->
     <Parameter Name="ReplicatorEndpoint" Value="SubscriptionActorServiceReplicatorEndpoint" />
     <Parameter Name="BatchAcknowledgementInterval" Value="0.005" />
   </Section>
@@ -15,9 +18,6 @@
     <Parameter Name="CredentialType" Value="None" />
   </Section>
   <Section Name="TransportSettings">
-    <!-- Default OperationTimeout is 5 minutes which for some of the operations like publishing files into a branch
-         is not enough. We first changed it to 10 minutes but turned out that was not enough for some repos, changing to
-         20 now so we are safe (the longest we've seen process take is 12 minutes) -->
     <Parameter Name="OperationTimeoutInSeconds" Value="1200" />
   </Section>
   <!-- The content will be generated during build -->

--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -319,7 +319,8 @@ namespace SubscriptionActorService
                         // that were just obtained. We don't want to unregister the reminder in these cases.
                         return (null, false);
                     default:
-                        throw new NotImplementedException($"Unknown pull request synchronization result {result}");
+                        Logger.LogError($"Unknown pull request synchronization result {result}");
+                        break;
                 }
             }
 

--- a/src/Maestro/SubscriptionActorService/SynchronizePullRequestResult.cs
+++ b/src/Maestro/SubscriptionActorService/SynchronizePullRequestResult.cs
@@ -6,10 +6,10 @@ namespace SubscriptionActorService
 {
     public enum SynchronizePullRequestResult
     {
-        Invalid,
-        UnknownPR,
-        Completed,
-        InProgressCanUpdate,
-        InProgressCannotUpdate,
+        Invalid = 0,
+        UnknownPR = 1,
+        Completed = 2,
+        InProgressCanUpdate = 3,
+        InProgressCannotUpdate = 4,
     }
 }

--- a/src/Maestro/SubscriptionActorService/SynchronizePullRequestResult.cs
+++ b/src/Maestro/SubscriptionActorService/SynchronizePullRequestResult.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace SubscriptionActorService
+{
+    public enum SynchronizePullRequestResult
+    {
+        Invalid,
+        UnknownPR,
+        Completed,
+        InProgressCanUpdate,
+        InProgressCannotUpdate,
+    }
+}


### PR DESCRIPTION
We used nullable booleans as tri-state enums in certain cases when synchronizing pull requests. The meanings of the true, false, and null states varied, but generally did not follow a pattern of "yes", "no" and "I don't know". Unfortunately, there was also a 4th state. If SynchronizePullRequestAsync threw, we would return null (default value for nullable bool) out of ActionRunner, causing us to lose track of the PR. Exceptions are relatively rare, but the dominant exception (Octokit credentials exception) is transient and we would end up tracking the PR properly upon retry 5 minutes later.

Fix this by changing the results of SynchronizePullRequestAsync and CheckMergePolicyAsync over to enums. The default value of the enum (Invalid) will now avoid unregistering the reminder.