### PR TITLE
Fix duplicate listed entries from coherency updates

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
When coherency updates form chains, where there is more than one leaf, at least 3 elements in the chains, and common elements in the chains, we would end up running the coherency update for the middle elements of the chain more than once. This was not necessary, and ended up listing those elements more than once.
Fix this by breaking the chain building process if we have already updated an element in the chain.