### PR TITLE
Change default channel list variable format

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                             enabled: true,
                             recordedBuild.GitHubRepository ?? recordedBuild.AzureDevOpsRepository);
 
-                        var defaultChannelsStr = string.Join(",", defaultChannels.Select(x => x.Channel.Id));
+                        var defaultChannelsStr = "[" + string.Join("][", defaultChannels.Select(x => x.Channel.Id)) + "]";
 
                         Console.WriteLine($"##vso[task.setvariable variable=BARBuildId]{recordedBuild.Id}");
                         Console.WriteLine($"##vso[task.setvariable variable=DefaultChannels]{defaultChannelsStr}");


### PR DESCRIPTION
Relates to https://github.com/dotnet/arcade/issues/3188

This is one of two PRs that I'll create to change the way stages are activated in the YAML publishing pipeline. 

With the current format and [the way we activate channel stages](https://github.com/dotnet/arcade/blob/master/eng/common/templates/post-build/channels/public-dev-release.yml#L16) substring matches will activate a channel. For instance, if the list of default channels is "131,141" and a channel has ID 3 or 4, the condition will be true and incorrectly activate the channel. 

Since AzDO doesn't have a good handling of these variables as array of strings/ints I resorted to adding a delimiter between each channel and then later I'll change the condition to include the delimiter. After this PR the example above would then become "[131][141]" and the check would be contains("[131][141]", "[4]") - I'll create another PR to update the check in the templates.