### PR TITLE
Log the duped asset name

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -209,7 +209,7 @@ namespace Microsoft.DotNet.DarcLib
                     }
                     else
                     {
-                        throw new DarcException("The use of the same asset, even with a different version, is currently not " +
+                        throw new DarcException($"The use of the same asset '{itemToUpdate.Name}', even with a different version, is currently not " +
                             "supported.");
                     }
                 }


### PR DESCRIPTION
Found this exception triggering quite a bit today. Ended up finding the culprit because the repo's version.Details.xml was small, but this should help with investigations in the future.