### PR TITLE
Versions.props cleanup

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,10 +56,4 @@
     <MicrosoftDotNetMaestroTasksPackage>Microsoft.DotNet.Maestro.Tasks</MicrosoftDotNetMaestroTasksPackage>
     <MicrosoftDotNetSwaggerGeneratorMSBuildPackage>Microsoft.DotNet.SwaggerGenerator.MSBuild</MicrosoftDotNetSwaggerGeneratorMSBuildPackage>
   </PropertyGroup>
-  <PropertyGroup>
-    <RestoreSources>
-      $(RestoreSources);
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-    </RestoreSources>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Remove `RestoreSources` from Versions.props in order to complete [step 2](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md#part-2)