### PR TITLE
Recover IsStableBuild from Manifest

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
@@ -60,6 +60,9 @@ namespace Microsoft.DotNet.Maestro.Tasks
             set => AzureDevOpsBuildDefinitionId = !string.IsNullOrEmpty(value) ? int.Parse(value) : default(int?);
         }
 
+        [XmlAttribute(AttributeName = "IsStable")]
+        public string IsStable { get; set; } = "false";
+
         [XmlAttribute(AttributeName = "AzureDevOpsAccount")]
         public string AzureDevOpsAccount { get; set; }
 


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/3476

Recover the `IsStable` property from the build manifest and expose it as an ADO variable.

Tested the modified version of Maestro.Tasks (Note the information recorded in ReleaseConfigs.txt):

  - Here for a non-stable build: https://dnceng.visualstudio.com/internal/_build/results?buildId=291482&view=results
  - Here for a stable build: https://dnceng.visualstudio.com/internal/_build/results?buildId=291483&view=results