### PR TITLE
Fix cache entry size setup

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -438,7 +438,8 @@ namespace Microsoft.DotNet.DarcLib
                     // (it has no way to do so). There are two bytes per each character in a string.
                     // We do not really need to worry about the size of the GitFile class itself,
                     // just the variable length elements.
-                    entry.Size = 2 * (file.Content.Length + file.FilePath.Length + file.Mode.Length);
+                    // Note: SetSize must be used for the cache instead of the Size property setter.
+                    entry.SetSize(2 * (file.Content.Length + file.FilePath.Length + file.Mode.Length));
 
                     return file;
                 });


### PR DESCRIPTION
The cache entries must have their size set with SetSize or the size is lost (maybe not set at all?) and the system will throw InvalidOperationException at runtime.