### PR TITLE
Fix memory caching (again)

### DIFF
--- a/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
+++ b/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
@@ -21,7 +21,7 @@ namespace SubscriptionActorService
             IConfigurationRoot configuration,
             IGitHubTokenProvider gitHubTokenProvider,
             IAzureDevOpsTokenProvider azureDevOpsTokenProvider,
-            IMemoryCache memoryCache,
+            DarcRemoteMemoryCache memoryCache,
             BuildAssetRegistryContext context)
         {
             Configuration = configuration;
@@ -35,7 +35,7 @@ namespace SubscriptionActorService
         public IGitHubTokenProvider GitHubTokenProvider { get; }
         public IAzureDevOpsTokenProvider AzureDevOpsTokenProvider { get; }
         public BuildAssetRegistryContext Context { get; }
-        public IMemoryCache Cache { get; set; }
+        public DarcRemoteMemoryCache Cache { get; set; }
 
         public Task<IRemote> GetBarOnlyRemoteAsync(ILogger logger)
         {
@@ -71,7 +71,7 @@ namespace SubscriptionActorService
                         }
 
                         gitClient = new GitHubClient(await GitHubTokenProvider.GetTokenForInstallation(installationId),
-                            logger, temporaryRepositoryRoot, Cache);
+                            logger, temporaryRepositoryRoot, Cache.Cache);
                         break;
                     case "dev.azure.com":
                         gitClient = new AzureDevOpsClient(await AzureDevOpsTokenProvider.GetTokenForRepository(normalizedUrl),

--- a/src/Maestro/SubscriptionActorService/DarcRemoteMemoryCache.cs
+++ b/src/Maestro/SubscriptionActorService/DarcRemoteMemoryCache.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Caching.Memory;
+
+namespace SubscriptionActorService
+{
+    public class DarcRemoteMemoryCache
+    {
+        public MemoryCache Cache { get; set; }
+        public DarcRemoteMemoryCache()
+        {
+            Cache = new MemoryCache(new MemoryCacheOptions
+            {
+                // The cache is generally targeted towards small objects, like
+                // files returned from GitHub or Azure DevOps, to reduce API calls.
+                // Limit the cache size to 64MB to avoid
+                // large amounts of growth if the service is alive for long periods of time.
+                SizeLimit = 1024 * 1024 * 64
+            });
+        }
+    }
+}

--- a/src/Maestro/SubscriptionActorService/Program.cs
+++ b/src/Maestro/SubscriptionActorService/Program.cs
@@ -44,14 +44,10 @@ namespace SubscriptionActorService
                             services.AddSingleton<IRemoteFactory, DarcRemoteFactory>();
                             services.AddGitHubTokenProvider();
                             services.AddAzureDevOpsTokenProvider();
-                            services.AddMemoryCache(options =>
-                            {
-                                // The cache is generally targeted towards small objects, like
-                                // files returned from GitHub or Azure DevOps, to reduce API calls.
-                                // Limit the cache size to 64MB to avoid
-                                // large amounts of growth if the service is alive for long periods of time.
-                                options.SizeLimit = 1024 * 1024 * 64;
-                            });
+                            // We do not use AddMemoryCache here. We use our own cache because we wish to
+                            // use a sized cache and some components, such as EFCore, do not implement their caching
+                            // in such a way that will work with sizing.
+                            services.AddSingleton<DarcRemoteMemoryCache>();
                             services.AddSingleton(
                                 provider => ServiceHostConfiguration.Get(
                                     provider.GetRequiredService<IHostingEnvironment>()));

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -438,8 +438,7 @@ namespace Microsoft.DotNet.DarcLib
                     // (it has no way to do so). There are two bytes per each character in a string.
                     // We do not really need to worry about the size of the GitFile class itself,
                     // just the variable length elements.
-                    // Note: SetSize must be used for the cache instead of the Size property setter.
-                    entry.SetSize(2 * (file.Content.Length + file.FilePath.Length + file.Mode.Length));
+                    entry.Size = 2 * (file.Content.Length + file.FilePath.Length + file.Mode.Length);
 
                     return file;
                 });

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitHubClientTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitHubClientTests.cs
@@ -8,10 +8,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Xunit;
 
 namespace Microsoft.DotNet.Darc.Tests
@@ -39,20 +37,7 @@ namespace Microsoft.DotNet.Darc.Tests
         public IList<PostEvictionCallbackRegistration> PostEvictionCallbacks => throw new NotImplementedException();
 
         public CacheItemPriority Priority { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        public long? Size
-        {
-            get => _size;
-            set
-            {
-                // The caching implementation does not work if Size on the caching entry is set only using the property
-                // setter. You must use SetSize instead of the setter. To avoid this mistake, grab the calling method
-                // and check that it is called SetSize. This check is pretty weak (implementation specific), but it's easy to
-                // make the mistake.  So just avoid it.
-                StackTrace stackTrace = new StackTrace();
-                Assert.Equal("SetSize", stackTrace.GetFrame(1).GetMethod().Name);
-                _size = value;
-            }
-        }
+        public long? Size { get => _size; set => _size = value; }
 
         public void Dispose() { }
     }


### PR DESCRIPTION
When setting up the memory cache with AddMemoryCache(), the memory cache ends up shared between components. As it turns out, EF does not implement their use of the cache as a Size based cache. Thus, the service will fail in unexpected ways when performing DB queries. Instead, a custom memory cache singleton should be created so that the cache is not shared.