### PR TITLE
Fix UxManager root git dir lookup

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
@@ -19,14 +19,12 @@ namespace Microsoft.DotNet.Darc.Helpers
     public class UxManager
     {
         private readonly string _editorPath;
-        private readonly string _rootDir;
         private readonly ILogger _logger;
         private bool _popUpClosed = false;
 
         public UxManager(string gitLocation, ILogger logger)
         {
             _editorPath = LocalHelpers.GetEditorPath(gitLocation, logger);
-            _rootDir = LocalHelpers.GetRootDir(gitLocation, logger);
             _logger = logger;
         }
 


### PR DESCRIPTION
The UxManager looks up the root dir, which is not necessary.  This causes the subscription tests to fail in rollout because they use the UxManager (read from stdin)