### PR TITLE
Disallow duplicate merge policies

### DIFF
--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Models/RepositoryBranch.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Models/RepositoryBranch.cs
@@ -5,12 +5,13 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace Maestro.Web.Api.v2018_07_16.Models
 {
-    public class RepositoryBranch
+    public class RepositoryBranch : IValidatableObject
     {
         public RepositoryBranch(Data.Models.RepositoryBranch other)
         {
@@ -22,5 +23,16 @@ namespace Maestro.Web.Api.v2018_07_16.Models
         public string Repository { get; set; }
         public string Branch { get; set; }
         public ImmutableList<MergePolicy> MergePolicies { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (MergePolicies != null &&
+                MergePolicies.Select(policy => policy.Name).Distinct(StringComparer.OrdinalIgnoreCase).Count() != MergePolicies.Count)
+            {
+                yield return new ValidationResult(
+                    "Repositories may not have duplicates of merge policies.",
+                    new[] { nameof(MergePolicies) });
+            }
+        }
     }
 }

--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Models/SubscriptionPolicy.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Models/SubscriptionPolicy.cs
@@ -43,7 +43,7 @@ namespace Maestro.Web.Api.v2018_07_16.Models
         {
             // Disallow two things:
             // - Merge policies set on batchable subscriptions. They should be set as a repository policy
-            // - More than version of a single policy.
+            // - More than one instance of a single policy.
             if (MergePolicies != null && MergePolicies.Count != 0)
             {
                 if (Batchable)

--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -170,7 +170,7 @@ function Darc-Command-WithPipeline([Parameter(ValueFromPipeline=$true)]$pipeline
     $commandOutput = $pipelineParams| & $darcTool @finalParams @darcAuthParams
     if ($LASTEXITCODE -ne 0) {
       Write-Host ${commandOutput}
-      throw "Darc command exited with exit code: $LASTEXITCODE"
+      throw "Darc command exited with exit code: $LASTEXITCODE`n${commandOutput}"
     } else {
       $commandOutput
     }
@@ -185,7 +185,7 @@ function Darc-Command([Parameter(ValueFromRemainingArguments=$true)]$darcParams)
     $commandOutput = & $darcTool @finalParams @darcAuthParams
     if ($LASTEXITCODE -ne 0) {
       Write-Host ${commandOutput}
-      throw "Darc command exited with exit code: $LASTEXITCODE"
+      throw "Darc command exited with exit code: $LASTEXITCODE`n${commandOutput}"
     } else {
       $commandOutput
     }

--- a/src/Maestro/tests/Scenarios/subscriptions.ps1
+++ b/src/Maestro/tests/Scenarios/subscriptions.ps1
@@ -142,6 +142,37 @@ Merge Policies:
     Validate-Subscription-Info $subscriptionId $expectedSubscriptionInfo
     Darc-Delete-Subscription $subscriptionId
 
+    # Attempt to add multiple of the same merge policy checks. Should fail.
+$yaml=@"
+Channel: $channel1Name
+Source Repository URL: $repo1Uri
+Target Repository URL: $repo3Uri
+Target Branch: master
+Update Frequency: everyweek
+Batchable: false
+Merge Policies:
+- Name: AllChecksSuccessful
+  Properties:
+    ignoreChecks:
+    - WIP
+    - license/cla
+- Name: AllChecksSuccessful
+  Properties:
+    ignoreChecks:
+    - WIP
+    - MySpecialCheck
+"@
+    try {
+        Darc-Add-Subscription-From-Yaml $yaml
+        throw "darc add-subscription should fail when creating a subscription with conflicting merge policies."
+    } catch {
+        if (-not ($_ -match ".*Subscriptions may not have duplicates of merge policies.*")) {
+            throw "darc add-subscription should fail when creating a subscription with conflicting merge policies"
+        } else {
+            Write-Host "Maestro successfully blocked creation of subscription with conflicting merge policies."
+        }
+    }
+
     # Duplicate subscription tests
 
     Write-Host ""
@@ -152,7 +183,7 @@ Merge Policies:
         Darc-Add-Subscription --channel "$channel1Name" --source-repo "$repo1Uri" --target-repo "$repo2Uri" --update-frequency everyDay --target-branch "master"
         throw "darc add-subscription should fail when creating an equivalent subscription."
     } catch {
-        if (-not $_.Message -match "The subscription .* already performs the same update.") {
+        if (-not ($_ -match ".*The subscription .* already performs the same update.*")) {
             throw "darc add-subscription should fail when creating an equivalent subscription"
         } else {
             Write-Host "Maestro successfully blocked creation of duplicate subscription"
@@ -163,7 +194,7 @@ Merge Policies:
         Darc-Add-Subscription --channel "$channel1Name" --source-repo "$($repo1Uri.toUpper())" --target-repo "$repo2Uri" --update-frequency everyDay --target-branch "master"
         throw "darc add-subscription should fail when creating an equivalent subscription."
     } catch {
-        if (-not $_.Message -match "The subscription .* already performs the same update.") {
+        if (-not ($_ -match ".*The subscription .* already performs the same update.*")) {
             throw "darc add-subscription should fail when creating an equivalent subscription"
         } else {
             Write-Host "Maestro successfully blocked creation of duplicate subscription"


### PR DESCRIPTION
Disallow creation of merge policies that have more than one merge policy with the same name. I don't know of any cases where this has actually happened, but it could create confusion, like if you created two AllChecksSuccessful policies with different ignored checks. In addition, having this invariant makes some of the forthcoming update subscription code simpler.