### PR TITLE
[production] Skip releasing if build is in different org/project

### DIFF
--- a/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
+++ b/src/Maestro/ReleasePipelineRunner/ReleasePipelineRunner.cs
@@ -255,6 +255,16 @@ namespace ReleasePipelineRunner
                     string project = pipeline.ReleasePipeline.Project;
                     int pipelineId = pipeline.ReleasePipeline.PipelineIdentifier;
 
+                    // If the release definition is in a separate organization or project than the
+                    // build, running the release won't work. This is not that interesting anymore as the repos that have
+                    // this issue are on stages. So we can just skip them.
+                    if (!organization.Equals(build.AzureDevOpsAccount, StringComparison.OrdinalIgnoreCase) ||
+                        !project.Equals(build.AzureDevOpsProject, StringComparison.OrdinalIgnoreCase))
+                    {
+                        Logger.LogWarning($"Skipping release of build {build.Id} because it is not in the same organzation or project as the release definition.");
+                        continue;
+                    }
+
                     Logger.LogInformation($"Going to create a release using pipeline {organization}/{project}/{pipelineId}");
 
                     AzureDevOpsReleaseDefinition pipeDef = await azdoClient.GetReleaseDefinitionAsync(organization, project, pipelineId);


### PR DESCRIPTION
Up to this point, we've not had a repo that had "PublishUsingPipelines" set to true and was in the DevDiv account. This doesn't work, since the release pipeline is in dnceng. This is a corner case that is not interesting because stages release handles this case already.  Skip releases if they are in a different org/project.