### PR TITLE
Ensure duplicate subscription handling works for update-subscriptions

### DIFF
--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/SubscriptionsController.cs
@@ -421,11 +421,18 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
         /// <returns>Subscription if it is found, null otherwise</returns>
         private async Task<Data.Models.Subscription> FindEquivalentSubscription(Data.Models.Subscription updatedOrNewSubscription)
         {
+            // Compare subscriptions based on the 4 key elements:
+            // - Channel
+            // - Source repo
+            // - Target repo
+            // - Target branch
+            // - Not the same subscription id (for updatess)
             return await _context.Subscriptions.FirstOrDefaultAsync(sub =>
                 sub.SourceRepository.Equals(updatedOrNewSubscription.SourceRepository, StringComparison.OrdinalIgnoreCase) &&
                 sub.ChannelId == updatedOrNewSubscription.Channel.Id &&
                 sub.TargetRepository.Equals(updatedOrNewSubscription.TargetRepository, StringComparison.OrdinalIgnoreCase) &&
-                sub.TargetBranch.Equals(updatedOrNewSubscription.TargetBranch, StringComparison.OrdinalIgnoreCase));
+                sub.TargetBranch.Equals(updatedOrNewSubscription.TargetBranch, StringComparison.OrdinalIgnoreCase) &&
+                sub.Id != updatedOrNewSubscription.Id);
         }
     }
 }

--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/SubscriptionsController.cs
@@ -426,7 +426,7 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
             // - Source repo
             // - Target repo
             // - Target branch
-            // - Not the same subscription id (for updatess)
+            // - Not the same subscription id (for updates)
             return await _context.Subscriptions.FirstOrDefaultAsync(sub =>
                 sub.SourceRepository.Equals(updatedOrNewSubscription.SourceRepository, StringComparison.OrdinalIgnoreCase) &&
                 sub.ChannelId == updatedOrNewSubscription.Channel.Id &&

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/SubscriptionsController.cs
@@ -336,7 +336,7 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
             // - Source repo
             // - Target repo
             // - Target branch
-            // - Not the same subscription id (for updatess)
+            // - Not the same subscription id (for updates)
             return await _context.Subscriptions.FirstOrDefaultAsync(sub =>
                 sub.SourceRepository.Equals(updatedOrNewSubscription.SourceRepository, StringComparison.OrdinalIgnoreCase) &&
                 sub.ChannelId == updatedOrNewSubscription.Channel.Id &&

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/SubscriptionsController.cs
@@ -336,11 +336,13 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
             // - Source repo
             // - Target repo
             // - Target branch
+            // - Not the same subscription id (for updatess)
             return await _context.Subscriptions.FirstOrDefaultAsync(sub =>
                 sub.SourceRepository.Equals(updatedOrNewSubscription.SourceRepository, StringComparison.OrdinalIgnoreCase) &&
                 sub.ChannelId == updatedOrNewSubscription.Channel.Id &&
                 sub.TargetRepository.Equals(updatedOrNewSubscription.TargetRepository, StringComparison.OrdinalIgnoreCase) &&
-                sub.TargetBranch.Equals(updatedOrNewSubscription.TargetBranch, StringComparison.OrdinalIgnoreCase));
+                sub.TargetBranch.Equals(updatedOrNewSubscription.TargetBranch, StringComparison.OrdinalIgnoreCase) &&
+                sub.Id != updatedOrNewSubscription.Id);
         }
     }
 }


### PR DESCRIPTION
Ensure that the duplicate subscription handling works for update by ensuring the duplicate lookup doesn't find the subscription you're trying to update.