### PR TITLE
Remove duplicated assets

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/AssetDataComparer.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/AssetDataComparer.cs
@@ -1,0 +1,23 @@
+using Microsoft.DotNet.Maestro.Client.Models;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Maestro.Tasks
+{
+    /// <summary>
+    ///     Compares asset data objects based on name and version.
+    /// </summary>
+    public class AssetDataComparer : IEqualityComparer<AssetData>
+    {
+        public bool Equals(AssetData x, AssetData y)
+        {
+            return x.Name.Equals(y.Name, StringComparison.OrdinalIgnoreCase) &&
+                x.Version == y.Version;
+        }
+
+        public int GetHashCode(AssetData obj)
+        {
+            return (obj.Name, obj.Version).GetHashCode();
+        }
+    }
+}

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -360,7 +360,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
             // Remove duplicated assets based on the top level properties of the asset.
             // The AssetLocations property isn't set at this point yet.
-            mergedBuild.Assets = mergedBuild.Assets.Distinct().ToImmutableList();
+            mergedBuild.Assets = mergedBuild.Assets.Distinct(new AssetDataComparer()).ToImmutableList();
 
             LookupForMatchingGitHubRepository(mergedBuild);
 

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -358,6 +358,10 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 mergedBuild.Assets = mergedBuild.Assets.AddRange(build.Assets);
             }
 
+            // Remove duplicated assets based on the top level properties of the asset.
+            // The AssetLocations property isn't set at this point yet.
+            mergedBuild.Assets = mergedBuild.Assets.Distinct().ToImmutableList();
+
             LookupForMatchingGitHubRepository(mergedBuild);
 
             return mergedBuild;


### PR DESCRIPTION
Remove duplicated assets when merging multiple build manifests.