### PR TITLE
Add an automated node to the dependency graph for .NET 3 Tools

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -42,6 +42,13 @@ namespace Microsoft.DotNet.Darc.Operations
                         Channel = await barOnlyRemote.GetChannelAsync(".NET Tools - Latest")
                     }
                 );
+                defaultChannels.Add(
+                    new DefaultChannel(0, "https://github.com/dotnet/arcade", true)
+                    {
+                        Branch = "refs/heads/release/3.x",
+                        Channel = await barOnlyRemote.GetChannelAsync(".NET 3 Tools")
+                    }
+                );
                 List<Subscription> subscriptions = (await barOnlyRemote.GetSubscriptionsAsync()).ToList();
 
                 // Build, then prune out what we don't want to see if the user specified


### PR DESCRIPTION
The dependency graph adds an automated node from arcade master to .NET Tools - Latest today because the master branch only goes to validation, but implicitly this always flows to .NET Tools - Latest. Add the same for .NET 3 Tools