### PR TITLE
temporarily revert to P6 sdk

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "3.0.100-preview9-014004"
+    "version": "3.0.100-preview6-012264"
   },
   "tools": {
-    "dotnet": "3.0.100-preview9-014004",
+    "dotnet": "3.0.100-preview6-012264",
     "runtimes": {
       "dotnet": [
         "2.1.11"


### PR DESCRIPTION
Preview 9 sdk is causing NuGet issues in the production CI build.