### PR TITLE
Fix location of <clear /> element

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -306,10 +306,7 @@ namespace Microsoft.DotNet.DarcLib
 
                         if (IsMaestroManagedFeed(feedValue.Value))
                         {
-                            var nextNodeToWalk = currentNode.NextSibling;
-                            packageSourcesNode.RemoveChild(currentNode);
-                            currentNode = nextNodeToWalk;
-
+                            currentNode = RemoveCurrentNode(currentNode);
                             continue;
                         }
                     }
@@ -317,10 +314,7 @@ namespace Microsoft.DotNet.DarcLib
                     // It will be added when we add the maestro managed sources.
                     else if (currentNode.Name.Equals(VersionFiles.ClearElement, StringComparison.OrdinalIgnoreCase))
                     {
-                        var nextNodeToWalk = currentNode.NextSibling;
-                        packageSourcesNode.RemoveChild(currentNode);
-                        currentNode = nextNodeToWalk;
-
+                        currentNode = RemoveCurrentNode(currentNode);
                         continue;
                     }
                 }
@@ -329,10 +323,7 @@ namespace Microsoft.DotNet.DarcLib
                     if (currentNode.Value.Equals(MaestroBeginComment, StringComparison.OrdinalIgnoreCase) 
                         || currentNode.Value.Equals(MaestroEndComment, StringComparison.OrdinalIgnoreCase))
                     {
-                        var nextNodeToWalk = currentNode.NextSibling;
-                        packageSourcesNode.RemoveChild(currentNode);
-                        currentNode = nextNodeToWalk;
-
+                        currentNode = RemoveCurrentNode(currentNode);
                         continue;
                     }
                 }
@@ -343,6 +334,18 @@ namespace Microsoft.DotNet.DarcLib
             InsertManagedPackagesBlock(nugetConfig, packageSourcesNode, managedSources);
 
             return nugetConfig;
+        }
+
+        /// <summary>
+        /// Remove the current node and return the next node that should be walked
+        /// </summary>
+        /// <param name="toRemove">Node to remove</param>
+        /// <returns>Next node to walk</returns>
+        private static XmlNode RemoveCurrentNode(XmlNode toRemove)
+        {
+            var nextNodeToWalk = toRemove.NextSibling;
+            toRemove.ParentNode.RemoveChild(toRemove);
+            return nextNodeToWalk;
         }
 
         // Insert the following structure at the beginning of the nodes pointed by `packageSourcesNode`.

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
@@ -38,6 +38,8 @@ namespace Microsoft.DotNet.Darc.Tests
         [InlineData("RemoveManagedFromFromOutside", new string[] {
             "https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-arcade-b0437974/nuget/v3/index.json",
             "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-4ac4c036/nuget/v3/index.json" })]
+        [InlineData("WhiteSpaceCorrectlyFormatted", new string[] {
+            "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-core-setup-7d57652f/nuget/v3/index.json" })]
         public async Task UpdatePackageSourcesTests(string testName, string[] managedFeeds)
         {
             GitFileManager gitFileManager = new GitFileManager(null, NullLogger.Instance);
@@ -48,8 +50,8 @@ namespace Microsoft.DotNet.Darc.Tests
                 ConfigFilesInput,
                 testName,
                 InputNugetConfigFile);
-            XmlDocument inputNuGetConfigFile = new XmlDocument();
-            inputNuGetConfigFile.Load(inputNugetPath);
+            string inputXmlContent = await File.ReadAllTextAsync(inputNugetPath);
+            var inputNuGetConfigFile = GitFileManager.ReadXmlFile(inputXmlContent);
 
             XmlDocument updatedConfigFile = 
                 gitFileManager.UpdatePackageSources(inputNuGetConfigFile, new HashSet<string>(managedFeeds));

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
@@ -773,6 +773,12 @@
     <None Update="inputs\NugetConfigFiles\AddFeedsToNuGetConfigWithoutManagedFeeds\NuGet.output.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="inputs\NugetConfigFiles\WhiteSpaceCorrectlyFormatted\NuGet.input.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="inputs\NugetConfigFiles\WhiteSpaceCorrectlyFormatted\NuGet.output.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="inputs\NugetConfigFiles\NoManagedFeedsToAdd\NuGet.input.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/RemoveAllManagedFeeds/NuGet.output.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/RemoveAllManagedFeeds/NuGet.output.config
@@ -2,6 +2,7 @@
 <!-- This file should be kept in sync across https://www.github.com/dotnet/wpf and dotnet-wpf-int repos. -->
 <configuration>
   <packageSources>
+    <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
     <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/WhiteSpaceCorrectlyFormatted/NuGet.input.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/WhiteSpaceCorrectlyFormatted/NuGet.input.config
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Only specify feed for RepoToolset SDK (see https://github.com/Microsoft/msbuild/issues/2982) -->
+  <packageSources>
+    
+    <clear />
+    
+    
+    
+    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <add key="darc-pub-dotnet-core-setup-7d57652" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-core-setup-7d57652f/nuget/v3/index.json" />
+    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+    
+    
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget-nugetclient" value="https://dotnetfeed.blob.core.windows.net/nuget-nugetclient/index.json" />
+    <add key="myget-dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/WhiteSpaceCorrectlyFormatted/NuGet.output.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/WhiteSpaceCorrectlyFormatted/NuGet.output.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Only specify feed for RepoToolset SDK (see https://github.com/Microsoft/msbuild/issues/2982) -->
+  <packageSources>
+    <clear />
+    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <add key="darc-pub-dotnet-core-setup-7d57652" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-core-setup-7d57652f/nuget/v3/index.json" />
+    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget-nugetclient" value="https://dotnetfeed.blob.core.windows.net/nuget-nugetclient/index.json" />
+    <add key="myget-dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
The location of the clear element was being moved to after the maestro managed feeds. The tests passed as expected. It turns out that the xml documents are read with "preserve whitespace" on inside Maestro, but the tests did not read them as such. This triggered a bug in the feed update code, it incorrectly assumed the first element after the package sources node would be the clear element, while it was actually a whitespace node.

Fix is twofold:
- Run the tests by reading the xml documents the same way that Maestro does (use GitFileManager)
- Always remove the clear node and add it directly after the package sources node.