### PR TITLE
Add sourcebranch to Timeline tables

### DIFF
--- a/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
@@ -148,9 +148,11 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline
                 latest = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(30));
                 _logger.LogWarning($"No table column 'Project' found, assumed reinialization: using {latest.LocalDateTime:O}");
             }
+
             _logger.LogInformation("Reading project {project}", project);
             Build[] builds = await GetBuildsAsync(azureServer, project, latest, buildBatchSize, cancellationToken);
             _logger.LogTrace("... found {builds} builds...", builds.Length);
+
             if (builds.Length == 0)
             {
                 _logger.LogTrace("No work to do");

--- a/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
@@ -151,7 +151,6 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline
             _logger.LogInformation("Reading project {project}", project);
             Build[] builds = await GetBuildsAsync(azureServer, project, latest, buildBatchSize, cancellationToken);
             _logger.LogTrace("... found {builds} builds...", builds.Length);
-
             if (builds.Length == 0)
             {
                 _logger.LogTrace("No work to do");
@@ -258,6 +257,7 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline
                     new KustoValue("DefinitionId", b.Definition?.Id.ToString(), KustoDataTypes.String),
                     new KustoValue("Definition", $"{b.Definition?.Path}\\{b.Definition?.Name}", KustoDataTypes.String),
                     new KustoValue("SourceBranch", b.SourceBranch, KustoDataTypes.String),
+                    new KustoValue("Organization", options.AzureDevOpsOrganization, KustoDataTypes.String),
                 });
 
             _logger.LogInformation("Saving TimelineValidationMessages...");
@@ -277,6 +277,7 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline
                     new KustoValue("Category", "ValidationResult", KustoDataTypes.String),
                     new KustoValue("Message", b.validationResult.Message, KustoDataTypes.String),
                     new KustoValue("Bucket", "ValidationResult", KustoDataTypes.String),
+                    new KustoValue("Organization", options.AzureDevOpsOrganization, KustoDataTypes.String),
                 });
 
             _logger.LogInformation("Saving TimelineRecords...");
@@ -311,6 +312,7 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline
                     new KustoValue("TaskName", b.Raw.Task?.Name, KustoDataTypes.String),
                     new KustoValue("TaskVersion", b.Raw.Task?.Version, KustoDataTypes.String),
                     new KustoValue("Attempt", b.Raw.Attempt.ToString(), KustoDataTypes.Int),
+                    new KustoValue("Organization", options.AzureDevOpsOrganization, KustoDataTypes.String),
                 });
 
             _logger.LogInformation("Saving TimelineIssues...");
@@ -330,6 +332,7 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline
                     new KustoValue("Category", b.Raw.Category, KustoDataTypes.String),
                     new KustoValue("Message", b.Raw.Message, KustoDataTypes.String),
                     new KustoValue("Bucket", b.Bucket, KustoDataTypes.String),
+                    new KustoValue("Organization", options.AzureDevOpsOrganization, KustoDataTypes.String),
                 });
         }
 

--- a/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
@@ -148,7 +148,6 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline
                 latest = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(30));
                 _logger.LogWarning($"No table column 'Project' found, assumed reinialization: using {latest.LocalDateTime:O}");
             }
-
             _logger.LogInformation("Reading project {project}", project);
             Build[] builds = await GetBuildsAsync(azureServer, project, latest, buildBatchSize, cancellationToken);
             _logger.LogTrace("... found {builds} builds...", builds.Length);
@@ -258,6 +257,7 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline
                     new KustoValue("Project", b.Project?.Name, KustoDataTypes.String),
                     new KustoValue("DefinitionId", b.Definition?.Id.ToString(), KustoDataTypes.String),
                     new KustoValue("Definition", $"{b.Definition?.Path}\\{b.Definition?.Name}", KustoDataTypes.String),
+                    new KustoValue("SourceBranch", b.SourceBranch, KustoDataTypes.String),
                 });
 
             _logger.LogInformation("Saving TimelineValidationMessages...");

--- a/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
@@ -257,7 +257,6 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline
                     new KustoValue("DefinitionId", b.Definition?.Id.ToString(), KustoDataTypes.String),
                     new KustoValue("Definition", $"{b.Definition?.Path}\\{b.Definition?.Name}", KustoDataTypes.String),
                     new KustoValue("SourceBranch", b.SourceBranch, KustoDataTypes.String),
-                    new KustoValue("Organization", options.AzureDevOpsOrganization, KustoDataTypes.String),
                 });
 
             _logger.LogInformation("Saving TimelineValidationMessages...");
@@ -277,7 +276,6 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline
                     new KustoValue("Category", "ValidationResult", KustoDataTypes.String),
                     new KustoValue("Message", b.validationResult.Message, KustoDataTypes.String),
                     new KustoValue("Bucket", "ValidationResult", KustoDataTypes.String),
-                    new KustoValue("Organization", options.AzureDevOpsOrganization, KustoDataTypes.String),
                 });
 
             _logger.LogInformation("Saving TimelineRecords...");
@@ -312,7 +310,6 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline
                     new KustoValue("TaskName", b.Raw.Task?.Name, KustoDataTypes.String),
                     new KustoValue("TaskVersion", b.Raw.Task?.Version, KustoDataTypes.String),
                     new KustoValue("Attempt", b.Raw.Attempt.ToString(), KustoDataTypes.Int),
-                    new KustoValue("Organization", options.AzureDevOpsOrganization, KustoDataTypes.String),
                 });
 
             _logger.LogInformation("Saving TimelineIssues...");
@@ -332,7 +329,6 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline
                     new KustoValue("Category", b.Raw.Category, KustoDataTypes.String),
                     new KustoValue("Message", b.Raw.Message, KustoDataTypes.String),
                     new KustoValue("Bucket", b.Bucket, KustoDataTypes.String),
-                    new KustoValue("Organization", options.AzureDevOpsOrganization, KustoDataTypes.String),
                 });
         }
 


### PR DESCRIPTION
We need sourcebranch for timelinebuilds to know what channel a build is *intending* to publish to (for determining channel reliability).

I need to add the column to Kusto before merging this PR.

FYI @mmitche @epananth 