### PR TITLE
Add names of potential future SDK package IDs

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/DependencyOperations.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/DependencyOperations.cs
@@ -15,7 +15,10 @@ namespace Microsoft.DotNet.DarcLib
             new Dictionary<string, KnownDependencyType>
             {
                 {"Microsoft.DotNet.Arcade.Sdk", KnownDependencyType.GlobalJson},
+                {"Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk", KnownDependencyType.GlobalJson},
                 {"Microsoft.DotNet.Helix.Sdk", KnownDependencyType.GlobalJson},
+                {"Microsoft.DotNet.SharedFramework.Sdk", KnownDependencyType.GlobalJson},
+                {"Microsoft.NET.SharedFramework.Sdk", KnownDependencyType.GlobalJson},
                 {"dotnet", KnownDependencyType.GlobalJson}
             };
 
@@ -49,7 +52,10 @@ namespace Microsoft.DotNet.DarcLib
             var dependencyMapping = new Dictionary<string, string>
             {
                 {"Microsoft.DotNet.Arcade.Sdk", "msbuild-sdks"},
+                {"Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk", "msbuild-sdks"},
                 {"Microsoft.DotNet.Helix.Sdk", "msbuild-sdks"},
+                {"Microsoft.DotNet.SharedFramework.Sdk", "msbuild-sdks"},
+                {"Microsoft.NET.SharedFramework.Sdk", "msbuild-sdks"},
                 {"dotnet", "tools"}
             };
 


### PR DESCRIPTION
Update the mapping of known SDK packages to include potential names of future SDKs. For https://github.com/dotnet/arcade/issues/4015.

Adding some preemptively to avoid potentially rollout lag in the future. If any aren't used when the actual names of these SDKs is finalized, they can be cleaned up. Alternatively, the hard-coded list could be replaced by a system that recognizes the SDK packages to avoid updates like this.