### PR TITLE
Add retries when checking the PR title during tests

### DIFF
--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -534,7 +534,20 @@ function Compare-Array-Output($expected, $actual) {
 function Validate-AzDO-PullRequest-Contents($pullRequest, $expectedPRTitle, $targetRepoName, $targetBranch, $expectedDependencies) {
     $pullRequestBaseBranch = $pullRequest.sourceRefName.Replace('refs/heads/','')
 
-    if ($pullRequest.title -ne $expectedPRTitle) {
+    # Depending on how quickly each dependency update comes through,
+    # we might have to wait for the title to be updated correctly for batched Subscriptions
+    $tries = 3
+    $validTitle = $false;
+    while ($tries-- -gt 0 -and (-not $validTitle)) {
+        Write-Host "Validating PR title. $tries tries remaining..."
+        if ($pullRequest.title -eq $expectedPRTitle) {
+            $validTitle = $true
+            break
+        }
+        Start-Sleep 30
+    }
+
+    if (-not $validTitle) {
         throw "Expected PR title to be $expectedPRTitle, was $($pullrequest.title)"
     }
 
@@ -781,7 +794,21 @@ function Check-Github-PullRequest-Created($targetRepoName, $targetBranch) {
 
 function Validate-Github-PullRequest-Contents($pullRequest, $expectedPRTitle, $targetRepoName, $targetBranch, $expectedDependencies) {
     $pullRequestBaseBranch = $pullRequest.head.ref
-    if ($pullRequest.title -ne $expectedPRTitle) {
+
+    # Depending on how quickly each dependency update comes through,
+    # we might have to wait for the title to be updated correctly for batched Subscriptions
+    $tries = 3
+    $validTitle = $false
+    while ($tries-- -gt 0) {
+        Write-Host "Validating PR title. $tries tries remaining..."
+        if ($pullRequest.title -eq $expectedPRTitle) {
+            $validTitle = $true
+            break
+        }
+        Start-Sleep 30
+    }
+
+    if (-not $validTitle) {
         throw "Expected PR title to be $expectedPRTitle, was $($pullrequest.title)"
     }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoExtension.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoExtension.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.DarcLib
         const string refsHeadsPrefix = "refs/heads/";
         public static string NormalizeBranchName(string branch)
         {
-            if (branch.StartsWith(refsHeadsPrefix))
+            if (branch != null && branch.StartsWith(refsHeadsPrefix))
             {
                 return branch.Substring(refsHeadsPrefix.Length);
             }


### PR DESCRIPTION
Add a 90 second wait while all the dependency update PRs are processed and the PR title gets updated.

should help with dotnet/arcade#3988

The INT logs are also filled with:

```
An exception occurred in the database while iterating the results of a query for context type 'Maestro.Data.BuildAssetRegistryContext'.
System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.DotNet.DarcLib.IGitRepoExtension.NormalizeBranchName(String branch) in /_/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoExtension.cs:line 45
   at lambda_method(Closure , MaterializationContext )
   at Microsoft.EntityFrameworkCore.Query.EntityLoadInfo.Materialize()
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryBuffer.GetEntity(IKey key, EntityLoadInfo entityLoadInfo, Boolean queryStateManager, Boolean throwOnNullKey)
   at Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.BufferedEntityShaper`1.Shape(QueryContext queryContext, ValueBuffer& valueBuffer)
   at Microsoft.EntityFrameworkCore.Query.Internal.AsyncQueryingEnumerable`1.AsyncEnumerator.BufferlessMoveNext(DbContext _, Boolean buffer, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal.SqlServerExecutionStrategy.ExecuteAsync[TState,TResult](TState state, Func`4 operation, Func`4 verifySucceeded, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.Internal.AsyncQueryingEnumerable`1.AsyncEnumerator.MoveNext(CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor.AsyncSelectEnumerable`2.AsyncSelectEnumerator.MoveNext(CancellationToken cancellationToken)
   at System.Linq.AsyncEnumerable.FirstOrDefault_[TSource](IAsyncEnumerable`1 source, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.Internal.AsyncLinqOperatorProvider.TaskResultAsyncEnumerable`1.Enumerator.MoveNext(CancellationToken cancellationToken)
   at System.Linq.AsyncEnumerable.SelectEnumerableAsyncIterator`2.MoveNextCore(CancellationToken cancellationToken)
   at System.Linq.AsyncEnumerable.AsyncIterator`1.MoveNext(CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.Internal.AsyncLinqOperatorProvider.ExceptionInterceptor`1.EnumeratorExceptionInterceptor.MoveNext(CancellationToken cancellationToken)
```

which I haven't been able to repro locally, but I believe is causing the other scenario tests to fail, so add a null check to `NormalizeBranchName`