### PR TITLE
[HOTFIX] Revert "Normalize branch names by removing refs/heads (#648)"

### DIFF
--- a/src/Maestro/Client/src/Generated/Builds.cs
+++ b/src/Maestro/Client/src/Generated/Builds.cs
@@ -239,7 +239,7 @@ namespace Microsoft.DotNet.Maestro.Client
             CancellationToken cancellationToken = default
         )
         {
-            if (body == null)
+            if (body == default)
             {
                 throw new ArgumentNullException(nameof(body));
             }
@@ -268,7 +268,7 @@ namespace Microsoft.DotNet.Maestro.Client
                 _req = new HttpRequestMessage(HttpMethod.Post, _url);
 
                 string _requestContent = null;
-                if (body != null)
+                if (body != default)
                 {
                     _requestContent = Client.Serialize(body);
                     _req.Content = new StringContent(_requestContent, Encoding.UTF8)

--- a/src/Maestro/Client/src/Generated/DefaultChannels.cs
+++ b/src/Maestro/Client/src/Generated/DefaultChannels.cs
@@ -194,7 +194,7 @@ namespace Microsoft.DotNet.Maestro.Client
             CancellationToken cancellationToken = default
         )
         {
-            if (body == null)
+            if (body == default)
             {
                 throw new ArgumentNullException(nameof(body));
             }
@@ -223,7 +223,7 @@ namespace Microsoft.DotNet.Maestro.Client
                 _req = new HttpRequestMessage(HttpMethod.Post, _url);
 
                 string _requestContent = null;
-                if (body != null)
+                if (body != default)
                 {
                     _requestContent = Client.Serialize(body);
                     _req.Content = new StringContent(_requestContent, Encoding.UTF8)
@@ -492,7 +492,7 @@ namespace Microsoft.DotNet.Maestro.Client
                 _req = new HttpRequestMessage(new HttpMethod("PATCH"), _url);
 
                 string _requestContent = null;
-                if (body != null)
+                if (body != default)
                 {
                     _requestContent = Client.Serialize(body);
                     _req.Content = new StringContent(_requestContent, Encoding.UTF8)

--- a/src/Maestro/Client/src/Generated/Models/BuildGraph.cs
+++ b/src/Maestro/Client/src/Generated/Models/BuildGraph.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Maestro.Client.Models
         {
             get
             {
-                if (Builds == null)
+                if (Builds == default)
                 {
                     return false;
                 }

--- a/src/Maestro/Client/src/Generated/Models/SubscriptionData.cs
+++ b/src/Maestro/Client/src/Generated/Models/SubscriptionData.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Maestro.Client.Models
                 {
                     return false;
                 }
-                if (Policy == null)
+                if (Policy == default)
                 {
                     return false;
                 }

--- a/src/Maestro/Client/src/Generated/Repository.cs
+++ b/src/Maestro/Client/src/Generated/Repository.cs
@@ -328,7 +328,7 @@ namespace Microsoft.DotNet.Maestro.Client
                 _req = new HttpRequestMessage(HttpMethod.Post, _url);
 
                 string _requestContent = null;
-                if (body != null)
+                if (body != default)
                 {
                     _requestContent = Client.Serialize(body);
                     _req.Content = new StringContent(_requestContent, Encoding.UTF8)

--- a/src/Maestro/Client/src/Generated/Subscriptions.cs
+++ b/src/Maestro/Client/src/Generated/Subscriptions.cs
@@ -216,7 +216,7 @@ namespace Microsoft.DotNet.Maestro.Client
             CancellationToken cancellationToken = default
         )
         {
-            if (body == null)
+            if (body == default)
             {
                 throw new ArgumentNullException(nameof(body));
             }
@@ -245,7 +245,7 @@ namespace Microsoft.DotNet.Maestro.Client
                 _req = new HttpRequestMessage(HttpMethod.Post, _url);
 
                 string _requestContent = null;
-                if (body != null)
+                if (body != default)
                 {
                     _requestContent = Client.Serialize(body);
                     _req.Content = new StringContent(_requestContent, Encoding.UTF8)
@@ -516,7 +516,7 @@ namespace Microsoft.DotNet.Maestro.Client
                 _req = new HttpRequestMessage(new HttpMethod("PATCH"), _url);
 
                 string _requestContent = null;
-                if (body != null)
+                if (body != default)
                 {
                     _requestContent = Client.Serialize(body);
                     _req.Content = new StringContent(_requestContent, Encoding.UTF8)

--- a/src/Maestro/Maestro.Data/Models/Build.cs
+++ b/src/Maestro/Maestro.Data/Models/Build.cs
@@ -16,8 +16,6 @@ namespace Maestro.Data.Models
     {
         private string _azureDevOpsRepository;
         private string _gitHubRepository;
-        private string _azureDevOpsBranch;
-        private string _githubBranch;
 
         static Build()
         {
@@ -70,19 +68,8 @@ namespace Maestro.Data.Models
             }
         }
 
-        public string AzureDevOpsBranch
-        {
-            get
-            {
-                return AzureDevOpsClient.NormalizeUrl(_azureDevOpsBranch);
-            }
-
-            set
-            {
-                _azureDevOpsBranch = AzureDevOpsClient.NormalizeUrl(value);
-            }
-        }
-
+        public string AzureDevOpsBranch { get; set; }
+      
         public string GitHubRepository
         {
             get
@@ -96,17 +83,7 @@ namespace Maestro.Data.Models
             }
         }
 
-        public string GitHubBranch
-        {
-            get
-            {
-                return IGitRepoExtension.NormalizeBranchName(_githubBranch);
-            }
-            set
-            {
-                _githubBranch = IGitRepoExtension.NormalizeBranchName(value);
-            }
-        }
+        public string GitHubBranch { get; set; }
 
         public bool PublishUsingPipelines { get; set; }
 

--- a/src/Maestro/Maestro.Data/Models/DefaultChannel.cs
+++ b/src/Maestro/Maestro.Data/Models/DefaultChannel.cs
@@ -30,22 +30,10 @@ namespace Maestro.Data.Models
             }
         }
 
-        private string _branch;
-
         [StringLength(100)]
         [Column(TypeName = "varchar(100)")]
         [Required]
-        public string Branch
-        {
-            get
-            {
-                return IGitRepoExtension.NormalizeBranchName(_branch);
-            }
-            set
-            {
-                _branch = IGitRepoExtension.NormalizeBranchName(value);
-            }
-        }
+        public string Branch { get; set; }
 
         [Required]
         public int ChannelId { get; set; }

--- a/src/Maestro/Maestro.Data/Models/Repository.cs
+++ b/src/Maestro/Maestro.Data/Models/Repository.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.DotNet.DarcLib;
 using Newtonsoft.Json;
 
 namespace Maestro.Data.Models
@@ -94,17 +93,7 @@ namespace Maestro.Data.Models
         public string RepositoryName { get; set; }
 
         [MaxLength(Repository.BranchNameLength)]
-        public string BranchName
-        {
-            get
-            {
-                return IGitRepoExtension.NormalizeBranchName(_branch);
-            }
-            set
-            {
-                _branch = IGitRepoExtension.NormalizeBranchName(value);
-            }
-        }
+        public string BranchName { get; set; }
 
         /// <summary>
         ///     **true** if the update succeeded; **false** otherwise.
@@ -131,7 +120,5 @@ namespace Maestro.Data.Models
         ///     The parameters to the called method.
         /// </summary>
         public string Arguments { get; set; }
-
-        private string _branch;
     }
 }

--- a/src/Maestro/Maestro.Data/Models/Subscription.cs
+++ b/src/Maestro/Maestro.Data/Models/Subscription.cs
@@ -14,7 +14,6 @@ namespace Maestro.Data.Models
     {
         private string _sourceRepository;
         private string _targetRepository;
-        private string _branch;
 
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
@@ -50,17 +49,7 @@ namespace Maestro.Data.Models
             }
         }
 
-        public string TargetBranch
-        {
-            get
-            {
-                return IGitRepoExtension.NormalizeBranchName(_branch);
-            }
-            set
-            {
-                _branch = IGitRepoExtension.NormalizeBranchName(value);
-            }
-        }
+        public string TargetBranch { get; set; }
 
         [Column("Policy")]
         public string PolicyString { get; set; }

--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -219,9 +219,7 @@ function Darc-Delete-Channel($channelName) {
 function Darc-Add-Default-Channel($channelName, $repoUri, $branch) {
     $darcParams = @( "add-default-channel", "--channel", "$channelName", "--repo", "$repoUri", "--branch", "$branch" )
     Darc-Command -darcParams $darcParams
-    # We sometimes call add-default-channel with a refs/heads/ prefix, which
-    # will get stripped away by the DB.
-    $global:defaultChannelsToDelete += @{ channel = $channelName; repo = $repoUri; branch = $branch.ToString().Replace("refs/heads/", "") }
+    $global:defaultChannelsToDelete += @{ channel = $channelName; repo = $repoUri; branch = $branch }
 }
 
 function Darc-Delete-Default-Channel($channelName, $repoUri, $branch) {

--- a/src/Maestro/tests/Scenarios/default-channels.ps1
+++ b/src/Maestro/tests/Scenarios/default-channels.ps1
@@ -11,7 +11,6 @@ $testChannel1Name = Get-Random
 $testChannel2Name = Get-Random
 $repoName = "maestro-test1"
 $branchName = Get-Random
-$branchNameWithRefsHeads = "refs/heads/$branchName"
 $buildNumber = Get-Random
 $commit = Get-Random
 $assets = @(
@@ -47,12 +46,9 @@ try {
     # Adding default channels'
     Write-Host "Creating default channels"
     try { Darc-Delete-Default-Channel -channelName $testChannel1Name -repoUri $repoUri -branch $branchName } catch {}
-    try { Darc-Delete-Default-Channel -channelName $testChannel2Name -repoUri $repoUri -branch $branchNameWithRefsHeads } catch {}
+    try { Darc-Delete-Default-Channel -channelName $testChannel2Name -repoUri $repoUri -branch $branchName } catch {}
     Darc-Add-Default-Channel -channelName $testChannel1Name -repoUri $repoUri -branch $branchName
-    Darc-Add-Default-Channel -channelName $testChannel2Name -repoUri $repoUri -branch $branchNameWithRefsHeads
-
-    # Retrieve the default channel and ensure that the refs/heads section was removed
-
+    Darc-Add-Default-Channel -channelName $testChannel2Name -repoUri $repoUri -branch $branchName
 
     Write-Host "Set up build for intake into target repository"
 
@@ -68,9 +64,6 @@ try {
     if ($buildInfo.channels.length -ne 2) {
         throw "Expected to see build in 2 channels, got ${$buildInfo.channels.length}"
     }
-    if ($buildInfo.gitHubBranch -ne $branchName){
-        throw "Expected to see build branch was $branchName but was ${$buildInfo.gitHubBranch}"
-    }
     $success = ((($buildInfo.channels[0].name -eq $testChannel1Name) -or ($buildInfo.channels[1].name -eq $testChannel1Name)) `
         -and (($buildInfo.channels[0].name -eq $testChannel2Name -or $buildInfo.channels[1].name -eq $testChannel2Name)))
 
@@ -83,7 +76,7 @@ try {
     Darc-Disable-Default-Channel -channelName $testChannel1Name -repoUri $repoUri -branch $branchName
 
     # Create a build for the source repo
-    $buildId = New-Build -repository $repoUri -branch $branchNameWithRefsHeads -commit $commit -buildNumber $buildNumber -assets $assets
+    $buildId = New-Build -repository $repoUri -branch $branchName -commit $commit -buildNumber $buildNumber -assets $assets
 
     # Look up the build and ensure that the channels were added
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -38,14 +38,14 @@ namespace Microsoft.DotNet.Darc.Operations
                 defaultChannels.Add(
                     new DefaultChannel(0, "https://github.com/dotnet/arcade", true)
                     {
-                        Branch = "master",
+                        Branch = "refs/heads/master",
                         Channel = await barOnlyRemote.GetChannelAsync(".NET Tools - Latest")
                     }
                 );
                 defaultChannels.Add(
                     new DefaultChannel(0, "https://github.com/dotnet/arcade", true)
                     {
-                        Branch = "release/3.x",
+                        Branch = "refs/heads/release/3.x",
                         Channel = await barOnlyRemote.GetChannelAsync(".NET 3 Tools")
                     }
                 );

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetHealthOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetHealthOperation.cs
@@ -155,8 +155,9 @@ namespace Microsoft.DotNet.Darc.Operations
             // Compute the combinations that make sense.
             IEnumerable<(string repo, string branch)> defaultChannelsRepoBranchCombinations = defaultChannels
                 .Where(df => channelsToEvaluate.Contains(df.Channel.Name))
+                // Replace refs/heads/
                 .Where(df => reposToEvaluate.Contains(df.Repository))
-                .Select<DefaultChannel, (string repo, string branch)>(df => (df.Repository, df.Branch));
+                .Select<DefaultChannel, (string repo, string branch)>(df => (df.Repository, df.Branch.Replace("refs/heads/", "")));
 
             HashSet<(string repo, string branch)> repoBranchCombinations = subscriptions
                 .Where(s => reposToEvaluate.Contains(s.TargetRepository))

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoExtension.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoExtension.cs
@@ -38,6 +38,7 @@ namespace Microsoft.DotNet.DarcLib
             string decodedContent = GetDecodedContent(gitRepo, content);
             return Encoding.UTF8.GetBytes(decodedContent);
         }
+<<<<<<< HEAD
 
         const string refsHeadsPrefix = "refs/heads/";
         public static string NormalizeBranchName(string branch)
@@ -49,4 +50,7 @@ namespace Microsoft.DotNet.DarcLib
             return branch;
         }
 }
+=======
+    }
+>>>>>>> parent of 8d5521f... Normalize branch names by removing refs/heads (#648)
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoExtension.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoExtension.cs
@@ -38,19 +38,5 @@ namespace Microsoft.DotNet.DarcLib
             string decodedContent = GetDecodedContent(gitRepo, content);
             return Encoding.UTF8.GetBytes(decodedContent);
         }
-<<<<<<< HEAD
-
-        const string refsHeadsPrefix = "refs/heads/";
-        public static string NormalizeBranchName(string branch)
-        {
-            if (branch != null && branch.StartsWith(refsHeadsPrefix))
-            {
-                return branch.Substring(refsHeadsPrefix.Length);
-            }
-            return branch;
-        }
-}
-=======
     }
->>>>>>> parent of 8d5521f... Normalize branch names by removing refs/heads (#648)
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
@@ -170,19 +170,34 @@ namespace Microsoft.DotNet.DarcLib
             return new DependencyFlowGraph(nodes.Select(kv => kv.Value).ToList(), edges);
         }
 
+        private static string NormalizeBranch(string branch)
+        {
+            // Normalize branch names. Branch names may have "refs/heads" prepended.
+            // Remove if they do.
+            const string refsHeadsPrefix = "refs/heads/";
+            string normalizedBranch = branch;
+            if (normalizedBranch.StartsWith(refsHeadsPrefix))
+            {
+                normalizedBranch = normalizedBranch.Substring(refsHeadsPrefix.Length);
+            }
+
+            return normalizedBranch;
+        }
+
         private static DependencyFlowNode GetOrCreateNode(
             string repo,
             string branch,
             Dictionary<string, DependencyFlowNode> nodes)
         {
-            string key = $"{repo}@{branch}";
+            string normalizedBranch = NormalizeBranch(branch);
+            string key = $"{repo}@{normalizedBranch}";
             if (nodes.TryGetValue(key, out DependencyFlowNode existingNode))
             {
                 return existingNode;
             }
             else
             {
-                DependencyFlowNode newNode = new DependencyFlowNode(repo, branch);
+                DependencyFlowNode newNode = new DependencyFlowNode(repo, normalizedBranch);
                 nodes.Add(key, newNode);
                 return newNode;
             }


### PR DESCRIPTION
This reverts commit 8d5521fc34ee78c009e74658d61fbdf1206c2822.

This change is messing up default channel assignment during the publishing process. Causing silent publishing failures.