### PR TITLE
Add staleness metric to barviz

### DIFF
--- a/src/Maestro/Maestro.Data/Models/Build.cs
+++ b/src/Maestro/Maestro.Data/Models/Build.cs
@@ -117,6 +117,9 @@ namespace Maestro.Data.Models
         public List<BuildChannel> BuildChannels { get; set; }
 
         [NotMapped]
+        public int Staleness { get; set; }
+
+        [NotMapped]
         public List<BuildDependency> DependentBuildIds { get; set; }
     }
 
@@ -147,5 +150,7 @@ namespace Maestro.Data.Models
         public int DependentBuildId { get; set; }
         public Build DependentBuild { get; set; }
         public bool IsProduct { get; set; }
+        [NotMapped]
+        public int Staleness { get; set; }
     }
 }

--- a/src/Maestro/Maestro.Data/Models/Build.cs
+++ b/src/Maestro/Maestro.Data/Models/Build.cs
@@ -150,7 +150,5 @@ namespace Maestro.Data.Models
         public int DependentBuildId { get; set; }
         public Build DependentBuild { get; set; }
         public bool IsProduct { get; set; }
-        [NotMapped]
-        public int Staleness { get; set; }
     }
 }

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Models/Build.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Models/Build.cs
@@ -38,6 +38,7 @@ namespace Maestro.Web.Api.v2019_01_16.Models
                 .ToList();
             Assets = other.Assets?.Select(a => new v2018_07_16.Models.Asset(a)).ToList();
             Dependencies = other.DependentBuildIds?.Select(d => new BuildRef(d.DependentBuildId, d.IsProduct)).ToList();
+            Staleness = other.Staleness;
         }
 
         public int Id { get; }
@@ -71,5 +72,7 @@ namespace Maestro.Web.Api.v2019_01_16.Models
         public List<v2018_07_16.Models.Asset> Assets { get; }
 
         public List<BuildRef> Dependencies { get; }
+
+        public int Staleness { get; }
     }
 }

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -67,7 +67,7 @@
     <th>Repository</th>
     <th>Date Produced</th>
     <th>Build Number</th>
-    <th>Staleness</th>
+    <th>Build Staleness</th>
     <th>Commit</th>
     <th>Link</th>
   </thead>

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -67,6 +67,7 @@
     <th>Repository</th>
     <th>Date Produced</th>
     <th>Build Number</th>
+    <th>Staleness</th>
     <th>Commit</th>
     <th>Link</th>
   </thead>
@@ -110,6 +111,14 @@
           [title]="!isCoherent(node) ? 'A newer build of this same repository is in the tree' : (hasIncoherentDependencies(node) ? 'This build relies on dependencies that are incoherent' : '')" 
           [style.visibility]="(!isCoherent(node) || hasIncoherentDependencies(node)) ? 'visible' : 'hidden'"></fa-icon>
         {{node.build.azureDevOpsBuildNumber}}
+      </td>
+      <td>
+        <span [style.display]="node.build.staleness == '0' ? 'inline' : 'none'">
+          latest
+        </span>
+        <div [style.display]="node.build.staleness != '0' ? 'inline' : 'none'">
+          {{node.build.staleness}} behind
+        </div>
       </td>
       <td class="text-monospace">
         <fa-icon [icon]="!isCoherent(node) ? 'exclamation-circle' : 'exclamation-triangle'" 

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -113,12 +113,12 @@
         {{node.build.azureDevOpsBuildNumber}}
       </td>
       <td>
-        <span [style.display]="node.build.staleness == '0' ? 'inline' : 'none'">
+        <span *ngIf="node.build.staleness == '0'">
           latest
         </span>
-        <div [style.display]="node.build.staleness != '0' ? 'inline' : 'none'">
+        <span *ngIf="node.build.staleness != '0'">
           {{node.build.staleness}} behind
-        </div>
+        </span>
       </td>
       <td class="text-monospace">
         <fa-icon [icon]="!isCoherent(node) ? 'exclamation-circle' : 'exclamation-triangle'" 

--- a/src/Maestro/maestro-angular/src/maestro-client/models.ts
+++ b/src/Maestro/maestro-angular/src/maestro-client/models.ts
@@ -406,6 +406,7 @@ export class Build {
             channels,
             assets,
             dependencies,
+            staleness,
         }: {
             id: number,
             commit?: string,
@@ -423,6 +424,7 @@ export class Build {
             channels?: Channel[],
             assets?: Asset[],
             dependencies?: BuildRef[],
+            staleness?: number,
         }
     ) {
         this._id = id;
@@ -441,6 +443,7 @@ export class Build {
         this._channels = channels;
         this._assets = assets;
         this._dependencies = dependencies;
+        this._staleness = staleness;
     }
 
     private _id: number;
@@ -578,6 +581,12 @@ export class Build {
     public get dependencies(): BuildRef[] | undefined {
         return this._dependencies;
     }
+
+    private _staleness?: number;
+
+    public get staleness(): number | undefined {
+        return this._staleness;
+    }
     
     public isValid(): boolean {
         return (
@@ -605,6 +614,7 @@ export class Build {
             channels: value["channels"] == null ? undefined : value["channels"].map((e: any) => Channel.fromRawObject(e)) as any,
             assets: value["assets"] == null ? undefined : value["assets"].map((e: any) => Asset.fromRawObject(e)) as any,
             dependencies: value["dependencies"] == null ? undefined : value["dependencies"].map((e: any) => BuildRef.fromRawObject(e)) as any,
+            staleness: value["staleness"] == null ? undefined : value["staleness"] as any,
         });
         return result;
     }
@@ -652,6 +662,9 @@ export class Build {
         }
         if (value._dependencies) {
             result["dependencies"] = value._dependencies.map((e: any) => BuildRef.toRawObject(e));
+        }
+        if (value._staleness) {
+            result["staleness"] = value._staleness;
         }
         return result;
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/2782, https://github.com/dotnet/arcade/issues/2784

![image](https://user-images.githubusercontent.com/10092143/66084042-897f9780-e522-11e9-8070-171224b92799.png)
 
Adds a "Staleness" column which is a "reasonably" accurate reflection of how many more recent version of a dependency are available.  "Reasonable" meaning, it tries to figure out which channels may have relevant dependencies and how many of those are newer.  It's possible that subscriptions have changed or some other abnormal behavior which means the estimate is no longer valid.

FYI @adiaaida @meganaquinn @epananth 