### PR TITLE
Add dependency cycle check to barviz

### DIFF
--- a/src/Maestro/maestro-angular/src/app/app.module.ts
+++ b/src/Maestro/maestro-angular/src/app/app.module.ts
@@ -19,6 +19,7 @@ import {
   faTimesCircle,
   faQuestionCircle,
   faLock,
+  faRedo,
   faLockOpen,
 } from "@fortawesome/free-solid-svg-icons";
 import {
@@ -120,5 +121,6 @@ library.add(
   faQuestionCircle,
   farQuestionCircle,
   faLock,
+  faRedo,
   faLockOpen,
 );

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -11,18 +11,18 @@
       </tr>
       <tr>
         <td>
-        <span class="align-self-center" style="padding-right: 1rem;"><fa-icon icon="angle-up"></fa-icon></span>
+          <span class="align-self-center" style="padding-right: 1rem;"><fa-icon icon="angle-up"></fa-icon></span>
         </td>
         <td>
-        <span>This node is a parent of the focused node.</span>
+          <span>This node is a parent of the focused node.</span>
         </td>
       </tr>
       <tr>
         <td>
-        <span class="align-self-center" style="padding-right: 1rem;"><fa-icon icon="angle-right"></fa-icon></span>
+          <span class="align-self-center" style="padding-right: 1rem;"><fa-icon icon="angle-right"></fa-icon></span>
         </td>
         <td>
-        <span>This node is a child of the focused node.</span>
+          <span>This node is a child of the focused node.</span>
         </td>
       </tr>
       <tr>
@@ -32,7 +32,7 @@
         </span>
         </td>
         <td>
-        <span>This node is a different build of the same repository as the focused node.</span>
+          <span>This node is a different build of the same repository as the focused node.</span>
         </td>
       </tr>
       <tr>
@@ -53,10 +53,10 @@
       </tr>
       <tr>
         <td>
-        <span class="align-self-center" style="padding-right: 1rem;"><fa-icon icon="redo"></fa-icon></span>
+          <span class="align-self-center" style="padding-right: 1rem;"><fa-icon icon="redo"></fa-icon></span>
         </td>
         <td>
-        <span>This node has a dependency cycle.</span>
+          <span>This node has a dependency cycle.</span>
         </td>
       </tr>
     </tbody>

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -74,6 +74,7 @@
     </th>
     <th>Repository</th>
     <th>Date Produced</th>
+    <th></th>
     <th>Build Number</th>
     <th>Commit</th>
     <th>Link</th>
@@ -114,20 +115,19 @@
         <mc-time-ago [value]="node.build.dateProduced"></mc-time-ago>
       </td>
       <td>
-        <fa-icon [icon]="!isCoherent(node) ? 'exclamation-circle' : 'exclamation-triangle'" 
-          [title]="!isCoherent(node) ? 'A newer build of this same repository is in the tree' : (hasIncoherentDependencies(node) ? 'This build relies on dependencies that are incoherent' : '')" 
-          [style.visibility]="(!isCoherent(node) || hasIncoherentDependencies(node)) ? 'visible' : 'hidden'"></fa-icon>
         <fa-icon [icon]="hasCycle(node) ? 'redo' : 'exclamation-triangle'" 
           [title]="hasCycle(node) ? 'Build contains a dependency cycle: \n' + cyclePath(node) : ''" 
           [style.visibility]="hasCycle(node) ? 'visible' : 'hidden'"></fa-icon>
+      </td>
+      <td>
+        <fa-icon [icon]="!isCoherent(node) ? 'exclamation-circle' : 'exclamation-triangle'" 
+          [title]="!isCoherent(node) ? 'A newer build of this same repository is in the tree' : (hasIncoherentDependencies(node) ? 'This build relies on dependencies that are incoherent' : '')" 
+          [style.visibility]="(!isCoherent(node) || hasIncoherentDependencies(node)) ? 'visible' : 'hidden'"></fa-icon>
         {{node.build.azureDevOpsBuildNumber}}
       </td>
       <td class="text-monospace">
         <fa-icon [icon]="!isCoherent(node) ? 'exclamation-circle' : 'exclamation-triangle'" 
         [style.visibility]="(!isCoherent(node) || hasIncoherentDependencies(node)) ? 'visible' : 'hidden'"></fa-icon>
-        <fa-icon [icon]="hasCycle(node) ? 'redo' : 'exclamation-triangle'" 
-          [title]="hasCycle(node) ? 'Build contains a dependency cycle: \n' + cyclePath(node) : ''" 
-          [style.visibility]="hasCycle(node) ? 'visible' : 'hidden'"></fa-icon>
         <a *ngIf="(node.build | commitLink) as link; else noCommitLink" [href]="link" target="_blank">
           {{node.build.commit | slice:0:7}}
           <fa-icon icon="external-link-alt"></fa-icon>

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -51,6 +51,14 @@
           <span class='table-warning'>This node has incoherent dependencies</span>
         </td>
       </tr>
+      <tr>
+        <td>
+        <span class="align-self-center" style="padding-right: 1rem;"><fa-icon icon="redo"></fa-icon></span>
+        </td>
+        <td>
+        <span>This node has a dependency cycle.</span>
+        </td>
+      </tr>
     </tbody>
   </table>
   <p>
@@ -109,11 +117,17 @@
         <fa-icon [icon]="!isCoherent(node) ? 'exclamation-circle' : 'exclamation-triangle'" 
           [title]="!isCoherent(node) ? 'A newer build of this same repository is in the tree' : (hasIncoherentDependencies(node) ? 'This build relies on dependencies that are incoherent' : '')" 
           [style.visibility]="(!isCoherent(node) || hasIncoherentDependencies(node)) ? 'visible' : 'hidden'"></fa-icon>
+        <fa-icon [icon]="hasCycle(node) ? 'redo' : 'exclamation-triangle'" 
+          [title]="hasCycle(node) ? 'Build contains a dependency cycle: \n' + cyclePath(node) : ''" 
+          [style.visibility]="hasCycle(node) ? 'visible' : 'hidden'"></fa-icon>
         {{node.build.azureDevOpsBuildNumber}}
       </td>
       <td class="text-monospace">
         <fa-icon [icon]="!isCoherent(node) ? 'exclamation-circle' : 'exclamation-triangle'" 
         [style.visibility]="(!isCoherent(node) || hasIncoherentDependencies(node)) ? 'visible' : 'hidden'"></fa-icon>
+        <fa-icon [icon]="hasCycle(node) ? 'redo' : 'exclamation-triangle'" 
+          [title]="hasCycle(node) ? 'Build contains a dependency cycle: \n' + cyclePath(node) : ''" 
+          [style.visibility]="hasCycle(node) ? 'visible' : 'hidden'"></fa-icon>
         <a *ngIf="(node.build | commitLink) as link; else noCommitLink" [href]="link" target="_blank">
           {{node.build.commit | slice:0:7}}
           <fa-icon icon="external-link-alt"></fa-icon>

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -115,9 +115,9 @@
         <mc-time-ago [value]="node.build.dateProduced"></mc-time-ago>
       </td>
       <td>
-        <fa-icon [icon]="hasCycle(node) ? 'redo' : 'exclamation-triangle'" 
-          [title]="hasCycle(node) ? 'Build contains a dependency cycle: \n' + cyclePath(node) : ''" 
-          [style.visibility]="hasCycle(node) ? 'visible' : 'hidden'"></fa-icon>
+        <fa-icon [icon]="node.hasCycles ? 'redo' : 'exclamation-triangle'" 
+          [title]="node.hasCycles ? 'Build contains a dependency cycle: \n' + node.cyclePath : ''" 
+          [style.visibility]="node.hasCycles ? 'visible' : 'hidden'"></fa-icon>
       </td>
       <td>
         <fa-icon [icon]="!isCoherent(node) ? 'exclamation-circle' : 'exclamation-triangle'" 

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
@@ -201,9 +201,9 @@ function hasCycles(build:Build, buildData: BuildData[]): [boolean,string?] {
     if (hasCycle)
     {
       let newCycle = [getRepo(currentBuildData.build), cyclePath];
-      return [true, newCycle.join('->\n')];
+      cyclePath = newCycle.join('->\n');
     }
-    return dependencyHasCycle(currentBuildData, buildData, repository);
+    return [hasCycle, cyclePath]
   }
   return [false, undefined];
 }
@@ -385,14 +385,6 @@ export class BuildGraphTableComponent implements OnChanges {
       return node.coherent.withAll;
     }
     return node.coherent.withProduct;
-  }
-
-  public hasCycle(node: BuildData) {
-    return node.hasCycles;
-  }
-
-  public cyclePath(node:BuildData) {
-    return node.cyclePath;
   }
 
   public hasIncoherentDependencies(node: BuildData) {

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
@@ -106,9 +106,7 @@ function sortBuilds(graph: BuildGraph): BuildData[] {
     node.hasIncoherentDependenciesIncludingToolsets = hasIncoherentDependencies(node.build, result, true);
 
     // If node is incoherent with product check to make sure there aren't any cycles in the dependencies
-    let cycles = hasCycles(node.build, result);
-    node.hasCycles = cycles[0];
-    node.cyclePath = cycles[1];
+    [node.hasCycles, node.cyclePath] = hasCycles(node.build, result);
   }
 
   result = result.reverse();
@@ -199,10 +197,10 @@ function hasCycles(build:Build, buildData: BuildData[]): [boolean,string?] {
   // a cycle with the current repository
   if (currentBuildData && repository)
   {
-    let dependencyCycle = dependencyHasCycle(currentBuildData,buildData, repository)
-    if (dependencyCycle[0])
+    let [hasCycle, cyclePath] = dependencyHasCycle(currentBuildData,buildData, repository)
+    if (hasCycle)
     {
-      let newCycle = [getRepo(currentBuildData.build), dependencyCycle[1]];
+      let newCycle = [getRepo(currentBuildData.build), cyclePath];
       return [true, newCycle.join('->\n')];
     }
     return dependencyHasCycle(currentBuildData, buildData, repository);
@@ -229,10 +227,10 @@ function dependencyHasCycle(currentBuildData: BuildData, buildData:BuildData[], 
           
           // Check the dependencies of the current dependency to see if they result in a cycle.
           // Break on the first cycle found
-          let dependencyCycle = dependencyHasCycle(depBuildData,buildData, repository)
-          if (dependencyCycle[0])
+          let [hasCycle, cyclePath] = dependencyHasCycle(depBuildData,buildData, repository)
+          if (hasCycle)
           {
-            let newCycle = [getRepo(depBuildData.build), dependencyCycle[1]];
+            let newCycle = [getRepo(depBuildData.build), cyclePath];
             return [true, newCycle.join('->\n')];
           }
         }


### PR DESCRIPTION
This change adds functionality to barviz to check the dependency graph
for dependency cycles. For each node, we walk through the dependency
tree for that node and check to see if any of its product subdependencies
share the same repository url as the node's repository url, indicating a
cycle. We record that there is a cycle and the cycle path in the
BuildData.

In the UI, we display a redo symbol to indicate that there is a cycle at
a particular node, and the hover text includes the cycle path.

![image](https://user-images.githubusercontent.com/9666644/66160184-729e7b00-e5de-11e9-8e28-649b9c5fc41e.png)

Note: The example includes toolsets since we do not currently have any product dependency cycles, and I wanted to test that it was working properly.
