### PR TITLE
Limit download concurrency

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
@@ -22,6 +22,9 @@ namespace Microsoft.DotNet.Darc.Options
         [Option('o',"output-dir", Required = true, HelpText = "Output directory to place build drop.")]
         public string OutputDirectory { get; set; }
 
+        [Option("max-downloads", Default = 4, HelpText = "Maximum concurrent downloads.")]
+        public int MaxConcurrentDownloads { get; set; }
+
         [Option('f', "full", HelpText = "Gather the full drop (build and all input builds).")]
         public bool Transitive { get; set; }
 


### PR DESCRIPTION
The amount of concurrency we were allowing when downloading builds was a little aggressive. It was regularly causing the downloads to hang (presumably thread pool starvation). Introduce a semaphore to limit concurrenycy a specific number of parallel downloads. The default is 4.