### PR TITLE
Require repo for add-dependency

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddDependencyCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddDependencyCommandLineOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Darc.Options
         [Option('v', "version", HelpText = "Dependency version.")]
         public string Version { get; set; }
 
-        [Option('r', "repo", HelpText = "Repository where the dependency was built.")]
+        [Option('r', "repo", Required = true, HelpText = "Repository where the dependency was built.")]
         public string RepoUri { get; set; }
 
         [Option('c', "commit", HelpText = "SHA at which the dependency was produced.")]


### PR DESCRIPTION
A common method for adding a new dependency involves using add-dependency, the calling update-dependencies to get the right version number and commit. update-dependencies uses the repo uri as a shorthand to look up what builds should be applied to the local branch, so not including the repo uri makes that flow impossible. You could push the branch, and allow Maestro to eventually update the dependencies, but most likely if you don't have the right version, you couldn't check in the new dependency anyway.

It's probably best to just require the repo uri initially.