### PR TITLE
Bump LibGit2Sharp version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
     <CommandLineParserVersion>2.2.1</CommandLineParserVersion>
     <CredentialManagementVersion>1.0.2</CredentialManagementVersion>
     <HandlebarsNetVersion>1.9.5</HandlebarsNetVersion>
-    <LibGit2SharpVersion>0.26.0</LibGit2SharpVersion>
+    <LibGit2SharpVersion>0.27.0-preview-0024</LibGit2SharpVersion>
     <log4netVersion>2.0.8</log4netVersion>
     <SystemNetHttpVersion>4.3.3</SystemNetHttpVersion>
     <MicrosoftApplicationInsightsVersion>2.10.0</MicrosoftApplicationInsightsVersion>


### PR DESCRIPTION
LibGit2Sharp 0.27.0-preview-0020 improves support for a number of architectures and linux distributions: https://github.com/libgit2/libgit2sharp/pull/1714

This makes it possible to use arcade (via source-build) on RHEL on arm64.

As an example, I need it for this PR: https://github.com/dotnet/source-build/pull/1300