### PR TITLE
Introduce "released" bit for builds

### DIFF
--- a/src/Maestro/Maestro.Data/Migrations/20191010154529_add_Released.Designer.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20191010154529_add_Released.Designer.cs
@@ -4,14 +4,16 @@ using Maestro.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Maestro.Data.Migrations
 {
     [DbContext(typeof(BuildAssetRegistryContext))]
-    partial class BuildAssetRegistryContextModelSnapshot : ModelSnapshot
+    [Migration("20191010154529_add_Released")]
+    partial class add_Released
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Maestro/Maestro.Data/Migrations/20191010154529_add_Released.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20191010154529_add_Released.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Maestro.Data.Migrations
+{
+    public partial class add_Released : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Released",
+                table: "Builds",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Released",
+                table: "Builds");
+        }
+    }
+}

--- a/src/Maestro/Maestro.Data/Models/Build.cs
+++ b/src/Maestro/Maestro.Data/Models/Build.cs
@@ -93,6 +93,12 @@ namespace Maestro.Data.Models
 
         public List<BuildChannel> BuildChannels { get; set; }
 
+        /// <summary>
+        /// If true, the build has been released to the public. This can be used to make decisions on whether certain
+        /// builds should be included in future release drops.
+        /// </summary>
+        public bool Released { get; set; } = false;
+
         [NotMapped]
         public int Staleness { get; set; }
 

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildsController.cs
@@ -143,6 +143,34 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
             return Ok(new Models.Build(build));
         }
 
+        [HttpPatch("{buildId}")]
+        [SwaggerApiResponse(HttpStatusCode.OK, Type = typeof(Build), Description = "Update a build with new information.")]
+        [ValidateModelState]
+        public virtual async Task<IActionResult> Update(int buildId, [FromBody, Required] BuildUpdate buildUpdate)
+        {
+            Data.Models.Build build = await _context.Builds.Where(b => b.Id == buildId).FirstOrDefaultAsync();
+
+            if (build == null)
+            {
+                return NotFound();
+            }
+
+            bool doUpdate = false;
+            if (buildUpdate.Released.HasValue)
+            {
+                build.Released = buildUpdate.Released.Value;
+                doUpdate = true;
+            }
+
+            if (doUpdate)
+            {
+                _context.Builds.Update(build);
+                await _context.SaveChangesAsync();
+            }
+
+            return Ok(new Models.Build(build));
+        }
+
         [ApiRemoved]
         public sealed override Task<IActionResult> Create(v2018_07_16.Models.BuildData build)
         {

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Models/Build.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Models/Build.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Maestro.Web.Api.v2019_01_16.Models;
+using Octokit;
 
 namespace Maestro.Web.Api.v2019_01_16.Models
 {
@@ -39,6 +40,7 @@ namespace Maestro.Web.Api.v2019_01_16.Models
             Assets = other.Assets?.Select(a => new v2018_07_16.Models.Asset(a)).ToList();
             Dependencies = other.DependentBuildIds?.Select(d => new BuildRef(d.DependentBuildId, d.IsProduct)).ToList();
             Staleness = other.Staleness;
+            Released = other.Released;
         }
 
         public int Id { get; }
@@ -74,5 +76,7 @@ namespace Maestro.Web.Api.v2019_01_16.Models
         public List<BuildRef> Dependencies { get; }
 
         public int Staleness { get; }
+
+        public bool Released { get; }
     }
 }

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Models/BuildData.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Models/BuildData.cs
@@ -44,6 +44,8 @@ namespace Maestro.Web.Api.v2019_01_16.Models
 
         public bool PublishUsingPipelines { get; set; }
 
+        public bool Released { get; set; }
+
         public Data.Models.Build ToDb()
         {
             return new Data.Models.Build
@@ -59,7 +61,8 @@ namespace Maestro.Web.Api.v2019_01_16.Models
                 AzureDevOpsRepository = AzureDevOpsRepository,
                 AzureDevOpsBranch = AzureDevOpsBranch,
                 Commit = Commit,
-                Assets = Assets?.Select(a => a.ToDb()).ToList()
+                Assets = Assets?.Select(a => a.ToDb()).ToList(),
+                Released = Released
             };
         }
     }

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Models/BuildUpdate.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Models/BuildUpdate.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Maestro.Web.Api.v2019_01_16.Models
+{
+    public class BuildUpdate
+    {
+        public bool? Released { get; set; }
+    }
+}


### PR DESCRIPTION
One issue with the current infra is that old builds will continue to be referenced throughout the graph because we do not ship all packages for every servicing release. This means that darc will gather the drop and include old builds. This bit gives us an easy way to trim those builds. As they are officially released, we can mark them as such and then gather-drop can trim them away automatically.

This change is the database and API change required for the feature. After this is checked in, I'll add the darc functionality and tests (using darc)