### PR TITLE
Do not stage files in local git client

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -156,7 +156,7 @@ namespace Microsoft.DotNet.DarcLib
             {
                 using (LibGit2Sharp.Repository localRepo = new LibGit2Sharp.Repository(repoDir))
                 {
-                    foreach (GitFile file in filesToCommit.Where(f => f.Operation != GitFileOperation.Delete))
+                    foreach (GitFile file in filesToCommit)
                     {
                         switch (file.Operation)
                         {
@@ -198,7 +198,6 @@ namespace Microsoft.DotNet.DarcLib
                                 break;
                         }
                     }
-                    LibGit2Sharp.Commands.Stage(localRepo, filesToCommit.Select(f => f.FilePath));
                 }
             }
             catch (Exception exc)


### PR DESCRIPTION
Do not stage files, except for adds (where the file mode may be interesting) when doing update dependencies locally.
Additionally, remove a filter preventing the deletion of files when operating locally.