### PR TITLE
Fix update-dependencies to honor nuget.config

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -55,22 +55,15 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns></returns>
         public async Task UpdateDependenciesAsync(List<DependencyDetail> dependencies, IRemoteFactory remoteFactory)
         {
-            // TODO: This should use known updaters, but today the updaters for global.json can only
-            // add, not actually update.  This needs a fix. https://github.com/dotnet/arcade/issues/1095
-            /*List<DependencyDetail> defaultUpdates = new List<DependencyDetail>(, IRemote remote);
-            foreach (DependencyDetail dependency in dependencies)
-            {
-                if (DependencyOperations.TryGetKnownUpdater(dependency.Name, out Delegate function))
-                {
-                    await (Task)function.DynamicInvoke(_fileManager, _repo, dependency);
-                }
-                else
-                {
-                    defaultUpdates.Add(dependency);
-                }
-            }*/
+            // Read the current dependency files and grab their locations so that nuget.config can be updated appropriately.
+            // Update the incoming dependencies with locations.
+            IEnumerable<DependencyDetail> oldDependencies = await GetDependenciesAsync();
 
-            var fileContainer = await _fileManager.UpdateDependencyFiles(dependencies, _repo, null);
+            IRemote barOnlyRemote = await remoteFactory.GetBarOnlyRemoteAsync(_logger);
+            await barOnlyRemote.AddAssetLocationToDependenciesAsync(oldDependencies);
+            await barOnlyRemote.AddAssetLocationToDependenciesAsync(dependencies);
+
+            var fileContainer = await _fileManager.UpdateDependencyFiles(dependencies, _repo, null, oldDependencies);
             List<GitFile> filesToUpdate = fileContainer.GetFilesToCommit();
 
             // TODO: This needs to be moved into some consistent handling between local/remote and add/update:

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -756,7 +756,7 @@ namespace Microsoft.DotNet.DarcLib
             string message)
         {
             IEnumerable<DependencyDetail> oldDependencies = await GetDependenciesAsync(repoUri, branch, loadAssetLocations: true);
-            itemsToUpdate = (await AddAssetLocationToDependenciesAsync(itemsToUpdate)).ToList();
+            await AddAssetLocationToDependenciesAsync(itemsToUpdate);
 
             CheckForValidGitClient();
             GitFileContentContainer fileContainer =
@@ -975,7 +975,7 @@ namespace Microsoft.DotNet.DarcLib
 
             if (loadAssetLocations)
             {
-                dependencies = await AddAssetLocationToDependenciesAsync(dependencies);
+                await AddAssetLocationToDependenciesAsync(dependencies);
             }
 
             return dependencies;
@@ -1099,7 +1099,12 @@ namespace Microsoft.DotNet.DarcLib
 
         }
 
-        private async Task<IEnumerable<DependencyDetail>> AddAssetLocationToDependenciesAsync(IEnumerable<DependencyDetail> dependencies)
+        /// <summary>
+        ///     Update a list of dependencies with asset locations.
+        /// </summary>
+        /// <param name="dependencies">Dependencies to load locations for</param>
+        /// <returns>Async task</returns>
+        public async Task AddAssetLocationToDependenciesAsync(IEnumerable<DependencyDetail> dependencies)
         {
             foreach (var dependency in dependencies)
             {
@@ -1134,7 +1139,6 @@ namespace Microsoft.DotNet.DarcLib
                     dependency.Locations = currentAssetLocations;
                 }
             }
-            return dependencies;
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -184,7 +184,7 @@ namespace Microsoft.DotNet.DarcLib
             IEnumerable<DependencyDetail> itemsToUpdate,
             string repoUri,
             string branch,
-            IEnumerable<DependencyDetail> oldDependencies = null)
+            IEnumerable<DependencyDetail> oldDependencies)
         {
             XmlDocument versionDetails = await ReadVersionDetailsXmlAsync(repoUri, branch);
             XmlDocument versionProps = await ReadVersionPropsAsync(repoUri, branch);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -410,6 +410,13 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns>List of assets.</returns>
         Task<IEnumerable<Asset>> GetAssetsAsync(string name = null, string version = null, int? buildId = null, bool? nonShipping = null);
 
+        /// <summary>
+        ///     Update a list of dependencies with asset locations.
+        /// </summary>
+        /// <param name="dependencies">Dependencies to load locations for</param>
+        /// <returns>Async task</returns>
+        Task AddAssetLocationToDependenciesAsync(IEnumerable<DependencyDetail> dependencies);
+
         #endregion
     }
 }

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
@@ -73,6 +73,7 @@ namespace Microsoft.DotNet.Darc.Tests
             GitFileContentContainer container = await _gitFileManager.UpdateDependencyFiles(
                 dependencies,
                 TemporaryRepositoryPath,
+                null,
                 null);
             List<GitFile> filesToUpdate = container.GetFilesToCommit();
             await _gitClient.CommitFilesAsync(filesToUpdate, TemporaryRepositoryPath, null, null);
@@ -87,6 +88,7 @@ namespace Microsoft.DotNet.Darc.Tests
             GitFileContentContainer container = await _gitFileManager.UpdateDependencyFiles(
                 dependencies,
                 TemporaryRepositoryPath,
+                null,
                 null);
             List<GitFile> filesToUpdate = container.GetFilesToCommit();
             await _gitClient.CommitFilesAsync(filesToUpdate, TemporaryRepositoryPath, null, null);


### PR DESCRIPTION
Asset locations were not being loaded for dependencies when doing local update-dependencies. This causes the updater to remove all maestro managed feeds in the nuget.config file.