### PR TITLE
Add TimeToInclusion to BAR and BarViz

### DIFF
--- a/src/Maestro/Client/src/Generated/Models/BuildRef.cs
+++ b/src/Maestro/Client/src/Generated/Models/BuildRef.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DotNet.Maestro.Client.Models
         {
             BuildId = buildId;
             IsProduct = isProduct;
+            TimeToInclusionInMinutes = 0;
         }
 
         [JsonProperty("buildId")]
@@ -17,5 +18,8 @@ namespace Microsoft.DotNet.Maestro.Client.Models
 
         [JsonProperty("isProduct")]
         public bool IsProduct { get; }
+
+        [JsonProperty("timeToInclusionInMinutes")]
+        public double TimeToInclusionInMinutes { get; }
     }
 }

--- a/src/Maestro/Maestro.Data/BuildAssetRegistryContext.cs
+++ b/src/Maestro/Maestro.Data/BuildAssetRegistryContext.cs
@@ -279,6 +279,7 @@ FOR SYSTEM_TIME ALL
             var buildIdColumnName = dependencyEntity.FindProperty(nameof(BuildDependency.BuildId)).Relational().ColumnName;
             var dependencyIdColumnName = dependencyEntity.FindProperty(nameof(BuildDependency.DependentBuildId)).Relational().ColumnName;
             var isProductColumnName = dependencyEntity.FindProperty(nameof(BuildDependency.IsProduct)).Relational().ColumnName;
+            var timeToInclusionInMinutesColumnName = dependencyEntity.FindProperty(nameof(BuildDependency.TimeToInclusionInMinutes)).Relational().ColumnName;
             var edgeTable = dependencyEntity.Relational().TableName;
 
             var edges = BuildDependencies.FromSql($@"
@@ -287,6 +288,7 @@ WITH traverse AS (
             {buildIdColumnName},
             {dependencyIdColumnName},
             {isProductColumnName},
+            {timeToInclusionInMinutesColumnName},
             0 as Depth
         from {edgeTable}
         WHERE {buildIdColumnName} = @id
@@ -295,6 +297,7 @@ WITH traverse AS (
             {edgeTable}.{buildIdColumnName},
             {edgeTable}.{dependencyIdColumnName},
             {edgeTable}.{isProductColumnName},
+            {edgeTable}.{timeToInclusionInMinutesColumnName},
             traverse.Depth + 1
         FROM {edgeTable}
         INNER JOIN traverse
@@ -302,7 +305,7 @@ WITH traverse AS (
         WHERE traverse.{isProductColumnName} = 1 -- The thing we previously traversed was a product dependency
             AND traverse.Depth < 10 -- Don't load all the way back because of incorrect isProduct columns
 )
-SELECT DISTINCT {buildIdColumnName}, {dependencyIdColumnName}, {isProductColumnName}
+SELECT DISTINCT {buildIdColumnName}, {dependencyIdColumnName}, {isProductColumnName}, {timeToInclusionInMinutesColumnName}
 FROM traverse;",
                new SqlParameter("id", buildId));
 

--- a/src/Maestro/Maestro.Data/Migrations/20191018204719_AddTimeToInclusionInMinutes.Designer.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20191018204719_AddTimeToInclusionInMinutes.Designer.cs
@@ -4,14 +4,16 @@ using Maestro.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Maestro.Data.Migrations
 {
     [DbContext(typeof(BuildAssetRegistryContext))]
-    partial class BuildAssetRegistryContextModelSnapshot : ModelSnapshot
+    [Migration("20191018204719_AddTimeToInclusionInMinutes")]
+    partial class AddTimeToInclusionInMinutes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Maestro/Maestro.Data/Migrations/20191018204719_AddTimeToInclusionInMinutes.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20191018204719_AddTimeToInclusionInMinutes.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Maestro.Data.Migrations
+{
+    public partial class AddTimeToInclusionInMinutes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "TimeToInclusionInMinutes",
+                table: "BuildDependencies",
+                nullable: false,
+                defaultValue: 0.0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TimeToInclusionInMinutes",
+                table: "BuildDependencies");
+        }
+    }
+}

--- a/src/Maestro/Maestro.Data/Models/Build.cs
+++ b/src/Maestro/Maestro.Data/Models/Build.cs
@@ -152,6 +152,9 @@ namespace Maestro.Data.Models
         public int DependentBuildId { get; set; }
         public Build DependentBuild { get; set; }
         public bool IsProduct { get; set; }
+
+        // Time between when the dependent build was produced and when it was first added as a dependency
+        // To this build's repository and branch
         public double TimeToInclusionInMinutes { get; set; }
     }
 }

--- a/src/Maestro/Maestro.Data/Models/Build.cs
+++ b/src/Maestro/Maestro.Data/Models/Build.cs
@@ -152,5 +152,6 @@ namespace Maestro.Data.Models
         public int DependentBuildId { get; set; }
         public Build DependentBuild { get; set; }
         public bool IsProduct { get; set; }
+        public double TimeToInclusionInMinutes { get; set; }
     }
 }

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildsController.cs
@@ -165,11 +165,20 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
             buildModel.DateProduced = DateTimeOffset.UtcNow;
             if (build.Dependencies != null)
             {
-                // For each Dependency, update the time to Inclusion
+                // For each Dependency, update the time to Inclusion.
+                // This measure is to be used for telemetry purposes, and has several known corner cases
+                // where the measurement will not be correct:
+                // 1. For any dependencies that were added before this column was added, the TimeToInclusionInMinutes
+                //    will be 0.
+                // 2. For new release branches, until new builds of dependencies are added, this will recalculate
+                //    the TimeToInclusion, so it will seem inordinately large until new builds are added. This will
+                //    be particularly true for dependencies that are infrequently updated.
                 foreach (var dep in build.Dependencies)
                 {
-                    // Find the dependency in BuildDependencies table where the build it is associated with
-                    // matches the repository and branch of the current build
+                    // Heuristic to discover if this dependency has been added to the same repository and branch 
+                    // of the current build. If we find a match in the BuildDependencies table, it means
+                    // that this is not a new dependency, and we should use the TimeToInclusionInMinutes
+                    // of the previous time this dependency was added.
                     var buildDependency = _context.BuildDependencies.Where( d =>
                             d.DependentBuildId == dep.BuildId &&
                             d.Build.GitHubRepository == buildModel.GitHubRepository &&
@@ -178,16 +187,9 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
                             d.Build.AzureDevOpsBranch == buildModel.AzureDevOpsBranch
                         ).FirstOrDefault();
 
-                    if (buildDependency != null && buildDependency.TimeToInclusionInMinutes != 0)
+                    if (buildDependency != null)
                     {
                         dep.TimeToInclusionInMinutes = buildDependency.TimeToInclusionInMinutes;
-                    }
-                    else if (buildDependency != null && buildDependency.TimeToInclusionInMinutes == 0)
-                    {
-                        // Calculate the buildDependency's time to inclusion, and use that
-                        Data.Models.Build originalBuild = await _context.Builds.FindAsync(buildDependency.BuildId);
-                        Data.Models.Build depBuild = await _context.Builds.FindAsync(dep.BuildId);
-                        dep.TimeToInclusionInMinutes = (originalBuild.DateProduced - depBuild.DateProduced).TotalMinutes;
                     }
                     else
                     {

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildsController.cs
@@ -208,9 +208,9 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
                         DateTimeOffset startTime = depBuild.DateProduced;
 
                         Data.Models.Subscription subscription = _context.Subscriptions.Where( s =>
-                            s.SourceRepository == depBuild.GitHubRepository &&
-                            s.TargetRepository == buildModel.GitHubRepository &&
-                            s.TargetBranch == buildModel.GitHubBranch
+                            (s.SourceRepository == depBuild.GitHubRepository || s.SourceRepository == depBuild.AzureDevOpsRepository ) &&
+                            (s.TargetRepository == buildModel.GitHubRepository || s.TargetRepository == buildModel.AzureDevOpsRepository) &&
+                            (s.TargetBranch == buildModel.GitHubBranch || s.TargetBranch == buildModel.AzureDevOpsBranch)
                         ).LastOrDefault();
 
                         

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildsController.cs
@@ -84,6 +84,9 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
                 return NotFound();
             }
 
+            List<Data.Models.BuildDependency> dependentBuilds = _context.BuildDependencies.Where(b => b.BuildId == id).ToList();
+            build.DependentBuildIds = dependentBuilds;
+
             return Ok(new Build(build));
         }
 

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Models/Build.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Models/Build.cs
@@ -37,7 +37,7 @@ namespace Maestro.Web.Api.v2019_01_16.Models
                 .Select(c => new v2018_07_16.Models.Channel(c))
                 .ToList();
             Assets = other.Assets?.Select(a => new v2018_07_16.Models.Asset(a)).ToList();
-            Dependencies = other.DependentBuildIds?.Select(d => new BuildRef(d.DependentBuildId, d.IsProduct)).ToList();
+            Dependencies = other.DependentBuildIds?.Select(d => new BuildRef(d.DependentBuildId, d.IsProduct, d.TimeToInclusionInMinutes)).ToList();
             Staleness = other.Staleness;
         }
 

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Models/BuildData.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Models/BuildData.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Maestro.Web.Api.v2019_01_16.Models;
 using Microsoft.AspNetCore.ApiVersioning;
+using Newtonsoft.Json;
 
 namespace Maestro.Web.Api.v2019_01_16.Models
 {
@@ -66,13 +67,22 @@ namespace Maestro.Web.Api.v2019_01_16.Models
 
     public class BuildRef
     {
+        [JsonConstructor]
         public BuildRef(int buildId, bool isProduct)
         {
             BuildId = buildId;
             IsProduct = isProduct;
         }
 
+        public BuildRef(int buildId, bool isProduct, double timeToInclusionInMinutes)
+        {
+            BuildId = buildId;
+            IsProduct = isProduct;
+            TimeToInclusionInMinutes = timeToInclusionInMinutes;
+        }
+
         public int BuildId { get; }
         public bool IsProduct { get; }
+        public double TimeToInclusionInMinutes { get; set; }
     }
 }

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -74,7 +74,15 @@
     </th>
     <th>Repository</th>
     <th>Date Produced</th>
-    <th><span title="Time it took for this dependency to flow to the root node in minutes">Time To Inclusion</span></th>
+    <th>
+      <span title="Cummulative time it took for the dependency to flow through each repository in the 
+build graph to the root node. For each edge in the dependency graph, when a dependency is added to BAR
+the first time for a given dependent build id and parent repository and branch, we calculate the difference
+between when the dependent build was added to BAR and when the parent build was added to BAR. The total time to
+inclusion is then calculated by walking the dependency graph and summing the individual edges' time to inclusion.">
+        Time To Inclusion
+      </span>
+    </th>
     <th></th>
     <th>Build Number</th>
     <th>Build Staleness</th>

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -74,6 +74,7 @@
     </th>
     <th>Repository</th>
     <th>Date Produced</th>
+    <th><span title="Time it took for this dependency to flow to the root node in minutes">Time To Inclusion</span></th>
     <th></th>
     <th>Build Number</th>
     <th>Build Staleness</th>
@@ -114,6 +115,11 @@
       </td>
       <td>
         <mc-time-ago [value]="node.build.dateProduced"></mc-time-ago>
+      </td>
+      <td>
+        <span>
+          {{timeToInclusion(node)}} minutes
+        </span>
       </td>
       <td>
         <fa-icon [icon]="node.hasCycles ? 'redo' : 'exclamation-triangle'" 

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
@@ -25,6 +25,7 @@ interface BuildData {
   hasIncoherentDependenciesIncludingToolsets?: boolean;
   hasCycles?: boolean;
   cyclePath?: string;
+  timeToInclusionInMinutes?: number;
 }
 
 function getState(b: BuildData): BuildState | undefined {
@@ -128,6 +129,9 @@ function sortBuilds(graph: BuildGraph): BuildData[] {
         }
       }
     }
+
+    result[0].timeToInclusionInMinutes = 0;
+    calculateNodeTimeToInclusion(result[0].build, result, result[0].timeToInclusionInMinutes);
   }
 
   for (const node of result) {
@@ -240,6 +244,21 @@ function dependencyHasCycle(currentBuildData: BuildData, buildData:BuildData[], 
 
   // No cycle was found
   return [false, undefined];
+}
+
+function calculateNodeTimeToInclusion(build:Build, buildData:BuildData[], inclusionTimeOfParent:number): void {
+  if (build.dependencies)
+  {
+    for (const dep of build.dependencies)
+    {
+      let depBuildData = buildData.find(r => r.build.id == dep.buildId);
+      if (depBuildData)
+      {
+        depBuildData.timeToInclusionInMinutes = inclusionTimeOfParent + dep.timeToInclusionInMinutes;
+        calculateNodeTimeToInclusion(depBuildData.build, buildData, depBuildData.timeToInclusionInMinutes);
+      }
+    }
+  }
 }
 
 const elementOutStyle = style({
@@ -385,6 +404,13 @@ export class BuildGraphTableComponent implements OnChanges {
       return node.coherent.withAll;
     }
     return node.coherent.withProduct;
+  }
+
+  public timeToInclusion(node:BuildData) {
+    if (node.timeToInclusionInMinutes) {
+      return node.timeToInclusionInMinutes.toLocaleString();
+    }
+    return 0;
   }
 
   public hasIncoherentDependencies(node: BuildData) {

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
@@ -247,13 +247,10 @@ function dependencyHasCycle(currentBuildData: BuildData, buildData:BuildData[], 
 }
 
 function calculateNodeTimeToInclusion(build:Build, buildData:BuildData[], inclusionTimeOfParent:number): void {
-  if (build.dependencies)
-  {
-    for (const dep of build.dependencies)
-    {
+  if (build.dependencies) {
+    for (const dep of build.dependencies) {
       let depBuildData = buildData.find(r => r.build.id == dep.buildId);
-      if (depBuildData)
-      {
+      if (depBuildData) {
         depBuildData.timeToInclusionInMinutes = inclusionTimeOfParent + dep.timeToInclusionInMinutes;
         calculateNodeTimeToInclusion(depBuildData.build, buildData, depBuildData.timeToInclusionInMinutes);
       }

--- a/src/Maestro/maestro-angular/src/maestro-client/models.ts
+++ b/src/Maestro/maestro-angular/src/maestro-client/models.ts
@@ -951,13 +951,16 @@ export class BuildRef {
         {
             buildId,
             isProduct,
+            timeToInclusionInMinutes,
         }: {
             buildId: number,
             isProduct: boolean,
+            timeToInclusionInMinutes: number,
         }
     ) {
         this._buildId = buildId;
         this._isProduct = isProduct;
+        this._timeToInclusionInMinutes = timeToInclusionInMinutes;
     }
 
     private _buildId: number;
@@ -971,11 +974,18 @@ export class BuildRef {
     public get isProduct(): boolean {
         return this._isProduct;
     }
+
+    private _timeToInclusionInMinutes: number;
+
+    public get timeToInclusionInMinutes(): number {
+        return this._timeToInclusionInMinutes;
+    }
     
     public isValid(): boolean {
         return (
             this._buildId !== undefined &&
-            this._isProduct !== undefined
+            this._isProduct !== undefined &&
+            this._timeToInclusionInMinutes !== undefined
         );
     }
 
@@ -983,6 +993,7 @@ export class BuildRef {
         let result = new BuildRef({
             buildId: value["buildId"] == null ? undefined : value["buildId"] as any,
             isProduct: value["isProduct"] == null ? undefined : value["isProduct"] as any,
+            timeToInclusionInMinutes: value["timeToInclusionInMinutes"] == null ? undefined : value["timeToInclusionInMinutes"] as any,
         });
         return result;
     }
@@ -991,6 +1002,7 @@ export class BuildRef {
         let result: any = {};
         result["buildId"] = value._buildId;
         result["isProduct"] = value._isProduct;
+        result["timeToInclusionInMinutes"] = value._timeToInclusionInMinutes;
         return result;
     }
 }

--- a/src/Maestro/tests/Scenarios/all.ps1
+++ b/src/Maestro/tests/Scenarios/all.ps1
@@ -22,7 +22,8 @@ $testScripts = (
     'githubflow-nonbatched-with-coherency.ps1',
     'githubflow-release-pipeline-nonbatched.ps1',
     'repo-policies.ps1',
-    'subscriptions.ps1'
+    'subscriptions.ps1',
+    'dependencies.ps1'
 )
 
 $failed = 0

--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -322,7 +322,7 @@ function Add-Build-To-Channel ($buildId, $channelName) {
     Invoke-WebRequest -Uri $uri -Headers $headers -Method Post
 }
 
-function New-Build($repository, $branch, $commit, $buildNumber, $assets, $publishUsingPipelines) {
+function New-Build($repository, $branch, $commit, $buildNumber, $assets, $publishUsingPipelines, $dependencies) {
     if (!$publishUsingPipelines) {
         $publishUsingPipelines = "false"
     }
@@ -340,6 +340,7 @@ function New-Build($repository, $branch, $commit, $buildNumber, $assets, $publis
         azureDevOpsBuildDefinitionId = 6;
         commit = $commit;
         assets = $assets;
+        dependencies = $dependencies;
         publishUsingPipelines = $publishUsingPipelines;
     }
     $bodyJson = ConvertTo-Json $body -Depth 4

--- a/src/Maestro/tests/Scenarios/dependencies.ps1
+++ b/src/Maestro/tests/Scenarios/dependencies.ps1
@@ -90,12 +90,31 @@ try {
     )
 
     # Add the target build once, should populate the BuildDependencies table and calculate TimeToInclusion
-    $targetBuild = New-Build -repository $targetRepoUri -branch $targetBranch -commit $targetCommit -buildNumber $target1BuildNumber -assets $targetAssets -dependencies $dependencies
-    Add-Build-To-Channel $targetBuild $testChannelName
+    $targetBuild1 = New-Build -repository $targetRepoUri -branch $targetBranch -commit $targetCommit -buildNumber $target1BuildNumber -assets $targetAssets -dependencies $dependencies
+    Add-Build-To-Channel $targetBuild1 $testChannelName
 
     # Add the target build a second time, should populate the BuildDependencies table and use the previous TimeToInclusion
-    $targetBuild = New-Build -repository $targetRepoUri -branch $targetBranch -commit $targetCommit -buildNumber $target2BuildNumber -assets $targetAssets -dependencies $dependencies
-    Add-Build-To-Channel $targetBuild $testChannelName
+    $targetBuild2 = New-Build -repository $targetRepoUri -branch $targetBranch -commit $targetCommit -buildNumber $target2BuildNumber -assets $targetAssets -dependencies $dependencies
+    Add-Build-To-Channel $targetBuild2 $testChannelName
+
+    $build1 = Get-Build -id $targetBuild1
+    $build2 = Get-Build -id $targetBuild2
+
+    if ($build1.dependencies.Count -ne 2)
+    {
+        throw "Unexpected number of dependencies for $targetBuild1"
+    }
+    if ($build2.dependencies.Count -ne 2)
+    {
+        throw "Unexpected number of dependencies for $targetBuild1"
+    }
+
+    if (( Compare-Object $build1.dependencies[0] $build2.dependencies[0]) -or (Compare-Object $build1.dependencies[1] $build2.dependencies[1]))
+    {
+        throw "Dependencies for $targetBuild1 and $targetBuild2 do not match"
+    }
+
+    Write-Host "Test Passed"
     
 } finally {
     Teardown

--- a/src/Maestro/tests/Scenarios/dependencies.ps1
+++ b/src/Maestro/tests/Scenarios/dependencies.ps1
@@ -108,6 +108,14 @@ try {
     {
         throw "Unexpected number of dependencies for $targetBuild1"
     }
+    if ($build1.dependencies[0].buildId -ne $build1Id -or $build1.dependencies[1].buildId -ne $build2Id)
+    {
+        throw "Incorrect dependencies for $targetBuild1"
+    }
+    if ($build2.dependencies[0].buildId -ne $build1Id -or $build2.dependencies[1].buildId -ne $build2Id)
+    {
+        throw "Incorrect dependencies for $targetBuild2"
+    }
 
     if (( Compare-Object $build1.dependencies[0] $build2.dependencies[0]) -or (Compare-Object $build1.dependencies[1] $build2.dependencies[1]))
     {

--- a/src/Maestro/tests/Scenarios/dependencies.ps1
+++ b/src/Maestro/tests/Scenarios/dependencies.ps1
@@ -50,7 +50,7 @@ $targetAssets = @(
 )
 try {
     Write-Host
-    Write-Host "Github Dependency Flow, batched"
+    Write-Host "BuildDependencies Update Check"
     Write-Host
 
     # Import common tooling and prep for tests

--- a/src/Maestro/tests/Scenarios/dependencies.ps1
+++ b/src/Maestro/tests/Scenarios/dependencies.ps1
@@ -1,0 +1,102 @@
+param(
+    [string]$maestroInstallation,
+    [string]$darcVersion,
+    [string]$maestroBearerToken,
+    [string]$githubPAT,
+    [string]$azdoPAT
+)
+
+$source1RepoName = "maestro-test1"
+$source2RepoName = "maestro-test3"
+$targetRepoName = "maestro-test2"
+$testChannelName = Get-Random
+$targetBranch = Get-Random
+$targetCommit = Get-Random
+$target1BuildNumber = Get-Random
+$target2BuildNumber = Get-Random
+$sourceBuildNumber = Get-Random
+$sourceCommit = Get-Random
+$sourceBranch = "master"
+$source1Assets = @(
+    @{
+        name = "Foo"
+        version = "1.1.0"
+    },
+    @{
+        name = "Bar"
+        version = "2.1.0"
+    }
+)
+$source2Assets = @(
+    @{
+        name = "Pizza"
+        version = "3.1.0"
+    },
+    @{
+        name = "Hamburger"
+        version = "4.1.0"
+    }
+)
+
+$targetAssets = @(
+    @{
+        name = "Source1"
+        version = "3.1.0"
+    },
+    @{
+        name = "Source2"
+        version = "4.1.0"
+    }
+)
+try {
+    Write-Host
+    Write-Host "Github Dependency Flow, batched"
+    Write-Host
+
+    # Import common tooling and prep for tests
+    . $PSScriptRoot/common.ps1
+
+    Write-Host "Running tests..."
+    Write-Host
+
+    $source1RepoUri = Get-Github-RepoUri $source1RepoName
+    $source2RepoUri = Get-Github-RepoUri $source2RepoName
+    $targetRepoUri = Get-Github-RepoUri $targetRepoName
+
+    Write-Host "Creating a test channel '$testChannelName'"
+    Darc-Add-Channel -channelName $testChannelName -classification "test"
+
+    Write-Host "Set up build1 for intake into target repository"
+    # Create a build for the first source repo
+    $build1Id = New-Build -repository $source1RepoUri -branch $sourceBranch -commit $sourceCommit -buildNumber $sourceBuildNumber -assets $source1Assets
+    # Add the build to the target channel
+    Add-Build-To-Channel $build1Id $testChannelName
+
+    Write-Host "Set up build2 for intake into target repository"
+    # Create a build for the second  source repo
+    $build2Id = New-Build -repository $source2RepoUri -branch $sourceBranch -commit $sourceCommit -buildNumber $sourceBuildNumber -assets $source2Assets
+    # Add the build to the target channel
+    Add-Build-To-Channel $build2Id $testChannelName
+
+    $dependencies = @(
+        @{
+            buildId = $build1Id
+            isProduct = $true
+        },
+        @{
+            buildId = $build2Id
+            isProduct = $true
+        }
+    )
+
+    # Add the target build once, should populate the BuildDependencies table and calculate TimeToInclusion
+    $targetBuild = New-Build -repository $targetRepoUri -branch $targetBranch -commit $targetCommit -buildNumber $target1BuildNumber -assets $targetAssets -dependencies $dependencies
+    Add-Build-To-Channel $targetBuild $testChannelName
+
+    # Add the target build a second time, should populate the BuildDependencies table and use the previous TimeToInclusion
+    $targetBuild = New-Build -repository $targetRepoUri -branch $targetBranch -commit $targetCommit -buildNumber $target2BuildNumber -assets $targetAssets -dependencies $dependencies
+    Add-Build-To-Channel $targetBuild $testChannelName
+    
+} finally {
+    Teardown
+}


### PR DESCRIPTION
We want to know, at each level of the dependency graph, how long it took
for a dependency to get to core-sdk. So, when a change is checked into
coreclr, how long does it take to get from coreclr, through the longest
path in the dependency graph, to core-sdk. This work adds
TimeToInclusion to the BuildDependencies table. TimeToInclusion measures
how long it took from when a build was added to the Build table until
the first build that depended on it was added to the BuildDependencies
table. We then can use the TimeToInclusion in BarViz to calculate how
long it took for that dependency to appear in the dependency graph of
each repo that has it in its dependency graph. This is most important at
the core-sdk level, where we can then discover how long it takes for a
runtime change to flow all the way to the final product. This is done by
adding the time to inclusion at each level, from the root to the leafs.
So if core-setup depends directly on corefx, and flowing the corefx
build took 203 minutes, and corefx depends directly on coreclr, which
took 400 minutes to flow into corefx, then the time to inclusion for the
coreclr build into the core-setup build would be 603 minutes, which will
be reflected in BarViz.

![image](https://user-images.githubusercontent.com/9666644/67132072-2ba6ad00-f1bc-11e9-84d6-c7decf59176a.png)
