### PR TITLE
Prompt the user when branches or repos do not exist

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
@@ -304,8 +304,17 @@ namespace Microsoft.DotNet.Darc
         public static bool PromptToContinue()
         {
             char keyChar;
+            int triesRemaining = 3;
             do
             {
+                if (triesRemaining == 0)
+                {
+                    // Don't continue if the user can't press y or n.
+                    Console.Write("Invalid input, aborting.");
+                    return false;
+                }
+                triesRemaining--;
+
                 Console.Write("Continue? (y/n) ");
                 ConsoleKeyInfo keyInfo = Console.ReadKey();
                 keyChar = char.ToUpperInvariant(keyInfo.KeyChar);

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
@@ -258,7 +258,7 @@ namespace Microsoft.DotNet.Darc
         /// <param name="branch">Branch to check the existence of</param>
         /// <param name="prompt">Prompt the user to verify that they want to continue</param>
         /// <returns>True if the branch exists, prompting is not desired, or if the user confirms that they want to continue. False otherwise.</returns>
-        public static async Task<bool> VerifyMaestroManagedBranchExists(IRemote remote, string repo, string branch, bool prompt)
+        public static async Task<bool> VerifyAndConfirmBranchExistsAsync(IRemote remote, string repo, string branch, bool prompt)
         {
             try
             {
@@ -283,7 +283,7 @@ namespace Microsoft.DotNet.Darc
         /// <param name="repo">Repository to check for</param>
         /// <param name="prompt">Prompt the user to verify that they want to continue</param>
         /// <returns>True if the repository exists, prompting is not desired, or if the user confirms that they want to continue. False otherwise.</returns>
-        public static async Task<bool> VerifyRepositoryExists(IRemote remote, string repo, bool prompt)
+        public static async Task<bool> VerifyAndConfirmRepositoryExistsAsync(IRemote remote, string repo, bool prompt)
         {
             if (!(await remote.RepositoryExistsAsync(repo)))
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddDefaultChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddDefaultChannelOperation.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Darc.Operations
             {
                 IRemote remote = RemoteFactory.GetRemote(_options, _options.Repository, Logger);
                 
-                if (!(await UxHelpers.VerifyMaestroManagedBranchExists(remote, _options.Repository, _options.Branch, !_options.NoConfirmation)))
+                if (!(await UxHelpers.VerifyAndConfirmBranchExistsAsync(remote, _options.Repository, _options.Branch, !_options.NoConfirmation)))
                 {
                     Console.WriteLine("Aborting default channel creation.");
                     return Constants.ErrorCode;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddDefaultChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddDefaultChannelOperation.cs
@@ -24,7 +24,13 @@ namespace Microsoft.DotNet.Darc.Operations
         {
             try
             {
-                IRemote remote = RemoteFactory.GetBarOnlyRemote(_options, Logger);
+                IRemote remote = RemoteFactory.GetRemote(_options, _options.Repository, Logger);
+                
+                if (!(await UxHelpers.VerifyMaestroManagedBranchExists(remote, _options.Repository, _options.Branch, !_options.NoConfirmation)))
+                {
+                    Console.WriteLine("Aborting default channel creation.");
+                    return Constants.ErrorCode;
+                }
 
                 await remote.AddDefaultChannelAsync(_options.Repository, _options.Branch, _options.Channel);
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddSubscriptionOperation.cs
@@ -171,7 +171,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 // Verify the target
                 IRemote targetVerifyRemote = RemoteFactory.GetRemote(_options, targetRepository, Logger);
-                if (!(await UxHelpers.VerifyMaestroManagedBranchExists(targetVerifyRemote, targetRepository, targetBranch, !_options.Quiet)))
+                if (!(await UxHelpers.VerifyAndConfirmBranchExistsAsync(targetVerifyRemote, targetRepository, targetBranch, !_options.Quiet)))
                 {
                     Console.WriteLine("Aborting subscription creation.");
                     return Constants.ErrorCode;
@@ -179,7 +179,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 // Verify the source.
                 IRemote sourceVerifyRemote = RemoteFactory.GetRemote(_options, sourceRepository, Logger);
-                if (!(await UxHelpers.VerifyRepositoryExists(targetVerifyRemote, sourceRepository, !_options.Quiet)))
+                if (!(await UxHelpers.VerifyAndConfirmRepositoryExistsAsync(sourceVerifyRemote, sourceRepository, !_options.Quiet)))
                 {
                     Console.WriteLine("Aborting subscription creation.");
                     return Constants.ErrorCode;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddSubscriptionOperation.cs
@@ -169,6 +169,22 @@ namespace Microsoft.DotNet.Darc.Operations
                     }
                 }
 
+                // Verify the target
+                IRemote targetVerifyRemote = RemoteFactory.GetRemote(_options, targetRepository, Logger);
+                if (!(await UxHelpers.VerifyMaestroManagedBranchExists(targetVerifyRemote, targetRepository, targetBranch, !_options.Quiet)))
+                {
+                    Console.WriteLine("Aborting subscription creation.");
+                    return Constants.ErrorCode;
+                }
+
+                // Verify the source.
+                IRemote sourceVerifyRemote = RemoteFactory.GetRemote(_options, sourceRepository, Logger);
+                if (!(await UxHelpers.VerifyRepositoryExists(targetVerifyRemote, sourceRepository, !_options.Quiet)))
+                {
+                    Console.WriteLine("Aborting subscription creation.");
+                    return Constants.ErrorCode;
+                }
+
                 var newSubscription = await remote.CreateSubscriptionAsync(channel,
                                                                            sourceRepository,
                                                                            targetRepository,

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
@@ -124,6 +124,13 @@ namespace Microsoft.DotNet.Darc.Operations
                 mergePolicies = initEditorPopUp.MergePolicies;
             }
 
+            IRemote verifyRemote = RemoteFactory.GetRemote(_options, repository, Logger);
+            if (!(await UxHelpers.VerifyMaestroManagedBranchExists(verifyRemote, repository, branch, !_options.Quiet)))
+            {
+                Console.WriteLine("Aborting merge policy creation.");
+                return Constants.ErrorCode;
+            }
+
             try
             {   
                 await remote.SetRepositoryMergePoliciesAsync(

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
@@ -125,7 +125,7 @@ namespace Microsoft.DotNet.Darc.Operations
             }
 
             IRemote verifyRemote = RemoteFactory.GetRemote(_options, repository, Logger);
-            if (!(await UxHelpers.VerifyMaestroManagedBranchExists(verifyRemote, repository, branch, !_options.Quiet)))
+            if (!(await UxHelpers.VerifyAndConfirmBranchExistsAsync(verifyRemote, repository, branch, !_options.Quiet)))
             {
                 Console.WriteLine("Aborting merge policy creation.");
                 return Constants.ErrorCode;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/TriggerSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/TriggerSubscriptionsOperation.cs
@@ -83,17 +83,7 @@ namespace Microsoft.DotNet.Darc.Operations
                         Console.WriteLine($"  {UxHelpers.GetSubscriptionDescription(subscription)}");
                     }
 
-                    char keyChar;
-                    do
-                    {
-                        Console.Write("Continue? (y/n) ");
-                        ConsoleKeyInfo keyInfo = Console.ReadKey();
-                        keyChar = char.ToUpperInvariant(keyInfo.KeyChar);
-                        Console.WriteLine();
-                    }
-                    while (keyChar != 'Y' && keyChar != 'N');
-
-                    if (keyChar == 'N')
+                    if (!UxHelpers.PromptToContinue())
                     {
                         Console.WriteLine($"No subscriptions triggered, exiting.");
                         return Constants.ErrorCode;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddDefaultChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddDefaultChannelCommandLineOptions.cs
@@ -19,6 +19,9 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("repo", Required = true, HelpText = "Build of this repo repo on 'branch' will be automatically applied to 'channel'")]
         public string Repository { get; set; }
 
+        [Option('q', "quiet", HelpText = "Do not prompt if the target repository/branch does not exist.")]
+        public bool NoConfirmation { get; set; }
+
         public override Operation GetOperation()
         {
             return new AddDefaultChannelOperation(this);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -845,6 +845,18 @@ namespace Microsoft.DotNet.DarcLib
         }
 
         /// <summary>
+        /// Checks that a repository exists
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <returns>True if the repository exists, false otherwise.</returns>
+        public async Task<bool> RepositoryExistsAsync(string repoUri)
+        {
+            CheckForValidGitClient();
+
+            return await _gitClient.RepoExistsAsync(repoUri);
+        }
+
+        /// <summary>
         ///     Get the latest commit in a branch
         /// </summary>
         /// <param name="repoUri">Remote repository</param>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -956,5 +956,28 @@ namespace Microsoft.DotNet.DarcLib
         {
             throw new NotImplementedException($"Cannot add a remote to a remote repo.");
         }
+
+        /// <summary>
+        /// Checks that a repository exists
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <returns>True if the repository exists, false otherwise.</returns>
+        public async Task<bool> RepoExistsAsync(string repoUri)
+        {
+            (string owner, string repo) = ParseRepoUri(repoUri);
+
+            try
+            {
+                using (await this.ExecuteRemoteGitCommandAsync(
+                      HttpMethod.Get,
+                      $"repos/{owner}/{repo}",
+                      _logger,
+                      logFailure: false)) { }
+                return true;
+            }
+            catch (Exception) { }
+
+            return false;
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -11,6 +11,13 @@ namespace Microsoft.DotNet.DarcLib
     public interface IGitRepo
     {
         /// <summary>
+        /// Checks that a repository exists
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <returns>True if the repository exists, false otherwise.</returns>
+        Task<bool> RepoExistsAsync(string repoUri);
+
+        /// <summary>
         /// Create a new branch in a repository
         /// </summary>
         /// <param name="repoUri">Repo to create a branch in</param>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -353,6 +353,13 @@ namespace Microsoft.DotNet.DarcLib
         Task<string> GetLatestCommitAsync(string repoUri, string branch);
 
         /// <summary>
+        /// Checks that a repository exists
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <returns>True if the repository exists, false otherwise.</returns>
+        Task<bool> RepositoryExistsAsync(string repoUri);
+
+        /// <summary>
         ///     Clone a remote repo.
         /// </summary>
         /// <param name="repoUri">Repository uri</param>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -490,5 +490,10 @@ namespace Microsoft.DotNet.DarcLib
                 LibGit2Sharp.Commands.Fetch(repo, remoteName, new[] { $"+refs/heads/*:refs/remotes/{remoteName}/*" }, new LibGit2Sharp.FetchOptions(), $"Fetching {repoUrl} into {repoDir}");
             }
         }
+
+        public Task<bool> RepoExistsAsync(string repoUri)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
One complaint from some users is that it's easy to mess up default channels, subscriptions, etc. with typos. You can easily type a wrong repo name or branch name and then be confused as to why things are not updating automatically.
To mitigate this, I've introduced checks on operations that deal with branches and repositories. These checks will make sure that branches and repositories exist, and if they do not, they will prompt the user to continue or abort.

This commit also fixes a case where AzDO will return bad request instead of 404 when checking for a branch that doesn't exist.