### PR TITLE
Add dotnet-tools feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,8 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json" />
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Add the dotnet-tools feed to fix Arcade restores.

Remove the dotnet-core feed as it doesn't look like we need anything from it given this test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=395610&view=results