### PR TITLE
Missing repositories in BarViz channel list

### DIFF
--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/ChannelsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/ChannelsController.cs
@@ -59,8 +59,9 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
         {
             List<string> list = await _context.BuildChannels
                     .Include(b => b.Build.GitHubRepository)
+                    .Include(b => b.Build.AzureDevOpsRepository)
                     .Where(bc => bc.ChannelId == id)
-                    .Select(bc => bc.Build.GitHubRepository)
+                    .Select(bc => bc.Build.GitHubRepository ?? bc.Build.AzureDevOpsRepository)
                     .Where(b => !String.IsNullOrEmpty(b))
                     .Distinct()
                     .ToListAsync();

--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/ChannelsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/ChannelsController.cs
@@ -52,6 +52,21 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
             return Ok(results);
         }
 
+        [HttpGet("{id}/repositories")]
+        [SwaggerApiResponse(HttpStatusCode.OK, Type = typeof(List<string>), Description = "List of repositories in Channel")]
+        [ValidateModelState]
+        public async Task<IActionResult> ListRepositories(int id)
+        {
+            List<string> list = await _context.BuildChannels
+                    .Include(b => b.Build.GitHubRepository)
+                    .Where(bc => bc.ChannelId == id)
+                    .Select(bc => bc.Build.GitHubRepository)
+                    .Where(b => !String.IsNullOrEmpty(b))
+                    .Distinct()
+                    .ToListAsync();
+            return Ok(list);
+        }
+
         /// <summary>
         ///   Gets a single <see cref="Channel"/>, including all <see cref="ReleasePipeline"/> data.
         /// </summary>

--- a/src/Maestro/maestro-angular/src/app/services/channel.service.ts
+++ b/src/Maestro/maestro-angular/src/app/services/channel.service.ts
@@ -46,23 +46,17 @@ export class ChannelService {
   }
 
   private buildRepositoriesList(channelId: number): Observable<DefaultChannel[]> {
-    let builds = this.maestro.builds.listBuildsAsync({ channelId: channelId });
+// new
+      let builds = this.maestro.channels.listRepositoriesAsync({ id: channelId });
 
-    let targetRepos = builds.pipe(map(x => x.map(y => {
-      return new DefaultChannel({
-        repository: y.gitHubRepository === undefined ? y.azureDevOpsRepository! : y.gitHubRepository!,
-        branch: y.gitHubBranch === undefined ? y.azureDevOpsBranch : y.gitHubBranch,
-        id: 0,
-      });
-    })));
-
-    const repos = targetRepos.pipe(
-      map(l => {
-        let dcArray = new Array<DefaultChannel>().concat(l);
-        dcArray = dcArray.filter((dc, index) => dc.repository != undefined);
-        return dcArray.filter((dc, index) => dcArray.findIndex(t => t.repository === dc.repository) === index).sort(repoSorter);
-      }),
-    );
-    return repos; 
+      let repos = builds.pipe(
+          map(x => x.map(y => {
+            return new DefaultChannel({
+            repository: y ,
+            branch: undefined,
+            id: 0,
+          });
+        })));
+      return repos;
   }
 }

--- a/src/Maestro/maestro-angular/src/maestro-client/maestro.ts
+++ b/src/Maestro/maestro-angular/src/maestro-client/maestro.ts
@@ -726,6 +726,12 @@ export interface IChannelsApi {
         }
     ): Observable<models.Channel[]>;
 
+    listRepositoriesAsync(
+        parameters: {
+            id: number,
+        }
+    ): Observable<string[]>;
+
     createChannelAsync(
         parameters: {
             classification: string,
@@ -811,6 +817,41 @@ export class ChannelsApiService implements IChannelsApi {
             map(raw => raw.map((e: any) => models.Channel.fromRawObject(e)))
         );
 
+    }
+
+    public listRepositoriesAsync(
+        {
+            id
+        }: {
+            id: number
+        }
+    ): Observable<string[]> {
+        if (id === undefined) {
+            throw new Error("Required parameter id is undefined.");
+        }
+
+        const apiVersion = "2019-01-16";
+        let _path = this.options.baseUrl;
+        if (_path.endsWith("/")) {
+            _path = _path.slice(0, -1);
+        }
+        _path = _path + "/api/channels/{id}/repositories";
+        _path = _path.replace("{id}", id + "");
+
+        let queryParameters = new HttpParams();
+        let headerParameters = new HttpHeaders(this.options.defaultHeaders);
+
+        queryParameters = queryParameters.set("api-version", apiVersion);
+
+        return this.client.request(
+            "get",
+            _path,
+            {
+                headers: headerParameters,
+                params: queryParameters,
+                responseType: "json",
+            }
+        );
     }
 
     public createChannelAsync(


### PR DESCRIPTION
BarViz wasn't showing all repositories in a channel because it was using a paged API to determine the repositories which are contributing to a channel.  Only the first page was returned and so, if a repository hadn't published recently, then it wouldn't show up in the repo list.  This change adds a new API which does the repo list query so that we get a more consistent result set.