### PR TITLE
Add --quiet to default channel creation operation during tests

### DIFF
--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -217,7 +217,7 @@ function Darc-Delete-Channel($channelName) {
 
 # Run darc add-channel and record the channel for later deletion
 function Darc-Add-Default-Channel($channelName, $repoUri, $branch) {
-    $darcParams = @( "add-default-channel", "--channel", "$channelName", "--repo", "$repoUri", "--branch", "$branch" )
+    $darcParams = @( "add-default-channel", "--channel", "$channelName", "--repo", "$repoUri", "--branch", "$branch", "--quiet")
     Darc-Command -darcParams $darcParams
     # We sometimes call add-default-channel with a refs/heads/ prefix, which
     # will get stripped away by the DB.


### PR DESCRIPTION
The latest prompt changes are causing these default channel tests to fail expecting user input. Passing the quiet switch will avoid the validation + prompt which are not necessary in this case.