### PR TITLE
Editor path error handling

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
@@ -143,6 +143,11 @@ namespace Microsoft.DotNet.Darc.Helpers
                     }
                 }
             }
+            catch (FileNotFoundException fnfe)
+            {
+                _logger.LogError(fnfe, $"Cannot start editor '{fnfe.FileName}'. Please verify that your git settings (`git config core.editor`) specify the path correctly.");
+                result = Constants.ErrorCode;
+            }
             catch (Exception exc)
             {
                 _logger.LogError(exc, $"There was an exception while trying to pop up an editor window.");

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Helpers/UxManagerHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Helpers/UxManagerHelpers.cs
@@ -1,0 +1,14 @@
+using Microsoft.DotNet.Darc.Helpers;
+using Xunit;
+
+namespace Microsoft.DotNet.Darc.Tests.Helpers
+{
+    public class UxManagerHelpers
+    {
+        [Fact]
+        public void GetParsedCommandHandlesFoldersWithSpacesWell()
+        {
+            UxManager.GetParsedCommand("");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Helpers/UxManagerHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Helpers/UxManagerHelpers.cs
@@ -6,9 +6,30 @@ namespace Microsoft.DotNet.Darc.Tests.Helpers
     public class UxManagerHelpers
     {
         [Fact]
-        public void GetParsedCommandHandlesFoldersWithSpacesWell()
+        public void PathCodeLocation()
         {
-            UxManager.GetParsedCommand("");
+            var codeCommand = UxManager.GetParsedCommand("code --wait");
+
+            Assert.Equal("code", codeCommand.FileName);
+            Assert.Equal(" --wait", codeCommand.Arguments);
+        }
+
+        [Fact]
+        public void EscapedCodeLocation()
+        {
+            var codeCommand = UxManager.GetParsedCommand(@"'C:\Users\lulansky\AppData\Local\Programs\Microsoft VS Code\Code.exe' --wait");
+
+            Assert.Equal(@"C:\Users\lulansky\AppData\Local\Programs\Microsoft VS Code\Code.exe", codeCommand.FileName);
+            Assert.Equal(" --wait", codeCommand.Arguments);
+        }
+
+        [Fact]
+        public void EscapedCodeLocationWithoutArg()
+        {
+            var codeCommand = UxManager.GetParsedCommand(@"'C:\Users\lulansky\AppData\Local\Programs\Microsoft VS Code\Code.exe'");
+
+            Assert.Equal(@"C:\Users\lulansky\AppData\Local\Programs\Microsoft VS Code\Code.exe", codeCommand.FileName);
+            Assert.Equal("", codeCommand.Arguments);
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\DarcLib.AzDev\Microsoft.DotNet.DarcLib.AzDev.csproj" />
     <ProjectReference Include="..\..\src\DarcLib\Microsoft.DotNet.DarcLib.csproj" />
+    <ProjectReference Include="..\..\src\Darc\Microsoft.DotNet.Darc.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Darc takes its editor config from git. When it fails because the git config is not correct (for example, in a case of bad escaping of paths with spaces), it errors out with a very generic error message.

The fix is to provide a more descriptive message.

I wrote few unit tests during research of the issue, so I'm adding them too even though they do not replicate any fixed problem with the codebase. They just demonstrate the current code handles the git config well as long as it's properly escaped.