### PR TITLE
Editor path error handling, 2

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.Work.WebApi;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -143,7 +144,7 @@ namespace Microsoft.DotNet.Darc.Helpers
                     }
                 }
             }
-            catch (System.ComponentModel.Win32Exception exc)
+            catch (Win32Exception exc)
             {
                 _logger.LogError(exc, $"Cannot start editor '{parsedCommand.FileName}'. Please verify that your git settings (`git config core.editor`) specify the path correctly.");
                 result = Constants.ErrorCode;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
@@ -143,9 +143,9 @@ namespace Microsoft.DotNet.Darc.Helpers
                     }
                 }
             }
-            catch (FileNotFoundException fnfe)
+            catch (System.ComponentModel.Win32Exception exc)
             {
-                _logger.LogError(fnfe, $"Cannot start editor '{fnfe.FileName}'. Please verify that your git settings (`git config core.editor`) specify the path correctly.");
+                _logger.LogError(exc, $"Cannot start editor '{parsedCommand.FileName}'. Please verify that your git settings (`git config core.editor`) specify the path correctly.");
                 result = Constants.ErrorCode;
             }
             catch (Exception exc)


### PR DESCRIPTION
Sorry, https://github.com/dotnet/arcade-services/pull/734 isn't complete. The happy path is alright, but the fix does not work as Process.Start() won't trigger `FileNotFoundException` -- it's `Win32Exception` in the case we are interested in. The `FileNotFoundException` is an artifact of my previous testing.

`Win32Exception` seems generic, but the [docs](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.start?redirectedfrom=MSDN&view=netframework-4.8#System_Diagnostics_Process_Start) states it happens when "There was an error in opening the associated file."