### PR TITLE
 Record longest build path for a build in Kusto

### DIFF
--- a/src/Shared/KustoDataTypes.cs
+++ b/src/Shared/KustoDataTypes.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DotNet.Shared
         public const string Long = "long";
         public const string Int = "int";
         public const string Boolean = "bool";
+        public const string Decimal = "decimal";
         public const string DateTime = "datetime";
     }
 }

--- a/src/Telemetry/AzureDevOpsTimeline/.config/settings.Development.json
+++ b/src/Telemetry/AzureDevOpsTimeline/.config/settings.Development.json
@@ -1,8 +1,12 @@
 {
-    "KeyVaultUri": "https://maestrolocal.vault.azure.net/",
+  "KeyVaultUri": "https://maestrolocal.vault.azure.net/",
 
-    "KustoIngestConnectionString": "",
-    "InitialDelay": "0:00:00",
-    "Interval": "0:30:00",
-    "BuildBatchSize":  1000 
+  "BuildAssetRegistry": {
+    "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
+  },
+
+  "KustoIngestConnectionString": "[vault(nethelix-engsrv-kusto-connection-string-ingest)]",
+  "InitialDelay": "0:00:00",
+  "Interval": "0:30:00",
+  "BuildBatchSize": 1000
 }

--- a/src/Telemetry/AzureDevOpsTimeline/.config/settings.json
+++ b/src/Telemetry/AzureDevOpsTimeline/.config/settings.json
@@ -5,6 +5,10 @@
     "KustoIngestConnectionString": "[vault(nethelix-engsrv-kusto-connection-string-ingest)]",
     "KustoQueryConnectionString": "[vault(nethelix-engsrv-kusto-connection-string-query)]",
 
+    "BuildAssetRegistry": {
+      "ConnectionString": "[vault(build-asset-registry-sql-connection-string)]"
+    },
+
     "AzureDevOpsAccessToken": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
     "AzureDevOpsOrganization": "dnceng",
     "AzureDevOpsProjects": "internal;public",

--- a/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.csproj
+++ b/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.DotNet.ServiceFabric.ServiceHost\Microsoft.DotNet.ServiceFabric.ServiceHost.csproj" />
     <ProjectReference Include="..\..\Shared\Shared.csproj" />
+    <ProjectReference Include="..\..\Maestro\Maestro.Data\Maestro.Data.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Telemetry/AzureDevOpsTimeline/Program.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/Program.cs
@@ -6,6 +6,8 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Maestro.Data;
 
 namespace Microsoft.DotNet.AzureDevOpsTimeline
 {
@@ -41,6 +43,12 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline
                                 o.Interval = c["Interval"];
                                 o.BuildBatchSize = c["BuildBatchSize"];
                             });
+                            services.AddDbContext<BuildAssetRegistryContext>(
+                                (provider, options) =>
+                                {
+                                    var config = provider.GetRequiredService<IConfigurationRoot>();
+                                    options.UseSqlServer(config.GetSection("BuildAssetRegistry")["ConnectionString"]);
+                                });
                         });
                 });
         }


### PR DESCRIPTION
This change adds an algorithm that uses the TimeToInclusion metric in BAR in conjunction with build start and end time in the TimelineBuilds Kusto table to determine which path from the root node to each of its leaf nodes has the longest build time. As Kusto is the only place where we have any information on the runtime of a particular build, we need to calculate this information when we ingest into Kusto. This algorithm walks the dependency graph, stopping when we find a node that either a) has no product dependencies (a leaf) or b) finds a repository it has already seen before (a cycle). For the end node (leaf or cycle found), we use the build time by subtracting the start time from the finish time of the azdo run. For all other nodes in the path, we use the TimeToInclusionInMinutes. We do this for each build being ingested into Kusto, and record the buildid, the path that we discovered as the longest, and the time of that path. This data will be used in a power bi report to track our longest build path time over time.