### PR TITLE
Darc support for release/non-released builds

### DIFF
--- a/src/Maestro/Client/src/Generated/Models/Build.cs
+++ b/src/Maestro/Client/src/Generated/Models/Build.cs
@@ -6,11 +6,12 @@ namespace Microsoft.DotNet.Maestro.Client.Models
 {
     public partial class Build
     {
-        public Build(int id, DateTimeOffset dateProduced, int staleness, bool publishUsingPipelines, string commit, IImmutableList<Channel> channels, IImmutableList<Asset> assets, IImmutableList<BuildRef> dependencies)
+        public Build(int id, DateTimeOffset dateProduced, int staleness, bool released, bool publishUsingPipelines, string commit, IImmutableList<Channel> channels, IImmutableList<Asset> assets, IImmutableList<BuildRef> dependencies)
         {
             Id = id;
             DateProduced = dateProduced;
             Staleness = staleness;
+            Released = released;
             PublishUsingPipelines = publishUsingPipelines;
             Commit = commit;
             Channels = channels;
@@ -68,5 +69,8 @@ namespace Microsoft.DotNet.Maestro.Client.Models
 
         [JsonProperty("staleness")]
         public int Staleness { get; }
+
+        [JsonProperty("released")]
+        public bool Released { get; }
     }
 }

--- a/src/Maestro/Client/src/Generated/Models/BuildData.cs
+++ b/src/Maestro/Client/src/Generated/Models/BuildData.cs
@@ -6,7 +6,7 @@ namespace Microsoft.DotNet.Maestro.Client.Models
 {
     public partial class BuildData
     {
-        public BuildData(string commit, string azureDevOpsAccount, string azureDevOpsProject, string azureDevOpsBuildNumber, string azureDevOpsRepository, string azureDevOpsBranch, bool publishUsingPipelines)
+        public BuildData(string commit, string azureDevOpsAccount, string azureDevOpsProject, string azureDevOpsBuildNumber, string azureDevOpsRepository, string azureDevOpsBranch, bool publishUsingPipelines, bool released)
         {
             Commit = commit;
             AzureDevOpsAccount = azureDevOpsAccount;
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Maestro.Client.Models
             AzureDevOpsRepository = azureDevOpsRepository;
             AzureDevOpsBranch = azureDevOpsBranch;
             PublishUsingPipelines = publishUsingPipelines;
+            Released = released;
         }
 
         [JsonProperty("commit")]
@@ -55,6 +56,9 @@ namespace Microsoft.DotNet.Maestro.Client.Models
 
         [JsonProperty("publishUsingPipelines")]
         public bool PublishUsingPipelines { get; set; }
+
+        [JsonProperty("released")]
+        public bool Released { get; set; }
 
         [JsonIgnore]
         public bool IsValid

--- a/src/Maestro/Client/src/Generated/Models/BuildRef.cs
+++ b/src/Maestro/Client/src/Generated/Models/BuildRef.cs
@@ -6,11 +6,11 @@ namespace Microsoft.DotNet.Maestro.Client.Models
 {
     public partial class BuildRef
     {
-        public BuildRef(int buildId, bool isProduct)
+        public BuildRef(int buildId, bool isProduct, double timeToInclusionInMinutes)
         {
             BuildId = buildId;
             IsProduct = isProduct;
-            TimeToInclusionInMinutes = 0;
+            TimeToInclusionInMinutes = timeToInclusionInMinutes;
         }
 
         [JsonProperty("buildId")]
@@ -20,6 +20,6 @@ namespace Microsoft.DotNet.Maestro.Client.Models
         public bool IsProduct { get; }
 
         [JsonProperty("timeToInclusionInMinutes")]
-        public double TimeToInclusionInMinutes { get; }
+        public double TimeToInclusionInMinutes { get; set; }
     }
 }

--- a/src/Maestro/Client/src/Generated/Models/BuildUpdate.cs
+++ b/src/Maestro/Client/src/Generated/Models/BuildUpdate.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Immutable;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Maestro.Client.Models
+{
+    public partial class BuildUpdate
+    {
+        public BuildUpdate()
+        {
+        }
+
+        [JsonProperty("released")]
+        public bool? Released { get; set; }
+    }
+}

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -157,7 +157,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 }
             }
 
-            return builds.Select(t => new BuildRef(t.Key, t.Value)).ToImmutableList();
+            return builds.Select(t => new BuildRef(t.Key, t.Value, 0)).ToImmutableList();
         }
 
         private static async Task<int?> GetBuildId(DependencyDetail dep, IMaestroApi client, Dictionary<int, Client.Models.Build> buildCache,
@@ -268,7 +268,8 @@ namespace Microsoft.DotNet.Maestro.Tasks
                         azureDevOpsBuildNumber: manifest.AzureDevOpsBuildNumber ?? GetAzDevBuildNumber(),
                         azureDevOpsRepository: manifest.AzureDevOpsRepository ?? GetAzDevRepository(),
                         azureDevOpsBranch: manifest.AzureDevOpsBranch ?? GetAzDevBranch(),
-                        publishUsingPipelines: PublishUsingPipelines)
+                        publishUsingPipelines: PublishUsingPipelines,
+                        released: false)
                     {
                         Assets = assets.ToImmutableList(),
                         AzureDevOpsBuildId = manifest.AzureDevOpsBuildId ?? GetAzDevBuildId(),

--- a/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
+++ b/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
@@ -151,6 +151,11 @@ namespace SubscriptionActorService
             return ToClientModelBuild(build);
         }
 
+        public Task<Build> UpdateBuildAsync(int buildId, BuildUpdate buildUpdate)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         ///     Get a list of builds for the given repo uri and commit.
         /// </summary>
@@ -217,8 +222,9 @@ namespace SubscriptionActorService
 
         private Build ToClientModelBuild(Maestro.Data.Models.Build other)
         {
-            return new Build(other.Id, other.DateProduced, other.Staleness, other.PublishUsingPipelines, other.Commit,
-                null, other.Assets?.Select(a => ToClientModelAsset(a)).ToImmutableList(), null)
+            return new Build(other.Id, other.DateProduced, other.Staleness, false, other.PublishUsingPipelines, other.Commit,
+                null, other.Assets?.Select(a => ToClientModelAsset(a)).ToImmutableList(), 
+                other.DependentBuildIds?.Select(b => new BuildRef(b.BuildId, b.IsProduct, b.TimeToInclusionInMinutes)).ToImmutableList())
             {
                 AzureDevOpsBranch = other.AzureDevOpsBranch,
                 GitHubBranch = other.GitHubBranch,

--- a/src/Maestro/tests/Scenarios/builds.ps1
+++ b/src/Maestro/tests/Scenarios/builds.ps1
@@ -83,7 +83,7 @@ try {
     }
     if (($gatherDropOutput -match "Downloading asset Bar@2.1.0") -or
         ($gatherDropOutput -match "Downloading asset Foo@1.1.0")) {
-        throw "Build should not download either Foo and Bar"
+        throw "Build should not download either Foo or Bar"
     }
     Write-Host $gatherDropOutput
 

--- a/src/Maestro/tests/Scenarios/builds.ps1
+++ b/src/Maestro/tests/Scenarios/builds.ps1
@@ -1,0 +1,111 @@
+param(
+    [string]$maestroInstallation,
+    [string]$darcVersion,
+    [string]$maestroBearerToken,
+    [string]$githubPAT,
+    [string]$azdoPAT
+)
+
+$sourceRepoName = "maestro-test1"
+$sourceBuildNumber = Get-Random
+$sourceCommit = Get-Random
+$sourceBranch = "master"
+$sourceAssets = @(
+    @{
+        name = "Foo"
+        version = "1.1.0"
+        locations = @(
+            @{
+                location = "https://pkgs.dev.azure.com/dnceng/public/_packaging/NotARealFeed/nuget/v3/index.json"
+                type = "NugetFeed"
+            }
+        )
+    },
+    @{
+        name = "Bar"
+        version = "2.1.0"
+        locations = @(
+            @{
+                location = "https://pkgs.dev.azure.com/dnceng/public/_packaging/NotARealFeed/nuget/v3/index.json"
+                type = "NugetFeed"
+            }
+        )
+    }
+)
+
+try {
+    Write-Host
+    Write-Host "Darc/Maestro build handling tests"
+    Write-Host
+
+    # Import common tooling and prep for tests
+    . $PSScriptRoot/common.ps1
+
+    Write-Host "Running tests..."
+    Write-Host
+
+    $sourceRepoUri = Get-Github-RepoUri $sourceRepoName
+
+    # Create a new build and check some of the metadata. Then mark as released and check again
+    Write-Host "Set up build for intake into target repository"
+    # Create a build for the source repo
+    $buildId = New-Build -repository $sourceRepoUri -branch $sourceBranch -commit $sourceCommit -buildNumber $sourceBuildNumber -assets $sourceAssets
+
+    $output = Darc-Get-Build $buildId
+    if (-not $output -match "Released: +False") {
+        throw "Build should be marked unreleased"
+    }
+
+    # Release the build
+    $output = Darc-Update-Build -id $buildId -updateParams @( "--released" )
+    if (-not $output -match "Released: +True") {
+        throw "Build should be marked released"
+    }
+
+    # Gather a drop with released included
+    $gatherWithReleasedDir = Join-Path -Path $testRoot -ChildPath "gather-with-released"
+    $darcParams = @( "gather-drop", "--id", "$buildId", "--dry-run", "--output-dir", $gatherWithReleasedDir )
+    $gatherDropOutput = Darc-Command -darcParams $darcParams
+    if ((-not $gatherDropOutput -match "Gathering drop for build $sourceBuildNumber")) {
+        throw "Build should download build $sourceBuildNumber"
+    }
+    if ((-not $gatherDropOutput -match "Downloading asset Bar@2.1.0") -or
+        (-not $gatherDropOutput -match "Downloading asset Foo@1.1.0")) {
+        throw "Build should download both Foo and Bar"
+    }
+
+    # Gather with release excluded
+    $gatherWithNoReleasedDir = Join-Path -Path $testRoot -ChildPath "gather-no-released"
+    $darcParams = @( "gather-drop", "--id", "$buildId", "--dry-run", "--skip-released", "--output-dir", $gatherWithNoReleasedDir )
+    $gatherDropOutput = Darc-Command -darcParams $darcParams
+    if ((-not $gatherDropOutput -match "Skipping download of released build $sourceBuildNumber of $sourceRepoUri @ $sourceCommit")) {
+        throw "Build should not download build $sourceBuildNumber"
+    }
+    if (($gatherDropOutput -match "Downloading asset Bar@2.1.0") -or
+        ($gatherDropOutput -match "Downloading asset Foo@1.1.0")) {
+        throw "Build should not download either Foo and Bar"
+    }
+    Write-Host $gatherDropOutput
+
+    # Unrelease the build
+    # $output = Darc-Update-Build -id $buildId -updateParams @( "--not-released" )
+    if (-not $output -match "Released: +False") {
+        throw "Build should be marked unreleased"
+    }
+
+    # Gather with release excluded
+    $gatherWithNoReleased2Dir = Join-Path -Path $testRoot -ChildPath "gather-no-released-2"
+    $darcParams = @( "gather-drop", "--id", "$buildId", "--dry-run", "--skip-released", "--output-dir", $gatherWithNoReleased2Dir )
+    $gatherDropOutput = Darc-Command -darcParams $darcParams
+    if ((-not $gatherDropOutput -match "Gathering drop for build $sourceBuildNumber")) {
+        throw "Build should download build $sourceBuildNumber"
+    }
+    if ((-not $gatherDropOutput -match "Downloading asset Bar@2.1.0") -or
+        (-not $gatherDropOutput -match "Downloading asset Foo@1.1.0")) {
+        throw "Build should download both Foo and Bar"
+    }
+
+    Write-Host "Tests passed."
+} finally {
+    Teardown
+}

--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -375,6 +375,15 @@ function Get-Build($id) {
     $response
 }
 
+function Darc-Get-Build($id) {
+    $darcParams = @( "get-build", "--id", "$id" )
+    Darc-Command -darcParams $darcParams
+}
+function Darc-Update-Build($id, $updateParams) {
+    $darcParams = @( "update-build", "--id", "$id" ) + $updateParams
+    Darc-Command -darcParams $darcParams
+}
+
 function Get-Bar-Headers([string]$accept) {
     $headers = New-Object 'System.Collections.Generic.Dictionary[[String],[String]]'
     $headers.Add('Accept', $accept)

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
@@ -98,10 +98,14 @@ namespace Microsoft.DotNet.Darc
                 builder.AppendLine($"Build Link:    {azdoLink}");
             }
             builder.AppendLine($"BAR Build Id:  {build.Id}");
-            builder.AppendLine($"Channels:");
-            foreach (Channel buildChannel in build.Channels)
+            builder.AppendLine($"Released:      {build.Released}");
+            if (build.Channels != null)
             {
-                builder.AppendLine($"- {buildChannel.Name}");
+                builder.AppendLine($"Channels:");
+                foreach (Channel buildChannel in build.Channels)
+                {
+                    builder.AppendLine($"- {buildChannel.Name}");
+                }
             }
 
             return builder.ToString();

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateBuildOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateBuildOperation.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Darc.Helpers;
+using Microsoft.DotNet.Darc.Models.PopUps;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Darc.Operations
+{
+    internal class UpdateBuildOperation : Operation
+    {
+        UpdateBuildCommandLineOptions _options;
+        public UpdateBuildOperation(UpdateBuildCommandLineOptions options)
+            : base(options)
+        {
+            _options = options;
+        }
+
+        public async override Task<int> ExecuteAsync()
+        {
+            if (!(_options.Released ^ _options.NotReleased))
+            {
+                Console.WriteLine("Please specify either --released or --not-released.");
+                return Constants.ErrorCode;
+            }
+
+            try
+            {
+                IRemote remote = RemoteFactory.GetBarOnlyRemote(_options, Logger);
+
+                Build updatedBuild = await remote.UpdateBuildAsync(_options.Id, new BuildUpdate { Released = _options.Released });
+
+                Console.WriteLine($"Updated build {_options.Id} with new information.");
+                Console.WriteLine(UxHelpers.GetBuildDescription(updatedBuild));
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, $"Error: Failed to update build with id '{_options.Id}'");
+                return Constants.ErrorCode;
+            }
+
+            return Constants.SuccessCode;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
@@ -67,6 +67,9 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("skip-existing", HelpText = "Skip files that already exist at the destination.")]
         public bool SkipExisting { get; set; }
 
+        [Option("skip-released", HelpText = "Skip builds that are marked as released")]
+        public bool SkipReleased { get; set; }
+
         [Option("latest-location", HelpText = "Download assets from their latest known location.")]
         public bool LatestLocation { get; set; }
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateBuildCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateBuildCommandLineOptions.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommandLine;
+using Microsoft.DotNet.Darc.Operations;
+
+namespace Microsoft.DotNet.Darc.Options
+{
+    [Verb("update-build", HelpText = "Update a build with new information.")]
+    internal class UpdateBuildCommandLineOptions : CommandLineOptions
+    {
+        [Option("id", Required = true, HelpText = "Build id.")]
+        public int Id { get; set; }
+
+        [Option("released", HelpText = "Set the build to being 'released'.")]
+        public bool Released { get; set; }
+
+        [Option("not-released", HelpText = "Set the build to 'not released'.")]
+        public bool NotReleased { get; set; }
+
+        public override Operation GetOperation()
+        {
+            return new UpdateBuildOperation(this);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
@@ -76,6 +76,7 @@ namespace Microsoft.DotNet.Darc
                     typeof(SetRepositoryMergePoliciesCommandLineOptions),
                     typeof(SubscriptionStatusCommandLineOptions),
                     typeof(TriggerSubscriptionsCommandLineOptions),
+                    typeof(UpdateBuildCommandLineOptions),
                     typeof(UpdateDependenciesCommandLineOptions),
                     typeof(UpdateSubscriptionCommandLineOptions),
                     typeof(VerifyCommandLineOptions),

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -1152,5 +1152,17 @@ namespace Microsoft.DotNet.DarcLib
                 }
             }
         }
+
+        /// <summary>
+        ///     Update an existing build.
+        /// </summary>
+        /// <param name="buildId">Build to update</param>
+        /// <param name="buildUpdate">Updated build info</param>
+        /// <returns>Updated build</returns>
+        public Task<Build> UpdateBuildAsync(int buildId, BuildUpdate buildUpdate)
+        {
+            CheckForValidBarClient();
+            return _barClient.UpdateBuildAsync(buildId, buildUpdate);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
@@ -223,6 +223,13 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns>Async task</returns>
         Task AssignBuildToChannel(int buildId, int channelId);
 
+        /// <summary>
+        ///     Update an existing build.
+        /// </summary>
+        /// <param name="buildId">Build to update</param>
+        /// <param name="buildUpdate">Updated build info</param>
+        Task<Build> UpdateBuildAsync(int buildId, BuildUpdate buildUpdate);
+
         #endregion
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -424,6 +424,13 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns>Async task</returns>
         Task AddAssetLocationToDependenciesAsync(IEnumerable<DependencyDetail> dependencies);
 
+        /// <summary>
+        ///     Update an existing build.
+        /// </summary>
+        /// <param name="buildId">Build to update</param>
+        /// <param name="buildUpdate">Updated build info</param>
+        Task<Build> UpdateBuildAsync(int buildId, BuildUpdate buildUpdate);
+
         #endregion
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/MaestroApiBarClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/MaestroApiBarClient.cs
@@ -373,5 +373,16 @@ namespace Microsoft.DotNet.DarcLib
                                                     channelId: channelId,
                                                     loadCollections: true);
         }
+
+        /// <summary>
+        ///     Update an existing build.
+        /// </summary>
+        /// <param name="buildId">Build to update</param>
+        /// <param name="buildUpdate">Updated build info</param>
+        /// <returns>Updated build</returns>
+        public Task<Build> UpdateBuildAsync(int buildId, BuildUpdate buildUpdate)
+        {
+            return _barClient.Builds.UpdateAsync(buildUpdate, buildId);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
@@ -574,7 +574,7 @@ namespace Microsoft.DotNet.Darc.Tests
             var buildAssets = assets.Select<(string, string), Asset>(a =>
             new Asset(GetRandomId(), buildId, true, a.Item1, a.Item2, null));
 
-            var build = new Build(buildId, DateTimeOffset.Now, 0, false, commit, null, buildAssets.ToImmutableList(), null)
+            var build = new Build(buildId, DateTimeOffset.Now, 0, false, false, commit, null, buildAssets.ToImmutableList(), null)
             {
                 AzureDevOpsRepository = repo,
                 GitHubRepository = repo


### PR DESCRIPTION
This adds support for marking builds as released or non-released and optionally skipping downloads of released builds. This is so the coherency QB can more easily trim out previously released builds that show up in the graph.
Includes:
- Tests
- Darc command to set a build as released (`update-build`)
- get-build print out

Also regenerates the client