### PR TITLE
Remove time to inclusion visualization

### DIFF
--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -74,15 +74,6 @@
     </th>
     <th>Repository</th>
     <th>Date Produced</th>
-    <th>
-      <span title="Cummulative time it took for the dependency to flow through each repository in the 
-build graph to the root node. For each edge in the dependency graph, when a dependency is added to BAR
-the first time for a given dependent build id and parent repository and branch, we calculate the difference
-between when the dependent build was added to BAR and when the parent build was added to BAR. The total time to
-inclusion is then calculated by walking the dependency graph and summing the individual edges' time to inclusion.">
-        Time To Inclusion
-      </span>
-    </th>
     <th></th>
     <th>Build Number</th>
     <th>Build Staleness</th>
@@ -123,11 +114,6 @@ inclusion is then calculated by walking the dependency graph and summing the ind
       </td>
       <td>
         <mc-time-ago [value]="node.build.dateProduced"></mc-time-ago>
-      </td>
-      <td>
-        <span>
-          {{timeToInclusion(node)}} minutes
-        </span>
       </td>
       <td>
         <fa-icon [icon]="node.hasCycles ? 'redo' : 'exclamation-triangle'" 


### PR DESCRIPTION
The visualization is confusing for BarViz users, so remove the column until we have something that is easier to explain.