### PR TITLE
Add a coherency only option to update-dependencies

### DIFF
--- a/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
@@ -90,7 +90,7 @@
   </DefaultServices>
   <Principals>
     <Users>
-        <User Name="SetupLocalSystem" AccountType="LocalSystem" />
+      <User Name="SetupLocalSystem" AccountType="LocalSystem" />
     </Users>
   </Principals>
   <Certificates>

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Darc.Operations
                     {
                         if (string.IsNullOrEmpty(_options.Channel))
                         {
-                            Console.WriteLine($"Please suppy either a channel name (--channel), a packages folder (--packages-folder) " +
+                            Console.WriteLine($"Please supply either a channel name (--channel), a packages folder (--packages-folder) " +
                                 $"or a specific dependency name and version (--name and --version).");
                             return Constants.ErrorCode;
                         }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateDependenciesCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateDependenciesCommandLineOptions.cs
@@ -30,6 +30,9 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("dry-run", HelpText = "Show what will be updated, but make no changes.")]
         public bool DryRun { get; set; }
 
+        [Option("coherency-only", HelpText = "Only do coherency updates.")]
+        public bool CoherencyOnly { get; set; }
+
         public override Operation GetOperation()
         {
             return new UpdateDependenciesOperation(this);


### PR DESCRIPTION
For remote coherency scenarios (not specific version update or update from a directory), include an option that will only bring dependencies into correct coherency state. This allows users to adjust a dependency manually and then ask the tool to bring everything else into line.