### PR TITLE
Update Darc to netcoreapp3.0.

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <SignAssembly>false</SignAssembly>
     <IsPackable>true</IsPackable>
@@ -12,8 +12,15 @@
     <ToolCommandName>darc</ToolCommandName>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <ProjectReference Include="..\DarcLib.AzDev\Microsoft.DotNet.DarcLib.AzDev.csproj" AdditionalProperties="TargetFramework=netstandard2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <ProjectReference Include="..\DarcLib.AzDev\Microsoft.DotNet.DarcLib.AzDev.csproj" AdditionalProperties="TargetFramework=netstandard2.1" />
+  </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\DarcLib.AzDev\Microsoft.DotNet.DarcLib.AzDev.csproj" />
     <ProjectReference Include="..\DarcLib\Microsoft.DotNet.DarcLib.csproj" />
   </ItemGroup>
   

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/Microsoft.DotNet.DarcLib.AzDev.csproj
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/Microsoft.DotNet.DarcLib.AzDev.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>7.1</LangVersion>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
     <SignAssembly>false</SignAssembly>
@@ -20,8 +20,8 @@
       Needed to appease Microsoft.TeamFoundationServer.Client package
       They don't actually use these references, but they have package dependencies on them
     -->
-    <PackageReference Include="Microsoft.Bcl" Version="1.1.10" ExcludeAssets="All" />
-    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" ExcludeAssets="All" />
+    <PackageReference Include="Microsoft.Bcl" Version="1.1.10" ExcludeAssets="All" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
+    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" ExcludeAssets="All" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>7.1</LangVersion>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
     <SignAssembly>false</SignAssembly>


### PR DESCRIPTION
The change to upgrade LibGit2Sharp and enable Darc on arm64 (https://github.com/dotnet/arcade-services/pull/694) does not actually work without also using netcoreapp3.0.