### PR TITLE
Always return cached arcade items with an add operation

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -86,8 +86,12 @@ namespace Microsoft.DotNet.DarcLib
                     {
                         if (!engCommonFiles.Where(f => f.FilePath == file.FilePath).Any())
                         {
-                            file.Operation = GitFileOperation.Delete;
-                            filesToUpdate.Add(file);
+                            filesToUpdate.Add(new GitFile(
+                                file.FilePath,
+                                file.Content,
+                                file.ContentEncoding,
+                                file.Mode,
+                                GitFileOperation.Delete));
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -86,6 +86,11 @@ namespace Microsoft.DotNet.DarcLib
                     {
                         if (!engCommonFiles.Where(f => f.FilePath == file.FilePath).Any())
                         {
+                            // This is a file in the repo's eng/common folder that isn't present in Arcade at the
+                            // requested SHA so delete it during the update.
+                            // GitFile instances do not have public setters since we insert/retrieve them from an
+                            // In-memory cache during remote updates and we don't want anything to modify the cached,
+                            // references, so add a copy with a Delete FileOperation.
                             filesToUpdate.Add(new GitFile(
                                 file.FilePath,
                                 file.Content,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -804,6 +804,11 @@ namespace Microsoft.DotNet.DarcLib
                     if (!engCommonFiles.Where(f => f.FilePath == file.FilePath).Any())
                     {
                         deletedFiles.Add(file.FilePath);
+                        // This is a file in the repo's eng/common folder that isn't present in Arcade at the
+                        // requested SHA so delete it during the update.
+                        // GitFile instances do not have public setters since we insert/retrieve them from an
+                        // In-memory cache and we don't want anything to modify the cached references,
+                        // so add a copy with a Delete FileOperation.
                         filesToCommit.Add(new GitFile(
                                 file.FilePath,
                                 file.Content,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -804,8 +804,12 @@ namespace Microsoft.DotNet.DarcLib
                     if (!engCommonFiles.Where(f => f.FilePath == file.FilePath).Any())
                     {
                         deletedFiles.Add(file.FilePath);
-                        file.Operation = GitFileOperation.Delete;
-                        filesToCommit.Add(file);
+                        filesToCommit.Add(new GitFile(
+                                file.FilePath,
+                                file.Content,
+                                file.ContentEncoding,
+                                file.Mode,
+                                GitFileOperation.Delete));
                     }
                 }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -430,7 +430,7 @@ namespace Microsoft.DotNet.DarcLib
 
             if (Cache != null)
             {
-                GitFile cachedFile = await Cache.GetOrCreateAsync(treeItem.Sha, async (entry) =>
+                return await Cache.GetOrCreateAsync(treeItem.Sha, async (entry) =>
                 {
                     GitFile file = await GetGitItemImpl(path, treeItem, owner, repo);
 
@@ -442,8 +442,6 @@ namespace Microsoft.DotNet.DarcLib
 
                     return file;
                 });
-
-                return cachedFile;
             }
             else
             {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -443,9 +443,6 @@ namespace Microsoft.DotNet.DarcLib
                     return file;
                 });
 
-                // Change the cached file back to its default state (Add operation).
-                // If the file was found in the cache, it means the file exists in the repo we are checking.
-                cachedFile.Operation = GitFileOperation.Add;
                 return cachedFile;
             }
             else
@@ -485,8 +482,8 @@ namespace Microsoft.DotNet.DarcLib
             GitFile newFile = new GitFile(
                 path + "/" + treeItem.Path,
                 blob.Content,
-                encoding)
-            { Mode = treeItem.Mode };
+                encoding,
+                treeItem.Mode);
 
             return newFile;
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -430,7 +430,7 @@ namespace Microsoft.DotNet.DarcLib
 
             if (Cache != null)
             {
-                return await Cache.GetOrCreateAsync(treeItem.Sha, async (entry) =>
+                var cachedFile = await Cache.GetOrCreateAsync(treeItem.Sha, async (entry) =>
                 {
                     GitFile file = await GetGitItemImpl(path, treeItem, owner, repo);
 
@@ -442,6 +442,11 @@ namespace Microsoft.DotNet.DarcLib
 
                     return file;
                 });
+
+                // Change the cached file back to its default state (Add operation).
+                // If the file was found in the cache, it means the file exists in the repo we are checking.
+                cachedFile.Operation = GitFileOperation.Add;
+                return cachedFile;
             }
             else
             {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -430,7 +430,7 @@ namespace Microsoft.DotNet.DarcLib
 
             if (Cache != null)
             {
-                var cachedFile = await Cache.GetOrCreateAsync(treeItem.Sha, async (entry) =>
+                GitFile cachedFile = await Cache.GetOrCreateAsync(treeItem.Sha, async (entry) =>
                 {
                     GitFile file = await GetGitItemImpl(path, treeItem, owner, repo);
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFile.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFile.cs
@@ -25,7 +25,12 @@ namespace Microsoft.DotNet.DarcLib
         {
         }
 
-        public GitFile(string filePath, string content, ContentEncoding contentEncoding)
+        public GitFile(
+            string filePath,
+            string content,
+            ContentEncoding contentEncoding,
+            string mode = "100644",
+            GitFileOperation operation = GitFileOperation.Add)
         {
             FilePath = filePath;
             // TODO: Newline normalization should happen on the writer side,
@@ -37,17 +42,19 @@ namespace Microsoft.DotNet.DarcLib
                 Content = $"{Content}\n";
             }
             ContentEncoding = contentEncoding;
+            Mode = mode;
+            Operation = operation;
         }
 
         public string FilePath { get; }
 
-        public string Content { get; set; }
+        public string Content { get; }
 
-        public ContentEncoding ContentEncoding { get; set; }
+        public ContentEncoding ContentEncoding { get; }
 
-        public string Mode { get; set; } = "100644";
+        public string Mode { get; } = "100644";
 
-        public GitFileOperation Operation { get; set; } = GitFileOperation.Add;
+        public GitFileOperation Operation { get; } = GitFileOperation.Add;
 
         private static string GetIndentedXmlBody(XmlDocument xmlDocument)
         {


### PR DESCRIPTION
This should make sure that https://github.com/dotnet/arcade/issues/4193 stops happening.

Presumably, if we get a cache hit for the file, it means it was found in the repo we are checking it for, so we should always default to adding the file.