### PR TITLE
Allow deletion of subscriptions based on filters.

### DIFF
--- a/src/Maestro/maestro-angular/package-lock.json
+++ b/src/Maestro/maestro-angular/package-lock.json
@@ -3892,8 +3892,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3907,23 +3906,21 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -3936,20 +3933,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3990,7 +3984,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.5"
           }
         },
         "fs.realpath": {
@@ -4005,14 +3999,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "glob": {
@@ -4021,12 +4015,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -4041,7 +4035,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -4050,7 +4044,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -4059,15 +4053,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4079,9 +4072,8 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -4094,25 +4086,22 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "minizlib": {
@@ -4121,14 +4110,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.5"
           }
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4145,9 +4133,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.24",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -4156,16 +4144,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.4",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.2.0",
+            "npmlog": "4.1.2",
+            "rc": "1.2.8",
+            "rimraf": "2.6.3",
+            "semver": "5.6.0",
+            "tar": "4.4.8"
           }
         },
         "nopt": {
@@ -4174,8 +4162,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -4190,8 +4178,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.5"
           }
         },
         "npmlog": {
@@ -4200,17 +4188,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4222,9 +4209,8 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -4245,8 +4231,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -4267,10 +4253,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -4287,13 +4273,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -4302,14 +4288,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.3"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4345,11 +4330,10 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -4358,16 +4342,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -4382,13 +4365,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.1.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.5",
+            "minizlib": "1.2.1",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "util-deprecate": {
@@ -4403,20 +4386,18 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -166,7 +166,7 @@ function Darc-Command-WithPipeline([Parameter(ValueFromPipeline=$true)]$pipeline
     if ($darcCommandPrefix) {
         $finalParams = ,"$darcCommandPrefix" + $finalParams
     }
-    Write-Host "Running 'pipelineParams | $darcTool $finalParams $darcAuthParams'"
+    Write-Host "Running 'pipelineParams | $darcTool $finalParams ***'"
     $commandOutput = $pipelineParams| & $darcTool @finalParams @darcAuthParams
     if ($LASTEXITCODE -ne 0) {
       Write-Host ${commandOutput}
@@ -181,7 +181,7 @@ function Darc-Command([Parameter(ValueFromRemainingArguments=$true)]$darcParams)
     if ($darcCommandPrefix) {
         $finalParams = ,"$darcCommandPrefix" + $finalParams
     }
-    Write-Host "Running '$darcTool $finalParams $darcAuthParams'"
+    Write-Host "Running '$darcTool $finalParams ***'"
     $commandOutput = & $darcTool @finalParams @darcAuthParams
     if ($LASTEXITCODE -ne 0) {
       Write-Host ${commandOutput}
@@ -248,7 +248,7 @@ function Darc-Get-Default-Channel-From-Api($repoUri, $branch) {
 }
 
 function Darc-Delete-Subscription($subscriptionId) {
-    Darc-Command delete-subscription --id $subscriptionId
+    Darc-Command delete-subscriptions --id $subscriptionId --quiet
 }
 
 function Darc-Get-Subscription($subscriptionId) {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteSubscriptionOperation.cs
@@ -23,28 +23,10 @@ namespace Microsoft.DotNet.Darc.Operations
             _options = options;
         }
 
-        public override async Task<int> ExecuteAsync()
+        public override Task<int> ExecuteAsync()
         {
-            IRemote remote = RemoteFactory.GetBarOnlyRemote(_options, Logger);
-
-            try
-            {
-                Subscription deletedSubscription = await remote.DeleteSubscriptionAsync(_options.Id);
-                Console.WriteLine($"Successfully deleted subscription with id '{_options.Id}'");
-                return Constants.SuccessCode;
-            }
-            catch (RestApiException e) when (e.Response.StatusCode == HttpStatusCode.NotFound)
-            {
-                // Not found is fine to ignore.  If we get this, it will be an aggregate exception with an inner API exception
-                // that has a response message code of NotFound.  Return success.
-                Console.WriteLine($"Subscription with id '{_options.Id}' does not exist.");
-                return Constants.SuccessCode;
-            }
-            catch (Exception e)
-            {
-                Logger.LogError(e, $"Failed to delete subscription with id '{_options.Id}'");
-                return Constants.ErrorCode;
-            }
+            Console.WriteLine("The 'delete-subscription' command has been removed. Please use 'delete-subscriptions' instead");
+            return Task.FromResult(Constants.ErrorCode);
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteSubscriptionsOperation.cs
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.Darc.Operations
             }
             catch (Exception e)
             {
-                Logger.LogError(e, "Unexpected error while delete subscriptions.");
+                Logger.LogError(e, "Unexpected error while deleting subscriptions.");
                 return Constants.ErrorCode;
             }
         }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteSubscriptionsOperation.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Darc.Helpers;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Maestro.Client;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Darc.Operations
+{
+    internal class DeleteSubscriptionsOperation : Operation
+    {
+        DeleteSubscriptionsCommandLineOptions _options;
+        public DeleteSubscriptionsOperation(DeleteSubscriptionsCommandLineOptions options)
+            : base(options)
+        {
+            _options = options;
+        }
+
+        public override async Task<int> ExecuteAsync()
+        {
+            try
+            {
+                IRemote remote = RemoteFactory.GetBarOnlyRemote(_options, Logger);
+
+                bool noConfirm = _options.NoConfirmation;
+                List<Subscription> subscriptionsToDelete = new List<Subscription>();
+
+                if (!string.IsNullOrEmpty(_options.Id))
+                {
+                    // Look up subscription so we can print it later.
+                    try
+                    {
+                        Subscription subscription = await remote.GetSubscriptionAsync(_options.Id);
+                        subscriptionsToDelete.Add(subscription);
+                    }
+                    catch (RestApiException e) when (e.Response.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        Console.WriteLine($"Subscription with id '{_options.Id}' was not found.");
+                        return Constants.ErrorCode;
+                    }
+                }
+                else
+                {
+                    if (!_options.HasAnyFilters())
+                    {
+                        Console.WriteLine($"Please specify one or more filters to select which subscriptions should be deleted (see help).");
+                        return Constants.ErrorCode;
+                    }
+
+                    IEnumerable<Subscription> subscriptions = await _options.FilterSubscriptions(remote);
+
+                    if (subscriptions.Count() == 0)
+                    {
+                        Console.WriteLine("No subscriptions found matching the specified criteria.");
+                        return Constants.ErrorCode;
+                    }
+
+                    subscriptionsToDelete.AddRange(subscriptions);
+                }
+
+                if (!noConfirm)
+                {
+                    // Print out the list of subscriptions about to be triggered.
+                    Console.WriteLine($"Will delete the following {subscriptionsToDelete.Count} subscriptions...");
+                    foreach (var subscription in subscriptionsToDelete)
+                    {
+                        Console.WriteLine($"  {UxHelpers.GetSubscriptionDescription(subscription)}");
+                    }
+
+                    if (!UxHelpers.PromptForYesNo("Continue?"))
+                    {
+                        Console.WriteLine($"No subscriptions deleted, exiting.");
+                        return Constants.ErrorCode;
+                    }
+                }
+
+                Console.Write($"Deleting {subscriptionsToDelete.Count} subscriptions...{(noConfirm ? Environment.NewLine : "")}");
+                foreach (var subscription in subscriptionsToDelete)
+                {
+                    // If noConfirm was passed, print out the subscriptions as we go
+                    if (noConfirm)
+                    {
+                        Console.WriteLine($"  {UxHelpers.GetSubscriptionDescription(subscription)}");
+                    }
+                    await remote.DeleteSubscriptionAsync(subscription.Id.ToString());
+                }
+                Console.WriteLine($"done");
+
+                return Constants.SuccessCode;
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Unexpected error while delete subscriptions.");
+                return Constants.ErrorCode;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/DeleteSubscriptionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/DeleteSubscriptionCommandLineOptions.cs
@@ -7,7 +7,7 @@ using Microsoft.DotNet.Darc.Operations;
 
 namespace Microsoft.DotNet.Darc.Options
 {
-    [Verb("delete-subscription", HelpText = "Remove a subscription.")]
+    [Verb("delete-subscription", Hidden = true, HelpText = "Please use delete-subscriptions.")]
     class DeleteSubscriptionCommandLineOptions : CommandLineOptions
     {
         [Option('i', "id", Required = true, HelpText = "ID of subscription to delete.")]

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/DeleteSubscriptionsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/DeleteSubscriptionsCommandLineOptions.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommandLine;
+using Microsoft.DotNet.Darc.Operations;
+
+namespace Microsoft.DotNet.Darc.Options
+{
+    [Verb("delete-subscriptions", HelpText = "Delete a subscription or set of subscriptions matching criteria.")]
+    internal class DeleteSubscriptionsCommandLineOptions : SubscriptionsCommandLineOptions
+    {
+        [Option("id", HelpText = "Delete a specific subscription by id.")]
+        public string Id { get; set; }
+
+        [Option('q', "quiet", HelpText = "Do not confirm which subscriptions are about to be triggered.")]
+        public bool NoConfirmation { get; set; }
+
+        public override Operation GetOperation()
+        {
+            return new DeleteSubscriptionsOperation(this);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
@@ -61,6 +61,7 @@ namespace Microsoft.DotNet.Darc
                     typeof(DeleteChannelCommandLineOptions),
                     typeof(DeleteDefaultChannelCommandLineOptions),
                     typeof(DeleteSubscriptionCommandLineOptions),
+                    typeof(DeleteSubscriptionsCommandLineOptions),
                     typeof(GatherDropCommandLineOptions),
                     typeof(GetAssetCommandLineOptions),
                     typeof(GetBuildCommandLineOptions),


### PR DESCRIPTION
Deprecate delete-subscription and replace with delete-subscriptions (same parameter set supported, plus all the filters of get-subscriptions and trigger subscriptions). This will allow easier cleanup of large numbers of subscriptions.