### PR TITLE
Get the pull request information when waiting for the title to match during scenario tests.

### DIFF
--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -517,6 +517,11 @@ function Get-AzDO-PullRequests($targetRepoName, $targetBranch) {
     Invoke-WebRequest -Uri $uri -Headers $(Get-AzDO-Headers) -Method Get | ConvertFrom-Json
 }
 
+function Get-AzDO-PullRequest($targetRepoName, $prId) {
+    $uri = "$(Get-AzDO-RepoApiUri($targetRepoName))/pullrequests/${prId}?api-version=${azdoApiVersion}"
+    Invoke-WebRequest -Uri $uri -Headers $(Get-AzDO-Headers) -Method Get | ConvertFrom-Json
+}
+
 function Check-AzDO-PullRequest-Completed($targetRepoName, $pullRequestNumber) {
     $uri = "$(Get-AzDO-RepoApiUri($targetRepoName))/pullrequests/$pullRequestNumber"
     $tries = 7
@@ -572,10 +577,11 @@ function Validate-AzDO-PullRequest-Contents($pullRequest, $expectedPRTitle, $tar
 
     # Depending on how quickly each dependency update comes through,
     # we might have to wait for the title to be updated correctly for batched Subscriptions.
-    $tries = 10
+    $tries = 5
     $validTitle = $false;
     while ($tries-- -gt 0 -and (-not $validTitle)) {
         Write-Host "Validating PR title. $tries tries remaining..."
+        $pullRequest = Get-AzDO-PullRequest $targetRepoName $pullRequest.pullRequestId
         if ($pullRequest.title -eq $expectedPRTitle) {
             $validTitle = $true
             break
@@ -765,6 +771,11 @@ function Get-GitHub-PullRequests($targetRepoName, $targetBranch) {
     Invoke-WebRequest -Uri $uri -Headers $(Get-Github-Headers) -Method Get | ConvertFrom-Json
 }
 
+function Get-GitHub-PullRequest($targetRepoName, $prId) {
+    $uri = "$(Get-Github-RepoApiUri($targetRepoName))/pulls/$prId"
+    Invoke-WebRequest -Uri $uri -Headers $(Get-Github-Headers) -Method Get | ConvertFrom-Json
+}
+
 function Get-Github-File-Contents($targetRepoName, $path, $ref) {
     $uri = "$(Get-Github-RepoApiUri($targetRepoName))/contents/${path}?ref=$ref"
     Invoke-WebRequest -Uri $uri -Headers $(Get-Github-Headers) -Method Get | ConvertFrom-Json
@@ -815,10 +826,11 @@ function Check-Github-PullRequest-Created($targetRepoName, $targetBranch) {
 function Validate-Github-PullRequest-Contents($pullRequest, $expectedPRTitle, $targetRepoName, $targetBranch, $expectedDependencies) {
     # Depending on how quickly each dependency update comes through,
     # we might have to wait for the title to be updated correctly for batched Subscriptions
-    $tries = 10
+    $tries = 5
     $validTitle = $false;
     while ($tries-- -gt 0) {
         Write-Host "Validating PR title. $tries tries remaining..."
+        $pullRequest = Get-GitHub-PullRequest $targetRepoName $pullRequest.number
         if ($pullRequest.title -eq $expectedPRTitle) {
             $validTitle = $true
             break


### PR DESCRIPTION
Actually get the PR information every time we check for the title.


fix for https://github.com/dotnet/arcade/issues/3988 which were not flaky, just broken because of this and only passed by sheer luck.