### PR TITLE
Fix channel info in get-flow-graph

### DIFF
--- a/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
+++ b/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
@@ -232,5 +232,10 @@ namespace SubscriptionActorService
                 AzureDevOpsRepository = other.AzureDevOpsRepository,
             };
         }
+
+        public Task<Channel> GetChannelAsync(int channelId)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -27,6 +27,9 @@ namespace Microsoft.DotNet.Darc.Operations
             _options = options;
         }
 
+        const int engLatestChannelId = 2;
+        const int eng3ChannelId = 344;
+
         public override async Task<int> ExecuteAsync()
         {
             try
@@ -34,21 +37,30 @@ namespace Microsoft.DotNet.Darc.Operations
                 RemoteFactory remoteFactory = new RemoteFactory(_options);
                 var barOnlyRemote = await remoteFactory.GetBarOnlyRemoteAsync(Logger);
 
+                Channel engLatestChannel = await barOnlyRemote.GetChannelAsync(engLatestChannelId);
+                Channel eng3Channel = await barOnlyRemote.GetChannelAsync(eng3ChannelId);
+
                 List<DefaultChannel> defaultChannels = (await barOnlyRemote.GetDefaultChannelsAsync()).ToList();
-                defaultChannels.Add(
-                    new DefaultChannel(0, "https://github.com/dotnet/arcade", true)
-                    {
-                        Branch = "master",
-                        Channel = await barOnlyRemote.GetChannelAsync(".NET Tools - Latest")
-                    }
-                );
-                defaultChannels.Add(
-                    new DefaultChannel(0, "https://github.com/dotnet/arcade", true)
-                    {
-                        Branch = "release/3.x",
-                        Channel = await barOnlyRemote.GetChannelAsync(".NET 3 Tools")
-                    }
-                );
+                if (engLatestChannel != null)
+                {
+                    defaultChannels.Add(
+                        new DefaultChannel(0, "https://github.com/dotnet/arcade", true)
+                        {
+                            Branch = "master",
+                            Channel = engLatestChannel
+                        }
+                    );
+                }
+                if (eng3Channel != null)
+                {
+                    defaultChannels.Add(
+                        new DefaultChannel(0, "https://github.com/dotnet/arcade", true)
+                        {
+                            Branch = "release/3.x",
+                            Channel = eng3Channel
+                        }
+                    );
+                }
                 List<Subscription> subscriptions = (await barOnlyRemote.GetSubscriptionsAsync()).ToList();
 
                 // Build, then prune out what we don't want to see if the user specified

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -911,6 +911,17 @@ namespace Microsoft.DotNet.DarcLib
         }
 
         /// <summary>
+        ///     Retrieve a specific channel by id.
+        /// </summary>
+        /// <param name="channel">Channel id.</param>
+        /// <returns>Channel or null if not found.</returns>
+        public Task<Channel> GetChannelAsync(int channel)
+        {
+            CheckForValidBarClient();
+            return _barClient.GetChannelAsync(channel);
+        }
+
+        /// <summary>
         ///     Retrieve the latest build of a repository on a specific channel.
         /// </summary>
         /// <param name="repoUri">URI of repository to obtain a build for.</param>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
@@ -115,6 +115,13 @@ namespace Microsoft.DotNet.DarcLib
         Task<Channel> GetChannelAsync(string channel);
 
         /// <summary>
+        ///     Retrieve a specific channel by id.
+        /// </summary>
+        /// <param name="channel">Channel id.</param>
+        /// <returns>Channel or null if not found.</returns>
+        Task<Channel> GetChannelAsync(int channelId);
+
+        /// <summary>
         ///     Retrieve a set of default channel associations based on the provided filters.
         /// </summary>
         /// <param name="repository">Repository name</param>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -80,6 +80,13 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns>Channel or null if not found.</returns>
         Task<Channel> GetChannelAsync(string channel);
 
+        /// <summary>
+        ///     Retrieve a specific channel by id.
+        /// </summary>
+        /// <param name="channel">Channel id.</param>
+        /// <returns>Channel or null if not found.</returns>
+        Task<Channel> GetChannelAsync(int channelId);
+
         #endregion
 
         #region Subscription Operations

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/MaestroApiBarClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/MaestroApiBarClient.cs
@@ -350,6 +350,23 @@ namespace Microsoft.DotNet.DarcLib
         }
 
         /// <summary>
+        ///     Retrieve a specific channel by id.
+        /// </summary>
+        /// <param name="channel">Channel id.</param>
+        /// <returns>Channel or null if not found.</returns>
+        public async Task<Channel> GetChannelAsync(int channel)
+        {
+            try
+            {
+                return await _barClient.Channels.GetChannelAsync(channel);
+            }
+            catch (RestApiException e) when (e.Response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         ///     Retrieve the list of channels from the build asset registry.
         /// </summary>
         /// <param name="classification">Optional classification to get</param>


### PR DESCRIPTION
When the channel names were changed for .NET Tools, get-flow-graph broke because it hard coded the channel names. Fix these up and change over to using an ID instead, which is stable.