### PR TITLE
Allow bots-high to get access site too

### DIFF
--- a/src/Dotnet.Status.Web/Startup.cs
+++ b/src/Dotnet.Status.Web/Startup.cs
@@ -131,7 +131,7 @@ namespace DotNet.Status.Web
                             policy.RequireAuthenticatedUser();
                             if (!Env.IsDevelopment())
                             {
-                                policy.RequireRole("github:team:dotnet/dnceng");
+                                policy.RequireRole("github:team:dotnet/dnceng", "github:team:dotnet/bots-high");
                             }
                         });
                 });


### PR DESCRIPTION
So that we can manage permissions and tokens without having specific people on the hook