### PR TITLE
Return null from GetLastCommitShaAsync if there are no commits

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -563,7 +563,7 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         /// <param name="repoUri">Repository uri</param>
         /// <param name="branch">Branch to retrieve the latest sha for</param>
-        /// <returns>Latest sha.  Throws if no commits were found.</returns>
+        /// <returns>Latest sha.  Nulls if no commits were found.</returns>
         public Task<string> GetLastCommitShaAsync(string repoUri, string branch)
         {
             (string owner, string repo) = ParseRepoUri(repoUri);
@@ -579,21 +579,23 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns>Latest sha.  Throws if no commits were found.</returns>
         private async Task<string> GetLastCommitShaAsync(string owner, string repo, string branch)
         {
-            JObject content;
-            using (HttpResponseMessage response = await this.ExecuteRemoteGitCommandAsync(
-                HttpMethod.Get,
-                $"repos/{owner}/{repo}/commits/{branch}",
-                _logger))
+            try
             {
-                content = JObject.Parse(await response.Content.ReadAsStringAsync());
-            }
+                JObject content;
+                using (HttpResponseMessage response = await this.ExecuteRemoteGitCommandAsync(
+                    HttpMethod.Get,
+                    $"repos/{owner}/{repo}/commits/{branch}",
+                    _logger))
+                {
+                    content = JObject.Parse(await response.Content.ReadAsStringAsync());
+                }
 
-            if (content == null)
+                return content["sha"].ToString();
+            }
+            catch (HttpRequestException exc) when (exc.Message.Contains(((int)HttpStatusCode.NotFound).ToString()))
             {
-                throw new DarcException($"No commits found in branch '{branch}' of repo '{owner}/{repo}'!");
+                return null;
             }
-
-            return content["sha"].ToString();
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/HealthMetrics/ProductDependencyCyclesHealthMetric.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/HealthMetrics/ProductDependencyCyclesHealthMetric.cs
@@ -51,6 +51,15 @@ namespace Microsoft.DotNet.DarcLib.HealthMetrics
             var remote = await RemoteFactory.GetRemoteAsync(Repository, Logger);
             var commit = await remote.GetLatestCommitAsync(Repository, Branch);
 
+            if (commit == null)
+            {
+                // If there were no commits, then there can be no cycles. This would be typical of newly
+                // created branches.
+                Result = HealthResult.Passed;
+                Cycles = new List<List<string>>();
+                return;
+            }
+
             DependencyGraph graph =
                 await DependencyGraph.BuildRemoteDependencyGraphAsync(RemoteFactory, Repository, commit, options, Logger);
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         /// <param name="repoUri">Repository uri</param>
         /// <param name="branch">Branch to retrieve the latest sha for</param>
-        /// <returns>Latest sha.  Throws if no commits were found.</returns>
+        /// <returns>Latest sha.  Null if no commits were found.</returns>
         Task<string> GetLastCommitShaAsync(string repoUri, string branch);
 
         /// <summary>


### PR DESCRIPTION
The API was previously throwing an http exception when this happened, leading health checks to fail.