### PR TITLE
Bring back deleted eng/common file

### DIFF
--- a/eng/common/templates/steps/publish-logs.yml
+++ b/eng/common/templates/steps/publish-logs.yml
@@ -1,0 +1,23 @@
+parameters:
+  StageLabel: ''
+  JobLabel: ''
+
+steps:
+- task: Powershell@2
+  displayName: Prepare Binlogs to Upload
+  inputs:
+    targetType: inline
+    script: |
+      New-Item -ItemType Directory $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
+      Move-Item -Path $(Build.SourcesDirectory)/artifacts/log/Debug/* $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
+  continueOnError: true
+  condition: always()
+  
+- task: PublishBuildArtifacts@1
+  displayName: Publish Logs
+  inputs:
+    PathtoPublish: '$(Build.SourcesDirectory)/PostBuildLogs'
+    PublishLocation: Container
+    ArtifactName: PostBuilLogs
+  continueOnError: true
+  condition: always()


### PR DESCRIPTION
File was deleted during  https://github.com/dotnet/arcade-services/pull/816 due to https://github.com/dotnet/arcade/issues/4193

I'll disable the daily arcade subscription for arcade-services until we roll out next week (which includes the fix for #4193) as I want us to make sure everything is stable, and there's a likelyhood that tomorrow's update will delete the file again.