### PR TITLE
Cleanup temporary files

### DIFF
--- a/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
+++ b/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
@@ -101,7 +101,7 @@ namespace SubscriptionActorService
         }
 
         /// <summary>
-        ///     Download and install git to the a temporarily location.
+        ///     Download and install git to the a temporary location.
         ///     Git is used by DarcLib, and the Service Fabric nodes do not have it installed natively.
         ///     
         ///     The file is assumed to be on a public endpoint.

--- a/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
+++ b/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
@@ -12,6 +12,7 @@ using Maestro.AzureDevOps;
 using Maestro.Data;
 using Microsoft.Dotnet.GitHub.Authentication;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.ServiceFabric.ServiceHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -24,8 +25,10 @@ namespace SubscriptionActorService
             IGitHubTokenProvider gitHubTokenProvider,
             IAzureDevOpsTokenProvider azureDevOpsTokenProvider,
             DarcRemoteMemoryCache memoryCache,
-            BuildAssetRegistryContext context)
+            BuildAssetRegistryContext context,
+            TemporaryFiles tempFiles)
         {
+            _tempFiles = tempFiles;
             Configuration = configuration;
             GitHubTokenProvider = gitHubTokenProvider;
             AzureDevOpsTokenProvider = azureDevOpsTokenProvider;
@@ -37,9 +40,12 @@ namespace SubscriptionActorService
         public IGitHubTokenProvider GitHubTokenProvider { get; }
         public IAzureDevOpsTokenProvider AzureDevOpsTokenProvider { get; }
         public BuildAssetRegistryContext Context { get; }
-        public DarcRemoteMemoryCache Cache { get; set; }
-        private string _gitExecutable { get; set; }
-        private SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
+        public DarcRemoteMemoryCache Cache { get; }
+
+        private readonly TemporaryFiles _tempFiles;
+        private readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
+        
+        private string _gitExecutable;
 
         public Task<IRemote> GetBarOnlyRemoteAsync(ILogger logger)
         {
@@ -60,7 +66,7 @@ namespace SubscriptionActorService
                 string temporaryRepositoryRoot = Configuration.GetValue<string>("DarcTemporaryRepoRoot", null);
                 if (string.IsNullOrEmpty(temporaryRepositoryRoot))
                 {
-                    temporaryRepositoryRoot = Path.GetTempPath();
+                    temporaryRepositoryRoot = _tempFiles.GetFilePath("repos");
                 }
                 IGitRepo gitClient;
 
@@ -95,7 +101,7 @@ namespace SubscriptionActorService
         }
 
         /// <summary>
-        ///     Download and install git to the TEMP directory, if it does not already exist in that location.
+        ///     Download and install git to the a temporarily location.
         ///     Git is used by DarcLib, and the Service Fabric nodes do not have it installed natively.
         ///     
         ///     The file is assumed to be on a public endpoint.
@@ -115,29 +121,30 @@ namespace SubscriptionActorService
                     {
                         using (logger.BeginScope($"Installing a local copy of git"))
                         {
-                            string gitTempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-                            string gitZipFile = Path.Combine(gitTempDirectory, Path.GetRandomFileName());
                             string gitLocation = Configuration.GetValue<string>("GitDownloadLocation", null);
+                            string[] pathSegments = new Uri(gitLocation, UriKind.Absolute).Segments;
+                            string remoteFileName = pathSegments[pathSegments.Length - 1];
+
+                            string gitRoot = _tempFiles.GetFilePath("git-portable");
+                            string targetPath = Path.Combine(gitRoot, Path.GetFileNameWithoutExtension(remoteFileName));
+                            string gitZipFile = Path.Combine(gitRoot, remoteFileName);
 
                             logger.LogInformation($"Downloading git from '{gitLocation}' to '{gitZipFile}'");
 
-                            Directory.CreateDirectory(gitTempDirectory);
+                            Directory.CreateDirectory(targetPath);
 
-                            // Download file.
-                            HttpClient client = new HttpClient();
-                            using (FileStream outStream = new FileStream(gitZipFile, FileMode.CreateNew, FileAccess.Write))
+                            using (HttpClient client = new HttpClient())
+                            using (FileStream outStream = new FileStream(gitZipFile, FileMode.Create, FileAccess.Write))
+                            using (var inStream = await client.GetStreamAsync(gitLocation))
                             {
-                                using (var inStream = await client.GetStreamAsync(gitLocation))
-                                {
-                                    await inStream.CopyToAsync(outStream);
-                                }
+                                await inStream.CopyToAsync(outStream);
                             }
 
-                            logger.LogInformation($"Extracting '{gitZipFile}' to '{gitTempDirectory}'");
+                            logger.LogInformation($"Extracting '{gitZipFile}' to '{targetPath}'");
 
-                            ZipFile.ExtractToDirectory(gitZipFile, gitTempDirectory);
+                            ZipFile.ExtractToDirectory(gitZipFile, targetPath, overwriteFiles: true);
 
-                            _gitExecutable = Path.Combine(gitTempDirectory, "bin", "git.exe");
+                            _gitExecutable = Path.Combine(targetPath, "bin", "git.exe");
                         }
                     }
                 }

--- a/src/Maestro/SubscriptionActorService/Program.cs
+++ b/src/Maestro/SubscriptionActorService/Program.cs
@@ -44,7 +44,6 @@ namespace SubscriptionActorService
                             services.AddSingleton<IMergePolicyEvaluator, MergePolicyEvaluator>();
                             services.AddSingleton<IRemoteFactory, DarcRemoteFactory>();
                             services.AddSingleton<TemporaryFiles>();
-                            services.AddSingleton<TemporaryFiles>();
                             services.AddGitHubTokenProvider();
                             services.AddAzureDevOpsTokenProvider();
                             // We do not use AddMemoryCache here. We use our own cache because we wish to

--- a/src/Maestro/SubscriptionActorService/Program.cs
+++ b/src/Maestro/SubscriptionActorService/Program.cs
@@ -43,6 +43,8 @@ namespace SubscriptionActorService
                             services.AddSingleton<IActionRunner, ActionRunner>();
                             services.AddSingleton<IMergePolicyEvaluator, MergePolicyEvaluator>();
                             services.AddSingleton<IRemoteFactory, DarcRemoteFactory>();
+                            services.AddSingleton<TemporaryFiles>();
+                            services.AddSingleton<TemporaryFiles>();
                             services.AddGitHubTokenProvider();
                             services.AddAzureDevOpsTokenProvider();
                             // We do not use AddMemoryCache here. We use our own cache because we wish to

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/PackagesHelper.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/PackagesHelper.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.DarcLib.Helpers
 {
-    public class PackagesHelper
+    public static class PackagesHelper
     {
         public static ManifestMetadata GetManifestMetadata(string packagePath)
         {

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Actors/DelegatedActor.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Actors/DelegatedActor.cs
@@ -345,6 +345,9 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost.Actors
             builder.Populate(services);
             _configureContainer(builder);
             Container = builder.Build();
+
+            // This requires the ServiceContext up a few lines, so we can't inject it in the constructor
+            Container.ResolveOptional<TemporaryFiles>()?.Initialize();
         }
 
         protected override async Task OnCloseAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatefulService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatefulService.cs
@@ -50,6 +50,10 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
             builder.Populate(services);
             _configureContainer(builder);
             _container = builder.Build();
+            
+            // This requires the ServiceContext up a few lines, so we can't inject it in the constructor
+            _container.ResolveOptional<TemporaryFiles>()?.Initialize();
+
             return Task.CompletedTask;
         }
 

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatelessService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatelessService.cs
@@ -42,6 +42,9 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
             builder.Populate(services);
             _configureContainer(builder);
             _container = builder.Build();
+
+            // This requires the ServiceContext up a few lines, so we can't inject it in the constructor
+            _container.ResolveOptional<TemporaryFiles>()?.Initialize();
         }
 
         protected override Task OnCloseAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/TemporaryFiles.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/TemporaryFiles.cs
@@ -19,11 +19,10 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
             ILogger<TemporaryFiles> logger)
         {
             _logger = logger;
-            ServiceContext context1 = context;
             _isolatedTempPath = Path.Combine(
                 Path.GetTempPath(),
-                context1.ServiceTypeName,
-                context1.ReplicaOrInstanceId.ToString()
+                context.ServiceTypeName,
+                context.ReplicaOrInstanceId.ToString()
             );
         }
 
@@ -49,12 +48,13 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
         {
             try
             {
-                // Try and delete/clean it
-                if (Directory.Exists(_isolatedTempPath))
+                if (!Directory.Exists(_isolatedTempPath))
                 {
-                    _logger.LogTrace("Temporary files found, cleaning up {path}", _isolatedTempPath);
-                    Directory.Delete(_isolatedTempPath, true);
+                    return;
                 }
+
+                _logger.LogTrace("Temporary files found, cleaning up {path}", _isolatedTempPath);
+                Directory.Delete(_isolatedTempPath, true);
             }
             catch (IOException e)
             {

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/TemporaryFiles.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/TemporaryFiles.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Fabric;
+using System.IO;
+
+namespace Microsoft.DotNet.ServiceFabric.ServiceHost
+{
+    public class TemporaryFiles : IDisposable
+    {
+        private string _isolatedTempPath;
+
+        public TemporaryFiles(ServiceContext context)
+        {
+            ServiceContext context1 = context;
+            _isolatedTempPath = Environment.ExpandEnvironmentVariables($"%TEMP%\\{context1.ServiceTypeName}\\{context1.ReplicaOrInstanceId}");
+        }
+
+        public void Initialize()
+        {
+            // Do cleanup in the case of unhealthy exit last time.
+            Cleanup();
+            Directory.CreateDirectory(_isolatedTempPath);
+        }
+
+        public string GetFilePath(params string[] parts)
+        {
+            return Path.Combine(_isolatedTempPath, Path.Combine(parts));
+        }
+
+        public void Dispose()
+        {
+            Cleanup();
+        }
+
+        private void Cleanup()
+        {
+            try
+            {
+                // Try and delete/clean it
+                if (Directory.Exists(_isolatedTempPath))
+                    Directory.Delete(_isolatedTempPath, true);
+            }
+            catch (IOException)
+            {
+                // It might not be here, it might be locked... there isn't really anything interesting to do, move on
+                // this is just best effort to keep the machine clean
+            }
+        }
+    }
+}


### PR DESCRIPTION
In particular, the "git-portable" downloads were filling the harddrive.

Try and manage the temporary files a little better... each instance of each service gets
it's own directory, and we'll clean them at startup and shutdown.

Fixes dotnet/core-eng#8483
Fixes dotnet/core-eng#8482