### PR TITLE
Add Code Coverage and run unit tests for Arcade Services during PR

### DIFF
--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -1,0 +1,21 @@
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <Configuration>
+          <CodeCoverage>
+            <ModulePaths>
+              <Exclude>
+                <ModulePath>.*Moq.dll</ModulePath>
+                <ModulePath>.*fluentassertions.dll</ModulePath>
+                <ModulePath>.*microsoft.extensions.logging.applicationinsights.dll</ModulePath>
+                <ModulePath>.*libgit2sharp.dll</ModulePath>
+                <ModulePath>.*quartz.dll</ModulePath>
+              </Exclude>
+            </ModulePaths>
+          </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/arcade-services.sln
+++ b/arcade-services.sln
@@ -65,6 +65,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		azure-pipelines.yml = azure-pipelines.yml
 		Build.cmd = Build.cmd
 		build.sh = build.sh
+		CodeCoverage.runsettings = CodeCoverage.runsettings
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		global.json = global.json
@@ -83,9 +84,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNet.Status.Web", "src\Do
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Web.Authentication", "src\shared\Microsoft.DotNet.Web.Authentication\Microsoft.DotNet.Web.Authentication.csproj", "{FE6E749D-9C95-4E7D-A0DB-EE288C5CA7BB}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Validation", "Validation", "{B6FA6294-F939-46DB-B8D7-A8C5CDB5425F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DependencyUpdater.Tests", "src\Maestro\tests\DependencyUpdater.Tests\DependencyUpdater.Tests.csproj", "{574719D7-D038-4184-848D-02DEEAD60017}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scenarios", "Scenarios", "{0E820A31-1372-4303-A4E2-B11F3A8B4152}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Validation", "Validation", "{F92E1B5C-26D4-4244-A4F9-41E22BA8E1CE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scenarios", "Scenarios", "{939DD755-B5FC-46EF-AE8B-5073DA6D4490}"
 	ProjectSection(SolutionItems) = preProject
 		src\Maestro\tests\Scenarios\all.ps1 = src\Maestro\tests\Scenarios\all.ps1
 		src\Maestro\tests\Scenarios\arcade-update.ps1 = src\Maestro\tests\Scenarios\arcade-update.ps1
@@ -491,6 +494,18 @@ Global
 		{FE6E749D-9C95-4E7D-A0DB-EE288C5CA7BB}.Release|x64.Build.0 = Release|Any CPU
 		{FE6E749D-9C95-4E7D-A0DB-EE288C5CA7BB}.Release|x86.ActiveCfg = Release|Any CPU
 		{FE6E749D-9C95-4E7D-A0DB-EE288C5CA7BB}.Release|x86.Build.0 = Release|Any CPU
+		{574719D7-D038-4184-848D-02DEEAD60017}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{574719D7-D038-4184-848D-02DEEAD60017}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{574719D7-D038-4184-848D-02DEEAD60017}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{574719D7-D038-4184-848D-02DEEAD60017}.Debug|x64.Build.0 = Debug|Any CPU
+		{574719D7-D038-4184-848D-02DEEAD60017}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{574719D7-D038-4184-848D-02DEEAD60017}.Debug|x86.Build.0 = Debug|Any CPU
+		{574719D7-D038-4184-848D-02DEEAD60017}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{574719D7-D038-4184-848D-02DEEAD60017}.Release|Any CPU.Build.0 = Release|Any CPU
+		{574719D7-D038-4184-848D-02DEEAD60017}.Release|x64.ActiveCfg = Release|Any CPU
+		{574719D7-D038-4184-848D-02DEEAD60017}.Release|x64.Build.0 = Release|Any CPU
+		{574719D7-D038-4184-848D-02DEEAD60017}.Release|x86.ActiveCfg = Release|Any CPU
+		{574719D7-D038-4184-848D-02DEEAD60017}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -519,7 +534,8 @@ Global
 		{224E1B78-812F-4E1A-965D-2CB46AD83711} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
 		{F017F709-6F02-4FFE-A4A4-5FE3EA720B4A} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
 		{FE6E749D-9C95-4E7D-A0DB-EE288C5CA7BB} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
-		{0E820A31-1372-4303-A4E2-B11F3A8B4152} = {B6FA6294-F939-46DB-B8D7-A8C5CDB5425F}
+		{574719D7-D038-4184-848D-02DEEAD60017} = {AE791E26-78E1-4936-BCF4-1BF5152CBBD6}
+		{939DD755-B5FC-46EF-AE8B-5073DA6D4490} = {F92E1B5C-26D4-4244-A4F9-41E22BA8E1CE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {32B9C883-432E-4FC8-A1BF-090EB033DD5B}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,6 +124,8 @@ stages:
           displayName: Build / Publish
           condition: succeeded()
 
+        - template: /eng/test.yaml
+
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         
           ## Prepare service fabric artifact

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,15 +17,15 @@
     <SystemNetHttpVersion>4.3.3</SystemNetHttpVersion>
     <MicrosoftApplicationInsightsVersion>2.10.0</MicrosoftApplicationInsightsVersion>
     <MicrosoftAzureKeyVaultVersion>3.0.3</MicrosoftAzureKeyVaultVersion>
-    <MicrosoftBuildVersion>15.7.179</MicrosoftBuildVersion>
-    <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildTasksCoreVersion>15.7.179</MicrosoftBuildTasksCoreVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildVersion>16.3.0</MicrosoftBuildVersion>
+    <MicrosoftBuildFrameworkVersion>16.3.0</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildTasksCoreVersion>16.3.0</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>16.3.0</MicrosoftBuildUtilitiesCoreVersion>
     <MicrosoftCodeAnalysisCSharpVersion>2.9.0</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.19.8</MicrosoftIdentityModelClientsActiveDirectoryVersion>
     <MicrosoftRestClientRuntimeVersion>2.3.13</MicrosoftRestClientRuntimeVersion>
     <MicrosoftExtensionsFileSystemGlobbingVersion>2.0.0</MicrosoftExtensionsFileSystemGlobbingVersion>
-    <MicrosoftNetTestSdkVersion>15.7.2</MicrosoftNetTestSdkVersion>
+    <MicrosoftNetTestSdkVersion>15.8.0</MicrosoftNetTestSdkVersion>
     <MoqVersion>4.8.3</MoqVersion>
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>

--- a/eng/convert-codecoveragetoxml.ps1
+++ b/eng/convert-codecoveragetoxml.ps1
@@ -1,0 +1,19 @@
+[cmdletbinding()]
+param(
+    [Parameter(Mandatory=$True)]
+    [string]$Path
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+$coverageFile = Get-ChildItem -Path $Path -Filter *.coverage -Recurse -ErrorAction SilentlyContinue -Force
+Write-Host "Code coverage files found: "
+Write-Host $coverageFile.FullName
+
+$codeCoverageExe = "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe"
+
+& $codeCoverageExe analyze /output:$Path\codecoverage.coveragexml $coverageFile.FullName
+
+Write-Host "Was the coverage XML file created?"
+Test-Path $Path\codecoverage.coveragexml -PathType Leaf

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -1,0 +1,43 @@
+steps: 
+
+- task: DotNetCoreCLI@2
+  displayName: Test C# (dotnet test)
+  inputs:
+    command: 'custom'
+    projects: |
+      src/**/*.Tests.csproj
+      !src/**/Microsoft.DotNet.Darc.Tests.csproj
+    custom: 'test'
+    arguments: > 
+      --configuration $(_BuildConfig)
+      --collect:"Code Coverage"
+      --settings:CodeCoverage.runsettings
+      --filter "TestCategory!=PostDeployment&TestCategory!=Nightly&TestCategory!=PreDeployment"
+      --no-build
+  env:
+    NUGET_PACKAGES: '$(Build.SourcesDirectory)/.packages'
+  condition: succeededOrFailed()
+
+- task: Powershell@2
+  inputs: 
+    targetType: 'filePath'
+    filePath: eng\convert-codecoveragetoxml.ps1
+    arguments: -Path "$(system.defaultworkingdirectory)"
+  displayName: Convert Code Coverage to XML (powershell)
+
+- task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
+  displayName: ReportGenerator
+  inputs:
+    reports: '$(system.defaultworkingdirectory)\codecoverage.coveragexml'
+    targetdir: '$(Build.SourcesDirectory)\CodeCoverage'
+    reporttypes: 'HtmlInline_AzurePipelines;Cobertura'
+    sourcedirs: '$(Build.SourcesDirectory)'
+
+- task: PublishCodeCoverageResults@1
+  displayName: 'Publish Code Coverage'
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: '$(Build.SourcesDirectory)\CodeCoverage\Cobertura.xml'
+    reportDirectory: '$(Build.SourcesDirectory)\CodeCoverage'
+    pathToSources: '$(Build.SourcesDirectory)'
+    publishRunAttachments: true

--- a/src/Maestro/DependencyUpdater/DependencyUpdater.csproj
+++ b/src/Maestro/DependencyUpdater/DependencyUpdater.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,6 +8,7 @@
     <TargetLatestRuntimePatch>False</TargetLatestRuntimePatch>
     <SignAssembly>false</SignAssembly>
     <LangVersion>7.1</LangVersion>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Maestro/SubscriptionActorService/SubscriptionActorService.csproj
+++ b/src/Maestro/SubscriptionActorService/SubscriptionActorService.csproj
@@ -12,6 +12,7 @@
     <FabActUtilWorkingDir>$(BaseIntermediateOutputPath)\FabActUtilTemp</FabActUtilWorkingDir>
     <SignAssembly>false</SignAssembly>
     <LangVersion>7.1</LangVersion>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <!-- Disable the service fabric actors build time logic on non windows because it has dependencies on windows -->

--- a/src/Maestro/tests/DependencyUpdater.Tests/CheckSubscriptionsAsyncTests.cs
+++ b/src/Maestro/tests/DependencyUpdater.Tests/CheckSubscriptionsAsyncTests.cs
@@ -25,18 +25,18 @@ namespace DependencyUpdater.Tests
             };
             var oldBuild = new Build
             {
-                Branch = "source.branch",
-                Repository = "source.repo",
-                BuildNumber = "old.build.number",
+                AzureDevOpsBranch = "source.branch",
+                AzureDevOpsRepository = "source.repo",
+                AzureDevOpsBuildNumber = "old.build.number",
                 Commit = "oldSha",
                 DateProduced = DateTimeOffset.UtcNow.AddDays(-2)
             };
             var location = "https://source.feed/index.json";
             var build = new Build
             {
-                Branch = "source.branch",
-                Repository = "source.repo",
-                BuildNumber = "build.number",
+                AzureDevOpsBranch = "source.branch",
+                AzureDevOpsRepository = "source.repo",
+                AzureDevOpsBuildNumber = "build.number",
                 Commit = "sha",
                 DateProduced = DateTimeOffset.UtcNow,
                 Assets = new List<Asset>
@@ -89,7 +89,7 @@ namespace DependencyUpdater.Tests
             SubscriptionActor.Setup(a => a.UpdateAsync(build.Id)).Returns(Task.CompletedTask);
 
             var updater = ActivatorUtilities.CreateInstance<DependencyUpdater>(Scope.ServiceProvider);
-            await updater.CheckSubscriptionsAsync(CancellationToken.None);
+            await updater.CheckDailySubscriptionsAsync(CancellationToken.None);
         }
 
         [Fact]
@@ -102,18 +102,18 @@ namespace DependencyUpdater.Tests
             };
             var oldBuild = new Build
             {
-                Branch = "source.branch",
-                Repository = "source.repo",
-                BuildNumber = "old.build.number",
+                AzureDevOpsBranch = "source.branch",
+                AzureDevOpsRepository = "source.repo",
+                AzureDevOpsBuildNumber = "old.build.number",
                 Commit = "oldSha",
                 DateProduced = DateTimeOffset.UtcNow.AddDays(-2)
             };
             var location = "https://source.feed/index.json";
             var build = new Build
             {
-                Branch = "source.branch",
-                Repository = "source.repo",
-                BuildNumber = "build.number",
+                AzureDevOpsBranch = "source.branch",
+                AzureDevOpsRepository = "source.repo",
+                AzureDevOpsBuildNumber = "build.number",
                 Commit = "sha",
                 DateProduced = DateTimeOffset.UtcNow,
                 Assets = new List<Asset>
@@ -166,7 +166,7 @@ namespace DependencyUpdater.Tests
             SubscriptionActor.Verify(a => a.UpdateAsync(build.Id), Times.Never());
 
             var updater = ActivatorUtilities.CreateInstance<DependencyUpdater>(Scope.ServiceProvider);
-            await updater.CheckSubscriptionsAsync(CancellationToken.None);
+            await updater.CheckDailySubscriptionsAsync(CancellationToken.None);
         }
 
         [Fact]
@@ -194,7 +194,7 @@ namespace DependencyUpdater.Tests
             await Context.SaveChangesAsync();
 
             var updater = ActivatorUtilities.CreateInstance<DependencyUpdater>(Scope.ServiceProvider);
-            await updater.CheckSubscriptionsAsync(CancellationToken.None);
+            await updater.CheckDailySubscriptionsAsync(CancellationToken.None);
         }
 
         [Fact]
@@ -207,9 +207,9 @@ namespace DependencyUpdater.Tests
             };
             var build = new Build
             {
-                Branch = "source.branch",
-                Repository = "source.repo",
-                BuildNumber = "build.number",
+                AzureDevOpsBranch = "source.branch",
+                AzureDevOpsRepository = "source.repo",
+                AzureDevOpsBuildNumber = "build.number",
                 Commit = "sha",
                 DateProduced = DateTimeOffset.UtcNow
             };
@@ -236,7 +236,7 @@ namespace DependencyUpdater.Tests
             await Context.SaveChangesAsync();
 
             var updater = ActivatorUtilities.CreateInstance<DependencyUpdater>(Scope.ServiceProvider);
-            await updater.CheckSubscriptionsAsync(CancellationToken.None);
+            await updater.CheckDailySubscriptionsAsync(CancellationToken.None);
         }
     }
 }

--- a/src/Maestro/tests/DependencyUpdater.Tests/UpdateDependenciesAsyncTests.cs
+++ b/src/Maestro/tests/DependencyUpdater.Tests/UpdateDependenciesAsyncTests.cs
@@ -25,9 +25,9 @@ namespace DependencyUpdater.Tests
             };
             var build = new Build
             {
-                Branch = "source.branch",
-                Repository = "source.repo",
-                BuildNumber = "build.number",
+                AzureDevOpsBranch = "source.branch",
+                AzureDevOpsRepository = "source.repo",
+                AzureDevOpsBuildNumber = "build.number",
                 Commit = "sha",
                 DateProduced = DateTimeOffset.UtcNow.AddDays(-1)
             };
@@ -48,9 +48,9 @@ namespace DependencyUpdater.Tests
             };
             var newBuild = new Build
             {
-                Branch = "source.branch",
-                Repository = "source.repo",
-                BuildNumber = "build.number.2",
+                AzureDevOpsBranch = "source.branch",
+                AzureDevOpsRepository = "source.repo",
+                AzureDevOpsBuildNumber = "build.number.2",
                 Commit = "sha2",
                 DateProduced = DateTimeOffset.UtcNow,
                 Assets = new List<Asset> {newAsset}
@@ -110,9 +110,9 @@ namespace DependencyUpdater.Tests
             };
             var build = new Build
             {
-                Branch = "source.branch",
-                Repository = "source.repo",
-                BuildNumber = "build.number",
+                AzureDevOpsBranch = "source.branch",
+                AzureDevOpsRepository = "source.repo",
+                AzureDevOpsBuildNumber = "build.number",
                 Commit = "sha",
                 DateProduced = DateTimeOffset.UtcNow.AddDays(-1)
             };
@@ -133,9 +133,9 @@ namespace DependencyUpdater.Tests
             };
             var newBuild = new Build
             {
-                Branch = "source.branch",
-                Repository = "source.repo",
-                BuildNumber = "build.number.2",
+                AzureDevOpsBranch = "source.branch",
+                AzureDevOpsRepository = "source.repo",
+                AzureDevOpsBuildNumber = "build.number.2",
                 Commit = "sha2",
                 DateProduced = DateTimeOffset.UtcNow,
                 Assets = new List<Asset> {newAsset}
@@ -193,17 +193,17 @@ namespace DependencyUpdater.Tests
             };
             var build = new Build
             {
-                Branch = "source.branch",
-                Repository = "source.repo",
-                BuildNumber = "build.number",
+                AzureDevOpsBranch = "source.branch",
+                AzureDevOpsRepository = "source.repo",
+                AzureDevOpsBuildNumber = "build.number",
                 Commit = "sha",
                 DateProduced = DateTimeOffset.UtcNow.AddDays(-1)
             };
             var newBuild = new Build
             {
-                Branch = "source.branch",
-                Repository = "source.repo",
-                BuildNumber = "build.number.2",
+                AzureDevOpsBranch = "source.branch",
+                AzureDevOpsRepository = "source.repo",
+                AzureDevOpsBuildNumber = "build.number.2",
                 Commit = "sha2",
                 DateProduced = DateTimeOffset.UtcNow
             };

--- a/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,6 +10,7 @@
     <PackageTags>Arcade Darc CLI Dependency Flow</PackageTags>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>darc</ToolCommandName>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">


### PR DESCRIPTION
Code coverage was added: https://dnceng.visualstudio.com/internal/_build/results?buildId=454615&view=codecoverage-tab 

Notes: 
- Excluded the Microsoft.DotNet.Darc.Tests project since it was throwing OutOfMemory eceptions. Will write an issue for those to be investigated. 
- Increased the MSBuild and Microsoft.NET.Test.Sdk versions in order to support code coverage from dotnet test. 
- DebugType = Full is required for code coverage, too. 