### PR TITLE
Subscription Table Bug Fixes

### DIFF
--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.html
@@ -120,8 +120,6 @@
           <progress-ring [style]="{ 'width.px': 150, 'height.px': 150 }"></progress-ring>
         </ng-template>
       </div>
-
-      <div class="container-fluid">
         <div class="card mt-3">
           <div class="card-body">
             <h5 class="card-title float-left">
@@ -136,8 +134,6 @@
             <progress-ring [style]="{ 'width.px': 150, 'height.px': 150 }"></progress-ring>
           </ng-template>
         </div>
-      </div>
-
       <mc-asset-table [assets]="build.assets"></mc-asset-table>
     </div>
   </ng-container>

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
@@ -228,7 +228,6 @@ export class BuildComponent implements OnInit, OnChanges {
         statefulSwitchMap(([build, params]) => {
           const currentChannelId = +params.channelId;
           return this.maestroService.subscriptions.listSubscriptionsAsync({
-            channelId: currentChannelId,
             targetRepository: this.getRepo(build),
           }).pipe(
             map(subs => {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         /// <param name="sourceRepo">Filter by the source repository of the subscription.</param>
         /// <param name="targetRepo">Filter by the target repository of the subscription.</param>
-        /// <param name="channelId">Filter by the target channel id of the subscription.</param>
+        /// <param name="channelId">Filter by the source channel id of the subscription.</param>
         /// <returns>Set of subscription.</returns>
         public Task<IEnumerable<Subscription>> GetSubscriptionsAsync(
             string sourceRepo = null,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/HealthMetrics/SubscriptionHealthMetric.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/HealthMetrics/SubscriptionHealthMetric.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.DarcLib.HealthMetrics
 
             Logger.LogInformation("Evaluating subscription health metrics for {repo}@{branch}", Repository, Branch);
 
-            // Get suscriptions that target this repo/branch
+            // Get subscriptions that target this repo/branch
             Subscriptions = (await remote.GetSubscriptionsAsync(targetRepo: Repository))
                 .Where(s => s.TargetBranch.Equals(Branch, StringComparison.OrdinalIgnoreCase)).ToList();
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         /// <param name="sourceRepo">Filter by the source repository of the subscription.</param>
         /// <param name="targetRepo">Filter by the target repository of the subscription.</param>
-        /// <param name="channelId">Filter by the target channel id of the subscription.</param>
+        /// <param name="channelId">Filter by the source channel id of the subscription.</param>
         /// <returns>Set of subscription.</returns>
         Task<IEnumerable<Subscription>> GetSubscriptionsAsync(
             string sourceRepo = null,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         /// <param name="sourceRepo">Filter by the source repository of the subscription.</param>
         /// <param name="targetRepo">Filter by the target repository of the subscription.</param>
-        /// <param name="channelId">Filter by the target channel id of the subscription.</param>
+        /// <param name="channelId">Filter by the source channel id of the subscription.</param>
         /// <returns>Set of subscription.</returns>
         Task<IEnumerable<Subscription>> GetSubscriptionsAsync(
             string sourceRepo = null,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/MaestroApiBarClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/MaestroApiBarClient.cs
@@ -202,7 +202,7 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         /// <param name="sourceRepo">Filter by the source repository of the subscription.</param>
         /// <param name="targetRepo">Filter by the target repository of the subscription.</param>
-        /// <param name="channelId">Filter by the target channel id of the subscription.</param>
+        /// <param name="channelId">Filter by the source channel id of the subscription.</param>
         /// <returns>Set of subscription.</returns>
         public async Task<IEnumerable<Subscription>> GetSubscriptionsAsync(string sourceRepo = null, string targetRepo = null, int? channelId = null)
         {


### PR DESCRIPTION
- Fix Subscription table width
- Fix incorrect comments (subscriptions have source channels, not target channels)
- Remove channel filter from Subscription table data (filter should not be applied because the display page is the target channel and subscriptions have source channels, so filtering on the display page's channel is incorrect)