### PR TITLE
Download from authenticated locations

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -13,6 +13,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -907,7 +908,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 string finalUri = assetLocation.Location.Substring(0, assetLocation.Location.Length - "index.json".Length);
                 finalUri += $"flatcontainer/{name}/{version}/{name}.{version}.nupkg";
 
-                if (await DownloadFileAsync(client, finalUri, fullTargetPath, errors, downloadOutput))
+                if (await DownloadFileAsync(client, finalUri, null, fullTargetPath, errors, downloadOutput))
                 {
                     return new DownloadedAsset()
                     {
@@ -958,6 +959,7 @@ namespace Microsoft.DotNet.Darc.Operations
             string packageContentUrl = $"https://pkgs.dev.azure.com/{feedAccount}/{feedVisibility}_apis/packaging/feeds/{feedName}/nuget/packages/{asset.Name}/versions/{asset.Version}/content";
 
             // feedVisibility == "" means that the feed is internal.
+            AuthenticationHeaderValue authHeader = null;
             if (string.IsNullOrEmpty(feedVisibility))
             {
                 if (string.IsNullOrEmpty(_options.AzureDevOpsPat))
@@ -966,12 +968,12 @@ namespace Microsoft.DotNet.Darc.Operations
                     _options.AzureDevOpsPat = localSettings.AzureDevOpsToken;
                 }
 
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                authHeader = new AuthenticationHeaderValue(
                     "Basic",
                     Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", _options.AzureDevOpsPat))));
             }
 
-            if (await DownloadFileAsync(client, packageContentUrl, fullTargetPath, errors, downloadOutput))
+            if (await DownloadFileAsync(client, packageContentUrl, authHeader, fullTargetPath, errors, downloadOutput))
             {
                 return new DownloadedAsset()
                 {
@@ -1048,11 +1050,11 @@ namespace Microsoft.DotNet.Darc.Operations
         }
 
         private async Task<DownloadedAsset> DownloadBlobAsync(HttpClient client,
-                                                                Asset asset,
-                                                                AssetLocation assetLocation,
-                                                                string subPath,
-                                                                List<string> errors,
-                                                                StringBuilder downloadOutput)
+                                                            Asset asset,
+                                                            AssetLocation assetLocation,
+                                                            string subPath,
+                                                            List<string> errors,
+                                                            StringBuilder downloadOutput)
         {
             // Normalize the asset name.  Sometimes the upload to the BAR will have
             // "assets/" prepended to it and sometimes not (depending on the Maestro tasks version).
@@ -1083,24 +1085,25 @@ namespace Microsoft.DotNet.Darc.Operations
                 string finalBaseUri = assetLocation.Location.Substring(0, assetLocation.Location.Length - "index.json".Length);
                 string finalUri1 = $"{finalBaseUri}{asset.Name}";
                 string finalUri2 = $"{finalBaseUri}assets/{asset.Name}";
-                if (await DownloadFileAsync(client, finalUri1, fullTargetPath, errors, downloadOutput))
+                if (await DownloadFileAsync(client, finalUri1, null, fullTargetPath, errors, downloadOutput))
                 {
                     downloadedAsset.Successful = true;
                     downloadedAsset.SourceLocation = finalUri1;
                     return downloadedAsset;
                 }
-                if (await DownloadFileAsync(client, finalUri2, fullTargetPath, errors, downloadOutput))
+                if (await DownloadFileAsync(client, finalUri2, null, fullTargetPath, errors, downloadOutput))
                 {
                     downloadedAsset.Successful = true;
                     downloadedAsset.SourceLocation = finalUri2;
                     return downloadedAsset;
                 }
+
                 // Could be under assets/assets/ in some recent builds due to a bug in the release
                 // pipeline.
                 if (!_options.NoWorkarounds)
                 {
                     string finalUri3 = $"{finalBaseUri}assets/assets/{asset.Name}";
-                    if (await DownloadFileAsync(client, finalUri3, fullTargetPath, errors, downloadOutput))
+                    if (await DownloadFileAsync(client, finalUri3, null, fullTargetPath, errors, downloadOutput))
                     {
                         downloadedAsset.Successful = true;
                         downloadedAsset.SourceLocation = finalUri3;
@@ -1109,7 +1112,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
                     // Could also not be under /assets, so strip that from the url
                     string finalUri4 = finalUri1.Replace("assets/", "", StringComparison.OrdinalIgnoreCase);
-                    if (await DownloadFileAsync(client, finalUri4, fullTargetPath, errors, downloadOutput))
+                    if (await DownloadFileAsync(client, finalUri4, null, fullTargetPath, errors, downloadOutput))
                     {
                         downloadedAsset.Successful = true;
                         downloadedAsset.SourceLocation = finalUri4;
@@ -1178,15 +1181,17 @@ namespace Microsoft.DotNet.Darc.Operations
         }
 
         /// <summary>
-        ///     Download a single file and write it to targetFile. For now we just support
-        ///     unauthenticated blob storage. Later there could be a version that uses the storage
-        ///     SDK.
+        ///     Download a single file and write it to targetFile. If suffixes were passed in
+        ///     to darc, use those if the unauthenticated download fails.
         /// </summary>
         /// <param name="client">Http client</param>
         /// <param name="sourceUri">Source uri</param>
         /// <param name="targetFile">Target file path. Directories are created.</param>
-        /// <returns>Error message if the </returns>
-        private async Task<bool> DownloadFileAsync(HttpClient client, string sourceUri, string targetFile, List<string> errors, StringBuilder downloadOutput)
+        /// <param name="authHeader">Optional authentication header if necessary</param>
+        /// <param name="downloadOutput">Console output for the download.</param>
+        /// <param name="errors">List of errors. Append error messages to this list if there are failures.</param>
+        /// <returns>True if the download succeeded, false otherwise.</returns>
+        private async Task<bool> DownloadFileAsync(HttpClient client, string sourceUri, AuthenticationHeaderValue authHeader, string targetFile, List<string> errors, StringBuilder downloadOutput)
         {
             if (_options.DryRun)
             {
@@ -1194,6 +1199,42 @@ namespace Microsoft.DotNet.Darc.Operations
                 return true;
             }
 
+            if (_options.SkipExisting && File.Exists(targetFile))
+            {
+                return true;
+            }
+
+            if (await DownloadFileImplAsync(client, sourceUri, authHeader, targetFile, errors, downloadOutput))
+            {
+                return true;
+            }
+            else
+            {
+                // Append and attempt to use the suffixes that were passed in to download from the uri
+                foreach (string sasSuffix in _options.SASSuffixes)
+                {
+                    if (await DownloadFileImplAsync(client, $"{sourceUri}{sasSuffix}", authHeader, targetFile, errors, downloadOutput))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Download a single file and write it to targetFile.
+        /// </summary>
+        /// <param name="client">Http client</param>
+        /// <param name="sourceUri">Source uri</param>
+        /// <param name="targetFile">Target file path. Directories are created.</param>
+        /// <param name="authHeader">Optional authentication header if necessary</param>
+        /// <param name="downloadOutput">Console output for the download.</param>
+        /// <param name="errors">List of errors. Append error messages to this list if there are failures.</param>
+        /// <returns>True if the download succeeded, false otherwise.</returns>
+        private async Task<bool> DownloadFileImplAsync(HttpClient client, string sourceUri, AuthenticationHeaderValue authHeader, string targetFile, List<string> errors, StringBuilder downloadOutput)
+        {
             // Use a temporary in progress file name so we don't end up with corrupted
             // half downloaded files.
             string temporaryFileName = $"{targetFile}.inProgress";
@@ -1202,26 +1243,43 @@ namespace Microsoft.DotNet.Darc.Operations
                 File.Delete(temporaryFileName);
             }
 
+            HttpRequestMessage requestMessage = null;
+
             try
             {
-                if (_options.SkipExisting && File.Exists(targetFile))
-                {
-                    return true;
-                }
-
                 string directory = Path.GetDirectoryName(targetFile);
                 Directory.CreateDirectory(directory);
+
+                if (authHeader != null)
+                {
+                    requestMessage = new HttpRequestMessage(HttpMethod.Get, sourceUri)
+                    {
+                        Headers =
+                        {
+                            { HttpRequestHeader.Authorization.ToString(), authHeader.ToString() }
+                        }
+                    };
+                }
+                else
+                {
+                    requestMessage = new HttpRequestMessage(HttpMethod.Get, sourceUri);
+                }
 
                 // Ensure the parent target directory has been created.
                 using (FileStream outStream = new FileStream(temporaryFileName,
                                                       _options.Overwrite ? FileMode.Create : FileMode.CreateNew,
                                                       FileAccess.Write))
                 {
-                    using (var inStream = await client.GetStreamAsync(sourceUri))
+                    using (var response = await client.SendAsync(requestMessage))
                     {
-                        downloadOutput.Append($"  {sourceUri} => {targetFile}...");
-                        await inStream.CopyToAsync(outStream);
-                        downloadOutput.AppendLine("Done");
+                        response.EnsureSuccessStatusCode();
+
+                        using (var inStream = await response.Content.ReadAsStreamAsync())
+                        {
+                            downloadOutput.Append($"  {sourceUri} => {targetFile}...");
+                            await inStream.CopyToAsync(outStream);
+                            downloadOutput.AppendLine("Done");
+                        }
                     }
                 }
 
@@ -1249,6 +1307,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 if (File.Exists(temporaryFileName))
                 {
                     File.Delete(temporaryFileName);
+                }
+
+                if (requestMessage != null)
+                {
+                    requestMessage.Dispose();
                 }
             }
             return false;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
@@ -4,6 +4,7 @@
 
 using CommandLine;
 using Microsoft.DotNet.Darc.Operations;
+using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Darc.Options
 {
@@ -73,6 +74,8 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("latest-location", HelpText = "Download assets from their latest known location.")]
         public bool LatestLocation { get; set; }
 
+        [Option("sas-suffixes", Separator = ',', HelpText = "List of potential SAS suffixes that can be used if anonymous access to a blob uri fails.")]
+        public IEnumerable<string> SASSuffixes { get; set; }
 
         public override Operation GetOperation()
         {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
@@ -74,7 +74,8 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("latest-location", HelpText = "Download assets from their latest known location.")]
         public bool LatestLocation { get; set; }
 
-        [Option("sas-suffixes", Separator = ',', HelpText = "List of potential SAS suffixes that can be used if anonymous access to a blob uri fails.")]
+        [Option("sas-suffixes", Separator = ',', HelpText = "List of potential uri suffixes that can be used if anonymous " +
+            "access to a blob uri fails. Appended directly to the end of the URI (use full SAS suffix starting with '?'.")]
         public IEnumerable<string> SASSuffixes { get; set; }
 
         public override Operation GetOperation()


### PR DESCRIPTION
Add support for downloading from authenticated locations.  These come in two forms:
- Azure DevOps feeds. This was half-supported before, but the default headers were set on the client, rather than a header per-request. This was both not thread safe as well as incorrect if there was any mix of auth and non-auth.
- Blob storage accounts or other general URIs. In this case, I added a parameter to the gather drop operation which accepts a list of sas suffixes. If an anonymous request fails, the sas uris will be appended one by one and the downloads will retry. While a bit 'brute force', this approach has better ux than others, like providing specific key/value pairs for specific blob url prefixes, etc.