### PR TITLE
Fix download of blobs from package feeds

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -601,6 +601,11 @@ namespace Microsoft.DotNet.Darc.Operations
             using (HttpClient client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }))
             {
                 var assets = await remote.GetAssetsAsync(buildId: build.Id, nonShipping: (!_options.IncludeNonShipping ? (bool?)false : null));
+                if (!string.IsNullOrEmpty(_options.AssetFilter))
+                {
+                    assets = assets.Where(asset => Regex.IsMatch(asset.Name, _options.AssetFilter));
+                }
+
                 using (var clientThrottle = new SemaphoreSlim(_options.MaxConcurrentDownloads, _options.MaxConcurrentDownloads))
                 {
                     await Task.WhenAll(assets.Select(async asset =>
@@ -959,7 +964,18 @@ namespace Microsoft.DotNet.Darc.Operations
                                                                                 List<string> errors,
                                                                                 StringBuilder downloadOutput)
         {
-            string packageContentUrl = $"https://pkgs.dev.azure.com/{feedAccount}/{feedVisibility}_apis/packaging/feeds/{feedName}/nuget/packages/{asset.Name}/versions/{asset.Version}/content";
+            string assetName = asset.Name;
+
+            // Some blobs get pushed as packages. This is an artifact of a one-off issue in core-sdk
+            // see https://github.com/dotnet/arcade/issues/4608 for an overall fix of this.
+            // For now, if we get here, ensure that we ask for the package from the right location by
+            // stripping off the leading path elements.
+            if (!_options.NoWorkarounds)
+            {
+                assetName = Path.GetFileName(assetName);
+            }
+
+            string packageContentUrl = $"https://pkgs.dev.azure.com/{feedAccount}/{feedVisibility}_apis/packaging/feeds/{feedName}/nuget/packages/{assetName}/versions/{asset.Version}/content";
 
             // feedVisibility == "" means that the feed is internal.
             AuthenticationHeaderValue authHeader = null;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
@@ -81,6 +81,9 @@ namespace Microsoft.DotNet.Darc.Options
             "access to a blob uri fails. Appended directly to the end of the URI (use full SAS suffix starting with '?'.")]
         public IEnumerable<string> SASSuffixes { get; set; }
 
+        [Option("asset-filter", HelpText = "Only download assets matching the given regex filter")]
+        public string AssetFilter { get; set; }
+
         public override Operation GetOperation()
         {
             return new GatherDropOperation(this);


### PR DESCRIPTION
When blobs are published to package feeds, they still have the full path of the asset (not just the package name) in the BAR DB. Strip off the other path elements.

Also add an asset filter parameter to allow for better debugging.