### PR TITLE
Project TargetBranch for public kusto query for buildtimes api

### DIFF
--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildTimeController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildTimeController.cs
@@ -76,7 +76,7 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
             // as all PRs come in as refs/heads/#/merge rather than what branch they are trying to
             // apply to.
             string publicQueryText = $@"TimelineBuilds 
-                | project Repository, SourceBranch, DefinitionId, StartTime, FinishTime, Result, Project, Reason
+                | project Repository, SourceBranch, TargetBranch, DefinitionId, StartTime, FinishTime, Result, Project, Reason
                 | where Project == 'public'
                 | where Reason == 'pullRequest' 
                 | where TargetBranch == _SourceBranch


### PR DESCRIPTION
I'm not sure how I missed this, but in all of the edits, I somehow missed projecting the TargetBranch channel in the public kusto query.