### PR TITLE
Add longest build path to darc get-flow-graph

### DIFF
--- a/src/Maestro/Client/src/Generated/BuildTime.cs
+++ b/src/Maestro/Client/src/Generated/BuildTime.cs
@@ -74,7 +74,6 @@ namespace Microsoft.DotNet.Maestro.Client
                 {
                     if (_res.Status < 200 || _res.Status >= 300)
                     {
-                        // await OnGetBuildTimesFailed(_req, _res).ConfigureAwait(false);
                         return new Models.BuildTime(id, 0, 0);
                     }
 

--- a/src/Maestro/Client/src/Generated/BuildTime.cs
+++ b/src/Maestro/Client/src/Generated/BuildTime.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Core;
+using Microsoft.DotNet.Maestro.Client.Models;
+
+namespace Microsoft.DotNet.Maestro.Client
+{
+    public partial interface IBuildTime
+    {
+        Task<Models.BuildTime> GetBuildTimesAsync(
+            int days,
+            int id,
+            CancellationToken cancellationToken = default
+        );
+
+    }
+
+    internal partial class BuildTime : IServiceOperations<MaestroApi>, IBuildTime
+    {
+        public BuildTime(MaestroApi client)
+        {
+            Client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        public MaestroApi Client { get; }
+
+        partial void HandleFailedRequest(RestApiException ex);
+
+        partial void HandleFailedGetBuildTimesRequest(RestApiException ex);
+
+        public async Task<Models.BuildTime> GetBuildTimesAsync(
+            int days,
+            int id,
+            CancellationToken cancellationToken = default
+        )
+        {
+            if (days == default(int))
+            {
+                throw new ArgumentNullException(nameof(days));
+            }
+
+            if (id == default(int))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            const string apiVersion = "2019-01-16";
+
+            var _baseUri = Client.Options.BaseUri;
+            var _url = new RequestUriBuilder();
+            _url.Reset(_baseUri);
+            _url.AppendPath(
+                "/api/buildtime/{id}".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
+                false);
+
+            if (days != default(int))
+            {
+                _url.AppendQuery("days", Client.Serialize(days));
+            }
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
+
+
+            using (var _req = Client.Pipeline.CreateRequest())
+            {
+                _req.Uri = _url;
+                _req.Method = RequestMethod.Get;
+
+                using (var _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false))
+                {
+                    if (_res.Status < 200 || _res.Status >= 300)
+                    {
+                        // await OnGetBuildTimesFailed(_req, _res).ConfigureAwait(false);
+                        return new Models.BuildTime(id, 0, 0);
+                    }
+
+                    if (_res.ContentStream == null)
+                    {
+                        await OnGetBuildTimesFailed(_req, _res).ConfigureAwait(false);
+                    }
+
+                    using (var _reader = new StreamReader(_res.ContentStream))
+                    {
+                        var _content = await _reader.ReadToEndAsync().ConfigureAwait(false);
+                        var _body = Client.Deserialize<Models.BuildTime>(_content);
+                        return _body;
+                    }
+                }
+            }
+        }
+
+        internal async Task OnGetBuildTimesFailed(Request req, Response res)
+        {
+            string content = null;
+            if (res.ContentStream != null)
+            {
+                using (var reader = new StreamReader(res.ContentStream))
+                {
+                    content = await reader.ReadToEndAsync().ConfigureAwait(false);
+                }
+            }
+
+            var ex = new RestApiException<ApiError>(
+                req,
+                res,
+                content,
+                Client.Deserialize<ApiError>(content)
+                );
+            HandleFailedGetBuildTimesRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+    }
+}

--- a/src/Maestro/Client/src/Generated/MaestroApi.cs
+++ b/src/Maestro/Client/src/Generated/MaestroApi.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.Maestro.Client
 
         IAssets Assets { get; }
         IBuilds Builds { get; }
+        IBuildTime BuildTime { get; }
         IChannels Channels { get; }
         IDefaultChannels DefaultChannels { get; }
         IGoal Goal { get; }
@@ -110,6 +111,8 @@ namespace Microsoft.DotNet.Maestro.Client
 
         public IBuilds Builds { get; }
 
+        public IBuildTime BuildTime { get; }
+
         public IChannels Channels { get; }
 
         public IDefaultChannels DefaultChannels { get; }
@@ -133,6 +136,7 @@ namespace Microsoft.DotNet.Maestro.Client
             Options = options;
             Assets = new Assets(this);
             Builds = new Builds(this);
+            BuildTime = new BuildTime(this);
             Channels = new Channels(this);
             DefaultChannels = new DefaultChannels(this);
             Goal = new Goal(this);

--- a/src/Maestro/Client/src/Generated/Models/BuildTime.cs
+++ b/src/Maestro/Client/src/Generated/Models/BuildTime.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Immutable;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Maestro.Client.Models
+{
+    public partial class BuildTime
+    {
+        public BuildTime(int defaultChannelId, double officialBuildTime, double prBuildTime)
+        {
+            DefaultChannelId = defaultChannelId;
+            OfficialBuildTime = officialBuildTime;
+            PrBuildTime = prBuildTime;
+        }
+
+        [JsonProperty("defaultChannelId")]
+        public int DefaultChannelId { get; set; }
+
+        [JsonProperty("officialBuildTime")]
+        public double OfficialBuildTime { get; set; }
+
+        [JsonProperty("prBuildTime")]
+        public double PrBuildTime { get; set; }
+    }
+}

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildTimeController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildTimeController.cs
@@ -94,7 +94,6 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
 
             KustoQuery internalQuery = new KustoQuery(internalQueryText, parameters);
             KustoQuery publicQuery = new KustoQuery(publicQueryText, parameters);
-            System.Diagnostics.Debug.WriteLine($"Queries: {internalQueryText}\n {publicQueryText}");
 
             var results = await Task.WhenAll<TimeSpan>(_kustoClientProvider.GetSingleValueFromQueryAsync<TimeSpan>(internalQuery), 
                 _kustoClientProvider.GetSingleValueFromQueryAsync<TimeSpan>(publicQuery));

--- a/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
+++ b/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
@@ -254,5 +254,10 @@ namespace SubscriptionActorService
         {
             throw new NotImplementedException();
         }
+
+        public Task<BuildTime> GetBuildTimeAsync(int defaultChannelId, int days)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Darc.Operations
                     flowGraph.MarkLongestBuildPath();
                 }
 
-                await LogGraphViz(targetChannel, flowGraph, _options.IncludeBuildTimes);
+                await LogGraphVizAsync(targetChannel, flowGraph, _options.IncludeBuildTimes);
 
                 return Constants.SuccessCode;
             }
@@ -168,7 +168,7 @@ namespace Microsoft.DotNet.Darc.Operations
         /// For more info see https://www.graphviz.org/
         /// </remarks>
         /// <returns>Async task</returns>
-        private async Task LogGraphViz(Channel targetChannel, DependencyFlowGraph graph, bool includeBuildTimes)
+        private async Task LogGraphVizAsync(Channel targetChannel, DependencyFlowGraph graph, bool includeBuildTimes)
         {
             StringBuilder subgraphClusterWriter = null;
             bool writeToSubgraphCluster = targetChannel != null;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -277,9 +277,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 await writer.WriteLineAsync("    subgraph cluster2{");
                 await writer.WriteLineAsync("        rankdir=BT;");
                 await writer.WriteLineAsync("        style=invis;");
-                await writer.WriteLineAsync("        note[shape=plaintext label=\"* Longest build path marked in red\"];");
-                await writer.WriteLineAsync("        best[shape=plaintext label=\"Best Case: Time through the graph assuming no dependency flow\"];");
-                await writer.WriteLineAsync("        worst[shape=plaintext label=\"Worst Case: Time through the graph with dependency flow (PRs)\"];");
+                await writer.WriteLineAsync("        note[shape=plaintext label=\"* Longest build path marked in red\nBest Case: Time through the graph assuming no dependency flow\nWorst Case: Time through the graph with dependency flow (PRs)\"];");
                 await writer.WriteLineAsync("    }");
                 await writer.WriteLineAsync("    d->note[lhead=cluster2, ltail=cluster1, style=invis];");
                 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -206,18 +206,18 @@ namespace Microsoft.DotNet.Darc.Operations
                     {
                         // Append best case
                         nodeBuilder.Append(@"\n");
-                        nodeBuilder.Append($"Best Case: {node.BestCasePathTime}");
+                        nodeBuilder.Append($"Best Case: {Math.Round(node.BestCasePathTime, 2, MidpointRounding.AwayFromZero)} min");
                         nodeBuilder.Append(@"\n");
 
                         // Append worst case
-                        nodeBuilder.Append($"Worst Case: {node.WorstCasePathTime}");
+                        nodeBuilder.Append($"Worst Case: {Math.Round(node.WorstCasePathTime, 2, MidpointRounding.AwayFromZero)} min");
                         nodeBuilder.Append(@"\n");
 
                         // Append build times
-                        nodeBuilder.Append($"Official Build Time: {node.OfficialBuildTime}");
+                        nodeBuilder.Append($"Official Build Time: {Math.Round(node.OfficialBuildTime, 2, MidpointRounding.AwayFromZero)} min");
                         nodeBuilder.Append(@"\n");
 
-                        nodeBuilder.Append($"PR Build Time: {node.PrBuildTime}");
+                        nodeBuilder.Append($"PR Build Time: {Math.Round(node.PrBuildTime, 2, MidpointRounding.AwayFromZero)} min");
                     }
 
                     // Append end of label and end of node.
@@ -274,6 +274,12 @@ namespace Microsoft.DotNet.Darc.Operations
                 await writer.WriteLineAsync("        a->b[label = \"Updated Every Day\", style = dashed];");
                 await writer.WriteLineAsync("        e->f[label = \"Disabled/Updated On-demand\", style = dotted];");
                 await writer.WriteLineAsync("    }");
+                await writer.WriteLineAsync("    subgraph cluster2{");
+                await writer.WriteLineAsync("        style=invis;");
+                await writer.WriteLineAsync("        note[shape=plaintext label=\"* Longest build path marked in red\"];");
+                await writer.WriteLineAsync("    }");
+                await writer.WriteLineAsync("    d->note[lhead=cluster2, ltail=cluster1, style=invis];");
+                
             
                 await writer.WriteLineAsync("}");
             }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.Darc.Operations
         /// <returns></returns>
         private string GetEdgeStyle(DependencyFlowEdge edge)
         {
-            string color = edge.OnLongestBuildPath ? "color=\"black:invis:black\"" : "";
+            string color = edge.OnLongestBuildPath ? "color=\"red:invis:red\"" : "";
             switch (edge.Subscription.Policy.UpdateFrequency)
             {
                 case UpdateFrequency.EveryBuild:
@@ -187,7 +187,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 {
                     StringBuilder nodeBuilder = new StringBuilder();
 
-                    string style = node.OnLongestBuildPath ? "style=\"diagonals,bold\"" : "";
+                    string style = node.OnLongestBuildPath ? "style=\"diagonals,bold\" color=red" : "";
 
                     // First add the node name
                     nodeBuilder.Append($"    {UxHelpers.CalculateGraphVizNodeName(node)}");
@@ -270,12 +270,12 @@ namespace Microsoft.DotNet.Darc.Operations
                 await writer.WriteLineAsync("        d[style = invis];");
                 await writer.WriteLineAsync("        e[style = invis];");
                 await writer.WriteLineAsync("        f[style = invis];");
-                await writer.WriteLineAsync("        g[style = \"diagonals,bold\"];");
-                await writer.WriteLineAsync("        h[style = \"diagonals,bold\"];");
+                await writer.WriteLineAsync("        g[style = \"diagonals,bold\" color=red];");
+                await writer.WriteLineAsync("        h[style = \"diagonals,bold\" color=red];");
                 await writer.WriteLineAsync("        c->d[label = \"Updated Every Build\", style = bold];");
                 await writer.WriteLineAsync("        a->b[label = \"Updated Every Day\", style = dashed];");
                 await writer.WriteLineAsync("        e->f[label = \"Disabled/Updated On-demand\", style = dotted];");
-                await writer.WriteLineAsync("        g->h[label = \"Longest Build Path\", color=\"black:invis:black\"];");
+                await writer.WriteLineAsync("        g->h[label = \"Longest Build Path\", color=\"red:invis:red\"];");
                 await writer.WriteLineAsync("    }");
                 await writer.WriteLineAsync("    subgraph cluster2{");
                 await writer.WriteLineAsync("        rankdir=BT;");

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 // Build, then prune out what we don't want to see if the user specified
                 // channels.
-                DependencyFlowGraph flowGraph = DependencyFlowGraph.Build(defaultChannels, subscriptions);
+                DependencyFlowGraph flowGraph = await DependencyFlowGraph.Build(defaultChannels, subscriptions, barOnlyRemote, _options.Days);
 
                 Channel targetChannel = null;
                 if (!string.IsNullOrEmpty(_options.Channel))
@@ -83,7 +83,14 @@ namespace Microsoft.DotNet.Darc.Operations
                     flowGraph.PruneGraph(node => IsInterestingNode(targetChannel, node), edge => IsInterestingEdge(edge));
                 }
 
-                await LogGraphViz(targetChannel, flowGraph);
+                if (_options.IncludeBuildTimes)
+                {
+                    flowGraph.MarkBackEdges();
+                    flowGraph.CalculateLongestBuildPaths();
+                    flowGraph.MarkLongestBuildPath();
+                }
+
+                await LogGraphViz(targetChannel, flowGraph, _options.IncludeBuildTimes);
 
                 return Constants.SuccessCode;
             }
@@ -129,17 +136,18 @@ namespace Microsoft.DotNet.Darc.Operations
         /// <returns></returns>
         private string GetEdgeStyle(DependencyFlowEdge edge)
         {
+            string color = edge.OnLongestBuildPath ? "color=red" : "";
             switch (edge.Subscription.Policy.UpdateFrequency)
             {
                 case UpdateFrequency.EveryBuild:
                     // Solid
-                    return "style=bold";
+                    return $"{color} style=bold";
                 case UpdateFrequency.EveryDay:
                 case UpdateFrequency.TwiceDaily:
                 case UpdateFrequency.EveryWeek:
-                    return "style=dashed";
+                    return $"{color} style=dashed";
                 case UpdateFrequency.None:
-                    return "style=dotted";
+                    return $"{color} style=dotted";
                 default:
                     throw new NotImplementedException("Unknown update frequency");
             }
@@ -160,7 +168,7 @@ namespace Microsoft.DotNet.Darc.Operations
         /// For more info see https://www.graphviz.org/
         /// </remarks>
         /// <returns>Async task</returns>
-        private async Task LogGraphViz(Channel targetChannel, DependencyFlowGraph graph)
+        private async Task LogGraphViz(Channel targetChannel, DependencyFlowGraph graph, bool includeBuildTimes)
         {
             StringBuilder subgraphClusterWriter = null;
             bool writeToSubgraphCluster = targetChannel != null;
@@ -179,11 +187,13 @@ namespace Microsoft.DotNet.Darc.Operations
                 {
                     StringBuilder nodeBuilder = new StringBuilder();
 
+                    string color = node.OnLongestBuildPath ? "color=red style=bold" : "";
+
                     // First add the node name
                     nodeBuilder.Append($"    {UxHelpers.CalculateGraphVizNodeName(node)}");
 
                     // Then add the label.  label looks like [label="<info here>"]
-                    nodeBuilder.Append("[label=\"");
+                    nodeBuilder.Append($"[{color}\nlabel=\"");
 
                     // Append friendly repo name
                     nodeBuilder.Append(UxHelpers.GetSimpleRepoName(node.Repository));
@@ -191,6 +201,24 @@ namespace Microsoft.DotNet.Darc.Operations
 
                     // Append branch name
                     nodeBuilder.Append(node.Branch);
+
+                    if (includeBuildTimes)
+                    {
+                        // Append best case
+                        nodeBuilder.Append(@"\n");
+                        nodeBuilder.Append($"Best Case: {node.BestCasePathTime}");
+                        nodeBuilder.Append(@"\n");
+
+                        // Append worst case
+                        nodeBuilder.Append($"Worst Case: {node.WorstCasePathTime}");
+                        nodeBuilder.Append(@"\n");
+
+                        // Append build times
+                        nodeBuilder.Append($"Official Build Time: {node.OfficialBuildTime}");
+                        nodeBuilder.Append(@"\n");
+
+                        nodeBuilder.Append($"PR Build Time: {node.PrBuildTime}");
+                    }
 
                     // Append end of label and end of node.
                     nodeBuilder.Append("\"];");

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -275,8 +275,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 await writer.WriteLineAsync("        e->f[label = \"Disabled/Updated On-demand\", style = dotted];");
                 await writer.WriteLineAsync("    }");
                 await writer.WriteLineAsync("    subgraph cluster2{");
+                await writer.WriteLineAsync("        rankdir=BT;");
                 await writer.WriteLineAsync("        style=invis;");
                 await writer.WriteLineAsync("        note[shape=plaintext label=\"* Longest build path marked in red\"];");
+                await writer.WriteLineAsync("        best[shape=plaintext label=\"Best Case: Time through the graph assuming no dependency flow\"];");
+                await writer.WriteLineAsync("        worst[shape=plaintext label=\"Worst Case: Time through the graph with dependency flow (PRs)\"];");
                 await writer.WriteLineAsync("    }");
                 await writer.WriteLineAsync("    d->note[lhead=cluster2, ltail=cluster1, style=invis];");
                 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.Darc.Operations
         /// <returns></returns>
         private string GetEdgeStyle(DependencyFlowEdge edge)
         {
-            string color = edge.OnLongestBuildPath ? "color=red" : "";
+            string color = edge.OnLongestBuildPath ? "color=\"black:invis:black\"" : "";
             switch (edge.Subscription.Policy.UpdateFrequency)
             {
                 case UpdateFrequency.EveryBuild:
@@ -187,13 +187,13 @@ namespace Microsoft.DotNet.Darc.Operations
                 {
                     StringBuilder nodeBuilder = new StringBuilder();
 
-                    string color = node.OnLongestBuildPath ? "color=red style=bold" : "";
+                    string style = node.OnLongestBuildPath ? "style=\"diagonals,bold\"" : "";
 
                     // First add the node name
                     nodeBuilder.Append($"    {UxHelpers.CalculateGraphVizNodeName(node)}");
 
                     // Then add the label.  label looks like [label="<info here>"]
-                    nodeBuilder.Append($"[{color}\nlabel=\"");
+                    nodeBuilder.Append($"[{style}\nlabel=\"");
 
                     // Append friendly repo name
                     nodeBuilder.Append(UxHelpers.GetSimpleRepoName(node.Repository));
@@ -270,14 +270,17 @@ namespace Microsoft.DotNet.Darc.Operations
                 await writer.WriteLineAsync("        d[style = invis];");
                 await writer.WriteLineAsync("        e[style = invis];");
                 await writer.WriteLineAsync("        f[style = invis];");
+                await writer.WriteLineAsync("        g[style = \"diagonals,bold\"];");
+                await writer.WriteLineAsync("        h[style = \"diagonals,bold\"];");
                 await writer.WriteLineAsync("        c->d[label = \"Updated Every Build\", style = bold];");
                 await writer.WriteLineAsync("        a->b[label = \"Updated Every Day\", style = dashed];");
                 await writer.WriteLineAsync("        e->f[label = \"Disabled/Updated On-demand\", style = dotted];");
+                await writer.WriteLineAsync("        g->h[label = \"Longest Build Path\", color=\"black:invis:black\"];");
                 await writer.WriteLineAsync("    }");
                 await writer.WriteLineAsync("    subgraph cluster2{");
                 await writer.WriteLineAsync("        rankdir=BT;");
                 await writer.WriteLineAsync("        style=invis;");
-                await writer.WriteLineAsync("        note[shape=plaintext label=\"* Longest build path marked in red\nBest Case: Time through the graph assuming no dependency flow\nWorst Case: Time through the graph with dependency flow (PRs)\"];");
+                await writer.WriteLineAsync("        note[shape=plaintext label=\"Best Case: Time through the graph assuming no dependency flow\nWorst Case: Time through the graph with dependency flow (PRs)\"];");
                 await writer.WriteLineAsync("    }");
                 await writer.WriteLineAsync("    d->note[lhead=cluster2, ltail=cluster1, style=invis];");
                 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 // Build, then prune out what we don't want to see if the user specified
                 // channels.
-                DependencyFlowGraph flowGraph = await DependencyFlowGraph.Build(defaultChannels, subscriptions, barOnlyRemote, _options.Days);
+                DependencyFlowGraph flowGraph = await DependencyFlowGraph.BuildAsync(defaultChannels, subscriptions, barOnlyRemote, _options.Days);
 
                 Channel targetChannel = null;
                 if (!string.IsNullOrEmpty(_options.Channel))

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GetDependencyFlowGraphCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GetDependencyFlowGraphCommandLineOptions.cs
@@ -25,6 +25,12 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("channel", HelpText = @"Only include nodes/edges with flow on this channel.")]
         public string Channel { get; set; }
 
+        [Option("include-build-times", HelpText = @"Include build times for nodes and edges")]
+        public bool IncludeBuildTimes { get; set; }
+
+        [Option("days", Default = 7, HelpText = @"Number of Days to summarize build times over")]
+        public int Days { get; set; }
+
         public override Operation GetOperation()
         {
             return new GetDependencyFlowGraphOperation(this);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -1225,5 +1225,17 @@ namespace Microsoft.DotNet.DarcLib
             CheckForValidBarClient();
             return _barClient.GetGoalAsync(channel, definitionId);
         }
+
+        /// <summary>
+        ///     Gets official and pr build times (in minutes) for a default channel summarized over a number of days.
+        /// </summary>
+        /// <param name="defaultChannelId">Id of the default channel</param>
+        /// <param name="days">Number of days to summarize over</param>
+        /// <returns>Returns BuildTime in minutes</returns>
+        public Task<BuildTime> GetBuildTimeAsync(int defaultChannelId, int days)
+        {
+            CheckForValidBarClient();
+            return _barClient.GetBuildTimeAsync(defaultChannelId, days);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
@@ -266,6 +266,14 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns>Returns Goal in minutes.</returns>
         Task<Goal> GetGoalAsync(string channel, int definitionId);
 
+        /// <summary>
+        ///     Gets official and pr build time (in minutes) for a default channel summarized over a number of days.
+        /// </summary>
+        /// <param name="defaultChannelId">Id of the default channel</param>
+        /// <param name="days">Number of days to summarize over</param>
+        /// <returns>Returns BuildTime in minutes.</returns>
+        Task<BuildTime> GetBuildTimeAsync(int defaultChannelId, int days);
+
         #endregion
 
     }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -466,6 +466,14 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="definitionId">Azure DevOps DefinitionId.</param>
         /// <returns>Returns Goal in minutes.</returns>
         Task<Goal> GetGoalAsync(string channel, int definitionId);
+
+        /// <summary>
+        ///     Gets official and pr build times (in minutes) for a default channel summarized over a number of days.
+        /// </summary>
+        /// <param name="defaultChannelId">Id of the default channel</param>
+        /// <param name="days">Number of days to summarize over</param>
+        /// <returns>Returns BuildTime in minutes</returns>
+        Task<BuildTime> GetBuildTimeAsync(int defaultChannelId, int days);
         #endregion
 
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/MaestroApiBarClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/MaestroApiBarClient.cs
@@ -431,5 +431,17 @@ namespace Microsoft.DotNet.DarcLib
         {
             return _barClient.Goal.GetGoalTimesAsync(channelName: channel, definitionId: definitionId);
         }
+
+        /// <summary>
+        ///     Gets official and pr build time (in minutes) for a default channel summarized over a number of days.
+        /// </summary>
+        /// <param name="defaultChannelId">Id of the default channel</param>
+        /// <param name="days">Number of days to summarize over</param>
+        /// <returns>Returns BuildTime in minutes.</returns>
+
+        public Task<BuildTime> GetBuildTimeAsync(int defaultChannelId, int days)
+        {
+            return _barClient.BuildTime.GetBuildTimesAsync(id: defaultChannelId, days: days);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowEdge.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowEdge.cs
@@ -13,6 +13,8 @@ namespace Microsoft.DotNet.DarcLib
             Subscription = subscription;
             From = from;
             To = to;
+            OnLongestBuildPath = false;
+            BackEdge = false;
         }
 
         // An edge is associated with a subscription
@@ -23,5 +25,7 @@ namespace Microsoft.DotNet.DarcLib
         ///     True if the edge is part of a cycle, false if the edge is not, null if cycles have not been computed
         /// </summary>
         public bool? PartOfCycle { get; set; }
+        public bool BackEdge { get; set; }
+        public bool OnLongestBuildPath { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
@@ -249,9 +249,6 @@ namespace Microsoft.DotNet.DarcLib
                     {
                         DependencyFlowNode child = edge.From;
 
-                        // Match based on repository and branch since we are updating 
-                        // if (node.VisitedNodes.Where(n => n.Repository == child.Repository && n.Branch == child.Branch).Count() == 0
-                        //     && nodesToVisit.Where(n => n.Repository == child.Repository && n.Branch == child.Branch).Count() == 0)
                         if (!node.VisitedNodes.Contains(child) && !nodesToVisit.Contains(child))
                         {
                             child.VisitedNodes.AddRange(node.VisitedNodes);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
@@ -245,7 +245,7 @@ namespace Microsoft.DotNet.DarcLib
                     DependencyFlowNode node = nodesToVisit.Dequeue();
                     node.VisitedNodes.Add(node);
 
-                    foreach(var edge in node.IncomingEdges)
+                    foreach (var edge in node.IncomingEdges)
                     {
                         DependencyFlowNode child = edge.From;
 
@@ -319,7 +319,6 @@ namespace Microsoft.DotNet.DarcLib
                     flowNode.OfficialBuildTime = buildTime.OfficialBuildTime;
                     flowNode.PrBuildTime = buildTime.PrBuildTime;
                 }
-
                 else
                 {
                     flowNode.OfficialBuildTime = 0;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.DarcLib
                     {
                         // Nothing to do
                         continue;
-                    }                    
+                    }
                     foreach (var inputEdge in currentNode.IncomingEdges)
                     {
                         if (isInterestingEdge(inputEdge))

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
@@ -293,7 +293,7 @@ namespace Microsoft.DotNet.DarcLib
             }
         }
 
-        public static async Task<DependencyFlowGraph> Build(
+        public static async Task<DependencyFlowGraph> BuildAsync(
             List<DefaultChannel> defaultChannels,
             List<Subscription> subscriptions,
             IRemote barOnlyRemote,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
@@ -329,8 +329,8 @@ namespace Microsoft.DotNet.DarcLib
                 if (channel.Id != default(int))
                 {
                     BuildTime buildTime = await barOnlyRemote.GetBuildTimeAsync(channel.Id, days);
-                    flowNode.OfficialBuildTime = 10; // buildTime.OfficialBuildTime;
-                    flowNode.PrBuildTime = 10; //buildTime.PrBuildTime;
+                    flowNode.OfficialBuildTime = buildTime.OfficialBuildTime;
+                    flowNode.PrBuildTime = buildTime.PrBuildTime;
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
@@ -128,7 +128,10 @@ namespace Microsoft.DotNet.DarcLib
         }
 
         /// <summary>
-        ///    Mark the back edges of the graph so that they can be ignored when walking it
+        ///    Mark the back edges of the graph so that they can be ignored when walking it.
+        ///    Determine the backedges by computing dominators for each node. A node n is said to
+        ///    dominate another node if every path from the start to the other node must go through
+        ///    n.
         /// </summary>
         public void MarkBackEdges()
         {
@@ -148,8 +151,7 @@ namespace Microsoft.DotNet.DarcLib
             }
             Nodes.Add(startNode);
 
-            // Compute dominators. Start with a full set of nodes
-            // on edge dominator
+            // Dominator set for each node starts with the full set of nodes.
             Dictionary<DependencyFlowNode, HashSet<DependencyFlowNode>> dominators = new Dictionary<DependencyFlowNode, HashSet<DependencyFlowNode>>();
             foreach (var node in Nodes)
             {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowNode.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowNode.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.DotNet.DarcLib
 {
@@ -17,6 +18,10 @@ namespace Microsoft.DotNet.DarcLib
             InputChannels = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             OutgoingEdges = new List<DependencyFlowEdge>();
             IncomingEdges = new List<DependencyFlowEdge>();
+            VisitedNodes = new List<DependencyFlowNode>();
+            WorstCasePathTime = 0;
+            BestCasePathTime = 0;
+            OnLongestBuildPath = false;
         }
 
         public readonly string Repository;
@@ -27,5 +32,44 @@ namespace Microsoft.DotNet.DarcLib
 
         public List<DependencyFlowEdge> OutgoingEdges { get; set; }
         public List<DependencyFlowEdge> IncomingEdges { get; set; }
+
+        public List<DependencyFlowNode> VisitedNodes { get; set; }
+
+        public double OfficialBuildTime { get; set; }
+        public double PrBuildTime { get; set; }
+
+        public double WorstCasePathTime { get; set; }
+        public double BestCasePathTime { get; set; }
+        public bool OnLongestBuildPath { get; set; }
+
+        public void CalculateLongestPathTime()
+        {
+            // If the node does not have any outgoing edges, then it is a root, and its official build time is
+            // both its best and worst case time. Otherwise, its worst case path time is the slowest of its
+            // outgoing edges' worst case + Pr time for that edge + its official build time. Its best case 
+            // is the worst of its outgoing edges' best case + its official built time.
+            if (OutgoingEdges.Count == 0)
+            {
+                WorstCasePathTime = OfficialBuildTime;
+                BestCasePathTime = OfficialBuildTime;
+            }
+            else
+            {
+                // Our edges of interest are those that are not back edges
+                var edgesOfInterest = OutgoingEdges.Where(e => !e.BackEdge).ToList();
+
+                // If all of the edges were marked as backedges, use the full OutgoingEdges list
+                if (edgesOfInterest.Count == 0)
+                {
+                    edgesOfInterest = OutgoingEdges;
+                }
+
+                double worstCasePathTime = edgesOfInterest.Max(e => e.To.WorstCasePathTime + e.To.PrBuildTime) + OfficialBuildTime;
+                WorstCasePathTime = worstCasePathTime > WorstCasePathTime ? worstCasePathTime : WorstCasePathTime;
+
+                double bestCasePathTime = edgesOfInterest.Max(e => e.To.BestCasePathTime) + OfficialBuildTime;
+                BestCasePathTime = bestCasePathTime > BestCasePathTime ? bestCasePathTime : bestCasePathTime;
+            }
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowNode.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowNode.cs
@@ -18,7 +18,6 @@ namespace Microsoft.DotNet.DarcLib
             InputChannels = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             OutgoingEdges = new List<DependencyFlowEdge>();
             IncomingEdges = new List<DependencyFlowEdge>();
-            VisitedNodes = new List<DependencyFlowNode>();
             WorstCasePathTime = 0;
             BestCasePathTime = 0;
             OnLongestBuildPath = false;
@@ -32,8 +31,6 @@ namespace Microsoft.DotNet.DarcLib
 
         public List<DependencyFlowEdge> OutgoingEdges { get; set; }
         public List<DependencyFlowEdge> IncomingEdges { get; set; }
-
-        public List<DependencyFlowNode> VisitedNodes { get; set; }
 
         public double OfficialBuildTime { get; set; }
         public double PrBuildTime { get; set; }


### PR DESCRIPTION
This change does the following:

1. Adds the generated code so that the swagger api can be referenced by darc.
2. Adds two new flags to get-flow-graph: --include-build-times and --days.
   These two flags can be used together to control whether or not build
   times are calculated and displayed on the flow graph, and over how many
   days information is summarized.
3. Calls the api to gather build time data for each node in the graph. These
   exception is any default channel that does not have a channel id (which
   is the case for the manually added arcade nodes), as they are manually
   generated and don't exist in their current form in the database
4. Performs back-edge detection on the flow graph so that we do not following
   back edges when calculating build path times.
5. Using a breadth first search, calculate the longest build path time for
   each node.
6. Determine and mark the longest path in the graph.

Flow graph example:

`dotnet artifacts\bin\Microsoft.DotNet.Darc\Debug\netcoreapp3.0\Microsoft.DotNet.Darc.dll get-flow-graph --include-build-times --channel ".NET Core 5 Dev" --graphviz flow-real-30.dot --days 30 && dot -Tpng -o flow-real-30.png flow-real-30.dot && flow-real-30.png`:

![image](https://user-images.githubusercontent.com/9666644/72652788-0e10ed00-393d-11ea-95cb-87c3fabfb4d1.png)

* Note: any node with a 0 for Official build time or PR time had no successful builds in the time period.