### PR TITLE
Only flow feeds for an asset if it's only avaiable in maestro managed…

### DIFF
--- a/src/Maestro/tests/Scenarios/azdoflow-feedflow.ps1
+++ b/src/Maestro/tests/Scenarios/azdoflow-feedflow.ps1
@@ -158,7 +158,7 @@ try {
     )
 
     $expectedFeeds = @($proxyFeed, $azdoFeed1, $azdoFeed3)
-    $notExpectedFeeds = @($regularFeed, $azdoFeed2)
+    $notExpectedFeeds = @($regularFeed, $azdoFeed2, $buildContainer)
 
     Write-Host "Waiting on PR to be opened in $targetRepoUri"
     $success = Check-NonBatched-AzDO-PullRequest $sourceRepoName $targetRepoName $targetBranch $expectedDependencies $false $expectedFeeds $notExpectedFeeds

--- a/src/Maestro/tests/Scenarios/azdoflow-feedflow.ps1
+++ b/src/Maestro/tests/Scenarios/azdoflow-feedflow.ps1
@@ -15,7 +15,8 @@ $sourceBuildNumber = Get-Random
 $sourceCommit = Get-Random
 $sourceBranch = "master"
 $proxyFeed = "https://some-proxy.azurewebsites.net/container/some-container/sig/somesig/se/2020-02-02/darc-int-maestro-test1-bababababab-1/index.json"
-$azdoFeed = "https://some_org.pkgs.visualstudio.com/_packaging/darc-int-maestro-test1-efabaababababe-1/nuget/v3/index.json"
+$azdoFeed1 = "https://some_org.pkgs.visualstudio.com/_packaging/darc-int-maestro-test1-efabaababababe-1/nuget/v3/index.json"
+$azdoFeed2 = "https://some_org.pkgs.visualstudio.com/_packaging/darc-int-maestro-test1-efabaababababd-1/nuget/v3/index.json"
 $regularFeed = "https://dotnetfeed.blob.core.windows.net/maestro-test1/index.json"
 
 $sourceAssets = @(
@@ -34,7 +35,17 @@ $sourceAssets = @(
         version = "2.1.0"
         locations = @(
             @{
-                location = $azdoFeed
+                location = $azdoFeed1
+                type = "nugetFeed"
+            }
+        )
+    },
+    @{
+        name = "Pizza"
+        version = "3.1.0"
+        locations = @(
+            @{
+                location = $azdoFeed2
                 type = "nugetFeed"
             },
             @{
@@ -82,6 +93,7 @@ try {
         Push-Location -Path $(Get-Repo-Location $targetRepoName)
         Darc-Command add-dependency --name Foo --type product --repo "$sourceRepoUri"
         Darc-Command add-dependency --name Bar --type product --repo "$sourceRepoUri"
+        Darc-Command add-dependency --name Pizza --type product --repo "$sourceRepoUri"
     }
     finally {
         Pop-Location
@@ -111,11 +123,18 @@ try {
         "Commit:           $sourceCommit",
         "Type:             Product",
         "Pinned:           False",
+        "",
+        "Name:             Pizza",
+        "Version:          3.1.0",
+        "Repo:             $sourceRepoUri",
+        "Commit:           $sourceCommit",
+        "Type:             Product",
+        "Pinned:           False",
         ""
     )
 
-    $expectedFeeds = @($proxyFeed, $azdoFeed)
-    $notExpectedFeeds = @($regularFeed)
+    $expectedFeeds = @($proxyFeed, $azdoFeed1)
+    $notExpectedFeeds = @($regularFeed, $azdoFeed2)
 
     Write-Host "Waiting on PR to be opened in $targetRepoUri"
     $success = Check-NonBatched-AzDO-PullRequest $sourceRepoName $targetRepoName $targetBranch $expectedDependencies $false $expectedFeeds $notExpectedFeeds

--- a/src/Maestro/tests/Scenarios/azdoflow-feedflow.ps1
+++ b/src/Maestro/tests/Scenarios/azdoflow-feedflow.ps1
@@ -17,7 +17,9 @@ $sourceBranch = "master"
 $proxyFeed = "https://some-proxy.azurewebsites.net/container/some-container/sig/somesig/se/2020-02-02/darc-int-maestro-test1-bababababab-1/index.json"
 $azdoFeed1 = "https://some_org.pkgs.visualstudio.com/_packaging/darc-int-maestro-test1-efabaababababe-1/nuget/v3/index.json"
 $azdoFeed2 = "https://some_org.pkgs.visualstudio.com/_packaging/darc-int-maestro-test1-efabaababababd-1/nuget/v3/index.json"
+$azdoFeed3 = "https://some_org.pkgs.visualstudio.com/_packaging/darc-int-maestro-test1-efabaababababf-1/nuget/v3/index.json"
 $regularFeed = "https://dotnetfeed.blob.core.windows.net/maestro-test1/index.json"
+$buildContainer = "https://dev.azure.com/dnceng/internal/_apis/build/builds/9999999/artifacts" 
 
 $sourceAssets = @(
     @{
@@ -51,6 +53,20 @@ $sourceAssets = @(
             @{
                 location = $regularFeed
                 type = "nugetFeed"
+            }
+        )
+    },
+    @{
+        name = "Hamburger"
+        version = "4.1.0"
+        locations = @(
+            @{
+                location = $azdoFeed3
+                type = "nugetFeed"
+            },
+            @{
+                location = $buildContainer
+                type = "container"
             }
         )
     }
@@ -94,6 +110,7 @@ try {
         Darc-Command add-dependency --name Foo --type product --repo "$sourceRepoUri"
         Darc-Command add-dependency --name Bar --type product --repo "$sourceRepoUri"
         Darc-Command add-dependency --name Pizza --type product --repo "$sourceRepoUri"
+        Darc-Command add-dependency --name Hamburger --type product --repo "$sourceRepoUri"
     }
     finally {
         Pop-Location
@@ -130,10 +147,17 @@ try {
         "Commit:           $sourceCommit",
         "Type:             Product",
         "Pinned:           False",
+        "",
+        "Name:             Hamburger",
+        "Version:          4.1.0",
+        "Repo:             $sourceRepoUri",
+        "Commit:           $sourceCommit",
+        "Type:             Product",
+        "Pinned:           False",
         ""
     )
 
-    $expectedFeeds = @($proxyFeed, $azdoFeed1)
+    $expectedFeeds = @($proxyFeed, $azdoFeed1, $azdoFeed3)
     $notExpectedFeeds = @($regularFeed, $azdoFeed2)
 
     Write-Host "Waiting on PR to be opened in $targetRepoUri"

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -1173,7 +1173,10 @@ namespace Microsoft.DotNet.DarcLib
                 var latestAsset = matchingAssetsFromSameSha.OrderByDescending(a => a.BuildId).FirstOrDefault();
                 if (latestAsset != null)
                 {
-                    IEnumerable<String> currentAssetLocations = latestAsset.Locations?.Select(l => l.Location);
+                    IEnumerable<String> currentAssetLocations = latestAsset.Locations?
+                        .Where(l=>l.Type == LocationType.NugetFeed)
+                        .Select(l => l.Location);
+
                     if (currentAssetLocations == null)
                     {
                         continue;


### PR DESCRIPTION
… feeds

part of https://github.com/dotnet/arcade/issues/3952

We shouldn't flow a feed if an asset is present in a non-managed feed.

Ran the modified scenario test locally and it opened https://dev.azure.com/dnceng/internal/_git/maestro-test2/pullrequest/5473 which only flowed the feeds for the assets that are only in our managed feeds.