### PR TITLE
[Rollout] Only flow feeds for an asset if it's only avaiable in maestro managed feeds

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -1173,7 +1173,10 @@ namespace Microsoft.DotNet.DarcLib
                 var latestAsset = matchingAssetsFromSameSha.OrderByDescending(a => a.BuildId).FirstOrDefault();
                 if (latestAsset != null)
                 {
-                    IEnumerable<String> currentAssetLocations = latestAsset.Locations?.Select(l => l.Location);
+                    IEnumerable<String> currentAssetLocations = latestAsset.Locations?
+                        .Where(l=>l.Type == LocationType.NugetFeed)
+                        .Select(l => l.Location);
+
                     if (currentAssetLocations == null)
                     {
                         continue;


### PR DESCRIPTION
* Only flow feeds for an asset if it's only avaiable in maestro managed feeds

* Only populate nugetFeed locations during dependency updates. The container feed type is unrestorable

* Explicitly check that the build container is not in the flowed feeds in the scenario tests