### PR TITLE
Allow basic auth with token

### DIFF
--- a/src/DotNet.Status.Web/GitHubUserTokenHandler.cs
+++ b/src/DotNet.Status.Web/GitHubUserTokenHandler.cs
@@ -3,10 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Security.Claims;
+using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
@@ -14,6 +16,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.DotNet.Web.Authentication.GitHub;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 
 namespace DotNet.Status.Web
 {
@@ -22,6 +25,8 @@ namespace DotNet.Status.Web
         private readonly GitHubClaimResolver _resolver;
         private readonly IDataProtector _dataProtector;
         private readonly ITokenRevocationProvider _revocation;
+        private readonly ArrayPool<byte> _bytePool = ArrayPool<byte>.Create();
+        private readonly ArrayPool<char> _charPool = ArrayPool<char>.Create();
 
         public GitHubUserTokenHandler(
             GitHubClaimResolver resolver,
@@ -40,22 +45,31 @@ namespace DotNet.Status.Web
         protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
         {
             string protectedToken = null;
-            if (Request.Headers.TryGetValue("Authorization", out var authHeader) &&
-                AuthenticationHeaderValue.TryParse(authHeader.ToString(), out var auth) &&
-                auth.Scheme == "Bearer")
+            if (Request.Headers.TryGetValue("Authorization", out StringValues authHeader) &&
+                AuthenticationHeaderValue.TryParse(authHeader.ToString(), out AuthenticationHeaderValue auth) &&
+                !string.IsNullOrEmpty(auth.Parameter) &&
+                auth.Parameter.Length < 1000)
             {
-                protectedToken = auth.Parameter;
+                switch (auth.Scheme.ToLowerInvariant())
+                {
+                    case "basic":
+                        protectedToken = ParseBasicAuth(auth.Parameter);
+                        break;
+                    case "bearer":
+                        protectedToken = auth.Parameter;
+                        break;
+                }
             }
 
             if (string.IsNullOrEmpty(protectedToken) &&
-                Request.Query.TryGetValue("token", out var tokenQuery))
+                Request.Query.TryGetValue("token", out StringValues tokenQuery))
             {
-                protectedToken = tokenQuery;
+                protectedToken = tokenQuery.ToString();
             }
 
             if (string.IsNullOrEmpty(protectedToken))
             {
-                Logger.LogInformation("No token found in 'Authorization: Bearer <token>' or '?token=<token>'");
+                Logger.LogInformation("No token found in 'Authorization: Bearer <token>', 'Authorization: Basic <base64(ignored:<token>)>', or '?token=<token>'");
                 return AuthenticateResult.NoResult();
             }
 
@@ -86,6 +100,35 @@ namespace DotNet.Status.Web
             var principal = new ClaimsPrincipal(new[] {identity});
             var ticket = new AuthenticationTicket(principal, Scheme.Name);
             return AuthenticateResult.Success(ticket);
+        }
+
+        private string ParseBasicAuth(string authParameter)
+        {
+            string value = null;
+            byte[] rentedBytes = _bytePool.Rent(1000);
+            if (Convert.TryFromBase64String(authParameter, rentedBytes, out int size))
+            {
+                Span<byte> basicBytes = rentedBytes.AsSpan(0, size);
+
+                char[] rentedChars = _charPool.Rent(1000);
+                int cb = Encoding.UTF8.GetChars(basicBytes, rentedChars);
+                Span<char> basicChars = rentedChars.AsSpan(0, cb);
+
+                int separatorIndex = basicChars.IndexOf(':');
+                if (separatorIndex != -1)
+                {
+                    value = new string(basicChars.Slice(separatorIndex + 1));
+                }
+
+                // Clear out the auth stuff, no reason to leave it in memory if we don't have to
+                basicChars.Fill('\0');
+                basicBytes.Fill(0);
+
+                _charPool.Return(rentedChars);
+            }
+
+            _bytePool.Return(rentedBytes);
+            return value;
         }
 
         private bool TryDecodeToken(string protectedToken, out GitHubTokenData token)

--- a/src/DotNet.Status.Web/Startup.cs
+++ b/src/DotNet.Status.Web/Startup.cs
@@ -120,7 +120,15 @@ namespace DotNet.Status.Web
 
         private void AddServices(IServiceCollection services)
         {
-            services.AddMvc().WithRazorPagesRoot("/Pages").AddRazorPagesOptions(o => o.Conventions.AuthorizeFolder("/", MsftAuthorizationPolicyName).AllowAnonymousToPage("/Index"));
+            services.AddMvc()
+                .WithRazorPagesRoot("/Pages")
+                .AddRazorPagesOptions(o =>
+                    o.Conventions
+                        .AuthorizeFolder("/", MsftAuthorizationPolicyName)
+                        .AllowAnonymousToPage("/Index")
+                        .AllowAnonymousToPage("/Status")
+                        .AllowAnonymousToPage("/Error")
+                    );
             services.AddApplicationInsightsTelemetry(Configuration.GetSection("ApplicationInsights").Bind);
             services.Configure<LoggerFilterOptions>(o =>
             {


### PR DESCRIPTION
Too many web hook style programs use basic auth for their
mechanism. Let's to what Azure DevOps does and treat
the password as the token and ignore the username

Also fix bouncing from the the status and error pages