### PR TITLE
Fix CPD unusual choice issue

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -526,12 +526,13 @@ namespace Microsoft.DotNet.Darc.Operations
 
             var filteredBuilds = FilterReleasedBuilds(builds);
 
-            if (graph.DependenciesMissingBuilds.Any())
+            var nodesWithNoContributingBuilds = graph.Nodes.Where(node => !node.ContributingBuilds.Any());
+            if (nodesWithNoContributingBuilds.Any())
             {
-                Console.WriteLine("Dependencies missing builds:");
-                foreach (DependencyDetail dependency in graph.DependenciesMissingBuilds)
+                Console.WriteLine("Dependency graph nodes missing builds:");
+                foreach (var node in nodesWithNoContributingBuilds)
                 {
-                    Console.WriteLine($"  {dependency.Name}@{dependency.Version} @ ({dependency.RepoUri}@{dependency.Commit})");
+                    Console.WriteLine($"  {node.Repository}@{node.Commit}");
                 }
                 if (!_options.ContinueOnError)
                 {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -2,17 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.DarcLib
 {
@@ -487,20 +486,7 @@ namespace Microsoft.DotNet.DarcLib
                 foreach (DependencyDetail dependencyInUpdateChain in updateList)
                 {
                     (Asset coherentAsset, Build buildForAsset) =
-                        FindAssetInBuildTree(dependencyInUpdateChain.Name, rootNode);
-
-                    // If we originally got the root node from the cache the graph may be incomplete.
-                    // Rebuild to attempt to find all the assets we have left to find. If we still can't find, or if
-                    // the root node did not come the cache, then we're in an invalid state.
-                    if (coherentAsset == null && nodeFromCache)
-                    {
-                        _logger.LogInformation($"Asset {dependencyInUpdateChain.Name} was not found in cached graph, rebuilding from " +
-                            $"{currentDependency.RepoUri}@{currentDependency.Commit}");
-                        rootNode = await BuildGraphAtDependencyAsync(remoteFactory, currentDependency, leftToFind, nodeCache);
-                        // And attempt to find again.
-                        (coherentAsset, buildForAsset) =
-                            FindAssetInBuildTree(dependencyInUpdateChain.Name, rootNode);
-                    }
+                        FindNewestAssetInBuildTree(dependencyInUpdateChain.Name, rootNode);
 
                     if (coherentAsset == null)
                     {
@@ -557,12 +543,7 @@ namespace Microsoft.DotNet.DarcLib
             {
                 IncludeToolset = true,
                 LookupBuilds = true,
-                NodeDiff = NodeDiff.None,
-                EarlyBuildBreak = new EarlyBreakOn
-                {
-                    Type = EarlyBreakOnType.Assets,
-                    BreakOn = new List<string>(updateList.Select(d => d.Name))
-                }
+                NodeDiff = NodeDiff.None
             };
 
             DependencyGraph dependencyGraph = await DependencyGraph.BuildRemoteDependencyGraphAsync(
@@ -582,40 +563,49 @@ namespace Microsoft.DotNet.DarcLib
 
         /// <summary>
         ///     Given an asset name, find the asset in the dependency tree.
-        ///     Returns the asset with the shortest path to the root node.
+        ///     Returns the newest asset in the tree.
         /// </summary>
         /// <param name="assetName">Name of asset.</param>
         /// <param name="currentNode">Dependency graph node to find the asset in.</param>
         /// <returns>(Asset, Build, depth), or (null, null, maxint) if not found.</returns>
-        private (Asset asset, Build build, int buildDepth) FindAssetInBuildTree(string assetName, DependencyGraphNode currentNode, int currentDepth)
+        private (Asset asset, Build build) FindNewestAssetInBuildTree(string assetName, DependencyGraphNode currentNode, DateTimeOffset assetProductionTime)
         {
+            Asset newestMatchingAsset = null;
+            Build newestMatchingBuild = null;
+            DateTimeOffset newestAssetProductionTime = assetProductionTime;
             foreach (Build build in currentNode.ContributingBuilds)
             {
+                // If the contributing build is older than the current asset production time,
+                // don't need to check here
+                if (build.DateProduced.CompareTo(newestAssetProductionTime) < 0)
+                {
+                    continue;
+                }
+                
                 Asset matchingAsset = build.Assets.FirstOrDefault(a => a.Name.Equals(assetName, StringComparison.OrdinalIgnoreCase));
                 if (matchingAsset != null)
                 {
-                    return (matchingAsset, build, currentDepth);
+                    newestMatchingAsset = matchingAsset;
+                    newestMatchingBuild = build;
+                    newestAssetProductionTime = build.DateProduced;
                 }
             }
 
             // Walk child nodes
-            Asset shallowestAsset = null;
-            Build shallowestBuild = null;
-            int shallowestBuildDepth = int.MaxValue;
             foreach (DependencyGraphNode childNode in currentNode.Children)
             {
-                (Asset asset, Build build, int buildDepth) = FindAssetInBuildTree(assetName, childNode, currentDepth + 1);
+                (Asset asset, Build build) = FindNewestAssetInBuildTree(assetName, childNode, newestAssetProductionTime);
                 if (asset != null)
                 {
-                    if (buildDepth < shallowestBuildDepth)
+                    if (build.DateProduced.CompareTo(newestAssetProductionTime) > 0)
                     {
-                        shallowestAsset = asset;
-                        shallowestBuild = build;
-                        shallowestBuildDepth = buildDepth;
+                        newestMatchingAsset = asset;
+                        newestMatchingBuild = build;
+                        newestAssetProductionTime = build.DateProduced;
                     }
                 }
             }
-            return (shallowestAsset, shallowestBuild, shallowestBuildDepth);
+            return (newestMatchingAsset, newestMatchingBuild);
         }
 
         /// <summary>
@@ -625,9 +615,9 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="assetName">Name of asset.</param>
         /// <param name="currentNode">Dependency graph node to find the asset in.</param>
         /// <returns>(Asset, Build), or (null, null) if not found.</returns>
-        private (Asset asset, Build build) FindAssetInBuildTree(string assetName, DependencyGraphNode currentNode)
+        private (Asset asset, Build build) FindNewestAssetInBuildTree(string assetName, DependencyGraphNode currentNode)
         {
-            (Asset asset, Build build, int depth) = FindAssetInBuildTree(assetName, currentNode, 0);
+            (Asset asset, Build build) = FindNewestAssetInBuildTree(assetName, currentNode, DateTimeOffset.MinValue);
             return (asset, build);
         }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/HealthMetrics/ProductDependencyCyclesHealthMetric.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/HealthMetrics/ProductDependencyCyclesHealthMetric.cs
@@ -40,7 +40,6 @@ namespace Microsoft.DotNet.DarcLib.HealthMetrics
 
             DependencyGraphBuildOptions options = new DependencyGraphBuildOptions
             {
-                EarlyBuildBreak = EarlyBreakOn.NoEarlyBreak,
                 IncludeToolset = false,
                 LookupBuilds = false,
                 NodeDiff = NodeDiff.None,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
@@ -441,8 +441,12 @@ namespace Microsoft.DotNet.DarcLib
                 logger.LogInformation($"Starting build of graph from ({repoUri}@{commit})");
             }
 
-            // Look up the dependency and get the creating build.
-            IRemote barOnlyRemote = await remoteFactory.GetBarOnlyRemoteAsync(logger);
+            IRemote barOnlyRemote = null;
+            if (remote)
+            {
+                // Look up the dependency and get the creating build.
+                barOnlyRemote = await remoteFactory.GetBarOnlyRemoteAsync(logger);
+            }
 
             List<LinkedList<DependencyGraphNode>> cycles = new List<LinkedList<DependencyGraphNode>>();
             Dictionary<string, Task<IEnumerable<Build>>> buildLookupTasks = null;
@@ -651,8 +655,7 @@ namespace Microsoft.DotNet.DarcLib
                                                                               IEnumerable<DependencyGraphNode> allNodes,
                                                                               ILogger logger)
         {
-            AssetComparer assetEqualityComparer = new AssetComparer();
-            logger.LogInformation($"Computing contributing builds");
+            logger.LogInformation("Computing contributing builds");
 
             List<Build> allContributingBuilds = new List<Build>();
 
@@ -675,14 +678,15 @@ namespace Microsoft.DotNet.DarcLib
                 }
             }
 
-            logger.LogInformation($"Done computing contributing builds");
+            logger.LogInformation("Done computing contributing builds");
 
             return allContributingBuilds;
         }
         
         /// <summary>
         /// Determines whether a build contributes to a given node by looking at the parents'
-        /// input dependencies. If there are no parents, then we assume that the build could contribute.
+        /// input dependencies. If there are no parents, then we assume that the build could contribute. This
+        /// would happen for the root node.
         /// </summary>
         /// <param name="node">Node</param>
         /// <param name="potentialContributingBuild">Potentially contributing build</param>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
@@ -34,41 +34,6 @@ namespace Microsoft.DotNet.DarcLib
         LatestInChannel,
     }
 
-    public enum EarlyBreakOnType
-    {
-        /// <summary>
-        /// Do not break graph build early
-        /// </summary>
-        None,
-        /// <summary>
-        /// Break graph when all the specified dependencies have
-        /// been found
-        /// </summary>
-        Dependencies,
-        /// <summary>
-        /// Break when the specified assets have been found
-        /// </summary>
-        Assets
-    }
-
-    public class EarlyBreakOn
-    {
-        /// <summary>
-        ///     Do not break early
-        /// </summary>
-        public static readonly EarlyBreakOn NoEarlyBreak = new EarlyBreakOn() { Type = EarlyBreakOnType.None };
-
-        /// <summary>
-        ///     When should early breaking be done (how should the BreakOn list be interpreted)
-        /// </summary>
-        public EarlyBreakOnType Type { get; set; }
-        /// <summary>
-        ///     When all the elements in BreakOn have been found,
-        ///     (interpreted based on Type), break the graph build.
-        /// </summary>
-        public List<string> BreakOn { get; set; }
-    }
-
     public class DependencyGraphBuildOptions
     {
         /// <summary>
@@ -80,23 +45,23 @@ namespace Microsoft.DotNet.DarcLib
         /// Lookup build information for each node. Only valid for remote builds.
         /// </summary>
         public bool LookupBuilds { get; set; }
-        
+
+        /// <summary>
+        /// Determine which dependencies are missing builds
+        /// </summary>
+        public bool ComputeMissingBuilds { get; set; }
+
         /// <summary>
         /// Type of node diff to perform. Local build only supports 'None' 
         /// </summary>
         public NodeDiff NodeDiff { get; set; } = NodeDiff.None;
-        
-        /// <summary>
-        /// Stop the graph build based on the provided options
-        /// </summary>
-        public EarlyBreakOn EarlyBuildBreak { get; set; } = EarlyBreakOn.NoEarlyBreak;
 
         /// <summary>
         ///     If true, cycles are computed as part of the graph build
         ///     if cycles are encountered, and the Cycles member of DependencyGraph
         ///     will be non-empty
         /// </summary>
-        public bool ComputeCyclePaths { get; set; } = true;
+        public bool ComputeCyclePaths { get; set; } = false;
 
         /// <summary>
         ///     Location of git executable for use if any git commands need to be run.
@@ -115,7 +80,6 @@ namespace Microsoft.DotNet.DarcLib
             IEnumerable<DependencyGraphNode> allNodes,
             IEnumerable<DependencyGraphNode> incoherentNodes,
             IEnumerable<Build> contributingBuilds,
-            IEnumerable<DependencyDetail> dependenciesMissingBuilds,
             IEnumerable<IEnumerable<DependencyGraphNode>> cycles)
         {
             Root = root;
@@ -124,7 +88,6 @@ namespace Microsoft.DotNet.DarcLib
             IncoherentNodes = incoherentNodes;
             IncoherentDependencies = incoherentDependencies;
             ContributingBuilds = contributingBuilds;
-            DependenciesMissingBuilds = dependenciesMissingBuilds;
             Cycles = cycles;
         }
 
@@ -157,12 +120,6 @@ namespace Microsoft.DotNet.DarcLib
         ///     Builds that contributed dependencies to the graph.
         /// </summary>
         public IEnumerable<Build> ContributingBuilds { get; set; }
-
-        /// <summary>
-        ///     Dependencies in the graph for which a corresponding build could not
-        ///     be found.
-        /// </summary>
-        public IEnumerable<DependencyDetail> DependenciesMissingBuilds { get; set; }
 
         /// <summary>
         ///     A list of cycles.  Each cycle is represented as a list of nodes
@@ -467,7 +424,7 @@ namespace Microsoft.DotNet.DarcLib
             IEnumerable<string> remotesMap,
             string testPath)
         {
-            ValidateBuildOptions(remoteFactory, rootDependencies, repoUri, commit, 
+            ValidateBuildOptions(remoteFactory, rootDependencies, repoUri, commit,
                 options, remote, logger, reposFolder, remotesMap, testPath);
 
             if (rootDependencies != null)
@@ -484,49 +441,23 @@ namespace Microsoft.DotNet.DarcLib
                 logger.LogInformation($"Starting build of graph from ({repoUri}@{commit})");
             }
 
-            AssetComparer assetEqualityComparer = new AssetComparer();
-            HashSet<Build> allContributingBuilds = null;
-            HashSet<DependencyDetail> dependenciesMissingBuilds = null;
-            HashSet<Build> rootNodeBuilds = null;
-            Dictionary<DependencyDetail, Build> dependencyCache =
-                new Dictionary<DependencyDetail, Build>(new DependencyDetailComparer());
-            List<LinkedList<DependencyGraphNode>> cycles = new List<LinkedList<DependencyGraphNode>>();
+            // Look up the dependency and get the creating build.
+            IRemote barOnlyRemote = await remoteFactory.GetBarOnlyRemoteAsync(logger);
 
-            EarlyBreakOnType breakOnType = options.EarlyBuildBreak.Type;
-            HashSet<string> breakOn = null;
-            if (breakOnType != EarlyBreakOnType.None)
-            {
-                breakOn = new HashSet<string>(options.EarlyBuildBreak.BreakOn, StringComparer.OrdinalIgnoreCase);
-            }
+            List<LinkedList<DependencyGraphNode>> cycles = new List<LinkedList<DependencyGraphNode>>();
+            Dictionary<string, Task<IEnumerable<Build>>> buildLookupTasks = null;
 
             if (options.LookupBuilds)
             {
-                allContributingBuilds = new HashSet<Build>(new BuildComparer());
-                dependenciesMissingBuilds = new HashSet<DependencyDetail>(new DependencyDetailComparer());
-                rootNodeBuilds = new HashSet<Build>(new BuildComparer());
+                buildLookupTasks = new Dictionary<string, Task<IEnumerable<Build>>>();
 
                 // Look up the dependency and get the creating build.
-                IRemote barOnlyRemote = await remoteFactory.GetBarOnlyRemoteAsync(logger);
-                IEnumerable<Build> potentialRootNodeBuilds = await barOnlyRemote.GetBuildsAsync(repoUri, commit);
-                // Filter by those actually producing the root dependencies, if they were supplied
-                if (rootDependencies != null)
-                {
-                    potentialRootNodeBuilds = potentialRootNodeBuilds.Where(b =>
-                        b.Assets.Any(a => rootDependencies.Any(d => assetEqualityComparer.Equals(a, d))));
-                }
-                // It's entirely possible that the root has no builds (e.g. change just checked in).
-                // Don't record those. Instead, users of the graph should just look at the
-                // root node's contributing builds and determine whether it's empty or not.
-                foreach (Build build in potentialRootNodeBuilds)
-                {
-                    allContributingBuilds.Add(build);
-                    rootNodeBuilds.Add(build);
-                    AddAssetsToBuildCache(build, dependencyCache, breakOnType, breakOn);
-                }
+                buildLookupTasks.Add($"{repoUri}@{commit}", barOnlyRemote.GetBuildsAsync(repoUri, commit));
             }
 
             // Create the root node and add the repo to the visited bit vector.
-            DependencyGraphNode rootGraphNode = new DependencyGraphNode(repoUri, commit, rootDependencies, rootNodeBuilds);
+            List<Build> allContributingBuilds = null;
+            DependencyGraphNode rootGraphNode = new DependencyGraphNode(repoUri, commit, rootDependencies, null);
             rootGraphNode.VisitedNodes.Add(repoUri);
             // Nodes to visit is a queue, so that the evaluation order
             // of the graph is breadth first.
@@ -539,25 +470,11 @@ namespace Microsoft.DotNet.DarcLib
                 uniqueDependencyDetails = new HashSet<DependencyDetail>(
                     rootGraphNode.Dependencies,
                     new DependencyDetailComparer());
-                // Remove the dependencies details from the
-                // break on if break on type is Dependencies
-                if (breakOnType == EarlyBreakOnType.Dependencies)
-                {
-                    rootGraphNode.Dependencies.Select(d => breakOn.Remove(d.Name));
-                }
             }
             else
             {
                 uniqueDependencyDetails = new HashSet<DependencyDetail>(
                     new DependencyDetailComparer());
-            }
-
-            // If we already found the assets/dependencies we wanted, clear the
-            // visit list and we'll drop through.
-            if (breakOnType != EarlyBreakOnType.None && breakOn.Count == 0)
-            {
-                logger.LogInformation($"Stopping graph build after finding all assets/dependencies.");
-                nodesToVisit.Clear();
             }
 
             // Cache of nodes we've visited. If we reach a repo/commit combo already in the cache,
@@ -619,6 +536,14 @@ namespace Microsoft.DotNet.DarcLib
                             continue;
                         }
 
+                        if (options.LookupBuilds)
+                        {
+                            if (!buildLookupTasks.ContainsKey($"{dependency.RepoUri}@{dependency.Commit}"))
+                            {
+                                buildLookupTasks.Add($"{dependency.RepoUri}@{dependency.Commit}", barOnlyRemote.GetBuildsAsync(dependency.RepoUri, dependency.Commit));
+                            }
+                        }
+
                         // If the dependency's repo uri has been traversed, we've reached a cycle in this subgraph
                         // and should break.
                         if (node.VisitedNodes.Contains(dependency.RepoUri))
@@ -647,57 +572,10 @@ namespace Microsoft.DotNet.DarcLib
                             incoherentDependenciesCache.Add(dependency.Name, dependency);
                         }
 
-                        HashSet<Build> nodeContributingBuilds = null;
-                        if (options.LookupBuilds)
-                        {
-                            nodeContributingBuilds = new HashSet<Build>(new BuildComparer());
-                            // Look up dependency in cache first
-                            if (dependencyCache.TryGetValue(dependency, out Build existingBuild))
-                            {
-                                nodeContributingBuilds.Add(existingBuild);
-                                allContributingBuilds.Add(existingBuild);
-                            }
-                            else
-                            {
-                                // Look up the dependency and get the creating build.
-                                IRemote barOnlyRemote = await remoteFactory.GetBarOnlyRemoteAsync(logger);
-                                IEnumerable<Build> potentiallyContributingBuilds = await barOnlyRemote.GetBuildsAsync(dependency.RepoUri, dependency.Commit);
-                                // Filter by those actually producing the dependency. Most of the time this won't
-                                // actually result in a different set of contributing builds, but should avoid any subtle bugs where
-                                // there might be overlap between repos, or cases where there were multiple builds at the same sha.
-                                potentiallyContributingBuilds = potentiallyContributingBuilds.Where(b =>
-                                    b.Assets.Any(a => assetEqualityComparer.Equals(a, dependency)));
-                                if (!potentiallyContributingBuilds.Any())
-                                {
-                                    // Couldn't find a build that produced the dependency.
-                                    dependenciesMissingBuilds.Add(dependency);
-                                }
-                                else
-                                {
-                                    foreach (Build build in potentiallyContributingBuilds)
-                                    {
-                                        allContributingBuilds.Add(build);
-                                        nodeContributingBuilds.Add(build);
-                                        AddAssetsToBuildCache(build, dependencyCache, breakOnType, breakOn);
-                                    }
-                                }
-                            }
-                        }
-
                         // We may have visited this node before.  If so, add it as a child and avoid additional walks.
                         // Update the list of contributing builds.
                         if (nodeCache.TryGetValue($"{dependency.RepoUri}@{dependency.Commit}", out DependencyGraphNode existingNode))
                         {
-                            if (options.LookupBuilds)
-                            {
-                                // Add the contributing builds. It's possible that
-                                // different dependencies on a single node (repo/sha) were produced
-                                // from multiple builds
-                                foreach (Build build in nodeContributingBuilds)
-                                {
-                                    existingNode.ContributingBuilds.Add(build);
-                                }
-                            }
                             logger.LogInformation($"Node {dependency.RepoUri}@{dependency.Commit} has already been created, adding as child");
                             node.AddChild(existingNode, dependency);
                             continue;
@@ -709,14 +587,14 @@ namespace Microsoft.DotNet.DarcLib
                             dependency.Commit,
                             null,
                             node.VisitedNodes,
-                            nodeContributingBuilds);
-                        
+                            null);
+
                         // Cache the dependency and add it to the visitation stack.
                         nodeCache.Add($"{dependency.RepoUri}@{dependency.Commit}", newNode);
                         nodesToVisit.Enqueue(newNode);
                         newNode.VisitedNodes.Add(dependency.RepoUri);
                         node.AddChild(newNode, dependency);
-                        
+
                         // Calculate incoherencies. If we've not yet visited the repo uri, add the
                         // new node based on its repo uri. Otherwise, add both the new node and the visited
                         // node to the incoherent nodes.
@@ -729,25 +607,18 @@ namespace Microsoft.DotNet.DarcLib
                         {
                             visitedRepoUriNodes.Add(newNode.Repository, newNode);
                         }
-
-                        // If breaking on dependencies, then decide whether we need to break
-                        // here.
-                        if (breakOnType == EarlyBreakOnType.Dependencies)
-                        {
-                            breakOn.Remove(dependency.Name);
-                        }
-
-                        if (breakOnType != EarlyBreakOnType.None && breakOn.Count == 0)
-                        {
-                            logger.LogInformation($"Stopping graph build after finding all assets/dependencies.");
-                            nodesToVisit.Clear();
-                            break;
-                        }
                     }
                 }
             }
 
-            switch(options.NodeDiff)
+            if (options.LookupBuilds)
+            {
+                allContributingBuilds = await ComputeContributingBuildsAsync(buildLookupTasks,
+                                                                             nodeCache.Values,
+                                                                             logger);
+            }
+
+            switch (options.NodeDiff)
             {
                 case NodeDiff.None:
                     // Nothing
@@ -766,8 +637,77 @@ namespace Microsoft.DotNet.DarcLib
                                        nodeCache.Values,
                                        incoherentNodes,
                                        allContributingBuilds,
-                                       dependenciesMissingBuilds,
                                        cycles);
+        }
+
+        /// <summary>
+        /// Compute which builds contribute to each node in the graph, as well as the overall graph
+        /// </summary>
+        /// <param name="buildLookupTasks">Set of tasks that are looking up builds</param>
+        /// <param name="allNodes">All nodes in the graph</param>
+        /// <param name="logger">Logger</param>
+        /// <returns></returns>
+        private static async Task<List<Build>> ComputeContributingBuildsAsync(Dictionary<string, Task<IEnumerable<Build>>> buildLookupTasks,
+                                                                              IEnumerable<DependencyGraphNode> allNodes,
+                                                                              ILogger logger)
+        {
+            AssetComparer assetEqualityComparer = new AssetComparer();
+            logger.LogInformation($"Computing contributing builds");
+
+            List<Build> allContributingBuilds = new List<Build>();
+
+            foreach (DependencyGraphNode node in allNodes)
+            {
+                node.ContributingBuilds = new HashSet<Build>(new BuildComparer());
+                IEnumerable<Build> potentiallyContributingBuilds = await buildLookupTasks[$"{node.Repository}@{node.Commit}"];
+
+                // Filter down. The parent nodes of this node may have specific dependency versions that narrow down
+                // which potential builds this could be.  For instance, if sha A was built twice, producing asset B.1 and B.2,
+                // we wouldn't know which by a simple query. But we can narrow the potential
+                // builds by any of those that produced assets that match any parent's dependency name+version
+                foreach (var potentialContributingBuild in potentiallyContributingBuilds)
+                {
+                    if (BuildContributesToNode(node, potentialContributingBuild))
+                    {
+                        allContributingBuilds.Add(potentialContributingBuild);
+                        node.ContributingBuilds.Add(potentialContributingBuild);
+                    }
+                }
+            }
+
+            logger.LogInformation($"Done computing contributing builds");
+
+            return allContributingBuilds;
+        }
+        
+        /// <summary>
+        /// Determines whether a build contributes to a given node by looking at the parents'
+        /// input dependencies. If there are no parents, then we assume that the build could contribute.
+        /// </summary>
+        /// <param name="node">Node</param>
+        /// <param name="potentialContributingBuild">Potentially contributing build</param>
+        /// <returns>True if the build contributes, false otherwise.</returns>
+        private static bool BuildContributesToNode(DependencyGraphNode node, Build potentialContributingBuild)
+        {
+            if (!node.Parents.Any())
+            {
+                return true;
+            }
+
+            AssetComparer assetEqualityComparer = new AssetComparer();
+            foreach (DependencyGraphNode parentNode in node.Parents)
+            {
+                foreach (var dependency in parentNode.Dependencies)
+                {
+                    if (dependency.Commit == node.Commit &&
+                        dependency.RepoUri == node.Repository &&
+                        potentialContributingBuild.Assets.Any(a => assetEqualityComparer.Equals(a, dependency)))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
 
         /// <summary>
@@ -811,41 +751,6 @@ namespace Microsoft.DotNet.DarcLib
             }
 
             return allCyclesRootedAtNode;
-        }
-
-        /// <summary>
-        ///     Add the assets from each build to the cache.
-        ///     Also evaluate whether we see any of the assets that we are supposed to break
-        ///     on, and remove them from the break on set if so.
-        /// </summary>
-        /// <param name="build">Build producing assets</param>
-        /// <param name="dependencyCache">Dependency cache</param>
-        /// <param name="earlyBreakOnType">Early break on type</param>
-        /// <param name="breakOn">Hash set of assets. Any assets in the <paramref name="build"/>
-        ///     that exist in <paramref name="breakOn"/> will be removed from
-        ///     <paramref name="breakOn"/> if <paramref name="earlyBreakOnType"/> is "Assets"</param>
-        private static void AddAssetsToBuildCache(
-            Build build, 
-            Dictionary<DependencyDetail, Build> dependencyCache,
-            EarlyBreakOnType earlyBreakOnType,
-            HashSet<string> breakOn)
-        {
-            foreach (Asset buildAsset in build.Assets)
-            {
-                DependencyDetail newDependency =
-                    new DependencyDetail() { Name = buildAsset.Name, Version = buildAsset.Version, Commit = build.Commit };
-                // Possible that the same asset could be listed multiple times in a build, so avoid accidentally adding
-                // things multiple times
-                if (!dependencyCache.ContainsKey(newDependency))
-                {
-                    dependencyCache.Add(newDependency, build);
-                }
-
-                if (earlyBreakOnType == EarlyBreakOnType.Assets)
-                {
-                    breakOn.Remove(buildAsset.Name);
-                }
-            }
         }
 
         private static string GetRepoPath(

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraphNode.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraphNode.cs
@@ -52,7 +52,11 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         public readonly string Commit;
 
+        /// <summary>
+        /// Builds that potentially contributed the assets in this node in the graph.
+        /// </summary>
         public HashSet<Build> ContributingBuilds { get; set; }
+
         /// <summary>
         ///     Dependencies of the node at RepoUri and Commit.
         /// </summary>


### PR DESCRIPTION
Up to this point, CPD has some odd quirks. It chooses the dependency that it wants to update to based how shallow the asset it finds it in the graph (lowest wins). But it does so using incomplete information in some cases. In order to improve the overall performance of CPD, most of which is graph build time, the graph build was aborted when a specific set of assets was found. This might lead to some odd choices. For instance, if a repo depends on two input dependencies from repo A, one pinned and one not pinned, then a CPD that is reachable from those two dependencies will could potentially choose to update based on the pinned input.

These choices are not wrong, but they aren't usually what the user wants. The user often just wants the path to the newest potential dependency. Doing this requires that a full build of the graph be done, which is pretty inefficient. A full build with necessary information for CPD from dotnet/extensions, for instance, was just under 2 minutes. After looking into this, I discovered that the GetBuildsAsync call was the majority of the time. Without this, the build is ~10 seconds. Most of this is because the GetBuildAsync call blocks further evaluation of the graph. On the plus side, the results of the calls aren't really needed during build, though steps need to be taken to avoid excessive calls.

What I ended up doing was starting the GetBuildsAsync calls each time a new required one was identified, then only analyzing the results at the very end of the graph build, before handing the data back to the caller.  Thus, the calls end up largely running in parallel and we only block on the results at the very end. In the process, I was able to remove a bunch of complexity as we no longer have a need for the early break build modes. The build takes at least an order of magnitude less time, quite possibly a lot more. The reuslts for a full graph build are identical to before.

The CPD algorithm is then changes to choose the newest asset with a matching name in the graph, and some additional complexity can be removed where we needed to rebuild the graph in some cases if the previous build was incomplete.