### PR TITLE
Make Microsoft.DotNet.Kusto packable

### DIFF
--- a/src/Shared/Microsoft.DotNet.Kusto/Microsoft.DotNet.Kusto.csproj
+++ b/src/Shared/Microsoft.DotNet.Kusto/Microsoft.DotNet.Kusto.csproj
@@ -8,6 +8,7 @@
     <LangVersion>7.1</LangVersion>
     <RootNamespace>Microsoft.DotNet.Kusto</RootNamespace>
     <AssemblyName>Microsoft.DotNet.Kusto</AssemblyName>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
I need the Microsoft.DotNet.Kusto package in a project in dotnet-helix-machine so I need it to be published as a package as some other projects in this solution.