### PR TITLE
Use the endpoint parameter during Notify deployment end job

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -176,7 +176,7 @@ stages:
       displayName: Notify dotnet-eng-staus/end
       continueOnError: true
       inputs:
-        serviceConnection: .NET Engineering Deployment Notification - Staging
+        serviceConnection: ${{ parameters.DotNetStatusEndpoint }}
         method: POST
         urlSuffix: /arcade-services/$(Build.BuildNumber)/end
   - job: updateMetrics


### PR DESCRIPTION
I believe this is the fix for https://github.com/dotnet/core-eng/issues/8638