### PR TITLE
Add missing alert label required for finding open issue

### DIFF
--- a/src/DotNet.Status.Web/Controllers/AlertHookController.cs
+++ b/src/DotNet.Status.Web/Controllers/AlertHookController.cs
@@ -181,6 +181,7 @@ namespace DotNet.Status.Web.Controllers
 ".Replace("\r\n","\n")
             };
 
+            issue.Labels.Add(NotificationIdLabel);
             issue.Labels.Add(ActiveAlertLabel);
             foreach (string label in options.AlertLabels.OrEmpty())
             {


### PR DESCRIPTION
We weren't adding this label, which is the label we attempt to use to find a live issue to mark it as "inactive"