### PR TITLE
uid is, of course, a string now

### DIFF
--- a/src/Monitoring/Sdk/GrafanaClient.cs
+++ b/src/Monitoring/Sdk/GrafanaClient.cs
@@ -156,7 +156,7 @@ namespace Microsoft.DotNet.Monitoring.Sdk
                 (d, x) =>
                 {
                     d["id"] = x.Value<int>("id");
-                    d["uid"] = x.Value<int>("uid");
+                    d["uid"] = x.Value<string>("uid");
                     d["version"] = x.Value<int>("version");
                 }
             );


### PR DESCRIPTION
The most recent deployment changed the uid to a string (as it should, it should be "statusHook"), but that breaks the <int> cast we had when trying to update it.