### PR TITLE
Also take the path into account when storing/retrieving an eng/common…

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -426,7 +426,8 @@ namespace Microsoft.DotNet.DarcLib
             // arcade update sent to each repository daily per subscription. This is inefficient, as it means we
             // request each file N times, where N is the number of subscriptions. The number of files (M),
             // is non-trivial, so reducing N*M to M is vast improvement.
-            // Use the treeItem.Sha as the key. I think it is overkill to hash the repo and owner into
+            // Use a combination of (treeItem.Path, treeItem.Sha as the key) as items with identical contents but
+            // different paths will have the same SHA. I think it is overkill to hash the repo and owner into
             // the key.
 
             if (Cache != null)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -431,7 +431,7 @@ namespace Microsoft.DotNet.DarcLib
 
             if (Cache != null)
             {
-                return await Cache.GetOrCreateAsync(treeItem.Sha, async (entry) =>
+                return await Cache.GetOrCreateAsync((treeItem.Path, treeItem.Sha), async (entry) =>
                 {
                     GitFile file = await GetGitItemImpl(path, treeItem, owner, repo);
 


### PR DESCRIPTION
… file in the cache

This is the fix for https://github.com/dotnet/arcade/issues/4701

This should also close https://github.com/dotnet/core-eng/issues/7180, as we have tests for the caching logic that no one remembered about.