### PR TITLE
Move to vs2017-win2016 image for scenario tests

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -217,7 +217,7 @@ stages:
 - stage: validateDeployment
   displayName: Validate deployment
   pool:
-    vmImage: windows-2019
+    vmImage: vs2017-win2016
   dependsOn: 
   - deploy
   variables:


### PR DESCRIPTION
It looks like the vs2019 image causes the powershell based tests to fail: https://github.com/dotnet/core-eng/issues/8884

I tested this image in this "validate only" deployment of a test branch: https://dev.azure.com/dnceng/internal/_build/results?buildId=514478&view=results

