### PR TITLE
Add json option for manifest file creation

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 }
 
                 // Write the unified drop manifest
-                await WriteDropManifest(downloadedBuilds, _options.OutputDirectory);
+                await WriteDropManifestAsync(downloadedBuilds, _options.OutputDirectory);
 
                 // Write the release json
                 await WriteReleaseJson(downloadedBuilds, _options.OutputDirectory);
@@ -375,7 +375,7 @@ namespace Microsoft.DotNet.Darc.Operations
         ///     Write out a manifest of the items in the drop
         /// </summary>
         /// <returns></returns>
-        private async Task WriteDropManifest(List<DownloadedBuild> downloadedBuilds, string outputDirectory)
+        private async Task WriteDropManifestAsync(List<DownloadedBuild> downloadedBuilds, string outputDirectory)
         {
             if (_options.DryRun)
             {
@@ -386,10 +386,10 @@ namespace Microsoft.DotNet.Darc.Operations
             switch(_options.OutputFormat)
             {
                 case DarcOutputType.yaml:
-                    await WriteYamlDropManifest(downloadedBuilds, Path.Combine(outputDirectory, "manifest.yaml"));
+                    await WriteYamlDropManifestAsync(downloadedBuilds, Path.Combine(outputDirectory, "manifest.yaml"));
                     break;
                 case DarcOutputType.json:
-                    await WriteJsonDropManifest(downloadedBuilds, Path.Combine(outputDirectory, "manifest.json"));
+                    await WriteJsonDropManifestAsync(downloadedBuilds, Path.Combine(outputDirectory, "manifest.json"));
                     break;
                 default:
                     throw new NotImplementedException($"Darc output type {_options.OutputFormat} not supported in manifest generation");
@@ -402,7 +402,7 @@ namespace Microsoft.DotNet.Darc.Operations
         /// <param name="downloadedBuilds">List of downloaded builds in the manifest</param>
         /// <param name="outputPath">Output file path of the manifest</param>
         /// <returns>Async task</returns>
-        private async Task WriteYamlDropManifest(List<DownloadedBuild> downloadedBuilds, string outputPath)
+        private async Task WriteYamlDropManifestAsync(List<DownloadedBuild> downloadedBuilds, string outputPath)
         {
             if (_options.Overwrite)
             {
@@ -440,7 +440,7 @@ namespace Microsoft.DotNet.Darc.Operations
         /// <param name="downloadedBuilds">List of downloaded builds in the manifest</param>
         /// <param name="outputPath">Output file path of the manifest</param>
         /// <returns>Async task</returns>
-        private async Task WriteJsonDropManifest(List<DownloadedBuild> downloadedBuilds, string outputPath)
+        private async Task WriteJsonDropManifestAsync(List<DownloadedBuild> downloadedBuilds, string outputPath)
         {
             // Construct an ad-hoc object with the necessary fields and use the json
             // serializer to write it to disk
@@ -455,7 +455,7 @@ namespace Microsoft.DotNet.Darc.Operations
                         branch = build.Build.AzureDevOpsBranch,
                         produced = build.Build.DateProduced,
                         buildNumber = build.Build.AzureDevOpsBuildNumber,
-                        barBuildID = build.Build.Id,
+                        barBuildId = build.Build.Id,
                         assets = build.DownloadedAssets.Select(asset =>
                         new
                         {
@@ -749,7 +749,7 @@ namespace Microsoft.DotNet.Darc.Operations
             // If separated drop, generate a manifest per build
             if (_options.ReleaseLayout)
             {
-                await WriteDropManifest(new List<DownloadedBuild>() { newBuild }, outputDirectory);
+                await WriteDropManifestAsync(new List<DownloadedBuild>() { newBuild }, outputDirectory);
             }
 
             return newBuild;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/CommandLineOptions.cs
@@ -30,6 +30,10 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("git-location", Default = "git", HelpText = "Location of git executable used for internal commands.")]
         public string GitLocation { get; set; }
 
+        [Option("output-format", Default = DarcOutputType.yaml,
+            HelpText = "Desired output type of darc. Valid values are 'json' and 'yaml'. Case sensitive.")]
+        public DarcOutputType OutputFormat { get; set; }
+
         public abstract Operation GetOperation();
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/DarcOutputType.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/DarcOutputType.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Darc.Options
     /// Output type that darc should use. Commandline enum parsing is case sensitive
     /// so we put these as lower case.
     /// </summary>
-    enum DarcOutputType
+    public enum DarcOutputType
     {
         yaml,
         json

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/DarcOutputType.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/DarcOutputType.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.Darc.Options
+{
+    /// <summary>
+    /// Output type that darc should use. Commandline enum parsing is case sensitive
+    /// so we put these as lower case.
+    /// </summary>
+    enum DarcOutputType
+    {
+        yaml,
+        json
+    }
+}


### PR DESCRIPTION
- Add a global option to darc to switch to yaml/json.
- Implement option for gather-drop's manifest generation

Uses newtonsoft.json rather than System.Text.Json because of the netstandard2.1 target