### PR TITLE
Improve graph display

### DIFF
--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/ChannelsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/ChannelsController.cs
@@ -319,6 +319,7 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
         /// <param name="includedFrequencies">Frequencies to include</param>
         /// <param name="includeBuildTimes">If we should create the flow graph with build times</param>
         /// <param name="days">Number of days over which to summarize build times</param>
+        /// <param name="includeArcade">If we should include arcade in the flow graph</param>
         [HttpGet("{channelId}/graph")]
         [SwaggerApiResponse(HttpStatusCode.OK, Type = typeof(FlowGraph), Description = "The dependency flow graph for a channel")]
         [ValidateModelState]
@@ -329,7 +330,8 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
             IEnumerable<string> includedFrequencies = default,
 #pragma warning restore API0001 // Versioned API methods should not expose non-versioned types.
             bool includeBuildTimes = false,
-            int days = 7)
+            int days = 7,
+            bool includeArcade = true)
         {
             var barOnlyRemote = await _remoteFactory.GetBarOnlyRemoteAsync(Logger);
 
@@ -338,26 +340,29 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
 
             List<Microsoft.DotNet.Maestro.Client.Models.DefaultChannel> defaultChannels = (await barOnlyRemote.GetDefaultChannelsAsync()).ToList();
 
-            if (engLatestChannel != null)
+            if (includeArcade)
             {
-                defaultChannels.Add(
-                    new Microsoft.DotNet.Maestro.Client.Models.DefaultChannel(0, "https://github.com/dotnet/arcade", true)
-                    {
-                        Branch = "master",
-                        Channel = engLatestChannel
-                    }
-                );
-            }
+                if (engLatestChannel != null)
+                {
+                    defaultChannels.Add(
+                        new Microsoft.DotNet.Maestro.Client.Models.DefaultChannel(0, "https://github.com/dotnet/arcade", true)
+                        {
+                            Branch = "master",
+                            Channel = engLatestChannel
+                        }
+                    );
+                }
 
-            if (eng3Channel != null)
-            {
-                defaultChannels.Add(
-                    new Microsoft.DotNet.Maestro.Client.Models.DefaultChannel(0, "https://github.com/dotnet/arcade", true)
-                    {
-                        Branch = "release/3.x",
-                        Channel = eng3Channel
-                    }
-                );
+                if (eng3Channel != null)
+                {
+                    defaultChannels.Add(
+                        new Microsoft.DotNet.Maestro.Client.Models.DefaultChannel(0, "https://github.com/dotnet/arcade", true)
+                        {
+                            Branch = "release/3.x",
+                            Channel = eng3Channel
+                        }
+                    );
+                }
             }
 
             List<Microsoft.DotNet.Maestro.Client.Models.Subscription> subscriptions = (await barOnlyRemote.GetSubscriptionsAsync()).ToList();

--- a/src/Maestro/maestro-angular/src/app/app-routing.module.ts
+++ b/src/Maestro/maestro-angular/src/app/app-routing.module.ts
@@ -21,6 +21,14 @@ const routes: Routes = [
   {
     path: ":channelId/graph",
     component: ChannelComponent,
+    data: {
+      title(params: any) {
+        return `Channel ${params.channelId}`;
+      },
+      name(params: any) {
+        return `Channel ${params.channelId}`;
+      }
+    },
   },
   {
     path: ":channelId/:repository",

--- a/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
@@ -87,6 +87,8 @@ export class ChannelGraphComponent implements AfterContentInit {
 
   ngAfterContentInit() {
     var g = new graphlib.Graph().setGraph({
+      marginy: 0,
+      marginx: 0,
       ranker: 'tight-tree'
     });
 
@@ -148,7 +150,9 @@ export class ChannelGraphComponent implements AfterContentInit {
       .text(function(v:any) { return g.edge(v).description });
   
     var bbox = (svg.node() as SVGGraphicsElement).getBBox();
+    var height = bbox.height < 800 ? 800 : bbox.height;
+    var width = bbox.width < 800 ? 800 : bbox.width;
 
-    svg.attr("viewBox", `0 0 ${bbox.width} ${bbox.height}`);
+    svg.attr("viewBox", `0 0 ${width} ${height}`);
   }
 }

--- a/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
@@ -11,8 +11,10 @@ function getRepositoryShortName(repo:string): string {
 }
 
 function getNodeLabel(node:FlowRef): string {
-  return `${getRepositoryShortName(node.repository)}\n`+
-         `${node.branch}`;
+  // The div makes the styling look better and centers the text
+  // Split the org and the repository on separate lines to make the nodes shorter
+  return `<div style="width:auto; height:auto;">${getRepositoryShortName(node.repository).split('/').join("<br>")}<br>`+
+         `${node.branch}</div>`;
 }
 
 function getNodeTitle(node:FlowRef): string {
@@ -84,12 +86,15 @@ export class ChannelGraphComponent implements AfterContentInit {
   constructor() { }
 
   ngAfterContentInit() {
-    var g = new graphlib.Graph().setGraph({});
+    var g = new graphlib.Graph().setGraph({
+      ranker: 'tight-tree'
+    });
 
     if (this.graph)
     {
       for ( var flowRef of this.graph.nodes ) {
         let nodeProperties:any = { 
+          labelType: "html",
           label: getNodeLabel(flowRef),
           title: getNodeTitle(flowRef),
           description: getNodeDescription(flowRef),
@@ -101,7 +106,7 @@ export class ChannelGraphComponent implements AfterContentInit {
 
         g.setNode(flowRef.id, nodeProperties);
       }
-      
+
       for (var edge of this.graph.edges) {
         let edgeProperties:any = { arrowheadClass: 'arrowhead',
                       description: getEdgeDescription(edge, this.graph)};
@@ -112,9 +117,14 @@ export class ChannelGraphComponent implements AfterContentInit {
         }
         
         g.setEdge(edge.fromId.toString(), edge.toId.toString(), edgeProperties);
-
       }
     }
+
+    // Round the node corners
+    g.nodes().forEach(function(v) {
+      var node = g.node(v);
+      node.rx = node.ry = 5;
+    });
 
     var render_graph = new render();
 

--- a/src/Maestro/maestro-angular/src/app/page/channel/channel.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/channel/channel.component.html
@@ -1,10 +1,12 @@
 <div class="d-flex flex-column" style="height: 100%;">
-      <h5 class="card-title">
-        Channel
-      </h5>
-      <div class="container-fluid" style="height: 100%;">
-        <ng-container *stateful="let graph from graph$">
-          <mc-channel-graph [graph]="graph"></mc-channel-graph>
-        </ng-container>
-      </div>
+  <ng-container *stateful="let channel from channel$">
+    <h5 class="card-title">
+      {{channel.name}}
+    </h5>
+  </ng-container>
+  <div class="container-fluid" style="height: 100%;">
+    <ng-container *stateful="let graph from graph$">
+      <mc-channel-graph [graph]="graph"></mc-channel-graph>
+    </ng-container>
+  </div>
 </div>

--- a/src/Maestro/maestro-angular/src/app/page/channel/channel.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/channel/channel.component.html
@@ -1,9 +1,9 @@
 <div class="d-flex flex-column" style="height: 100%;">
-  <ng-container *stateful="let channel from channel$">
-    <h5 class="card-title">
+  <h5 class="card-title">
+    <ng-container *stateful="let channel from channel$">
       {{channel.name}}
-    </h5>
-  </ng-container>
+    </ng-container>
+  </h5>
   <div class="container-fluid" style="height: 100%;">
     <ng-container *stateful="let graph from graph$">
       <mc-channel-graph [graph]="graph"></mc-channel-graph>

--- a/src/Maestro/maestro-angular/src/app/page/channel/channel.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel/channel.component.ts
@@ -18,6 +18,7 @@ export class ChannelComponent implements OnInit {
   constructor(private route: ActivatedRoute, private channelService: ChannelService, private maestroService: MaestroService) { }
 
   public graph$!: Observable<StatefulResult<FlowGraph>>;
+  public channel$?: Observable<StatefulResult<Channel>>;
 
   ngOnInit() {
     const channelId$ = this.route.paramMap.pipe(
@@ -34,6 +35,14 @@ export class ChannelComponent implements OnInit {
         console.log("Params: ", v);
       })
     );
+
+    this.channel$ = channelId$.pipe(
+      statefulPipe(
+        statefulSwitchMap((id) => {
+          return this.channelService.getChannel(id);
+        })
+      )
+    )
 
     this.graph$ = channelId$.pipe(
       statefulPipe(

--- a/src/Maestro/maestro-angular/src/app/services/channel.service.ts
+++ b/src/Maestro/maestro-angular/src/app/services/channel.service.ts
@@ -44,21 +44,15 @@ export class ChannelService {
     return this.channels$;
   }
 
+  public getChannel(id: number): Observable<Channel> {
+    return this.maestro.channels.getChannelAsync({id});
+  }
+
   public getRepositories(channelId: number): Observable<DefaultChannel[]> {
     return this.buildRepositoriesList(channelId);
   }
 
   public getFlowGraph(id: number): Observable<StatefulResult<FlowGraph>> {
-    // return of(channelId).pipe(
-    //   statefulSwitchMap(id => {
-    //     if (id in ChannelService.graphCache) {
-    //       return of(ChannelService.graphCache[id]);
-    //     }
-    //     return this.maestro.channels.getFlowGraphAsync({id}).pipe(
-    //       tap(graph => ChannelService.graphCache[id] = graph),
-    //     );
-    //   }),
-    // );
     if (id in ChannelService.graphCache) {
       return of(ChannelService.graphCache[id]);
     }

--- a/src/Maestro/maestro-angular/src/maestro-client/maestro.ts
+++ b/src/Maestro/maestro-angular/src/maestro-client/maestro.ts
@@ -1152,7 +1152,8 @@ export class ChannelsApiService implements IChannelsApi {
 
         queryParameters = queryParameters.set("includeDisabledSubscriptions", "false");
         queryParameters = queryParameters.set("includeBuildTimes", "true");
-        queryParameters = queryParameters.set("days", "7");
+        queryParameters = queryParameters.set("days", "30");
+        queryParameters = queryParameters.set("includeArcade", "false");
 
         queryParameters = queryParameters.set("api-version", apiVersion);
 

--- a/src/Maestro/maestro-angular/src/themes/_base.scss
+++ b/src/Maestro/maestro-angular/src/themes/_base.scss
@@ -137,11 +137,16 @@ mc-switch {
 .flowgraph {
   height: 95%;
   width: 95%;
-  
+    
   text {
     display: inline;
     font-weight: lighter;
     letter-spacing: 2px;
+  }
+
+  div {
+    line-height: 110%;
+    font-weight: normal;
   }
   
   .node rect {


### PR DESCRIPTION
To improve the viewability of the flow graph, this change:

* Adds includeArcade option to GetFlowGraphAsync so that on barviz we can exclude arcade and its children from the graph
* Splits the organization and repository name in node labels
* Puts the label in a div to improve font size
* Changes the ranker algorithm to tight-tree
* Round the corners of the nodes
* Increases the number of days to summarize over to 30
* Add GetChannel(id) so that we can display the channel name in the header of the graph, rather than just "Channel"

Also fixes some indentation and removes some commented out code.

Future work will be to enable the user to toggle between including arcade and excluding arcade, and potentially further extending this to toggling only the longest build path vs. the entire tree.

<img width="1598" alt="Screen Shot 2020-02-13 at 2 33 54 PM" src="https://user-images.githubusercontent.com/9666644/74484667-e0509280-4e6d-11ea-89f0-43061d527879.png">
