### PR TITLE
Make Darc wait for the promotion build to finish. Add option to not wait

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -140,9 +140,9 @@ namespace Microsoft.DotNet.Darc.Operations
 
             Console.WriteLine($"Build {build.Id} will be assigned to channel '{targetChannel.Name}' once this build finishes publishing assets: {promotionBuildUrl}");
 
-            if (_options.NoWaitPublishing)
+            if (_options.NoWait)
             {
-                Console.WriteLine("Returning before asset publishing and build to channel assignment finishes. The operation continues asynchronously in AzDO.");
+                Console.WriteLine("Returning before asset publishing and channel assignment finishes. The operation continues asynchronously in AzDO.");
                 return Constants.SuccessCode;
             }
 
@@ -153,7 +153,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 do
                 {
-                    Console.WriteLine($"Waiting more {waitIntervalInSeconds.TotalSeconds} seconds for promotion build to complete.");
+                    Console.WriteLine($"Waiting '{waitIntervalInSeconds.TotalSeconds}' seconds for promotion build to complete.");
                     await Task.Delay(waitIntervalInSeconds);
                     promotionBuild = await azdoClient.GetBuildAsync(BuildPromotionPipelineAccountName, BuildPromotionPipelineProjectName, azdoBuildId);
                 } while (!promotionBuild.Status.Equals("completed", StringComparison.OrdinalIgnoreCase));

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
@@ -43,8 +43,8 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("skip-assets-publishing", HelpText = "Add the build to the channel without publishing assets to the channel's feeds.")]
         public bool SkipAssetsPublishing { get; set; }
 
-        [Option("no-wait-promotion", HelpText = "If set Darc won't wait for the promotion build to finish execution.")]
-        public bool NoWaitPromotionBuild { get; set; }
+        [Option("no-wait-publishing", HelpText = "If set, Darc won't wait for the asset publishing and build to channel assignment. The operation continues asynchronously in AzDO.")]
+        public bool NoWaitPublishing { get; set; }
 
         public override Operation GetOperation()
         {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
@@ -43,6 +43,9 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("skip-assets-publishing", HelpText = "Add the build to the channel without publishing assets to the channel's feeds.")]
         public bool SkipAssetsPublishing { get; set; }
 
+        [Option("no-wait-promotion", HelpText = "If set Darc won't wait for the promotion build to finish execution.")]
+        public bool NoWaitPromotionBuild { get; set; }
+
         public override Operation GetOperation()
         {
             return new AddBuildToChannelOperation(this);

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
@@ -43,8 +43,8 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("skip-assets-publishing", HelpText = "Add the build to the channel without publishing assets to the channel's feeds.")]
         public bool SkipAssetsPublishing { get; set; }
 
-        [Option("no-wait-publishing", HelpText = "If set, Darc won't wait for the asset publishing and build to channel assignment. The operation continues asynchronously in AzDO.")]
-        public bool NoWaitPublishing { get; set; }
+        [Option("no-wait", HelpText = "If set, Darc won't wait for the asset publishing and channel assignment. The operation continues asynchronously in AzDO.")]
+        public bool NoWait { get; set; }
 
         public override Operation GetOperation()
         {


### PR DESCRIPTION
Make Darc add-build-to-channel wait (by default) for the promotion build to finish and report back to the user the result. Add option to let user tell Darc not to wait for said build.

Example outputs:

Default scenario (wait for promotion to finish) + success promotion:

```
PS C:\Users\disoares> dotnet C:\Workfolder\arcade-services\artifacts\bin\Microsoft.DotNet.Darc\Debug\netcoreapp2.1\Microsoft.DotNet.Darc.dll add-build-to-channel --id 43561 --channel "general testing"
Assigning the following build to channel 'General Testing':

Repository:    https://dev.azure.com/dnceng/internal/_git/dotnet-arcade
Branch:        refs/heads/FixConflictCheck
Commit:        07f46d783c0b017718a9c2c22e0a0e039bc8ae45
Build Number:  20200219.3
Date Produced: 2/19/2020 11:28 AM
Build Link:    https://dev.azure.com/dnceng/internal/_build/results?buildId=528180
BAR Build Id:  43561
Released:      False
Channels:
Build 43561 will be assigned to channel 'General Testing' once this promotion build finishes: https://dnceng.visualstudio.com/internal/_build/results?buildId=528557
Waiting more 60 seconds for promotion build to complete.
Waiting more 60 seconds for promotion build to complete.
Waiting more 60 seconds for promotion build to complete.
Waiting more 60 seconds for promotion build to complete.
Waiting more 60 seconds for promotion build to complete.
Build '43561' was successfully added to channel '529'
```

With the **no-wait-promotion** parameter:
```
PS C:\Users\disoares> dotnet C:\Workfolder\arcade-services\artifacts\bin\Microsoft.DotNet.Darc\Debug\netcoreapp2.1\Microsoft.DotNet.Darc.dll add-build-to-channel --id 43561 --channel "general testing" --no-wait-promotion
Assigning the following build to channel 'General Testing':

Repository:    https://dev.azure.com/dnceng/internal/_git/dotnet-arcade
Branch:        refs/heads/FixConflictCheck
Commit:        07f46d783c0b017718a9c2c22e0a0e039bc8ae45
Build Number:  20200219.3
Date Produced: 2/19/2020 11:28 AM
Build Link:    https://dev.azure.com/dnceng/internal/_build/results?buildId=528180
BAR Build Id:  43561
Released:      False
Channels:
Build 43561 will be assigned to channel 'General Testing' once this promotion build finishes: https://dnceng.visualstudio.com/internal/_build/results?buildId=528555
Returning before the promotion build finish.
```

When a build is **canceled** and Darc was waiting for it to finish:

```
PS C:\Users\disoares> dotnet C:\Workfolder\arcade-services\artifacts\bin\Microsoft.DotNet.Darc\Debug\netcoreapp2.1\Microsoft.DotNet.Darc.dll add-build-to-channel --id 43561 --channel "general testing"
Assigning the following build to channel 'General Testing':

Repository:    https://dev.azure.com/dnceng/internal/_git/dotnet-arcade
Branch:        refs/heads/FixConflictCheck
Commit:        07f46d783c0b017718a9c2c22e0a0e039bc8ae45
Build Number:  20200219.3
Date Produced: 2/19/2020 11:28 AM
Build Link:    https://dev.azure.com/dnceng/internal/_build/results?buildId=528180
BAR Build Id:  43561
Released:      False
Channels:
Build 43561 will be assigned to channel 'General Testing' once this promotion build finishes: https://dnceng.visualstudio.com/internal/_build/results?buildId=528557
Waiting more 60 seconds for promotion build to complete.
Waiting more 60 seconds for promotion build to complete.
Waiting more 60 seconds for promotion build to complete.
Waiting more 60 seconds for promotion build to complete.
Waiting more 60 seconds for promotion build to complete.
Error trying to promote build. The promotion build finished with this result: canceled
```


