### PR TITLE
Add a toggle for including arcade in the flow graph

### DIFF
--- a/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
@@ -176,7 +176,6 @@ function drawFlowGraph(graph: FlowGraph, includeArcade: boolean) {
 
   select('svg.flowgraph').selectAll('*').remove();
   select('svg.flowgraph').attr("viewBox", "");
-  console.log(select('svg.flowgraph'));
 
   var svg = select("svg.flowgraph"),
       inner = svg.append("g");

--- a/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
@@ -1,5 +1,6 @@
-import { Component, Input, AfterContentInit } from '@angular/core';
-import { graphlib, render } from 'dagre-d3';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { ApplicationInsightsService } from 'src/app/services/application-insights.service';
+import { graphlib, render, layout } from 'dagre-d3';
 import { select } from 'd3';
 
 import { FlowGraph, FlowRef, FlowEdge } from 'src/maestro-client/models';
@@ -13,13 +14,13 @@ function getRepositoryShortName(repo:string): string {
 function getNodeLabel(node:FlowRef): string {
   // The div makes the styling look better and centers the text
   // Split the org and the repository on separate lines to make the nodes shorter
-  return `<div style="width:auto; height:auto;">${getRepositoryShortName(node.repository).split('/').join("<br>")}<br>`+
-         `${node.branch}</div>`;
+  return `${getRepositoryShortName(node.repository).split('/').join("<br>")}<br>`+
+         `${node.branch}`;
 }
 
 function getNodeTitle(node:FlowRef): string {
-  let official = node.officialBuildTime == 0 ? "No successful runs in the last 7 days" : `${node.officialBuildTime.toFixed(2)} min`;
-  let pr = node.prBuildTime == 0 ? "No successful runs in the last 7 days" : `${node.prBuildTime.toFixed(2)} min`;
+  let official = node.officialBuildTime == 0 ? "No successful runs in the last 30 days" : `${node.officialBuildTime.toFixed(2)} min`;
+  let pr = node.prBuildTime == 0 ? "No successful runs in the last 30 days" : `${node.prBuildTime.toFixed(2)} min`;
   let goal = node.goalTime == 0 ? "No goal time set" : `${node.goalTime} min`;
 
   return `Repository: ${getRepositoryShortName(node.repository)}\n` +
@@ -74,85 +75,161 @@ function getEdgeDescription(edge:FlowEdge, graph:FlowGraph): string {
   return description;
 }
 
+function drawFlowGraph(graph: FlowGraph, includeArcade: boolean) {
+  var g = new graphlib.Graph().setGraph({
+    ranksep: 25,
+    ranker: 'tight-tree'
+  });
+
+  if (graph)
+  {
+    var singletons: string[] = [];
+    var arcadeMasterNode: string = "";
+    var arcade3xNode: string = "";
+
+    for ( var flowRef of graph.nodes ) {
+      let nodeProperties:any = { 
+        labelType: "html",
+        label: getNodeLabel(flowRef),
+        title: getNodeTitle(flowRef),
+        description: getNodeDescription(flowRef),
+      };
+
+      if (flowRef.onLongestBuildPath) {
+        nodeProperties.shape = "ellipse";
+      }
+
+      // Add all the nodes to the singletons list
+      singletons.push(flowRef.id)
+
+      // Find the arcade nodes, if they exist
+      var isArcade = flowRef.repository.endsWith("arcade");
+
+      if (isArcade && flowRef.branch == "master") {
+        arcadeMasterNode = flowRef.id;
+      }
+      else if (isArcade && flowRef.branch == "release/3.x") {
+        arcade3xNode = flowRef.id
+      }
+      
+      // If this node is not an arcade node, or if we are including 
+      // arcade in the graph, add the node to the graph
+      if (!isArcade || includeArcade) {
+        g.setNode(flowRef.id, nodeProperties);
+      }
+    }
+
+    for (var edge of graph.edges) {
+      let edgeProperties:any = { arrowheadClass: 'arrowhead',
+                    description: getEdgeDescription(edge, graph)};
+
+      if (edge.onLongestBuildPath) {
+        edgeProperties.style = "stroke: #FD625E; stroke-width: 3px; stroke-dasharray: 5,5;";
+        edgeProperties.arrowheadClass = 'longestPath';
+      }
+
+      // Remove nodes that have outgoing edges from the singletons list, as long as that edge 
+      // is not to the arcade master node
+      var index = singletons.indexOf(edge.fromId);
+      if (index > -1 && edge.toId != arcadeMasterNode ) {
+        singletons.splice(index, 1);
+      }
+
+      // Remove nodes that have incoming edges from the singletons list, as long as that edge
+      // is not from the arcade master node
+      index = singletons.indexOf(edge.toId);
+      if (index > -1 && edge.fromId != arcadeMasterNode) {
+        singletons.splice(index, 1);
+      }
+
+      // Draw all of the edges, exclusing the arcade edges if we are not including the arcade nodes
+      if (includeArcade || (edge.toId != arcade3xNode && edge.fromId != arcade3xNode && edge.toId != arcadeMasterNode && edge.fromId != arcadeMasterNode)) {
+        g.setEdge(edge.fromId.toString(), edge.toId.toString(), edgeProperties);
+      }
+    }
+
+    var previousSingleton: string | undefined = undefined;
+
+    // Add invisible edges between all of the singleton nodes so that they are all displayed
+    // vertically on the side of the graph, giving the rest of the graph more space
+    for (var singleton of singletons) {
+      if (previousSingleton != undefined) {
+        g.setEdge(previousSingleton, singleton, { style: "visibility: hidden;" , arrowhead: 'undirected', arrowheadClass: 'invisible'})
+      }
+
+      // If any of the nodes were on the longest build path with arcade on the graph,
+      // change their shape back to a regular node, so they no longer appear as part of the path.
+      if (!includeArcade) {
+        g.node(singleton).shape = 'rect';
+      }
+
+      previousSingleton = singleton;
+    }
+  }
+
+  // Round the node corners
+  g.nodes().forEach(function(v) {
+    var node = g.node(v);
+    node.rx = node.ry = 5;
+  });
+
+  var render_graph = new render();
+
+  select('svg.flowgraph').selectAll('*').remove();
+  select('svg.flowgraph').attr("viewBox", "");
+  console.log(select('svg.flowgraph'));
+
+  var svg = select("svg.flowgraph"),
+      inner = svg.append("g");
+
+  render_graph(inner as any,g);
+
+  inner.selectAll("g.node")
+    .append("svg:title")
+    .text(function(v:any) { return g.node(v).title });
+
+  inner.selectAll("g.node")
+    .append("svg:desc")
+    .text(function(v:any) { return g.node(v).description });
+
+  inner.selectAll("g.node")
+    .append("svg:a");
+  inner.selectAll("g.edgePath")
+    .append("svg:desc")
+    .text(function(v:any) { return g.edge(v).description });
+
+  var bbox = (svg.node() as SVGGraphicsElement).getBBox();
+  var height = bbox.height < 800 ? 810 : bbox.height+10;
+  var width = bbox.width < 800 ? 810 :bbox.width+10;
+
+  svg.attr("viewBox", `-5 -5 ${width} ${height}`);
+}
+
 @Component({
   selector: 'mc-channel-graph',
   templateUrl: './channel-graph.component.html',
   styleUrls: ['./channel-graph.component.scss']
 })
-export class ChannelGraphComponent implements AfterContentInit {
+export class ChannelGraphComponent implements OnChanges {
 
   @Input() public graph?: FlowGraph;
+  @Input() public includeArcade?: boolean;
 
-  constructor() { }
+  constructor(private ai: ApplicationInsightsService) { }
 
-  ngAfterContentInit() {
-    var g = new graphlib.Graph().setGraph({
-      marginy: 0,
-      marginx: 0,
-      ranker: 'tight-tree'
-    });
-
-    if (this.graph)
+  ngOnChanges(changes: SimpleChanges) {
+    if(changes.includeArcade && (changes.includeArcade.previousValue != changes.includeArcade.currentValue))
     {
-      for ( var flowRef of this.graph.nodes ) {
-        let nodeProperties:any = { 
-          labelType: "html",
-          label: getNodeLabel(flowRef),
-          title: getNodeTitle(flowRef),
-          description: getNodeDescription(flowRef),
-        };
-
-        if (flowRef.onLongestBuildPath) {
-          nodeProperties.shape = "ellipse";
-        }
-
-        g.setNode(flowRef.id, nodeProperties);
-      }
-
-      for (var edge of this.graph.edges) {
-        let edgeProperties:any = { arrowheadClass: 'arrowhead',
-                      description: getEdgeDescription(edge, this.graph)};
-
-        if (edge.onLongestBuildPath) {
-          edgeProperties.style = "stroke: #FD625E; stroke-width: 3px; stroke-dasharray: 5,5;";
-          edgeProperties.arrowheadClass = 'longestPath';
-        }
-        
-        g.setEdge(edge.fromId.toString(), edge.toId.toString(), edgeProperties);
-      }
+      this.ai.trackEvent({name: "featureEnabled"}, 
+        {
+          featureName: "includeArcade",
+          featureState: changes.includeArcade.currentValue
+        });
     }
 
-    // Round the node corners
-    g.nodes().forEach(function(v) {
-      var node = g.node(v);
-      node.rx = node.ry = 5;
-    });
-
-    var render_graph = new render();
-
-    var svg = select("svg.flowgraph"),
-        inner = svg.append("g");
-
-    render_graph(inner as any,g);
-
-    inner.selectAll("g.node")
-      .append("svg:title")
-      .text(function(v:any) { return g.node(v).title });
-
-    inner.selectAll("g.node")
-      .append("svg:desc")
-      .text(function(v:any) { return g.node(v).description });
-
-    inner.selectAll("g.node")
-      .append("svg:a");
-    inner.selectAll("g.edgePath")
-      .append("svg:desc")
-      .text(function(v:any) { return g.edge(v).description });
-  
-    var bbox = (svg.node() as SVGGraphicsElement).getBBox();
-    var height = bbox.height < 800 ? 800 : bbox.height;
-    var width = bbox.width < 800 ? 800 : bbox.width;
-
-    svg.attr("viewBox", `0 0 ${width} ${height}`);
+    var includeArcade: boolean = this.includeArcade ? this.includeArcade : false;
+    if (this.graph) {
+      drawFlowGraph(this.graph, includeArcade);
+    }
   }
 }

--- a/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
@@ -12,7 +12,6 @@ function getRepositoryShortName(repo:string): string {
 }
 
 function getNodeLabel(node:FlowRef): string {
-  // The div makes the styling look better and centers the text
   // Split the org and the repository on separate lines to make the nodes shorter
   return `${getRepositoryShortName(node.repository).split('/').join("<br>")}<br>`+
          `${node.branch}`;

--- a/src/Maestro/maestro-angular/src/app/page/channel/channel.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/channel/channel.component.html
@@ -4,9 +4,15 @@
       {{channel.name}}
     </ng-container>
   </h5>
+  <span class="form-check float-right">
+    <mc-switch [style]="" [(value)]="includeArcade" title="Include Arcade"></mc-switch>
+    <label class="form-check-label">
+      Include Arcade
+    </label>
+  </span>
   <div class="container-fluid" style="height: 100%;">
     <ng-container *stateful="let graph from graph$">
-      <mc-channel-graph [graph]="graph"></mc-channel-graph>
+      <mc-channel-graph [graph]="graph" [includeArcade]="includeArcade"></mc-channel-graph>
     </ng-container>
   </div>
 </div>

--- a/src/Maestro/maestro-angular/src/app/page/channel/channel.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel/channel.component.ts
@@ -19,6 +19,7 @@ export class ChannelComponent implements OnInit {
 
   public graph$!: Observable<StatefulResult<FlowGraph>>;
   public channel$?: Observable<StatefulResult<Channel>>;
+  public includeArcade: boolean = true;
 
   ngOnInit() {
     const channelId$ = this.route.paramMap.pipe(

--- a/src/Maestro/maestro-angular/src/maestro-client/maestro.ts
+++ b/src/Maestro/maestro-angular/src/maestro-client/maestro.ts
@@ -1153,7 +1153,6 @@ export class ChannelsApiService implements IChannelsApi {
         queryParameters = queryParameters.set("includeDisabledSubscriptions", "false");
         queryParameters = queryParameters.set("includeBuildTimes", "true");
         queryParameters = queryParameters.set("days", "30");
-        queryParameters = queryParameters.set("includeArcade", "false");
 
         queryParameters = queryParameters.set("api-version", apiVersion);
 

--- a/src/Maestro/maestro-angular/src/themes/_base.scss
+++ b/src/Maestro/maestro-angular/src/themes/_base.scss
@@ -204,4 +204,8 @@ mc-switch {
     fill: $gray-900;
     stroke-width: 1.5px;
   }
+
+  .invisible {
+    visibility: hidden;
+  }
 }


### PR DESCRIPTION
* Add the toggle
* Get the flow graph with arcade
* If the toggle is disabled, do not display arcade master or release/3.x
* Also creates a list of nodes that either have no input or output edges, or whose only edges are to/from arcade and creates invisible edges between them, so that they do not clog up the graph (this essentially tricks the layout algorithm into thinking that they all have different ranks)

<img width="1589" alt="Screen Shot 2020-02-19 at 4 23 31 PM" src="https://user-images.githubusercontent.com/9666644/74888885-2dcc7400-5334-11ea-8b21-84078e0ce6b2.png">

![image](https://user-images.githubusercontent.com/9666644/74889188-075b0880-5335-11ea-8909-3e7b6f9fb70a.png)
