### PR TITLE
Fix app configuration connection for local development.

### DIFF
--- a/src/Maestro/Maestro.Web/.config/settings.Development.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Development.json
@@ -1,6 +1,6 @@
 {
   "KeyVaultUri": "https://maestrolocal.vault.azure.net/",
-  "AppConfigurationUri": "https://maestrolocal.azconfig.io/",
+  "AppConfigurationConnectionString": "[vault(azure-appconfiguration-connection-string)]",
   "BuildAssetRegistry": {
     "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
   }


### PR DESCRIPTION
Relates to: https://github.com/dotnet/core-eng/issues/8696

Use connection string stored in KV to connect to maestrolocal Azure AppConfiguration when testing locally.

This one I can rightly say: it works on my machine.