### PR TITLE
Normalize branch names when comparing.

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.DotNet.Services.Utility;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -266,6 +267,8 @@ namespace Microsoft.DotNet.Darc
         {
             try
             {
+                branch = GitHelpers.NormalizeBranchName(branch);
+
                 var dependencies = await remote.GetDependenciesAsync(repo, branch);
             }
             catch (DependencyFileNotFoundException)

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddDefaultChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddDefaultChannelOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Services.Utility;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
@@ -25,6 +26,8 @@ namespace Microsoft.DotNet.Darc.Operations
             try
             {
                 IRemote remote = RemoteFactory.GetRemote(_options, _options.Repository, Logger);
+
+                _options.Branch = GitHelpers.NormalizeBranchName(_options.Branch);
 
                 if (!(await UxHelpers.VerifyAndConfirmBranchExistsAsync(remote, _options.Repository, _options.Branch, !_options.NoConfirmation)))
                 {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddSubscriptionOperation.cs
@@ -17,6 +17,7 @@ using Microsoft.DotNet.Maestro.Client;
 using Newtonsoft.Json.Linq;
 using Microsoft.VisualStudio.Services.FileContainer;
 using Microsoft.Azure.KeyVault.Models;
+using Microsoft.DotNet.Services.Utility;
 
 namespace Microsoft.DotNet.Darc.Operations
 {
@@ -96,7 +97,7 @@ namespace Microsoft.DotNet.Darc.Operations
             string channel = _options.Channel;
             string sourceRepository = _options.SourceRepository;
             string targetRepository = _options.TargetRepository;
-            string targetBranch = _options.TargetBranch;
+            string targetBranch = GitHelpers.NormalizeBranchName(_options.TargetBranch);
             string updateFrequency = _options.UpdateFrequency;
             bool batchable = _options.Batchable;
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDefaultChannelBaseOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDefaultChannelBaseOperation.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.DotNet.Services.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -60,7 +61,7 @@ namespace Microsoft.DotNet.Darc.Operations
             {
                 return (string.IsNullOrEmpty(_options.Repository) || d.Repository.Contains(_options.Repository, StringComparison.OrdinalIgnoreCase)) &&
                        (string.IsNullOrEmpty(_options.Channel) || d.Channel.Name.Contains(_options.Channel, StringComparison.OrdinalIgnoreCase)) &&
-                       (string.IsNullOrEmpty(_options.Branch) || d.Branch.Contains(_options.Branch, StringComparison.OrdinalIgnoreCase));
+                       (string.IsNullOrEmpty(_options.Branch) || d.Branch.Contains(GitHelpers.NormalizeBranchName(_options.Branch), StringComparison.OrdinalIgnoreCase));
             });
 
             if (!matchingChannels.Any())

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.DarcLib;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Services.Utility;
 
 namespace Microsoft.DotNet.Darc.Options
 {
@@ -67,7 +68,7 @@ namespace Microsoft.DotNet.Darc.Options
         public bool SubcriptionFilter(Subscription subscription, IEnumerable<DefaultChannel> defaultChannels)
         {
             return (SubscriptionParameterMatches(TargetRepository, subscription.TargetRepository) &&
-                    SubscriptionParameterMatches(TargetBranch, subscription.TargetBranch) &&
+                    SubscriptionParameterMatches(GitHelpers.NormalizeBranchName(TargetBranch), subscription.TargetBranch) &&
                     SubscriptionParameterMatches(SourceRepository, subscription.SourceRepository) &&
                     SubscriptionParameterMatches(Channel, subscription.Channel.Name) &&
                     SubscriptionEnabledParameterMatches(subscription) &&

--- a/src/Shared/Microsoft.DotNet.Services.Utility/GitHelpers.cs
+++ b/src/Shared/Microsoft.DotNet.Services.Utility/GitHelpers.cs
@@ -2,18 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace Microsoft.DotNet.Services.Utility
 {
     public static class GitHelpers
     {
         private const string RefsHeadsPrefix = "refs/heads/";
+        private const string SlashRefsHeadsPrefix = "/refs/heads/";
+
         public static string NormalizeBranchName(string branch)
         {
-            if (branch != null && branch.StartsWith(RefsHeadsPrefix))
+            if (branch != null) 
             {
-                return branch.Substring(RefsHeadsPrefix.Length);
+                if (branch.StartsWith(RefsHeadsPrefix)) {
+                    return branch.Substring(RefsHeadsPrefix.Length);
+                }
+                else if (branch.StartsWith(SlashRefsHeadsPrefix))
+                {
+                    return branch.Substring(SlashRefsHeadsPrefix.Length);
+                }
             }
             return branch;
         }


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/4883

Normalize branch names before doing subscription and default-channel operations.