### PR TITLE
Turn on code coverage for Darc tests

### DIFF
--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -6,7 +6,6 @@ steps:
     command: 'custom'
     projects: |
       src/**/*.Tests.csproj
-      !src/**/Microsoft.DotNet.Darc.Tests.csproj
     custom: 'test'
     arguments: > 
       --configuration $(_BuildConfig)


### PR DESCRIPTION
This bug doesn't repro in current code, so this change removes the exclusion.