### PR TITLE
Fix Path to DarcBot documentation

### DIFF
--- a/src/GitHubApps/src/DarcBot/AzureFunction.cs
+++ b/src/GitHubApps/src/DarcBot/AzureFunction.cs
@@ -25,7 +25,7 @@ namespace DarcBot
         private static readonly Regex _darcBotIssueIdentifierRegex = new Regex(@"\[BuildId=(?<buildid>[^,]+),RecordId=(?<recordid>[^,]+),Index=(?<index>[^\]]+)\]", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
         // Search for a darcbot property, example = "[Category=foo]"
         private static readonly Regex _darcBotPropertyRegex = new Regex(@"\[(?<key>.+)=(?<value>[^\]]+)\]", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
-        private static readonly string _docLink = "[DarcBot documentation](https://github.com/dotnet/arcade-services/tree/master/src/GitHubApps/src/DarcBot/Readme.md)";
+        private static readonly string _docLink = "[DarcBot documentation](https://github.com/dotnet/arcade-services/blob/master/src/GitHubApps/src/DarcBot/ReadMe.md)";
         private static readonly string _darcBotLabelName = "darcbot";
         [FunctionName("GitHubWebHook")]
         public static async Task<IActionResult> Run(


### PR DESCRIPTION
Fix link to documentation. See that [link on this message](https://github.com/dotnet/core-eng/issues/9071#issuecomment-591072498) is broken.