### PR TITLE
Remove Scenario Test from the test locally list

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ For any deployment changes, the only way to test would be to kick off the [build
 | ----------- | 
 | **This comes with a significant overhead of a possibility of leaving the int deployments in a broken or hung state, which then would require significant manual effort to undo the damage especially with the Service Fabric Clusters. This process should only be done if and only if absolutely necessary and after obtaining management approval.** | 
 
+<Details>
 
 Steps:
 - Execute the azurepipeline.yaml targeting dev branch by using run pipeline and selecting the branch
@@ -69,4 +70,5 @@ Steps:
 
 - Once the testing is done, rerun the pipeline for master branch to return the deployment to a last known good.
 
+</Details>
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ For any deployment changes, the only way to test would be to kick off the [build
 
 <Details>
 
+<Summary>
+:warning: :sweat: :boom:
+</Summary>
+
 Steps:
 - Execute the azurepipeline.yaml targeting dev branch by using run pipeline and selecting the branch
 ![RunPipeline](Images/RunPipeline.PNG)

--- a/README.md
+++ b/README.md
@@ -58,14 +58,11 @@ For any non-deployment code changes, the expectation is to have run the tests co
 
 For any deployment changes, the only way to test would be to kick off the [build pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=252&_a=summary) that deploys the intended service from the dev branch to staging / int environment.
 
-| **WARNING** | 
-| ----------- | 
-| **This comes with a significant overhead of a possibility of leaving the int deployments in a broken or hung state, which then would require significant manual effort to undo the damage especially with the Service Fabric Clusters. This process should only be done if and only if absolutely necessary and after obtaining management approval.** | 
-
 <Details>
 
 <Summary>
 :warning: :sweat: :boom:
+**This comes with a significant overhead of a possibility of leaving the int deployments in a broken or hung state, which then would require significant manual effort to undo the damage especially with the Service Fabric Clusters. This process should only be done if and only if absolutely necessary and after obtaining management approval.**
 </Summary>
 
 Steps:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ For any deployment changes, the only way to test would be to kick off the [build
 
 <Summary>
 :warning: :sweat: :boom:
+
 **This comes with a significant overhead of a possibility of leaving the int deployments in a broken or hung state, which then would require significant manual effort to undo the damage especially with the Service Fabric Clusters. This process should only be done if and only if absolutely necessary and after obtaining management approval.**
+
 </Summary>
 
 Steps:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ If you would like to see your repository on BARViz, it needs to be published to 
 For any non-deployment code changes, the expectation is to have run the tests corresponding to the service locally to confirm that the change works before putting up the PR. The tests for each of the major areas in arcade-services are as below:
 - [Maestro](src\Maestro\Tests)
 - [Darc](src\Microsoft.DotNet.Darc\tests)
-- [Scenario Tests](src\Maestro\tests\Scenarios)
 
 For any deployment changes, the only way to test would be to kick off the [build pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=252&_a=summary) that deploys the intended service from the dev branch to staging / int environment.
 


### PR DESCRIPTION
Based on feedback on the commit to add steps to validation, removing the line item to run scenario tests - https://github.com/dotnet/arcade-services/commit/50a6fae92044adeb6a11555b5664e47957352b36

Once the documentation on how to run scenario tests locally is added, the link for the same should be added to the ReadMe, this work is tracked here - https://github.com/dotnet/core-eng/issues/9103

Also collapsing the steps to manual deployment using a dev branch by default