### PR TITLE
Small grafana tweaks

### DIFF
--- a/src/Monitoring/Sdk/README.md
+++ b/src/Monitoring/Sdk/README.md
@@ -13,8 +13,24 @@ If you want to use different directories, do:
 ```
 
 The "GrafanaHost" and "GrafanaAccessToken" will need to be specified to either publish or import.
-Either in the project file, or, more likely, during the build invokation with the /p argument.
-e.g. `dotnet build -t:PublishGrafana /p:GrafanaHost=https://dotnet-eng-grafana.azurewebsites.net /p:GrafanaAccessToken=MY_ACCESS_TOKEN`
+Either in the project file, or, more likely, during the build invocation with the /p argument.
+e.g.
+
+```bash
+  dotnet build \
+    -t:PublishGrafana -p:GrafanaHost=https://dotnet-eng-grafana.azurewebsites.net \
+    -p:GrafanaAccessToken=GRAFANA_ADMIN_API_KEY \
+    -p:GrafanaKeyVaultName=dotnet-grafana \
+    -p:GrafanaKeyVaultAppId=2bdfceef-194a-4775-99d9-b5575c77bc6b \
+    -p:GrafanaKeyVaultAppSecret=KEY_VAULT_APP_SECRET \
+    -p:GrafanaEnvironment=DEPLOYMENT_ENVIRONMENT
+```
+
+`GrafanaAccessToken`: An API token with Admin access level
+`GrafanaKeyVaultName`: The name of the Azure Key Vault where data source secrets and deployment secrets are stored
+`GrafanaKeyVaultAppId`: The AppId of the this Key Vault
+`GrafanaKeyVaultAppSecret`: The App Secret for this App ID
+`GrafanaEnvironment`: Either "staging" or "production", the target environment for this deployment
 
 ## Publish dashboards
 Ideally the publish will happen as part of publishing the services that are being monitored during a deployment.
@@ -26,7 +42,9 @@ To run the publish, run:
 ## Import existing dashboard
 To import a dashboard, run:
 
-`dotnet build MyMonitoring.proj -t:ImportGrafana /p:DashBoardId=999`
+```bash
+  dotnet build MyMonitoring.proj -t:ImportGrafana -p:GrafanaHost=https://dotnet-eng-grafana-staging.azurewebsites.net -p:GrafanaAccessToken=MY_ACCESS_TOKEN -p:DashBoardId=MyDashboardUid
+```
 
 where 999 is the ID from grafana of the dashboard you wish to import.
 It, and any referenced data sources, will be placed in the <DashboardDirectory>

--- a/src/Monitoring/grafana-init/grafana.ini
+++ b/src/Monitoring/grafana-init/grafana.ini
@@ -69,3 +69,6 @@ provider = azure_blob
 account_name = dotnetgrafana
 ;account_key = <managed by environment>
 container_name = grafana
+
+[snapshots]
+external_enabled = false

--- a/src/Monitoring/grafana-init/setup.sh
+++ b/src/Monitoring/grafana-init/setup.sh
@@ -125,7 +125,7 @@ EOT
 # Reset grafana-server and start it up again (or the first time)
 systemctl stop grafana-server
 
-grafana-cli plugins install grafana-azure-data-explorer-datasource
+grafana-cli plugins install grafana-azure-data-explorer-datasource 2.0.0
 # update any plugins while it's stopped
 grafana-cli plugins update-all
 


### PR DESCRIPTION
- some doc changes I had yet to commit
- disable snapshots to external server. Snapshots can be useful and I think we'll use them more. There's no reason to use an external server to host them. 
