### PR TITLE
Fix gather-drop contributing builds

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -792,38 +792,35 @@ namespace Microsoft.DotNet.Darc.Operations
                 NodeDiff = NodeDiff.None
             };
 
-            Dictionary<DependencyDetail, Build> dependencyCache =
-                new Dictionary<DependencyDetail, Build>(new DependencyDetailComparer());
-
             Console.WriteLine("Building graph of all dependencies under root builds...");
             foreach (Build rootBuild in rootBuilds)
             {
                 Console.WriteLine($"Building graph for {rootBuild.AzureDevOpsBuildNumber} of {rootBuild.GitHubRepository ?? rootBuild.AzureDevOpsRepository} @ {rootBuild.Commit}");
 
+                string rootBuildRepository = rootBuild.GitHubRepository ?? rootBuild.AzureDevOpsRepository;
                 DependencyGraph graph = await DependencyGraph.BuildRemoteDependencyGraphAsync(
                     remoteFactory,
-                    rootBuild.GitHubRepository ?? rootBuild.AzureDevOpsRepository,
+                    rootBuildRepository,
                     rootBuild.Commit,
                     buildOptions,
                     Logger);
 
-                // Cache this root build's assets
-                foreach (Asset buildAsset in rootBuild.Assets)
-                {
-                    dependencyCache.Add(
-                        new DependencyDetail
-                        {
-                            Name = buildAsset.Name,
-                            Version = buildAsset.Version,
-                            Commit = rootBuild.Commit,
-                        },
-                        rootBuild);
-                }
+                // Because the dependency graph starts the build from a repo+sha, it's possible
+                // that multiple unique builds of that root repo+sha were done. But we don't want those other builds.
+                // So as we walk the full list of contributing builds, filter those that are from rootBuild's repo + sha but not the
+                // same build id.
 
                 Console.WriteLine($"There are {graph.UniqueDependencies.Count()} unique dependencies in the graph.");
                 Console.WriteLine("Full set of builds in graph:");
                 foreach (var build in graph.ContributingBuilds)
                 {
+                    if ((build.GitHubRepository ?? build.AzureDevOpsRepository) == rootBuildRepository && 
+                        build.Commit == rootBuild.Commit &&
+                        build.Id != rootBuild.Id)
+                    {
+                        continue;
+                    }
+
                     Console.WriteLine($"  Build - {build.AzureDevOpsBuildNumber} of {build.GitHubRepository ?? build.AzureDevOpsRepository} @ {build.Commit}");
                     builds.Add(build);
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/4929. Ensure that contributing builds matching the repo+sha also match the build id of the root build. Avoids cases where we would download two versions of the root repo.
Also removes some unused code