### PR TITLE
Validate AzDO build before promoting

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -271,6 +271,14 @@ namespace Microsoft.DotNet.Darc.Operations
                 return (null, null);
             }
 
+            var oldestSupportedArcadeSDKDate = new DateTimeOffset(2020, 01, 28, 0, 0, 0, new TimeSpan(0, 0, 0));
+            if (DateTimeOffset.Compare(sourceBuildArcadeSDKDepBuild.DateProduced, oldestSupportedArcadeSDKDate) < 0)
+            {
+                Console.WriteLine($"The target build needs to use a version of Arcade SDK released after {oldestSupportedArcadeSDKDate}.");
+                Console.Write($"The target build uses an SDK released in {sourceBuildArcadeSDKDepBuild.DateProduced}");
+                return (null, null);
+            }
+
             return (sourceBuildArcadeSDKDepBuild.GitHubBranch, sourceBuildArcadeSDKDepBuild.Commit);
         }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -1145,6 +1145,25 @@ namespace Microsoft.DotNet.DarcLib
         }
 
         /// <summary>
+        ///   Gets the list of Build Artifacts names.
+        /// </summary>
+        /// <param name="accountName">Azure DevOps account name</param>
+        /// <param name="projectName">Project name</param>
+        /// <returns>List of Azure DevOps build artifacts names.</returns>
+        public async Task<List<AzureDevOpsBuildArtifact>> GetBuildArtifactsAsync(string accountName, string projectName, int azureDevOpsBuildId)
+        {
+            JObject content = await this.ExecuteAzureDevOpsAPIRequestAsync(
+                HttpMethod.Get,
+                accountName,
+                projectName,
+                $"_apis/build/builds/{azureDevOpsBuildId}/artifacts",
+                _logger,
+                versionOverride: "5.0");
+
+            return ((JArray)content["value"]).ToObject<List<AzureDevOpsBuildArtifact>>();
+        }
+
+        /// <summary>
         ///   Gets all Artifact feeds along with their packages in an Azure DevOps account.
         /// </summary>
         /// <param name="accountName">Azure DevOps account name.</param>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/AzureDevOps/AzureDevOpsBuildArtifact.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/AzureDevOps/AzureDevOpsBuildArtifact.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.DarcLib
+{
+    public class AzureDevOpsBuildArtifact
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/4941

- Check that the target AzDO build exists and has the needed artifacts for being promoted and/or validating
- Check that the target build uses a recent enough Arcade SDK