### PR TITLE
Make skip-released the default behavior

### DIFF
--- a/src/Maestro/tests/Scenarios/builds.ps1
+++ b/src/Maestro/tests/Scenarios/builds.ps1
@@ -64,7 +64,7 @@ try {
 
     # Gather a drop with released included
     $gatherWithReleasedDir = Join-Path -Path $testRoot -ChildPath "gather-with-released"
-    $darcParams = @( "gather-drop", "--id", "$buildId", "--dry-run", "--output-dir", $gatherWithReleasedDir )
+    $darcParams = @( "gather-drop", "--id", "$buildId", "--dry-run", "--include-released", "--output-dir", $gatherWithReleasedDir )
     $gatherDropOutput = Darc-Command -darcParams $darcParams
     if ((-not $gatherDropOutput -match "Gathering drop for build $sourceBuildNumber")) {
         throw "Build should download build $sourceBuildNumber"
@@ -74,9 +74,9 @@ try {
         throw "Build should download both Foo and Bar"
     }
 
-    # Gather with release excluded. gather-drop should throw an error
+    # Gather with release excluded (default behavior). gather-drop should throw an error
     $gatherWithNoReleasedDir = Join-Path -Path $testRoot -ChildPath "gather-no-released"
-    $darcParams = @( "gather-drop", "--id", "$buildId", "--dry-run", "--skip-released", "--output-dir", $gatherWithNoReleasedDir )
+    $darcParams = @( "gather-drop", "--id", "$buildId", "--dry-run", "--output-dir", $gatherWithNoReleasedDir )
     $gatherDropOutput = $null
     try {
         $gatherDropOutput = Darc-Command -darcParams $darcParams
@@ -99,9 +99,9 @@ try {
         throw "Build should be marked unreleased"
     }
 
-    # Gather with release excluded
+    # Gather with release excluded again (defualt behavior)
     $gatherWithNoReleased2Dir = Join-Path -Path $testRoot -ChildPath "gather-no-released-2"
-    $darcParams = @( "gather-drop", "--id", "$buildId", "--dry-run", "--skip-released", "--output-dir", $gatherWithNoReleased2Dir )
+    $darcParams = @( "gather-drop", "--id", "$buildId", "--dry-run", "--output-dir", $gatherWithNoReleased2Dir )
     $gatherDropOutput = Darc-Command -darcParams $darcParams
     if ((-not $gatherDropOutput -match "Gathering drop for build $sourceBuildNumber")) {
         throw "Build should download build $sourceBuildNumber"

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -698,13 +698,13 @@ namespace Microsoft.DotNet.Darc.Operations
         }
 
         /// <summary>
-        /// Filter any released builds if the user specified --skip-released
+        /// Filter any released builds if the user did not specify --include-released
         /// </summary>
         /// <param name="inputBuilds">Input builds</param>
         /// <returns>Builds to download</returns>
         private IEnumerable<Build> FilterReleasedBuilds(IEnumerable<Build> builds)
         {
-            if (_options.SkipReleased)
+            if (!_options.IncludeReleased)
             {
                 var releasedBuilds = builds.Where(build => build.Released);
                 var nonReleasedBuilds = builds.Where(build => !build.Released);

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
@@ -71,8 +71,8 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("skip-existing", HelpText = "Skip files that already exist at the destination.")]
         public bool SkipExisting { get; set; }
 
-        [Option("skip-released", HelpText = "Skip builds that are marked as released")]
-        public bool SkipReleased { get; set; }
+        [Option("include-released", HelpText = "Include builds that are marked as released")]
+        public bool IncludeReleased { get; set; }
 
         [Option("latest-location", HelpText = "Download assets from their latest known location.")]
         public bool LatestLocation { get; set; }


### PR DESCRIPTION
By default, exclude released builds from a drop. This is the most common scenario.