### PR TITLE
Don't automerge PRs with package downgrades

### DIFF
--- a/src/Maestro/Maestro.Contracts/DependencyUpdateSummary.cs
+++ b/src/Maestro/Maestro.Contracts/DependencyUpdateSummary.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace Maestro.Contracts
+{
+    [DataContract]
+    public class DependencyUpdateSummary
+    {
+        [DataMember]
+        public string DependencyName { get; set; }
+
+        [DataMember]
+        public string FromVersion { get; set; }
+
+        [DataMember]
+        public string ToVersion { get; set; }
+    }
+}

--- a/src/Maestro/Maestro.Contracts/IPullRequest.cs
+++ b/src/Maestro/Maestro.Contracts/IPullRequest.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Maestro.Contracts
+{
+    public interface IPullRequest
+    {
+        string Url { get; set; }
+
+        List<DependencyUpdateSummary> RequiredUpdates { get; set; }
+    }
+}

--- a/src/Maestro/Maestro.MergePolicies/AllChecksSuccessfulMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/AllChecksSuccessfulMergePolicy.cs
@@ -20,7 +20,7 @@ namespace Maestro.MergePolicies
 
         public static async Task EvaluateChecksAsync(IMergePolicyEvaluationContext context, HashSet<string> ignoredChecks)
         {
-            IEnumerable<Check> checks = await context.Darc.GetPullRequestChecksAsync(context.PullRequestUrl);
+            IEnumerable<Check> checks = await context.Darc.GetPullRequestChecksAsync(context.PullRequest.Url);
             IEnumerable<Check> notIgnoredChecks = checks.Where(c => !ignoredChecks.Contains(c.Name));
 
             if (!notIgnoredChecks.Any())

--- a/src/Maestro/Maestro.MergePolicies/DontAutomergeDowngradesMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/DontAutomergeDowngradesMergePolicy.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Maestro.Contracts;
+using NuGet.Versioning;
+using System.Threading.Tasks;
+
+namespace Maestro.MergePolicies
+{
+    public class DontAutomergeDowngradesMergePolicy : MergePolicy
+    {
+        public override string DisplayName => "Do not automerge downgrades";
+
+        public override async Task EvaluateAsync(IMergePolicyEvaluationContext context, MergePolicyProperties properties)
+        {
+            EvaluateDowngrades(context);
+            await Task.CompletedTask;
+        }
+
+        internal static void EvaluateDowngrades(IMergePolicyEvaluationContext context)
+        {
+            if (HasAnyDowngrade(context.PullRequest))
+            {
+                context.Fail("Some dependency updates are downgrades. Aborting auto-merge.");
+            }
+            else
+            {
+                context.Succeed("No version downgrade detected.");
+            }
+        }
+
+        private static bool HasAnyDowngrade(IPullRequest pr)
+        {
+            foreach (var dependency in pr.RequiredUpdates)
+            {
+                SemanticVersion.TryParse(dependency.FromVersion, out var fromVersion);
+                SemanticVersion.TryParse(dependency.ToVersion, out var toVersion);
+
+                if (fromVersion.CompareTo(toVersion) > 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Maestro/Maestro.MergePolicies/IMergePolicyEvaluationContext.cs
+++ b/src/Maestro/Maestro.MergePolicies/IMergePolicyEvaluationContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Maestro.Contracts;
 using Microsoft.DotNet.DarcLib;
 
 namespace Maestro.MergePolicies
@@ -9,7 +10,7 @@ namespace Maestro.MergePolicies
     public interface IMergePolicyEvaluationContext
     {
         IRemote Darc { get; }
-        string PullRequestUrl { get; }
+        IPullRequest PullRequest { get; }
         void Succeed(string message);
         void Fail(string message);
         void Pending(string message);

--- a/src/Maestro/Maestro.MergePolicies/Maestro.MergePolicies.csproj
+++ b/src/Maestro/Maestro.MergePolicies/Maestro.MergePolicies.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
     <LangVersion>latest</LangVersion>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
@@ -14,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.DotNet.Darc\src\DarcLib\Microsoft.DotNet.DarcLib.csproj" />
+    <ProjectReference Include="..\Maestro.Contracts\Maestro.Contracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Maestro/Maestro.MergePolicies/NoRequestedChangesMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/NoRequestedChangesMergePolicy.cs
@@ -15,7 +15,7 @@ namespace Maestro.MergePolicies
 
         public static async Task EvaluateReviewAsync(IMergePolicyEvaluationContext context)
         {
-            IEnumerable<Review> reviews = await context.Darc.GetPullRequestReviewsAsync(context.PullRequestUrl);
+            IEnumerable<Review> reviews = await context.Darc.GetPullRequestReviewsAsync(context.PullRequest.Url);
 
             if (reviews.Any(r => r.Status == ReviewState.ChangesRequested || r.Status == ReviewState.Rejected))
             {

--- a/src/Maestro/Maestro.MergePolicies/StandardMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/StandardMergePolicy.cs
@@ -50,7 +50,7 @@ namespace Maestro.MergePolicies
             }
             await AllChecksSuccessfulMergePolicy.EvaluateChecksAsync(context, ignoredChecks);
             await NoRequestedChangesMergePolicy.EvaluateReviewAsync(context);
-            await DontAutomergeDowngradesMergePolicy.EvaluateDowngradesAsync(context);
+            DontAutomergeDowngradesMergePolicy.EvaluateDowngrades(context);
         }
     }
 }

--- a/src/Maestro/Maestro.MergePolicies/StandardMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/StandardMergePolicy.cs
@@ -35,7 +35,7 @@ namespace Maestro.MergePolicies
         public override async Task EvaluateAsync(IMergePolicyEvaluationContext context, MergePolicyProperties properties)
         {
             HashSet<string> ignoredChecks = null;
-            string prUrl = context.PullRequestUrl;
+            string prUrl = context.PullRequest.Url;
             if (prUrl.Contains("github.com"))
             {
                 ignoredChecks = standardGithubIgnoredChecks;
@@ -50,6 +50,7 @@ namespace Maestro.MergePolicies
             }
             await AllChecksSuccessfulMergePolicy.EvaluateChecksAsync(context, ignoredChecks);
             await NoRequestedChangesMergePolicy.EvaluateReviewAsync(context);
+            await DontAutomergeDowngradesMergePolicy.EvaluateDowngradesAsync(context);
         }
     }
 }

--- a/src/Maestro/SubscriptionActorService/IMergePolicyEvaluator.cs
+++ b/src/Maestro/SubscriptionActorService/IMergePolicyEvaluator.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Maestro.Contracts;
 using Maestro.Data.Models;
 using Microsoft.DotNet.DarcLib;
 
@@ -12,7 +13,7 @@ namespace SubscriptionActorService
     public interface IMergePolicyEvaluator
     {
         Task<MergePolicyEvaluationResult> EvaluateAsync(
-            string prUrl,
+            IPullRequest pr,
             IRemote darc,
             IReadOnlyList<MergePolicyDefinition> policyDefinitions);
     }

--- a/src/Maestro/SubscriptionActorService/InProgressPullRequest.cs
+++ b/src/Maestro/SubscriptionActorService/InProgressPullRequest.cs
@@ -6,11 +6,12 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Maestro.Contracts;
+using Microsoft.DotNet.DarcLib;
 
 namespace SubscriptionActorService
 {
     [DataContract]
-    public class InProgressPullRequest
+    public class InProgressPullRequest : IPullRequest
     {
         [DataMember]
         public string Url { get; set; }
@@ -23,6 +24,9 @@ namespace SubscriptionActorService
 
         [DataMember]
         public List<SubscriptionPullRequestUpdate> Contained { get; set; }
+
+        [DataMember]
+        public List<DependencyUpdateSummary> RequiredUpdates { get; set; }
     }
 
     [DataContract]

--- a/src/Maestro/SubscriptionActorService/MergePolicyEvaluationContext.cs
+++ b/src/Maestro/SubscriptionActorService/MergePolicyEvaluationContext.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Maestro.Contracts;
 using Maestro.MergePolicies;
 using Microsoft.DotNet.DarcLib;
 
@@ -10,10 +11,10 @@ namespace SubscriptionActorService
 {
     public class MergePolicyEvaluationContext : IMergePolicyEvaluationContext
     {
-        public MergePolicyEvaluationContext(string pullRequestUrl, IRemote darc)
+        public MergePolicyEvaluationContext(IPullRequest pr, IRemote darc)
         {
-            PullRequestUrl = pullRequestUrl;
             Darc = darc;
+            PullRequest = pr;
         }
 
         public MergePolicyEvaluationResult Result => new MergePolicyEvaluationResult(PolicyResults);
@@ -23,7 +24,8 @@ namespace SubscriptionActorService
 
         internal MergePolicy CurrentPolicy { get; set; }
 
-        public string PullRequestUrl { get; }
+        public IPullRequest PullRequest { get; }
+
         public IRemote Darc { get; }
 
         public void Pending(string message)

--- a/src/Maestro/SubscriptionActorService/MergePolicyEvaluator.cs
+++ b/src/Maestro/SubscriptionActorService/MergePolicyEvaluator.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Maestro.Contracts;
 using Maestro.Data.Models;
 using Maestro.MergePolicies;
 using Microsoft.DotNet.DarcLib;
@@ -24,11 +25,11 @@ namespace SubscriptionActorService
         public ILogger<MergePolicyEvaluator> Logger { get; }
 
         public async Task<MergePolicyEvaluationResult> EvaluateAsync(
-            string prUrl,
+            IPullRequest pr,
             IRemote darc,
             IReadOnlyList<MergePolicyDefinition> policyDefinitions)
         {
-            var context = new MergePolicyEvaluationContext(prUrl, darc);
+            var context = new MergePolicyEvaluationContext(pr, darc);
             foreach (MergePolicyDefinition definition in policyDefinitions)
             {
                 if (MergePolicies.TryGetValue(definition.Name, out MergePolicy policy))

--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -357,7 +357,7 @@ namespace SubscriptionActorService
                 // If the PR is currently open, then evaluate the merge policies, which will potentially
                 // merge the PR if they are successul.
                 case PrStatus.Open:
-                    ActionResult<MergePolicyCheckResult> checkPolicyResult = await CheckMergePolicyAsync(prUrl, darc);
+                    ActionResult<MergePolicyCheckResult> checkPolicyResult = await CheckMergePolicyAsync(pr, darc);
                     pr.MergePolicyResult = checkPolicyResult.Result;
 
                     switch (checkPolicyResult.Result)
@@ -412,11 +412,11 @@ namespace SubscriptionActorService
         /// <param name="prUrl">Pull request URL</param>
         /// <param name="darc">Darc remote</param>
         /// <returns>Result of the policy check.</returns>
-        private async Task<ActionResult<MergePolicyCheckResult>> CheckMergePolicyAsync(string prUrl, IRemote darc)
+        private async Task<ActionResult<MergePolicyCheckResult>> CheckMergePolicyAsync(IPullRequest pr, IRemote darc)
         {
             IReadOnlyList<MergePolicyDefinition> policyDefinitions = await GetMergePolicyDefinitions();
             MergePolicyEvaluationResult result = await MergePolicyEvaluator.EvaluateAsync(
-                prUrl,
+                pr,
                 darc,
                 policyDefinitions);
 
@@ -424,7 +424,7 @@ namespace SubscriptionActorService
             {
                 await UpdateStatusCommentAsync(
                     darc,
-                    prUrl,
+                    pr.Url,
                     $@"## Auto-Merge Status
 This pull request has not been merged because Maestro++ is waiting on the following merge policies.
 
@@ -432,7 +432,7 @@ This pull request has not been merged because Maestro++ is waiting on the follow
 
                 return ActionResult.Create(
                     result.Pending ? MergePolicyCheckResult.PendingPolicies : MergePolicyCheckResult.FailedPolicies,
-                    $"NOT Merged: PR '{prUrl}' failed policies {string.Join(", ", result.Results.Where(r => r.Success == null || r.Success == false).Select(r => r.Policy?.Name + r.Message))}");
+                    $"NOT Merged: PR '{pr.Url}' failed policies {string.Join(", ", result.Results.Where(r => r.Success == null || r.Success == false).Select(r => r.Policy?.Name + r.Message))}");
             }
 
             if (result.Succeeded)
@@ -440,7 +440,7 @@ This pull request has not been merged because Maestro++ is waiting on the follow
                 var merged = false;
                 try
                 {
-                    await darc.MergePullRequestAsync(prUrl, new MergePullRequestParameters());
+                    await darc.MergePullRequestAsync(pr.Url, new MergePullRequestParameters());
                     merged = true;
                 }
                 catch
@@ -450,7 +450,7 @@ This pull request has not been merged because Maestro++ is waiting on the follow
 
                 await UpdateStatusCommentAsync(
                     darc,
-                    prUrl,
+                    pr.Url,
                     $@"## Auto-Merge Status
 This pull request {(merged ? "has been merged" : "will be merged")} because the following merge policies have succeeded.
 
@@ -460,10 +460,10 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                 {
                     return ActionResult.Create(
                         MergePolicyCheckResult.Merged,
-                        $"Merged: PR '{prUrl}' passed policies {string.Join(", ", policyDefinitions.Select(p => p.Name))}");
+                        $"Merged: PR '{pr.Url}' passed policies {string.Join(", ", policyDefinitions.Select(p => p.Name))}");
                 }
 
-                return ActionResult.Create(MergePolicyCheckResult.FailedToMerge, $"NOT Merged: PR '{prUrl}' has merge conflicts.");
+                return ActionResult.Create(MergePolicyCheckResult.FailedToMerge, $"NOT Merged: PR '{pr.Url}' has merge conflicts.");
             }
 
             return ActionResult.Create(MergePolicyCheckResult.NoPolicies, "NOT Merged: There are no merge policies");
@@ -663,7 +663,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
             (string targetRepository, string targetBranch) = await GetTargetAsync();
             IRemote darcRemote = await DarcRemoteFactory.GetRemoteAsync(targetRepository, Logger);
 
-            List<(UpdateAssetsParameters update, List<DependencyDetail> deps)> requiredUpdates =
+            List<(UpdateAssetsParameters update, List<DependencyUpdate> deps)> requiredUpdates =
                 await GetRequiredUpdates(updates, DarcRemoteFactory, targetRepository, targetBranch);
 
             if (requiredUpdates.Count < 1)
@@ -694,7 +694,17 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                                 SubscriptionId = u.update.SubscriptionId,
                                 BuildId = u.update.BuildId
                             })
-                        .ToList()
+                        .ToList(),
+
+                    RequiredUpdates = requiredUpdates
+                            .SelectMany(update => update.deps)
+                            .Select(du => new DependencyUpdateSummary
+                            {
+                                DependencyName = du.To.Name,
+                                FromVersion = du.From.Version,
+                                ToVersion = du.To.Version
+                            })
+                            .ToList()
                 };
 
                 string prUrl = await darcRemote.CreatePullRequestAsync(
@@ -761,7 +771,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
         /// <param name="newBranchName">Target branch the updates should be to</param>
         /// <returns></returns>
         private async Task CommitUpdatesAsync(
-            List<(UpdateAssetsParameters update, List<DependencyDetail> deps)> requiredUpdates,
+            List<(UpdateAssetsParameters update, List<DependencyUpdate> deps)> requiredUpdates,
             StringBuilder description,
             IRemote darc,
             string targetRepository,
@@ -769,20 +779,20 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
         {
             // First run through non-coherency and then do a coherency
             // message if one exists.
-            List<(UpdateAssetsParameters update, List<DependencyDetail> deps)> nonCoherencyUpdates =
+            List<(UpdateAssetsParameters update, List<DependencyUpdate> deps)> nonCoherencyUpdates =
                 requiredUpdates.Where(u => !u.update.IsCoherencyUpdate).ToList();
             // Should max one coherency update
-            (UpdateAssetsParameters update, List<DependencyDetail> deps) coherencyUpdate =
+            (UpdateAssetsParameters update, List<DependencyUpdate> deps) coherencyUpdate =
                 requiredUpdates.Where(u => u.update.IsCoherencyUpdate).SingleOrDefault();
 
             // To keep a PR to as few commits as possible, if the number of
             // non-coherency updates is 1 then combine coherency updates with those.
             // Otherwise, put all coherency updates in a separate commit.
             bool combineCoherencyWithNonCoherency = (nonCoherencyUpdates.Count == 1);
-            foreach ((UpdateAssetsParameters update, List<DependencyDetail> deps) in nonCoherencyUpdates)
+            foreach ((UpdateAssetsParameters update, List<DependencyUpdate> deps) in nonCoherencyUpdates)
             {
                 var message = new StringBuilder();
-                List<DependencyDetail> dependenciesToCommit = deps;
+                List<DependencyUpdate> dependenciesToCommit = deps;
                 await CalculateCommitMessage(update, deps, message);
                 await CalculatePRDescription(update, deps, description);
 
@@ -793,7 +803,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                     dependenciesToCommit.AddRange(coherencyUpdate.deps);
                 }
 
-                await darc.CommitUpdatesAsync(targetRepository, newBranchName, dependenciesToCommit, message.ToString());
+                await darc.CommitUpdatesAsync(targetRepository, newBranchName, dependenciesToCommit.Select(du => du.To).ToList(), message.ToString());
             }
 
             // If the coherency update wasn't combined, then
@@ -803,20 +813,20 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                 var message = new StringBuilder();
                 await CalculateCommitMessage(coherencyUpdate.update, coherencyUpdate.deps, message);
                 await CalculatePRDescription(coherencyUpdate.update, coherencyUpdate.deps, description);
-                await darc.CommitUpdatesAsync(targetRepository, newBranchName, coherencyUpdate.deps, message.ToString());
+                await darc.CommitUpdatesAsync(targetRepository, newBranchName, coherencyUpdate.deps.Select(du => du.To).ToList(), message.ToString());
             }
         }
 
-        private async Task CalculateCommitMessage(UpdateAssetsParameters update, List<DependencyDetail> deps, StringBuilder message)
+        private async Task CalculateCommitMessage(UpdateAssetsParameters update, List<DependencyUpdate> deps, StringBuilder message)
         {
             if (update.IsCoherencyUpdate)
             {
                 message.AppendLine("Dependency coherency updates");
                 message.AppendLine();
 
-                foreach (DependencyDetail dep in deps)
+                foreach (DependencyUpdate dep in deps)
                 {
-                    message.AppendLine($"- {dep.Name} - {dep.Version} (parent: {dep.CoherentParentDependencyName})");
+                    message.AppendLine($"- {dep.To.Name}: {dep.From.Version} -> {dep.To.Version} (parent: {dep.To.CoherentParentDependencyName})");
                 }
             }
             else
@@ -826,9 +836,9 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                 message.AppendLine($"Update dependencies from {sourceRepository} build {build.AzureDevOpsBuildNumber}");
                 message.AppendLine();
 
-                foreach (DependencyDetail dep in deps)
+                foreach (DependencyUpdate dep in deps)
                 {
-                    message.AppendLine($"- {dep.Name} - {dep.Version}");
+                    message.AppendLine($"- {dep.To.Name}: {dep.From.Version} -> {dep.To.Version}");
                 }
             }
 
@@ -846,7 +856,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
         ///     Because PRs tend to be live for short periods of time, we can put more information
         ///     in the description than the commit message without worrying that links will go stale.
         /// </remarks>
-        private async Task CalculatePRDescription(UpdateAssetsParameters update, List<DependencyDetail> deps, StringBuilder description)
+        private async Task CalculatePRDescription(UpdateAssetsParameters update, List<DependencyUpdate> deps, StringBuilder description)
         {
 
             //Find the Coherency section of the PR description
@@ -865,9 +875,9 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                 coherencySection.AppendLine("See [Dependency Description Format](https://github.com/dotnet/arcade/blob/master/Documentation/DependencyDescriptionFormat.md#dependency-description-overview)");
                 coherencySection.AppendLine();
 
-                foreach (DependencyDetail dep in deps)
+                foreach (DependencyUpdate dep in deps)
                 {
-                    coherencySection.AppendLine($"- **{dep.Name}** -> {dep.Version} (parent: {dep.CoherentParentDependencyName})");
+                    coherencySection.AppendLine($"- **{dep.To.Name}**: from {dep.From.Version} to {dep.To.Version} (parent: {dep.To.CoherentParentDependencyName})");
                 }
                 coherencySection.AppendLine();
                 coherencySection.AppendLine(sectionEndMarker);
@@ -897,9 +907,9 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                 }
                 subscriptionSection.AppendLine($"- **Updates**:");
 
-                foreach (DependencyDetail dep in deps)
+                foreach (DependencyUpdate dep in deps)
                 {
-                    subscriptionSection.AppendLine($"  - **{dep.Name}** -> {dep.Version}");
+                    subscriptionSection.AppendLine($"  - **{dep.To.Name}**: from {dep.From.Version} to {dep.To.Version}");
                 }
                 subscriptionSection.AppendLine();
                 subscriptionSection.AppendLine(sectionEndMarker);
@@ -930,7 +940,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
             (string targetRepository, string targetBranch) = await GetTargetAsync();
             IRemote darcRemote = await DarcRemoteFactory.GetRemoteAsync(targetRepository, Logger);
 
-            List<(UpdateAssetsParameters update, List<DependencyDetail> deps)> requiredUpdates =
+            List<(UpdateAssetsParameters update, List<DependencyUpdate> deps)> requiredUpdates =
                 await GetRequiredUpdates(updates, DarcRemoteFactory, targetRepository, targetBranch);
 
             if (requiredUpdates.Count < 1)
@@ -947,7 +957,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
             // Replace all existing updates for the subscription id with the new update.
             // This avoids a potential issue where we may update the last applied build id
             // on the subscription to an older build id.
-            foreach ((UpdateAssetsParameters update, List<DependencyDetail> deps) update in requiredUpdates)
+            foreach ((UpdateAssetsParameters update, List<DependencyUpdate> deps) update in requiredUpdates)
             {
                 pr.ContainedSubscriptions.RemoveAll(s => s.SubscriptionId == update.update.SubscriptionId);
             }
@@ -1011,7 +1021,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
         ///     updates required based on the input updates.  The second pass uses the repo state + the
         ///     updates from the first pass to determine what else needs to change based on the coherency metadata.
         /// </remarks>
-        private async Task<List<(UpdateAssetsParameters update, List<DependencyDetail> deps)>> GetRequiredUpdates(
+        private async Task<List<(UpdateAssetsParameters update, List<DependencyUpdate> deps)>> GetRequiredUpdates(
             List<UpdateAssetsParameters> updates,
             IRemoteFactory remoteFactory,
             string targetRepository,
@@ -1020,7 +1030,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
             // Get a remote factory for the target repo
             IRemote darc = await remoteFactory.GetRemoteAsync(targetRepository, Logger);
 
-            var requiredUpdates = new List<(UpdateAssetsParameters update, List<DependencyDetail> deps)>();
+            var requiredUpdates = new List<(UpdateAssetsParameters update, List<DependencyUpdate> deps)>();
             // Existing details 
             List<DependencyDetail> existingDependencies = (await darc.GetDependenciesAsync(targetRepository, branch)).ToList();
 
@@ -1055,14 +1065,13 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                     continue;
                 }
 
-                List<DependencyDetail> targetOfUpdates = dependenciesToUpdate.Select(u => u.To).ToList();
                 // Update the existing details list
                 foreach (DependencyUpdate dependencyUpdate in dependenciesToUpdate)
                 {
                     existingDependencies.Remove(dependencyUpdate.From);
                     existingDependencies.Add(dependencyUpdate.To);
                 }
-                requiredUpdates.Add((update, targetOfUpdates));
+                requiredUpdates.Add((update, dependenciesToUpdate));
             }
 
             // Once we have applied all of non coherent updates, then we need to run a coherency check on the
@@ -1078,7 +1087,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                 {
                     IsCoherencyUpdate = true
                 };
-                requiredUpdates.Add((coherencyUpdateParameters, coherencyUpdates.Select(u => u.To).ToList()));
+                requiredUpdates.Add((coherencyUpdateParameters, coherencyUpdates.ToList()));
             }
 
             return requiredUpdates;

--- a/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
@@ -322,6 +322,14 @@ namespace SubscriptionActorService.Tests
                             SubscriptionId = Subscription.Id
                         }
                     },
+                    RequiredUpdates = forBuild.Assets.Select(
+                                d => new DependencyUpdateSummary
+                                {
+                                    DependencyName = d.Name,
+                                    FromVersion = d.Version,
+                                    ToVersion = d.Version
+                                })
+                    .ToList(),
                     Url = PrUrl
                 });
         }


### PR DESCRIPTION
Add merge policy that prevents auto merging PRs that contains package version downgrades.

@mmitche I implemented the idea that we discussed offline: add the list of required updates to the InProgressPullRequest object. To make that work I had to do a bunch of 'refactoring':

- Add the DependencyUpdateSummary class; This way we only serialize the information that we need.
- Had to create IPullRequest interface so that IMergePolicyEvaluatorContext could contain a 'PullRequest' property. 
- Small change in MergePolicies.csproj so that it can reference Maestro.Contracts.csproj
- Some changes to convert "prUrl" to "pr.Url"
- Some changes to work with DependencyUpdate instead of DependencyDetail

Tested locally + a private repo in Azdo: https://dnceng.visualstudio.com/internal/_git/Cesar2/pullrequest/6499