### PR TITLE
Remove url shorthand switches

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -165,35 +165,6 @@ namespace Microsoft.DotNet.Darc.Operations
         }
 
         /// <summary>
-        ///     Returns the repo uri if it's set explicity or one of the shorthand versions is used.
-        /// </summary>
-        /// <returns></returns>
-        private string GetRepoUri()
-        {
-            const string sdkUri = "https://github.com/dotnet/core-sdk";
-            const string runtimeUri = "https://github.com/dotnet/core-setup";
-            const string aspnetUri = "https://github.com/aspnet/AspNetCore";
-            string repoUri = _options.RepoUri;
-
-            if (string.IsNullOrEmpty(repoUri))
-            {
-                if (_options.DownloadSdk)
-                {
-                    repoUri = sdkUri;
-                }
-                else if (_options.DownloadRuntime)
-                {
-                    repoUri = runtimeUri;
-                }
-                else if (_options.DownloadAspNet)
-                {
-                    repoUri = aspnetUri;
-                }
-            }
-            return repoUri;
-        }
-
-        /// <summary>
         ///     Validate that the root build options are being used
         ///     properly.
         ///     
@@ -207,10 +178,7 @@ namespace Microsoft.DotNet.Darc.Operations
             {
                 if (!string.IsNullOrEmpty(_options.RepoUri) ||
                     !string.IsNullOrEmpty(_options.Channel) ||
-                    !string.IsNullOrEmpty(_options.Commit) ||
-                    _options.DownloadSdk ||
-                    _options.DownloadRuntime ||
-                    _options.DownloadAspNet)
+                    !string.IsNullOrEmpty(_options.Commit))
                 {
                     Console.WriteLine("--id should not be specified with other options.");
                     return false;
@@ -224,15 +192,6 @@ namespace Microsoft.DotNet.Darc.Operations
             }
             else
             {
-                // Should specify a repo uri or shorthand, and only one
-                if (!(!string.IsNullOrEmpty(_options.RepoUri) ^
-                    _options.DownloadSdk ^
-                    _options.DownloadRuntime ^
-                    _options.DownloadAspNet))
-                {
-                    Console.WriteLine("Please specify one of --id, --repo, --sdk, --runtime or --aspnet.");
-                    return false;
-                }
                 // Check that commit or channel was specified but not both
                 if (!(!string.IsNullOrEmpty(_options.Commit) ^
                     !string.IsNullOrEmpty(_options.Channel)))
@@ -252,7 +211,7 @@ namespace Microsoft.DotNet.Darc.Operations
         {
             IRemote remote = RemoteFactory.GetBarOnlyRemote(_options, Logger);
 
-            string repoUri = GetRepoUri();
+            string repoUri = _options.RepoUri;
 
             if (_options.RootBuildIds.Any())
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
@@ -50,15 +50,6 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("include-toolset", HelpText = "Include toolset dependencies.")]
         public bool IncludeToolset { get; set; }
 
-        [Option("sdk", HelpText = "Download an SDK (core-sdk). Requires --commit or --channel.")]
-        public bool DownloadSdk { get; set; }
-
-        [Option("runtime", HelpText = "Download a runtime (core-setup). Requires --commit or --channel.")]
-        public bool DownloadRuntime { get; set; }
-
-        [Option("aspnet", HelpText = "Download an aspnet drop (aspnet). Requires --commit or --channel.")]
-        public bool DownloadAspNet { get; set; }
-
         [Option("channel", HelpText = "Download the latest from this channel. Matched on substring.")]
         public string Channel { get; set; }
 


### PR DESCRIPTION
Remove the --sdk, --aspnet, and --runtime shorthand switches.
The repo consolidation, repo org changes, etc. have made these options not particularly useful,
and I don't think they were particularly useful in the first place.