### PR TITLE
Delete the Pull Request branch when a PR is manually merged or closed

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -400,6 +400,16 @@ namespace SubscriptionActorService
                         pr.MergePolicyResult,
                         prUrl);
                     await StateManager.RemoveStateAsync(PullRequest);
+
+                    // Also try to clean up the PR branch.
+                    try
+                    {
+                        await darc.DeletePullRequestBranchAsync(prUrl);
+                    }
+                    catch (DarcException e)
+                    {
+                        Logger.LogInformation(e, $"Failed to delete Branch associated with pull request {prUrl}");
+                    }
                     return ActionResult.Create(SynchronizePullRequestResult.Completed, $"PR Has been manually {status}");
                 default:
                     throw new NotImplementedException($"Unknown pr status '{status}'");

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -185,10 +185,29 @@ namespace Microsoft.DotNet.DarcLib
                 body);
         }
 
+        /// <summary>
+        /// Deletes a branch in a repository
+        /// </summary>
+        /// <param name="repoUri">Repository Uri</param>
+        /// <param name="branch">Branch to delete</param>
+        /// <returns>Async task</returns>
         public async Task DeleteBranchAsync(string repoUri, string branch)
         {
             (string accountName, string projectName, string repoName) = ParseRepoUri(repoUri);
 
+            await DeleteBranchAsync(accountName, projectName, repoName, branch);
+        }
+
+        /// <summary>
+        /// Deletes a branch in a repository
+        /// </summary>
+        /// <param name="accountName">Azure DevOps Account</param>
+        /// <param name="projectName">Azure DevOps project</param>
+        /// <param name="repoName">Name of the repository</param>
+        /// <param name="branch">Brach to delete</param>
+        /// <returns>Async Task</returns>
+        private async Task DeleteBranchAsync(string accountName, string projectName, string repoName, string branch)
+        {
             string latestSha = await GetLastCommitShaAsync(accountName, projectName, repoName, branch);
 
             var azureDevOpsRefs = new List<AzureDevOpsRef>();
@@ -1401,6 +1420,18 @@ namespace Microsoft.DotNet.DarcLib
             catch (Exception) { }
 
             return false;
+        }
+
+        /// <summary>
+        /// Deletes the head branch for a pull request
+        /// </summary>
+        /// <param name="pullRequestUri">Pull request Uri</param>
+        /// <returns>Async task</returns>
+        public async Task DeletePullRequestBranchAsync(string pullRequestUri)
+        {
+            PullRequest pr = await GetPullRequestAsync(pullRequestUri);
+            (string account, string project, string repo, int id) prInfo = ParsePullRequestUri(pullRequestUri);
+            await DeleteBranchAsync(prInfo.account, prInfo.project, prInfo.repo, pr.HeadBranch);
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -337,6 +337,18 @@ namespace Microsoft.DotNet.DarcLib
             return _gitClient.UpdatePullRequestAsync(pullRequestUri, pullRequest);
         }
 
+        public async Task DeletePullRequestBranchAsync(string pullRequestUri)
+        {
+            try
+            {
+                await _gitClient.DeletePullRequestBranchAsync(pullRequestUri);
+            }
+            catch (Exception e)
+            {
+                throw new DarcException("Failed to delete head branch for pull request {pullRequestUri}", e);
+            }
+        }
+
         public async Task MergePullRequestAsync(string pullRequestUrl, MergePullRequestParameters parameters)
         {
             CheckForValidGitClient();

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -337,6 +337,11 @@ namespace Microsoft.DotNet.DarcLib
             return _gitClient.UpdatePullRequestAsync(pullRequestUri, pullRequest);
         }
 
+        /// <summary>
+        ///     Delete a Pull Request branch
+        /// </summary>
+        /// <param name="pullRequestUri">URI of pull request to delete branch for</param>
+        /// <returns>Async task</returns>
         public async Task DeletePullRequestBranchAsync(string pullRequestUri)
         {
             try

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -178,10 +178,28 @@ namespace Microsoft.DotNet.DarcLib
             }
         }
 
+        /// <summary>
+        /// Deletes a branch in a repository
+        /// </summary>
+        /// <param name="repoUri">Repository URL</param>
+        /// <param name="branch">Branch to delete</param>
+        /// <returns>Async Task</returns>
         public async Task DeleteBranchAsync(string repoUri, string branch)
         {
             (string owner, string repo) = ParseRepoUri(repoUri);
 
+            await DeleteBranchAsync(owner, repo, branch);
+        }
+
+        /// <summary>
+        /// Deletes a branch in a repository
+        /// </summary>
+        /// <param name="owner">Repository owner</param>
+        /// <param name="repo">Repository name</param>
+        /// <param name="branch">Branch to delete</param>
+        /// <returns></returns>
+        private async Task DeleteBranchAsync(string owner, string repo, string branch)
+        {
             await Client.Git.Reference.Delete(owner, repo, $"heads/{branch}");
         }
 
@@ -982,6 +1000,18 @@ namespace Microsoft.DotNet.DarcLib
             catch (Exception) { }
 
             return false;
+        }
+
+        /// <summary>
+        /// Deletes the head branch for a pull request
+        /// </summary>
+        /// <param name="pullRequestUri">Pull request Uri</param>
+        /// <returns>Async task</returns>
+        public async Task DeletePullRequestBranchAsync(string pullRequestUri)
+        {
+            PullRequest pr = await GetPullRequestAsync(pullRequestUri);
+            (string owner, string repo, int id) prInfo = ParsePullRequestUri(pullRequestUri);
+            await DeleteBranchAsync(prInfo.owner, prInfo.repo, pr.HeadBranch);
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -182,7 +182,7 @@ namespace Microsoft.DotNet.DarcLib
         ///     Delete a pull request's branch if it still exists
         /// </summary>
         /// <param name="pullRequestUri"></param>
-        /// <returns></returns>
+        /// <returns>Async task</returns>
         Task DeletePullRequestBranchAsync(string pullRequestUri);
     }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -177,6 +177,13 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="repoDir">The local repo directory</param>
         /// <param name="repoUrl">The remote URL to add</param>
         void AddRemoteIfMissing(string repoDir, string repoUrl);
+
+        /// <summary>
+        ///     Delete a pull request's branch if it still exists
+        /// </summary>
+        /// <param name="pullRequestUri"></param>
+        /// <returns></returns>
+        Task DeletePullRequestBranchAsync(string pullRequestUri);
     }
 
     public class PullRequest

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -240,6 +240,13 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns>Async task.</returns>
         Task UpdatePullRequestAsync(string pullRequestUri, PullRequest pullRequest);
 
+        /// <summary>
+        ///     Delete a Pull Request branch
+        /// </summary>
+        /// <param name="pullRequestUri">URI of pull request to delete branch for</param>
+        /// <returns>Async task</returns>
+        Task DeletePullRequestBranchAsync(string pullRequestUri);
+
         #endregion
 
         #region Repo/Dependency Operations

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -494,5 +494,10 @@ namespace Microsoft.DotNet.DarcLib
         {
             throw new NotImplementedException();
         }
+
+        public Task DeletePullRequestBranchAsync(string pullRequestUri)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
Delete the PR branch when we detect that the PR has been merged or abandoned.

https://github.com/dotnet/arcade/issues/3214

Validation:
Validated this with these two dependency update PRs using the scenario tests:

https://github.com/maestro-auth-test/maestro-test2/pull/9519
https://dev.azure.com/dnceng/internal/_git/maestro-test2/pullrequest/6540

Github is nicer in that it actually shows that the app deleted the branch.
In the Azdo PR note that the Delete source branch button is greyed out, and that trying to get to the branch 404s.