### PR TITLE
Maestro scenario test base

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,11 +22,11 @@
     <MicrosoftBuildTasksCoreVersion>16.3.0</MicrosoftBuildTasksCoreVersion>
     <MicrosoftBuildUtilitiesCoreVersion>16.3.0</MicrosoftBuildUtilitiesCoreVersion>
     <MicrosoftCodeAnalysisCSharpVersion>2.9.0</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftCodeCoverageVersion>16.4.0</MicrosoftCodeCoverageVersion>
+    <MicrosoftCodeCoverageVersion>16.5.0</MicrosoftCodeCoverageVersion>
     <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.19.8</MicrosoftIdentityModelClientsActiveDirectoryVersion>
     <MicrosoftRestClientRuntimeVersion>2.3.13</MicrosoftRestClientRuntimeVersion>
     <MicrosoftExtensionsFileSystemGlobbingVersion>2.0.0</MicrosoftExtensionsFileSystemGlobbingVersion>
-    <MicrosoftNETTestSdkVersion>16.4.0</MicrosoftNETTestSdkVersion>
+    <MicrosoftNETTestSdkVersion>16.5.0</MicrosoftNETTestSdkVersion>
     <MoqVersion>4.8.3</MoqVersion>
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Octokit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Maestro.ScenarioTests
+{
+    public class ScenarioTests_SdkUpdate : MaestroScenarioTestBase
+    {
+        public ScenarioTests_SdkUpdate(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ArcadeSdkUpdate()
+        {
+            string testChannelName = "Test Channel " + _random.Next(int.MaxValue);
+            var sourceRepo = "arcade";
+            var sourceRepoUri = "https://github.com/dotnet/arcade";
+            var sourceBranch = "dependencyflow-tests";
+            var sourceCommit = "0b36b99e29b1751403e23cfad0a7dff585818051";
+            var sourceBuildNumber = _random.Next(int.MaxValue).ToString();
+            ImmutableList<AssetData> sourceAssets = ImmutableList.Create<AssetData>()
+                .Add(new AssetData(true)
+                {
+                    Name = "Microsoft.DotNet.Arcade.Sdk",
+                    Version = "2.1.0",
+                });
+            var targetRepo = "maestro-test2";
+            var targetBranch = _random.Next(int.MaxValue).ToString();
+            await using AsyncDisposableValue<string> channel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
+            await using AsyncDisposableValue<string> sub = await CreateSubscriptionAsync(testChannelName, sourceRepo, targetRepo, targetBranch, "none");
+            int buildId = await CreateBuildAsync(GetRepoUrl("dotnet", sourceRepo), sourceBranch, sourceCommit, sourceBuildNumber, sourceAssets);
+            await using IAsyncDisposable _ = await AddBuildToChannelAsync(buildId, testChannelName);
+
+            using TemporaryDirectory repo = await CloneRepositoryAsync(targetRepo);
+            using (ChangeDirectory(repo.Directory))
+            {
+                await RunGitAsync("checkout", "-b", targetBranch).ConfigureAwait(false);
+                await RunDarcAsync("add-dependency",
+                    "--name", "Microsoft.DotNet.Arcade.Sdk",
+                    "--type", "toolset",
+                    "--repo", sourceRepoUri);
+                await RunGitAsync("commit", "-am", "Add dependencies.");
+                await using IAsyncDisposable ___ = await PushGitBranchAsync("origin", targetBranch);
+                await TriggerSubscriptionAsync(sub.Value);
+
+                PullRequest pr = await WaitForPullRequestAsync(targetRepo, targetBranch);
+
+                Assert.Equal($"[{targetBranch}] Update dependencies from dotnet/arcade", pr.Title);
+
+                await CheckoutRemoteRefAsync(pr.MergeCommitSha);
+
+                string dependencies = await RunDarcAsync("get-dependencies");
+                string[] dependencyLines = dependencies.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
+                Assert.Equal(new[]
+                {
+                    "Name:             Microsoft.DotNet.Arcade.Sdk",
+                    "Version:          2.1.0",
+                    $"Repo:             {sourceRepoUri}",
+                    $"Commit:           {sourceCommit}",
+                    "Type:             Toolset",
+                    "Pinned:           False",
+                }, dependencyLines);
+
+                using TemporaryDirectory arcadeRepo = await CloneRepositoryAsync("dotnet", sourceRepo);
+                using (ChangeDirectory(arcadeRepo.Directory))
+                {
+                    await CheckoutRemoteRefAsync(sourceCommit);
+                }
+
+                var arcadeFiles = Directory.EnumerateFileSystemEntries(Path.Join(arcadeRepo.Directory, "eng", "common"),
+                        "*", SearchOption.AllDirectories)
+                    .Select(s => s.Substring(arcadeRepo.Directory.Length))
+                    .ToHashSet();
+                var repoFiles = Directory.EnumerateFileSystemEntries(Path.Join(repo.Directory, "eng", "common"), "*",
+                        SearchOption.AllDirectories)
+                    .Select(s => s.Substring(repo.Directory.Length))
+                    .ToHashSet();
+
+                Assert.Empty(arcadeFiles.Except(repoFiles));
+                Assert.Empty(repoFiles.Except(arcadeFiles));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Split out the shared logic in MaestroScenarioTests.cs and convert to a base class.
Update the test sdk version to 16.5 to avoid this issue: https://developercommunity.visualstudio.com/content/problem/831442/test-explorer-wont-run-tests-too-particular-about.html