### PR TITLE
Do not delete feeds after deleting all packages

### DIFF
--- a/src/Maestro/FeedCleanerService/FeedCleanerService.cs
+++ b/src/Maestro/FeedCleanerService/FeedCleanerService.cs
@@ -99,21 +99,7 @@ namespace FeedCleanerService
                         catch (Exception ex)
                         {
                             Logger.LogError(ex, $"Something failed while trying to update the released packages in feed {feed.Name}");
-                        }
-
-                        if (IsFeedEmpty(feed))
-                        {
-                            try
-                            {
-                                Logger.LogInformation($"Deleting feed {feed.Name} since it doesn't contain any active package versions...");
-                                await azdoClient.DeleteFeedAsync(azdoAccount, feed.Project?.Id, feed.Name);
-                                Logger.LogInformation($"Successfully deleted feed {feed.Name}");
-                            }
-                            catch (HttpRequestException ex)
-                            {
-                                Logger.LogError(ex, $"Something failed when attempting to delete feed {feed.Name}");
-                            }
-                        }
+                        } 
                     }
                 }
             }

--- a/src/Maestro/tests/FeedCleaner.Tests/FeedCleanerServiceTests.cs
+++ b/src/Maestro/tests/FeedCleaner.Tests/FeedCleanerServiceTests.cs
@@ -81,19 +81,6 @@ namespace FeedCleanerService.Tests
         }
 
         [Fact]
-        public async void DeletesFeedsWhenAllPackagesAreReleased()
-        {
-            FeedCleanerService cleaner = ConfigureFeedCleaner();
-            await cleaner.CleanManagedFeedsAsync();
-
-            Assert.Equal(3, Feeds.Count);
-            Assert.True(Feeds.ContainsKey(ReleaseFeedName));
-            Assert.True(Feeds.ContainsKey(UnmanagedFeedName));
-            Assert.True(Feeds.ContainsKey(FeedWithUnreleasedPackagesName));
-            Assert.False(Feeds.ContainsKey(FeedWithAllPackagesReleasedName));
-        }
-
-        [Fact]
         public async void OnlyDeletesReleasedPackagesFromManagedFeeds()
         {
             FeedCleanerService cleaner = ConfigureFeedCleaner();


### PR DESCRIPTION
Workaround for repos doing weird things and nuget being dumb with feeds that don't exist.


Tracking issue to re-enable this: https://github.com/dotnet/arcade/issues/5052