### PR TITLE
Add default IMetricTracker for all services

### DIFF
--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Microsoft.DotNet.ServiceFabric.ServiceHost.csproj
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Microsoft.DotNet.ServiceFabric.ServiceHost.csproj
@@ -38,6 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Monitoring\Microsoft.DotNet.Metrics\Microsoft.DotNet.Metrics.csproj" />
     <ProjectReference Include="..\Shared\MIcrosoft.DotNet.Internal.Logging\Microsoft.DotNet.Internal.Logging.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
@@ -15,6 +15,7 @@ using JetBrains.Annotations;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.DotNet.Internal.Logging;
+using Microsoft.DotNet.Metrics;
 using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -243,6 +244,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                     builder.AddDebug();
                     builder.AddFixedApplicationInsights(LogLevel.Information);
                 });
+            services.TryAddSingleton<IMetricTracker, ApplicationInsightsMetricTracker>();
         }
 
         private static HostingEnvironment InitializeEnvironment()


### PR DESCRIPTION
This is the one everyone is supposed to use, so lets just plop it in our default set