### PR TITLE
Fixes to darc-add-build-to-channel

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -213,20 +213,20 @@ namespace Microsoft.DotNet.Darc.Operations
                 if (!artifacts.Any(f => f.Name.Equals("AssetManifests")))
                 {
                     Console.Write("The build that you want to add to a new channel doesn't have a Build Manifest. That's required for publishing. Aborting.");
-                    return true;
+                    return false;
                 }
 
                 if ((_options.DoSigningValidation || _options.DoNuGetValidation || _options.DoSourcelinkValidation)
                     && !artifacts.Any(f => f.Name.Equals("PackageArtifacts")))
                 {
-                    Console.Write("The build that you want to add to a new channel doesn't have a list of package assets. That's required when running signing or NuGet validation. Aborting.");
-                    return true;
+                    Console.Write("The build that you want to add to a new channel doesn't have a list of package assets in the PackageArtifacts container. That's required when running signing or NuGet validation. Aborting.");
+                    return false;
                 }
 
                 if (_options.DoSourcelinkValidation && !artifacts.Any(f => f.Name.Equals("BlobArtifacts")))
                 {
-                    Console.Write("The build that you want to add to a new channel doesn't have a list of blob assets. That's required when running SourceLink validation. Aborting.");
-                    return true;
+                    Console.Write("The build that you want to add to a new channel doesn't have a list of blob assets in the BlobArtifacts container. That's required when running SourceLink validation. Aborting.");
+                    return false;
                 }
 
                 return true;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -17,9 +17,12 @@ namespace Microsoft.DotNet.Darc.Operations
 {
     internal class AddBuildToChannelOperation : Operation
     {
-        private const int BuildPromotionPipelineId = 750;
-        private const string BuildPromotionPipelineAccountName = "dnceng";
-        private const string BuildPromotionPipelineProjectName = "internal";
+        private static readonly Dictionary<string, (string project, int pipelineId)> BuildPromotionPipelinesForAccount =
+            new Dictionary<string, (string project, int pipelineId)>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "dnceng", ("internal", 750) },
+                { "devdiv", ("devdiv", 12603) }
+            };
 
         AddBuildToChannelCommandLineOptions _options;
         public AddBuildToChannelOperation(AddBuildToChannelCommandLineOptions options)
@@ -137,15 +140,24 @@ namespace Microsoft.DotNet.Darc.Operations
                 $"\"SDLValidationContinueOnError\": \"{ _options.SDLValidationContinueOnError }\", " +
                 $"}}";
 
-            var azdoBuildId = await azdoClient.StartNewBuildAsync(BuildPromotionPipelineAccountName, 
-                BuildPromotionPipelineProjectName, 
-                BuildPromotionPipelineId, 
+
+            if (!BuildPromotionPipelinesForAccount.TryGetValue(
+                build.AzureDevOpsAccount,
+                out (string project, int pipelineId) promotionPipelineInformation))
+            {
+                Console.WriteLine($"Promoting builds from AzureDevOps account {build.AzureDevOpsAccount} is not supported by this command.");
+                return Constants.ErrorCode;
+            }
+
+            int azdoBuildId = await azdoClient.StartNewBuildAsync(build.AzureDevOpsAccount,
+                promotionPipelineInformation.project,
+                promotionPipelineInformation.pipelineId,
                 arcadeSDKSourceBranch,
                 arcadeSDKSourceSHA,
                 queueTimeVariables)
                 .ConfigureAwait(false);
 
-            var promotionBuildUrl = $"https://{BuildPromotionPipelineAccountName}.visualstudio.com/{BuildPromotionPipelineProjectName}/_build/results?buildId={azdoBuildId}";
+            string promotionBuildUrl = $"https://{build.AzureDevOpsAccount}.visualstudio.com/{promotionPipelineInformation.project}/_build/results?buildId={azdoBuildId}";
 
             Console.WriteLine($"Build {build.Id} will be assigned to channel '{targetChannel.Name}' once this build finishes publishing assets: {promotionBuildUrl}");
 
@@ -164,7 +176,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 {
                     Console.WriteLine($"Waiting '{waitIntervalInSeconds.TotalSeconds}' seconds for promotion build to complete.");
                     await Task.Delay(waitIntervalInSeconds);
-                    promotionBuild = await azdoClient.GetBuildAsync(BuildPromotionPipelineAccountName, BuildPromotionPipelineProjectName, azdoBuildId);
+                    promotionBuild = await azdoClient.GetBuildAsync(
+                        build.AzureDevOpsAccount,
+                        promotionPipelineInformation.project,
+                        azdoBuildId);
+
                 } while (!promotionBuild.Status.Equals("completed", StringComparison.OrdinalIgnoreCase));
             }
             catch (Exception e)


### PR DESCRIPTION
* Enable darc-add-build-to-channel to promote builds from Devdiv: 
This is for https://github.com/dotnet/arcade/issues/4986 and is needed to get NuGet insertions into .NET working again.

  Triggered https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3556040&view=logs&j=f7bb3748-e35d-53de-9dd7-460ecd2014d6&t=299a6d6d-a279-539e-b6e9-1576018947a8 with these changes.

* Also fixes some validation errors that weren't failing the operation due to a bug in the validation code: dotnet/arcade#4941 