### PR TITLE
Publish Microsoft.DotNet.Services.Utility

### DIFF
--- a/src/Shared/Microsoft.DotNet.Services.Utility/Microsoft.DotNet.Services.Utility.csproj
+++ b/src/Shared/Microsoft.DotNet.Services.Utility/Microsoft.DotNet.Services.Utility.csproj
@@ -7,5 +7,8 @@
   <ItemGroup>
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
+  
+  <IsPackable>true</IsPackable>
+  <IsShipping>false</IsShipping>
 
 </Project>

--- a/src/Shared/Microsoft.DotNet.Services.Utility/Microsoft.DotNet.Services.Utility.csproj
+++ b/src/Shared/Microsoft.DotNet.Services.Utility/Microsoft.DotNet.Services.Utility.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-	<IsPackable>true</IsPackable>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Shared/Microsoft.DotNet.Services.Utility/Microsoft.DotNet.Services.Utility.csproj
+++ b/src/Shared/Microsoft.DotNet.Services.Utility/Microsoft.DotNet.Services.Utility.csproj
@@ -2,13 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+	<IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
   
-  <IsPackable>true</IsPackable>
-  <IsShipping>false</IsShipping>
-
 </Project>


### PR DESCRIPTION
This is a dependency for DarcLib, so it needs to be published in order for the DarcLib package to be useable.