### PR TITLE
Infra for refreshing service fabric services.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -143,6 +143,7 @@ stages:
           - powershell: |
               robocopy src/Maestro/MaestroApplication/PublishProfiles $(Build.ArtifactStagingDirectory)\ServiceFabric\MaestroApplication\projectartifacts\PublishProfiles /S *.xml
               robocopy src/Maestro/MaestroApplication/ApplicationParameters $(Build.ArtifactStagingDirectory)\ServiceFabric\MaestroApplication\projectartifacts\ApplicationParameters /S *.xml
+              robocopy src/Maestro/MaestroApplication/ApplicationPackageRoot $(Build.ArtifactStagingDirectory)\ServiceFabric\MaestroApplication\projectartifacts\ApplicationPackageRoot /S *.xml
               exit 0
             displayName: Copy Maestro Project Artifacts
 
@@ -157,6 +158,7 @@ stages:
           - powershell: |
               robocopy src/Telemetry/TelemetryApplication/PublishProfiles $(Build.ArtifactStagingDirectory)\ServiceFabric\TelemetryApplication\projectartifacts\PublishProfiles /S *.xml
               robocopy src/Telemetry/TelemetryApplication/ApplicationParameters $(Build.ArtifactStagingDirectory)\ServiceFabric\TelemetryApplication\projectartifacts\ApplicationParameters /S *.xml
+              robocopy src/Telemetry/TelemetryApplication/ApplicationPackageRoot $(Build.ArtifactStagingDirectory)\ServiceFabric\TelemetryApplication\projectartifacts\ApplicationPackageRoot /S *.xml
               exit 0
             displayName: Copy Telemetry Project Artifacts
 

--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -114,6 +114,15 @@ stages:
     steps:
     - download: current
       artifact: MaestroApplication
+    - task: ServiceFabricPowerShell@1
+      displayName: Refresh Service Fabric Services (Maestro)
+      inputs:
+        clusterConnection: ${{ parameters.ServiceFabricConnection }}
+        scriptType: filePath
+        scriptPath: $(Pipeline.Workspace)/ReleaseUtilities/refresh-service-fabric-services.ps1
+        scriptArguments: -ApplicationName fabric:/MaestroApplication 
+          -ApplicationManifestPath $(Pipeline.Workspace)/MaestroApplication/projectartifacts/ApplicationPackageRoot/ApplicationManifest.xml 
+          -ServicesSourceFolder $(Build.SourcesDirectory)/src/Maestro/
     - task: ServiceFabricDeploy@1
       displayName: Deploy Service Fabric Application (Maestro)
       inputs:
@@ -128,6 +137,15 @@ stages:
     steps:
     - download: current
       artifact: TelemetryApplication
+    - task: ServiceFabricPowerShell@1
+      displayName: Refresh Service Fabric Services (Telemetry)
+      inputs:
+        clusterConnection: ${{ parameters.ServiceFabricConnection }}
+        scriptType: filePath
+        scriptPath: $(Pipeline.Workspace)/ReleaseUtilities/refresh-service-fabric-services.ps1
+        scriptArguments: -ApplicationName fabric:/TelemetryApplication 
+          -ApplicationManifestPath $(Pipeline.Workspace)/TelemetryApplication/projectartifacts/ApplicationPackageRoot/ApplicationManifest.xml 
+          -ServicesSourceFolder $(Build.SourcesDirectory)/src/Telemetry/
     - task: ServiceFabricDeploy@1
       displayName: Deploy Service Fabric Application (Telemetry)
       inputs:

--- a/eng/refresh-service-fabric-services.ps1
+++ b/eng/refresh-service-fabric-services.ps1
@@ -1,0 +1,56 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$True)] [string]$ApplicationName,
+    [Parameter(Mandatory=$True)] [string]$ApplicationManifestPath,
+    [Parameter(Mandatory=$True)] [string]$ServicesSourceFolder,
+    [int]$TimeoutInSecs = 300
+)
+
+function Get-ServiceTypes() {
+    $serviceTypes = @()
+    [xml]$appManifest = Get-Content $ApplicationManifestPath 
+    $manifestsNames = $appManifest.ApplicationManifest.ServiceManifestImport.ServiceManifestRef.ServiceManifestName | Select-Object $_
+
+    foreach ($manifestName in $manifestsNames) {
+        $serviceName = $manifestName -replace "Pkg" 
+        $manifestPath = "${ServicesSourceFolder}${serviceName}\PackageRoot\ServiceManifest.xml"
+
+        [xml]$serviceManifest = Get-Content $manifestPath
+        $serviceTypes += $serviceManifest.ServiceManifest.ServiceTypes.StatefulServiceType.ServiceTypeName | Select-Object $_
+        $serviceTypes += $serviceManifest.ServiceManifest.ServiceTypes.StatelessServiceType.ServiceTypeName | Select-Object $_
+    }
+
+    Write-Host "Service types found: "
+    $serviceTypes | ForEach-Object { Write-Host "`t" $_ }
+    Write-Host
+    
+    return $serviceTypes
+}
+
+try {
+    $serviceTypes = Get-ServiceTypes
+
+    $runningServices = Get-ServiceFabricService -ApplicationName $ApplicationName
+
+    Write-Host "Currently running services: "
+    $runningServices | ForEach-Object { Write-Host "`t" $_.ServiceName ":" $_.ServiceTypeName }
+    Write-Host
+
+    $runningServices | ForEach-Object {
+        $serviceName = $_.ServiceName
+        $serviceTypeName = $_.ServiceTypeName
+        $shouldBeRemoved = ! ($serviceTypeName -in $serviceTypes)
+
+        Write-Host "Should '$serviceName : $serviceTypeName' service be removed? $shouldBeRemoved"
+
+        if ($shouldBeRemoved) {
+            Write-Host -NoNewline "`t Removing '$serviceName' service ... "  -ForegroundColor White -BackgroundColor Red
+            Remove-ServiceFabricService -ServiceName $serviceName -Force -ForceRemove -TimeOutSec $TimeoutInSecs | Out-Null
+            Write-Host "done." -ForegroundColor White -BackgroundColor Red
+        }
+    }
+}
+catch {
+	Write-Error "Problems while removing service fabric services."
+	Write-Error $_
+}

--- a/eng/refresh-service-fabric-services.ps1
+++ b/eng/refresh-service-fabric-services.ps1
@@ -9,15 +9,15 @@ param(
 function Get-ServiceTypes() {
     $serviceTypes = @()
     [xml]$appManifest = Get-Content $ApplicationManifestPath 
-    $manifestsNames = $appManifest.ApplicationManifest.ServiceManifestImport.ServiceManifestRef.ServiceManifestName | Select-Object $_
+    $manifestsNames = $appManifest.ApplicationManifest.ServiceManifestImport.ServiceManifestRef.ServiceManifestName
 
     foreach ($manifestName in $manifestsNames) {
         $serviceName = $manifestName -replace "Pkg" 
         $manifestPath = "${ServicesSourceFolder}${serviceName}\PackageRoot\ServiceManifest.xml"
 
         [xml]$serviceManifest = Get-Content $manifestPath
-        $serviceTypes += $serviceManifest.ServiceManifest.ServiceTypes.StatefulServiceType.ServiceTypeName | Select-Object $_
-        $serviceTypes += $serviceManifest.ServiceManifest.ServiceTypes.StatelessServiceType.ServiceTypeName | Select-Object $_
+        $serviceTypes += $serviceManifest.ServiceManifest.ServiceTypes.StatefulServiceType.ServiceTypeName | Where-Object { $_ }
+        $serviceTypes += $serviceManifest.ServiceManifest.ServiceTypes.StatelessServiceType.ServiceTypeName | Where-Object { $_ }
     }
 
     Write-Host "Service types found: "


### PR DESCRIPTION
Relates to: https://github.com/dotnet/core-eng/issues/9353

**What is it?**
A new script in `eng\` folder that removes all service fabric services currently running which type isn't present among the underlying Service Fabric Application service types. 

Implemented following suggestions from @alexperovich .

**Tests?**

- I tested the script locally for the Telemetry and Maestro applications. 
- **What's the best way to test this in INT? I.e., what's the best way to test the YAML part?**

**Sample output:**
```
Service types found:
         SubscriptionActorServiceType
         PullRequestActorServiceType
         DependencyUpdaterType
         Maestro.WebType
         FeedCleanerServiceType

Currently running services:
         fabric:/MaestroApplication/DependencyUpdater : DependencyUpdaterType
         fabric:/MaestroApplication/FeedCleanerService : FeedCleanerServiceType
         fabric:/MaestroApplication/Maestro.Web : Maestro.WebType
         fabric:/MaestroApplication/PullRequestActorService : PullRequestActorServiceType
         fabric:/MaestroApplication/ReleasePipelineRunner : ReleasePipelineRunnerType
         fabric:/MaestroApplication/SubscriptionActorService : SubscriptionActorServiceType

Should 'fabric:/MaestroApplication/DependencyUpdater : DependencyUpdaterType' service be removed? False
Should 'fabric:/MaestroApplication/FeedCleanerService : FeedCleanerServiceType' service be removed? False
Should 'fabric:/MaestroApplication/Maestro.Web : Maestro.WebType' service be removed? False
Should 'fabric:/MaestroApplication/PullRequestActorService : PullRequestActorServiceType' service be removed? False
Should 'fabric:/MaestroApplication/ReleasePipelineRunner : ReleasePipelineRunnerType' service be removed? True
         Removing 'fabric:/MaestroApplication/ReleasePipelineRunner' service ... done.
Should 'fabric:/MaestroApplication/SubscriptionActorService : SubscriptionActorServiceType' service be removed? False
```