### PR TITLE
Fix build due to missing artifact download

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -114,6 +114,8 @@ stages:
     steps:
     - download: current
       artifact: MaestroApplication
+    - download: current
+      artifact: ReleaseUtilities
     - task: ServiceFabricPowerShell@1
       displayName: Refresh Service Fabric Services (Maestro)
       inputs:
@@ -137,6 +139,8 @@ stages:
     steps:
     - download: current
       artifact: TelemetryApplication
+    - download: current
+      artifact: ReleaseUtilities
     - task: ServiceFabricPowerShell@1
       displayName: Refresh Service Fabric Services (Telemetry)
       inputs:


### PR DESCRIPTION
Build is broken because the ReleaseUtilities artifact wasn't downloaded before calling refresh-service-fabric-services.ps1: https://dnceng.visualstudio.com/internal/_build/results?buildId=573177&view=results

