### PR TITLE
Output build id as msbuild property in PushMetadataToBuildAssetRegistry

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
         public string RepoRoot { get; set; }
 
         [Output]
-        public string BuildId { get; set; }
+        public int BuildId { get; set; }
 
         private const string SearchPattern = "*.xml";
         private readonly CancellationTokenSource _tokenSource = new CancellationTokenSource();
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                     finalBuild.Dependencies = deps;
 
                     Client.Models.Build recordedBuild = await client.Builds.CreateAsync(finalBuild, cancellationToken);
-                    BuildId = recordedBuild.Id.ToString();
+                    BuildId = recordedBuild.Id;
 
                     Log.LogMessage(MessageImportance.High, $"Metadata has been pushed. Build id in the Build Asset Registry is '{recordedBuild.Id}'");
 

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -39,6 +39,9 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
         public string RepoRoot { get; set; }
 
+        [Output]
+        public string BuildId { get; set; }
+
         private const string SearchPattern = "*.xml";
         private readonly CancellationTokenSource _tokenSource = new CancellationTokenSource();
 
@@ -93,6 +96,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                     finalBuild.Dependencies = deps;
 
                     Client.Models.Build recordedBuild = await client.Builds.CreateAsync(finalBuild, cancellationToken);
+                    BuildId = recordedBuild.Id.ToString();
 
                     Log.LogMessage(MessageImportance.High, $"Metadata has been pushed. Build id in the Build Asset Registry is '{recordedBuild.Id}'");
 


### PR DESCRIPTION
fixes https://github.com/dotnet/arcade/issues/5122

Please note that I'm not an MSBuild expert. I don't know if creating this output parameter will have consequences on targets that call the task and don't handle the output.