### PR TITLE
Darc verify duplicated properties

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -712,6 +712,7 @@ namespace Microsoft.DotNet.DarcLib
 
             List<Task<bool>> verificationTasks = new List<Task<bool>>()
             {
+                VerifyNoDuplicatedProperties(await versionProps),
                 VerifyNoDuplicatedDependencies(await dependencyDetails),
                 VerifyMatchingVersionProps(
                     await dependencyDetails, 
@@ -750,6 +751,45 @@ namespace Microsoft.DotNet.DarcLib
             }
 
             File.SetAttributes(directoryPath, FileAttributes.Normal);
+        }
+
+        /// <summary>
+        ///     Ensure that there is a unique propertyName + condition on the list.
+        /// </summary>
+        /// <param name="versionProps">Xml object representing MSBuild properties file.</param>
+        /// <returns>True if there are no duplicated properties.</returns>
+        private Task<bool> VerifyNoDuplicatedProperties(XmlDocument versionProps)
+        {
+            bool hasNoDuplicatedProperties = true;
+            HashSet<string> existingProperties = new HashSet<string>();
+
+            XmlNodeList propertyGroups = versionProps.GetElementsByTagName("PropertyGroup");
+            foreach (XmlNode propertyGroup in propertyGroups)
+            {
+                foreach (var property in propertyGroup.ChildNodes)
+                {
+                    if (property is XmlElement)
+                    {
+                        var element = property as XmlElement;
+                        var propertyName = element.Name;
+
+                        propertyName = Regex.Replace(propertyName, @"PackageVersion$", String.Empty);
+                        propertyName = Regex.Replace(propertyName, @"Version$", String.Empty);
+
+                        propertyName += element.GetAttribute("Condition");
+                        propertyName += element.GetAttribute("condition");
+
+                        if (existingProperties.Contains(propertyName))
+                        {
+                            hasNoDuplicatedProperties = false;
+                        }
+
+                        existingProperties.Add(propertyName);
+                    }
+                }
+            }
+
+            return Task.FromResult(hasNoDuplicatedProperties);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -758,7 +758,7 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         /// <param name="versionProps">Xml object representing MSBuild properties file.</param>
         /// <returns>True if there are no duplicated properties.</returns>
-        private Task<bool> VerifyNoDuplicatedProperties(XmlDocument versionProps)
+        public Task<bool> VerifyNoDuplicatedProperties(XmlDocument versionProps)
         {
             bool hasNoDuplicatedProperties = true;
             HashSet<string> existingProperties = new HashSet<string>();

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
@@ -991,6 +991,21 @@
     <None Update="inputs\UpdateDependencies4\output\global.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="inputs\VersionPropsFiles\DuplicatedSameConditions.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="inputs\VersionPropsFiles\NoDuplicatedDifferentConditions.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="inputs\VersionPropsFiles\AlternateNamesDuplicated.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="inputs\VersionPropsFiles\SimpleDuplicated.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="inputs\VersionPropsFiles\NothingDuplicated.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/VersionPropsFiles/AlternateNamesDuplicated.props
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/VersionPropsFiles/AlternateNamesDuplicated.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <FooBarVersion>1.2.3</FooBarVersion>
+    <FooBarPackageVersion>1.2.3</FooBarPackageVersion>
+    <FooBar2Version>1.2.4</FooBar2Version>
+    <FooBar3Version>1.2.4</FooBar3Version>
+    <ExistingDependencyVersion>1.2.3</ExistingDependencyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/VersionPropsFiles/DuplicatedSameConditions.props
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/VersionPropsFiles/DuplicatedSameConditions.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <FooBarVersion Condition="'1' == '2'">1.2.3</FooBarVersion>
+    <FooBarVersion condition="'1' == '2'">1.2.3</FooBarVersion>
+    <FooBar2Version>1.2.4</FooBar2Version>
+    <FooBar3Version>1.2.4</FooBar3Version>
+    <ExistingDependencyVersion>1.2.3</ExistingDependencyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/VersionPropsFiles/NoDuplicatedDifferentConditions.props
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/VersionPropsFiles/NoDuplicatedDifferentConditions.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <FooBarVersion Condition="'$(mode)' == 'dev'">1.2.3</FooBarVersion>
+    <FooBarVersion Condition="'$(mode)' == 'release'">1.2.3</FooBarVersion>
+    <FooBar2Version>1.2.4</FooBar2Version>
+    <FooBar3Version>1.2.4</FooBar3Version>
+    <ExistingDependencyVersion>1.2.3</ExistingDependencyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/VersionPropsFiles/NothingDuplicated.props
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/VersionPropsFiles/NothingDuplicated.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <FooBarVersion>1.2.3</FooBarVersion>
+    <FooBar2Version>1.2.4</FooBar2Version>
+    <FooBar3Version>1.2.4</FooBar3Version>
+    <ExistingDependencyVersion>1.2.3</ExistingDependencyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/VersionPropsFiles/SimpleDuplicated.props
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/VersionPropsFiles/SimpleDuplicated.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <FooBarVersion>1.2.3</FooBarVersion>
+    <FooBarVersion>1.2.3</FooBarVersion>
+    <FooBar2Version>1.2.4</FooBar2Version>
+    <FooBar3Version>1.2.4</FooBar3Version>
+    <ExistingDependencyVersion>1.2.3</ExistingDependencyVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/4984

Check that no two combination of PropertyName + [cC]ondition exists in Version.props