### PR TITLE
Do exact comparison if Exact parameter is passed

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
@@ -122,12 +122,14 @@ namespace Microsoft.DotNet.Darc.Options
             {
                 return true;
             }
+
             // Compare properties ignoring case because branch, repo, etc. names cannot differ only by case.
-            else if (ExactMatch && inputParameter.Equals(subscriptionProperty, StringComparison.OrdinalIgnoreCase))
+            if (ExactMatch)
             {
-                return true;
+                return inputParameter.Equals(subscriptionProperty, StringComparison.OrdinalIgnoreCase);
             }
-            else if (RegexMatch && Regex.IsMatch(subscriptionProperty, inputParameter, RegexOptions.IgnoreCase))
+
+            if (RegexMatch && Regex.IsMatch(subscriptionProperty, inputParameter, RegexOptions.IgnoreCase))
             {
                 return true;
             }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
@@ -129,14 +129,12 @@ namespace Microsoft.DotNet.Darc.Options
                 return inputParameter.Equals(subscriptionProperty, StringComparison.OrdinalIgnoreCase);
             }
 
-            if (RegexMatch && Regex.IsMatch(subscriptionProperty, inputParameter, RegexOptions.IgnoreCase))
+            if (RegexMatch)
             {
-                return true;
+                return Regex.IsMatch(subscriptionProperty, inputParameter, RegexOptions.IgnoreCase);
             }
-            else
-            {
-                return subscriptionProperty.Contains(inputParameter, StringComparison.OrdinalIgnoreCase);
-            }
+
+            return subscriptionProperty.Contains(inputParameter, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/5157

Without this modification if the two strings are compared: "https://github.com/dotnet/aspnetcore" and "https://github.com/dotnet/aspnetcore-tooling" the result will be `true` because the final else clause will find that one string is substring of the other. Is that the behavior we want? It seems a bit misleading given the parameter name `-Exact`. Also, same thing will happen with the `RegexMatch` flag - i.e., the regex fail but then the substring condition returns true.