### PR TITLE
Make KeyValuePair.Deconstruct internal

### DIFF
--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/KeyValuePairExtensions.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/KeyValuePairExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
 {
     public static class KeyValuePairExtensions
     {
-        public static void Deconstruct<TKey, TValue>(
+        internal static void Deconstruct<TKey, TValue>(
             this KeyValuePair<TKey, TValue> pair,
             out TKey key,
             out TValue value)


### PR DESCRIPTION
When this is public, anyone referencing this namespace get's in trouble,
because it becomes ambiguous with the one in the framework itself.

This one only works because "my namespace" always beats "imported namespace",
so it's not ambiguous here, but anyone that references this DLL in it's standard configuration
is going to end up with two ambiguous methods here.