### PR TITLE
Fix local dev authentication flow

### DIFF
--- a/arcade-services.sln
+++ b/arcade-services.sln
@@ -140,6 +140,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Internal.L
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DncEng.DeployServiceFabricCluster", "src\Microsoft.DncEng.DeployServiceFabricCluster\Microsoft.DncEng.DeployServiceFabricCluster.csproj", "{6307FF01-47DB-4EE6-86FF-9E78D8832D37}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DncEng.Configuration.Bootstrap", "src\Microsoft.DncEng.Configuration.Bootstrap\Microsoft.DncEng.Configuration.Bootstrap.csproj", "{2D72FBB5-9F29-40D5-9206-92A814DF47EC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -678,6 +680,18 @@ Global
 		{6307FF01-47DB-4EE6-86FF-9E78D8832D37}.Release|x64.Build.0 = Release|Any CPU
 		{6307FF01-47DB-4EE6-86FF-9E78D8832D37}.Release|x86.ActiveCfg = Release|Any CPU
 		{6307FF01-47DB-4EE6-86FF-9E78D8832D37}.Release|x86.Build.0 = Release|Any CPU
+		{2D72FBB5-9F29-40D5-9206-92A814DF47EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D72FBB5-9F29-40D5-9206-92A814DF47EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D72FBB5-9F29-40D5-9206-92A814DF47EC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2D72FBB5-9F29-40D5-9206-92A814DF47EC}.Debug|x64.Build.0 = Debug|Any CPU
+		{2D72FBB5-9F29-40D5-9206-92A814DF47EC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2D72FBB5-9F29-40D5-9206-92A814DF47EC}.Debug|x86.Build.0 = Debug|Any CPU
+		{2D72FBB5-9F29-40D5-9206-92A814DF47EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D72FBB5-9F29-40D5-9206-92A814DF47EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D72FBB5-9F29-40D5-9206-92A814DF47EC}.Release|x64.ActiveCfg = Release|Any CPU
+		{2D72FBB5-9F29-40D5-9206-92A814DF47EC}.Release|x64.Build.0 = Release|Any CPU
+		{2D72FBB5-9F29-40D5-9206-92A814DF47EC}.Release|x86.ActiveCfg = Release|Any CPU
+		{2D72FBB5-9F29-40D5-9206-92A814DF47EC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <ApplicationManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ApplicationTypeName="MaestroApplicationType" ApplicationTypeVersion="1.0.42" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
     <Parameter Name="DependencyUpdateErrorProcessor_MinReplicaSetSize" DefaultValue="3" />
@@ -102,7 +102,11 @@
   </DefaultServices>
   <Principals>
     <Users>
-      <User Name="MaestroUser" LoadUserProfile="true" />
+      <User Name="MaestroUser" LoadUserProfile="true">
+        <MemberOf>
+          <SystemGroup Name="DncEngConfigurationUsers" />
+        </MemberOf>
+      </User>
     </Users>
   </Principals>
   <Policies>

--- a/src/Maestro/bootstrap.ps1
+++ b/src/Maestro/bootstrap.ps1
@@ -11,3 +11,8 @@ if (-not $?) {
   Write-Error "Failed to set up local db"
   exit $?
 }
+
+New-LocalGroup -Name "DncEngConfigurationUsers" -ErrorAction Continue
+Add-LocalGroupMember -Group "DncEngConfigurationUsers" -Member $(whoami) -ErrorAction Continue
+
+dotnet run -p "$PSScriptRoot\..\Microsoft.DncEng.Configuration.Bootstrap" -- -r "https://vault.azure.net" -r "https://management.azure.com"

--- a/src/Microsoft.DncEng.Configuration.Bootstrap/Microsoft.DncEng.Configuration.Bootstrap.csproj
+++ b/src/Microsoft.DncEng.Configuration.Bootstrap/Microsoft.DncEng.Configuration.Bootstrap.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="Mono.Options" Version="$(MonoOptionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DncEng.Configuration.Bootstrap/Microsoft.DncEng.Configuration.Bootstrap.csproj
+++ b/src/Microsoft.DncEng.Configuration.Bootstrap/Microsoft.DncEng.Configuration.Bootstrap.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <SignAssembly>false</SignAssembly>
+    <ToolCommandName>bootstrap-dnceng-configuration</ToolCommandName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DncEng.Configuration.Extensions\Microsoft.DncEng.Configuration.Extensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DncEng.Configuration.Bootstrap/Program.cs
+++ b/src/Microsoft.DncEng.Configuration.Bootstrap/Program.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Azure.Core;
+using Microsoft.DncEng.Configuration.Extensions;
+using Mono.Options;
+
+namespace Microsoft.DncEng.Configuration.Bootstrap
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var resources = new List<string>();
+            var options = new OptionSet
+            {
+                {"r|resource=", "AAD resource identifiers to authenticate to", (string r) => resources.Add(r)},
+            };
+            options.Parse(args);
+            Console.WriteLine("Bootstrapping configuration.");
+
+            LocalDevTokenCredential.IsBoostrapping = true;
+            var cred = new LocalDevTokenCredential();
+            foreach (var resource in resources)
+            {
+                cred.GetToken(new TokenRequestContext(new[] {resource + "/.default"}), CancellationToken.None);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DncEng.Configuration.Bootstrap/app.manifest
+++ b/src/Microsoft.DncEng.Configuration.Bootstrap/app.manifest
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+  -->
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>

--- a/src/Microsoft.DncEng.Configuration.Extensions/ConfigurationConstants.cs
+++ b/src/Microsoft.DncEng.Configuration.Extensions/ConfigurationConstants.cs
@@ -8,5 +8,10 @@ namespace Microsoft.DncEng.Configuration.Extensions
         public static string ReloadTimeSecondsConfigurationKey => "Secrets:ReloadTimeSeconds";
 
         public static string MsftAdTenantId => "72f988bf-86f1-41af-91ab-2d7cd011db47";
+
+        // This group name must be kept in sync with 2 other places
+        // - The ApplicationManifest.xml for the MaestroApplication service fabric
+        // - The bootstrap.ps1 script, where this group gets created
+        public static string ConfigurationAccessGroupName = "DncEngConfigurationUsers";
     }
 }

--- a/src/Microsoft.DncEng.Configuration.Extensions/LocalDevTokenCredential.cs
+++ b/src/Microsoft.DncEng.Configuration.Extensions/LocalDevTokenCredential.cs
@@ -3,7 +3,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Security.AccessControl;
 using System.Security.Cryptography;
+using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -13,6 +15,8 @@ namespace Microsoft.DncEng.Configuration.Extensions
 {
     public class LocalDevTokenCredential : TokenCredential
     {
+        public static bool IsBoostrapping { get; set; } = false;
+
         private readonly IPublicClientApplication _app;
 
         public LocalDevTokenCredential()
@@ -29,7 +33,7 @@ namespace Microsoft.DncEng.Configuration.Extensions
         }
 
         private static string CacheDirectory { get; } =
-            Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".auth-cache");
+            Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "DncEngConfiguration", ".auth-cache");
 
         private static string CacheLockPath => Path.Join(CacheDirectory, ".cache.lock");
 
@@ -44,12 +48,20 @@ namespace Microsoft.DncEng.Configuration.Extensions
             var ts = File.GetLastWriteTimeUtc(CacheFilePath);
             if (File.Exists(CacheFilePath) && _lastReadTime < ts)
             {
-                using (await SentinelFileLock.AcquireAsync(CacheLockPath, 100, TimeSpan.FromMilliseconds(600)))
+                try
                 {
-                    var protectedBytes = await File.ReadAllBytesAsync(CacheFilePath);
-                    var bytes = ProtectedData.Unprotect(protectedBytes, null, DataProtectionScope.CurrentUser);
-                    _lastReadTime = ts;
-                    arg.TokenCache.DeserializeMsalV3(bytes, false);
+
+                    using (await SentinelFileLock.AcquireAsync(CacheLockPath, 100, TimeSpan.FromMilliseconds(600)))
+                    {
+                        var protectedBytes = await File.ReadAllBytesAsync(CacheFilePath);
+                        var bytes = ProtectedData.Unprotect(protectedBytes, null, DataProtectionScope.LocalMachine);
+                        _lastReadTime = ts;
+                        arg.TokenCache.DeserializeMsalV3(bytes, false);
+                    }
+                }
+                catch (CryptographicException)
+                {
+                    // Unable to deserialize, just treat it as if the file is gone
                 }
             }
         }
@@ -60,8 +72,38 @@ namespace Microsoft.DncEng.Configuration.Extensions
             {
                 _lastReadTime = default;
                 var bytes = arg.TokenCache.SerializeMsalV3();
-                var protectedBytes = ProtectedData.Protect(bytes, null, DataProtectionScope.CurrentUser);
-                await File.WriteAllBytesAsync(CacheFilePath, protectedBytes);
+                var protectedBytes = ProtectedData.Protect(bytes, null, DataProtectionScope.LocalMachine);
+                var info = new FileInfo(CacheFilePath);
+                if (!info.Exists)
+                {
+                    if (!IsBoostrapping)
+                    {
+                        throw new InvalidOperationException("Token Cache File Not Found, Please re-run boostrap.");
+                    }
+
+                    try
+                    {
+                        using (info.Create()) { }
+                    }
+                    catch { }
+                    var sec = new FileSecurity();
+                    sec.SetAccessRuleProtection(true, false);
+                    sec.AddAccessRule(new FileSystemAccessRule(ConfigurationConstants.ConfigurationAccessGroupName, FileSystemRights.FullControl, AccessControlType.Allow));
+                    sec.AddAccessRule(new FileSystemAccessRule("Administrators", FileSystemRights.FullControl, AccessControlType.Allow));
+                    info.SetAccessControl(sec);
+
+                    using (FileStream stream = info.OpenWrite())
+                    {
+                        stream.Write(protectedBytes);
+                    }
+                }
+                else
+                {
+                    using (var stream = info.OpenWrite())
+                    {
+                        stream.Write(protectedBytes);
+                    }
+                }
             }
         }
 
@@ -109,14 +151,17 @@ namespace Microsoft.DncEng.Configuration.Extensions
         [MethodImpl(MethodImplOptions.NoOptimization)]
         private static Task DeviceCodeResultCallback(DeviceCodeResult arg)
         {
-            if (!Debugger.IsAttached)
-                throw new InvalidOperationException("Debugger required for local service fabric authentication.");
-
+            if (!IsBoostrapping)
+            {
+                throw new InvalidOperationException("Authentication is required, please re-run bootstrap.");
+            }
             var userCode = arg.UserCode;
             var verificationUrl = arg.VerificationUrl;
-            // If your debugger breaks here you need to authenticate to azure with a device code
-            // navigate a browser to the url contained in the "verificationUrl" variable and enter the code in the "userCode" variable
-            Debugger.Break();
+
+            Console.WriteLine($"To sign in, use a web browser to open the page {verificationUrl} and enter the code {userCode} to authenticate.");
+            Console.WriteLine("Press any key when finished...");
+            Console.ReadKey(true);
+
             return Task.CompletedTask;
         }
 

--- a/src/Microsoft.DncEng.Configuration.Extensions/Microsoft.DncEng.Configuration.Extensions.csproj
+++ b/src/Microsoft.DncEng.Configuration.Extensions/Microsoft.DncEng.Configuration.Extensions.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">

--- a/src/Microsoft.DncEng.DeployServiceFabricCluster/Microsoft.DncEng.DeployServiceFabricCluster.csproj
+++ b/src/Microsoft.DncEng.DeployServiceFabricCluster/Microsoft.DncEng.DeployServiceFabricCluster.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.31.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
-    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="Mono.Options" Version="$(MonoOptionsVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
   </ItemGroup>


### PR DESCRIPTION
This change updates the auth flow for local development
to use a group and ACLs to restrict access to the cache file.
This removes the need to sign in from a debug breakpoint,
the sign-in can be done beforehand in boostrap.ps1.

dotnet/core-eng#9235