### PR TITLE
Build lookup improvements

### DIFF
--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/BuildsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/BuildsController.cs
@@ -34,10 +34,13 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
         /// <summary>
         ///   Gets a paged list of all <see cref="Build"/>s that match the given search criteria.
         /// </summary>
-        /// <param name="repository"></param>
-        /// <param name="commit"></param>
-        /// <param name="buildNumber"></param>
-        /// <param name="channelId"></param>
+        /// <param name="repository">Repository</param>
+        /// <param name="commit">Commit</param>
+        /// <param name="buildNumber">Build number</param>
+        /// <param name="channelId">Id of the channel to which the build applies</param>
+        /// <param name="azdoAccount">Name of the Azure DevOps account</param>
+        /// <param name="azdoBuildId">ID of the Azure DevOps build</param>
+        /// <param name="azdoProject">Name of the Azure DevOps project</param>
         /// <param name="notBefore">Don't return <see cref="Build"/>s that happened before this time.</param>
         /// <param name="notAfter">Don't return <see cref="Build"/>s that happened after this time.</param>
         /// <param name="loadCollections">**true** to include the <see cref="Channel"/>, <see cref="Asset"/>, and dependent <see cref="Build"/> data with the response; **false** otherwise.</param>
@@ -49,6 +52,9 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
             string repository,
             string commit,
             string buildNumber,
+            int? azdoBuildId,
+            string azdoAccount,
+            string azdoProject,
             int? channelId,
             DateTimeOffset? notBefore,
             DateTimeOffset? notAfter,
@@ -58,6 +64,9 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
                 repository,
                 commit,
                 buildNumber,
+                azdoBuildId,
+                azdoAccount,
+                azdoProject,
                 channelId,
                 notBefore,
                 notAfter,
@@ -69,6 +78,9 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
             string repository,
             string commit,
             string buildNumber,
+            int? azdoBuildId,
+            string azdoAccount,
+            string azdoProject,
             int? channelId,
             DateTimeOffset? notBefore,
             DateTimeOffset? notAfter,
@@ -88,6 +100,21 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
             if (!string.IsNullOrEmpty(buildNumber))
             {
                 query = query.Where(b => b.AzureDevOpsBuildNumber == buildNumber);
+            }
+
+            if (azdoBuildId.HasValue)
+            {
+                query = query.Where(b => b.AzureDevOpsBuildId == azdoBuildId);
+            }
+
+            if (!string.IsNullOrEmpty(azdoAccount))
+            {
+                query = query.Where(b => b.AzureDevOpsAccount == azdoAccount);
+            }
+
+            if (!string.IsNullOrEmpty(azdoProject))
+            {
+                query = query.Where(b => b.AzureDevOpsProject == azdoProject);
             }
 
             if (notBefore.HasValue)
@@ -165,6 +192,9 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
                 repository,
                 commit,
                 buildNumber,
+                null,
+                null,
+                null,
                 channelId,
                 notBefore,
                 notAfter,

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildsController.cs
@@ -33,10 +33,13 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
         /// <summary>
         ///   Gets a paged list of all <see cref="Build"/>s that match the given search criteria.
         /// </summary>
-        /// <param name="repository"></param>
-        /// <param name="commit"></param>
-        /// <param name="buildNumber"></param>
-        /// <param name="channelId"></param>
+        /// <param name="repository">Repository</param>
+        /// <param name="commit">Commit</param>
+        /// <param name="buildNumber">Build number</param>
+        /// <param name="channelId">Id of the channel to which the build applies</param>
+        /// <param name="azdoAccount">Name of the Azure DevOps account</param>
+        /// <param name="azdoBuildId">ID of the Azure DevOps build</param>
+        /// <param name="azdoProject">Name of the Azure DevOps project</param>
         /// <param name="notBefore">Don't return <see cref="Build"/>s that happened before this time.</param>
         /// <param name="notAfter">Don't return <see cref="Build"/>s that happened after this time.</param>
         /// <param name="loadCollections">**true** to include the <see cref="v2018_07_16.Models.Channel"/>, <see cref="v2018_07_16.Models.Asset"/>, and dependent <see cref="Build"/> data with the response; **false** otherwise.</param>
@@ -48,6 +51,9 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
             string repository,
             string commit,
             string buildNumber,
+            int? azdoBuildId,
+            string azdoAccount,
+            string azdoProject,
             int? channelId,
             DateTimeOffset? notBefore,
             DateTimeOffset? notAfter,
@@ -57,6 +63,9 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
                 repository,
                 commit,
                 buildNumber,
+                azdoBuildId,
+                azdoAccount,
+                azdoProject,
                 channelId,
                 notBefore,
                 notAfter,
@@ -133,6 +142,9 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
                 repository,
                 commit,
                 buildNumber,
+                null,
+                null,
+                null,
                 channelId,
                 notBefore,
                 notAfter,

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/BuildsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/BuildsController.cs
@@ -33,10 +33,13 @@ namespace Maestro.Web.Api.v2020_02_20.Controllers
         /// <summary>
         ///   Gets a paged list of all <see cref="Build"/>s that match the given search criteria.
         /// </summary>
-        /// <param name="repository"></param>
-        /// <param name="commit"></param>
-        /// <param name="buildNumber"></param>
-        /// <param name="channelId"></param>
+        /// <param name="repository">Repository</param>
+        /// <param name="commit">Commit</param>
+        /// <param name="buildNumber">Build number</param>
+        /// <param name="channelId">Id of the channel to which the build applies</param>
+        /// <param name="azdoAccount">Name of the Azure DevOps account</param>
+        /// <param name="azdoBuildId">ID of the Azure DevOps build</param>
+        /// <param name="azdoProject">Name of the Azure DevOps project</param>
         /// <param name="notBefore">Don't return <see cref="Build"/>s that happened before this time.</param>
         /// <param name="notAfter">Don't return <see cref="Build"/>s that happened after this time.</param>
         /// <param name="loadCollections">**true** to include the <see cref="v2018_07_16.Models.Channel"/>, <see cref="v2018_07_16.Models.Asset"/>, and dependent <see cref="Build"/> data with the response; **false** otherwise.</param>
@@ -48,6 +51,9 @@ namespace Maestro.Web.Api.v2020_02_20.Controllers
             string repository,
             string commit,
             string buildNumber,
+            int? azdoBuildId,
+            string azdoAccount,
+            string azdoProject,
             int? channelId,
             DateTimeOffset? notBefore,
             DateTimeOffset? notAfter,
@@ -57,6 +63,9 @@ namespace Maestro.Web.Api.v2020_02_20.Controllers
                 repository,
                 commit,
                 buildNumber,
+                azdoBuildId,
+                azdoAccount,
+                azdoProject,
                 channelId,
                 notBefore,
                 notAfter,
@@ -133,6 +142,9 @@ namespace Maestro.Web.Api.v2020_02_20.Controllers
                 repository,
                 commit,
                 buildNumber,
+                null,
+                null,
+                null,
                 channelId,
                 notBefore,
                 notAfter,

--- a/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <ApplicationManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ApplicationTypeName="MaestroApplicationType" ApplicationTypeVersion="1.0.42" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
     <Parameter Name="DependencyUpdateErrorProcessor_MinReplicaSetSize" DefaultValue="3" />

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetBuildOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetBuildOperation.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Darc.Operations
             {
                 IRemote remote = RemoteFactory.GetBarOnlyRemote(_options, Logger);
 
-                IEnumerable<Build> matchingBuilds = null;
+                List<Build> matchingBuilds = null;
                 if (_options.Id != 0)
                 {
                     if (!string.IsNullOrEmpty(_options.BuildUri) ||
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Darc.Operations
                         return Constants.ErrorCode;
                     }
 
-                    matchingBuilds = await remote.GetBuildsAsync(_options.Repo, _options.Commit);
+                    matchingBuilds = (await remote.GetBuildsAsync(_options.Repo, _options.Commit)).ToList();
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetBuildOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetBuildOperation.cs
@@ -7,6 +7,7 @@ using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,22 +34,79 @@ namespace Microsoft.DotNet.Darc.Operations
             {
                 IRemote remote = RemoteFactory.GetBarOnlyRemote(_options, Logger);
 
-                Build build = await remote.GetBuildAsync(_options.Id);
-                if (build != null)
+                IEnumerable<Build> matchingBuilds = null;
+                if (_options.Id != 0)
                 {
-                    Console.Write(UxHelpers.GetTextBuildDescription(build));
+                    if (!string.IsNullOrEmpty(_options.BuildUri) ||
+                        !string.IsNullOrEmpty(_options.Repo) ||
+                        !string.IsNullOrEmpty(_options.Commit))
+                    {
+                        Console.WriteLine("--id should not be used with other options.");
+                        return Constants.ErrorCode;
+                    }
+
+                    matchingBuilds = new List<Build>() { await remote.GetBuildAsync(_options.Id) };
+                }
+                else if (!string.IsNullOrEmpty(_options.BuildUri))
+                {
+                    if (_options.Id != 0 || !string.IsNullOrEmpty(_options.Repo) || !string.IsNullOrEmpty(_options.Commit))
+                    {
+                        Console.WriteLine("--uri should not be used with other options.");
+                        return Constants.ErrorCode;
+                    }
+
+                    Console.WriteLine("This option is not yet supported.");
+                    return Constants.ErrorCode;
+                }
+                else if (!string.IsNullOrEmpty(_options.Repo) || !string.IsNullOrEmpty(_options.Commit))
+                {
+                    if (string.IsNullOrEmpty(_options.Repo) != string.IsNullOrEmpty(_options.Commit))
+                    {
+                        Console.WriteLine("--repo and --commit should be used together.");
+                        return Constants.ErrorCode;
+                    }
+                    else if (_options.Id != 0 || !string.IsNullOrEmpty(_options.BuildUri))
+                    {
+                        Console.WriteLine("--repo and --commit should not be used with other options.");
+                        return Constants.ErrorCode;
+                    }
+
+                    matchingBuilds = await remote.GetBuildsAsync(_options.Repo, _options.Commit);
                 }
                 else
                 {
-                    Console.WriteLine($"Could not find build with id '{_options.Id}'");
+                    Console.WriteLine("Please specify --id, --uri, or --repo and --commit to lookup a build.");
                     return Constants.ErrorCode;
+                }
+
+                // Print the build info.
+                if (!matchingBuilds.Any())
+                {
+                    Console.WriteLine($"Could not any builds matching the given criteria.");
+                    return Constants.ErrorCode;
+                }
+
+                switch (_options.OutputFormat)
+                {
+                    case DarcOutputType.text:
+                        foreach (Build build in matchingBuilds)
+                        {
+                            Console.Write(UxHelpers.GetTextBuildDescription(build));
+                        }
+                        break;
+                    case DarcOutputType.json:
+                        Console.WriteLine(JsonConvert.SerializeObject(
+                            matchingBuilds.Select(build => UxHelpers.GetJsonBuildDescription(build)), Formatting.Indented));
+                        break;
+                    default:
+                        throw new NotImplementedException($"Output format type {_options.OutputFormat} not yet supported for get-build.");
                 }
 
                 return Constants.SuccessCode;
             }
             catch (Exception e)
             {
-                Logger.LogError(e, $"Error: Failed to retrieve build with id '{_options.Id}'");
+                Logger.LogError(e, "Error: Failed to retrieve build information.");
                 return Constants.ErrorCode;
             }
         }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GetBuildCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GetBuildCommandLineOptions.cs
@@ -16,10 +16,10 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("uri", HelpText = "Uri of the build.")]
         public string BuildUri { get; set; }
 
-        [Option("repo", HelpText = "Repository")]
+        [Option("repo", HelpText = "Full url of the repository that was built")]
         public string Repo { get; set; }
 
-        [Option("commit", HelpText = "Commit")]
+        [Option("commit", HelpText = "Full commit sha that was built")]
         public string Commit { get; set; }
 
         public override Operation GetOperation()

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GetBuildCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GetBuildCommandLineOptions.cs
@@ -10,8 +10,17 @@ namespace Microsoft.DotNet.Darc.Options
     [Verb("get-build", HelpText = "Retrieves a specific build of a repository")]
     internal class GetBuildCommandLineOptions : CommandLineOptions
     {
-        [Option("id", Required = true, HelpText = "Build id.")]
+        [Option("id", HelpText = "Build id.")]
         public int Id { get; set; }
+
+        [Option("uri", HelpText = "Uri of the build.")]
+        public string BuildUri { get; set; }
+
+        [Option("repo", HelpText = "Repository")]
+        public string Repo { get; set; }
+
+        [Option("commit", HelpText = "Commit")]
+        public string Commit { get; set; }
 
         public override Operation GetOperation()
         {


### PR DESCRIPTION
- Add new optional parameters to lookup builds by the AzDO information
- Add new darc commands to lookup builds by repo+commit or the azdo URI.
  The azdo URI option is currently disabled as it requires the new REST api.