### PR TITLE
Support dry run flag in DownloadAssetAsync

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -927,6 +927,13 @@ namespace Microsoft.DotNet.Darc.Operations
             StringBuilder downloadOutput = new StringBuilder();
             downloadOutput.AppendLine($"  Downloading asset {assetNameAndVersion}");
 
+            // Don't attempt downloads if the DryRun flag is set
+            if (_options.DryRun)
+            {
+                Console.Write(downloadOutput.ToString());
+                return null;
+            }
+
             DownloadedAsset downloadedAsset = new DownloadedAsset()
             {
                 Successful = false,


### PR DESCRIPTION
DownloadAssetAsync doesn't currently respect the DryRun flag used for skipping downloading during testing, this change adds a check for it.