### PR TITLE
Additional params to add-build-to-channel

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -135,11 +135,15 @@ namespace Microsoft.DotNet.Darc.Operations
                 $"\"BARBuildId\": \"{ build.Id }\", " +
                 $"\"PromoteToMaestroChannelId\": \"{ targetChannel.Id }\", " +
                 $"\"EnableSigningValidation\": \"{ _options.DoSigningValidation }\", " +
+                $"\"SigningValidationAdditionalParameters\": \"{ _options.SigningValidationAdditionalParameters }\", " +
                 $"\"EnableNugetValidation\": \"{ _options.DoNuGetValidation }\", " +
                 $"\"EnableSourceLinkValidation\": \"{ _options.DoSourcelinkValidation }\", " +
                 $"\"EnableSDLValidation\": \"{ _options.DoSDLValidation }\", " +
                 $"\"SDLValidationCustomParams\": \"{ _options.SDLValidationParams }\", " +
                 $"\"SDLValidationContinueOnError\": \"{ _options.SDLValidationContinueOnError }\", " +
+                $"\"PublishInstallersAndChecksums\": \"{ _options.PublishInstallersAndChecksums }\", " +
+                $"\"SymbolPublishingAdditionalParameters\": \"{ _options.SymbolPublishingAdditionalParameters }\", " +
+                $"\"ArtifactsPublishingAdditionalParameters\": \"{ _options.ArtifactPublishingAdditionalParameters }\", " +
                 $"}}";
 
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
@@ -25,6 +25,9 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("validate-signing", HelpText = "Perform signing validation.")]
         public bool DoSigningValidation { get; set; }
 
+        [Option("signing-validation-parameters", HelpText = "Additional (MSBuild) properties to be passed to signing validation.")]
+        public string SigningValidationAdditionalParameters { get; set; }
+
         [Option("validate-nuget", HelpText = "Perform NuGet metadata validation.")]
         public bool DoNuGetValidation { get; set; }
 
@@ -39,6 +42,15 @@ namespace Microsoft.DotNet.Darc.Options
 
         [Option("sdl-validation-continue-on-error", HelpText = "Ignore SDL validation errors.")]
         public string SDLValidationContinueOnError { get; set; }
+
+        [Option("symbol-publishing-parameters", HelpText = "Additional (MSBuild) properties to be passed to symbol publishing")]
+        public string SymbolPublishingAdditionalParameters { get; set; }
+
+        [Option("artifact-publishing-parameters", HelpText = "Additional (MSBuild) properties to be passed to asset publishing.")]
+        public string ArtifactPublishingAdditionalParameters { get; set; }
+
+        [Option("publish-installers-and-checksums", HelpText = "Whether installers and checksums should be published.")]
+        public bool PublishInstallersAndChecksums { get; set; }
 
         [Option("skip-assets-publishing", HelpText = "Add the build to the channel without publishing assets to the channel's feeds.")]
         public bool SkipAssetsPublishing { get; set; }


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/5199

Adds additional parameters to Darc add-build-to-channel to let the user inform the new parameters added to the promotion pipelines: https://github.com/dotnet/arcade/pull/5160