### PR TITLE
Show update to global.json as part of PR description

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -849,7 +849,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
 
                 if (hasToolsDotnetUpdate)
                 {
-                    globalJsonSection.AppendLine($"  - Updates the tools.dotnet to " +
+                    globalJsonSection.AppendLine($"  - Updates tools.dotnet to " +
                         $"{globalJsonFile.Metadata[GitFileMetadataName.ToolsDotNetUpdate]}");
                 }
             }

--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -852,8 +852,6 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                     globalJsonSection.AppendLine($"  - Updates the tools.dotnet to " +
                         $"{globalJsonFile.Metadata[GitFileMetadataName.ToolsDotNetUpdate]}");
                 }
-
-                globalJsonSection.AppendLine();
             }
         }
 
@@ -951,7 +949,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                     subscriptionSection.AppendLine($"  - **{dep.To.Name}**: from {dep.From.Version} to {dep.To.Version}");
                 }
 
-                UpdatePRDescriptionDueConfigFiles(committedFiles, description);
+                UpdatePRDescriptionDueConfigFiles(committedFiles, subscriptionSection);
 
                 subscriptionSection.AppendLine();
                 subscriptionSection.AppendLine(sectionEndMarker);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFile.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFile.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Xml;
@@ -23,6 +24,12 @@ namespace Microsoft.DotNet.DarcLib
 
         public GitFile(string filePath, string content) : this(filePath, content, ContentEncoding.Utf8)
         {
+        }
+
+        public GitFile(string filePath, JObject jsonObject, Dictionary<GitFileMetadataName, string> metadata) 
+            : this(filePath, jsonObject.ToString(Formatting.Indented))
+        {
+            Metadata = metadata;
         }
 
         public GitFile(
@@ -56,6 +63,8 @@ namespace Microsoft.DotNet.DarcLib
 
         public GitFileOperation Operation { get; } = GitFileOperation.Add;
 
+        public Dictionary<GitFileMetadataName, string> Metadata { get; set; }
+
         private static string GetIndentedXmlBody(XmlDocument xmlDocument)
         {
             MemoryStream mStream = new MemoryStream();
@@ -80,6 +89,15 @@ namespace Microsoft.DotNet.DarcLib
                 throw;
             }
         }
+    }
+
+    public enum GitFileMetadataName
+    {
+        // Used when the GitFile contains an update to global.json -> tools.dotnet entry.
+        ToolsDotNetUpdate,
+
+        // Used when the GitFile contains an update to global.json -> sdk.version entry.
+        SdkVersionUpdate
     }
 
     public enum GitFileOperation

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -347,7 +347,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="itemsToUpdate">Dependencies that need updating.</param>
         /// <param name="message">Commit message.</param>
         /// <returns>Async task.</returns>
-        Task CommitUpdatesAsync(string repoUri, string branch, List<DependencyDetail> itemsToUpdate, string message);
+        Task<List<GitFile>> CommitUpdatesAsync(string repoUri, string branch, List<DependencyDetail> itemsToUpdate, string message);
 
         /// <summary>
         ///     Diff two commits in a repository and return information about them.


### PR DESCRIPTION
Relates to: dotnet/arcade#2427

The crux of the change is:

- The addition of a Metadata dictionary to the GitFile class so that we can record interesting information about files that were committed.
- Patch PullRequestActor to use the information below and update the PR description accordingly.

Tested it locally + private repo of mine. Sample PR is here: https://dnceng.visualstudio.com/internal/_git/Cesar2/pullrequest/7118