### PR TITLE
Break the ServiceHost dependency on the web project

### DIFF
--- a/arcade-services.sln
+++ b/arcade-services.sln
@@ -140,9 +140,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Internal.L
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DncEng.DeployServiceFabricCluster", "src\Microsoft.DncEng.DeployServiceFabricCluster\Microsoft.DncEng.DeployServiceFabricCluster.csproj", "{6307FF01-47DB-4EE6-86FF-9E78D8832D37}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DncEng.Configuration.Bootstrap", "src\Microsoft.DncEng.Configuration.Bootstrap\Microsoft.DncEng.Configuration.Bootstrap.csproj", "{2D72FBB5-9F29-40D5-9206-92A814DF47EC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DncEng.Configuration.Bootstrap", "src\Microsoft.DncEng.Configuration.Bootstrap\Microsoft.DncEng.Configuration.Bootstrap.csproj", "{2D72FBB5-9F29-40D5-9206-92A814DF47EC}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Internal.DependencyInjection.Testing", "src\Shared\Microsoft.DotNet.Internal.DependencyInjection.Testing\Microsoft.DotNet.Internal.DependencyInjection.Testing.csproj", "{B6A55DC4-18E2-4B1B-AE7E-9B80F2ADC048}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureDevOpsClient", "src\Telemetry\AzureDevOpsClient\AzureDevOpsClient.csproj", "{B9BA1250-C36F-4390-AAB2-D1A7A67889FD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -706,6 +708,18 @@ Global
 		{B6A55DC4-18E2-4B1B-AE7E-9B80F2ADC048}.Release|x64.Build.0 = Release|Any CPU
 		{B6A55DC4-18E2-4B1B-AE7E-9B80F2ADC048}.Release|x86.ActiveCfg = Release|Any CPU
 		{B6A55DC4-18E2-4B1B-AE7E-9B80F2ADC048}.Release|x86.Build.0 = Release|Any CPU
+		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD}.Debug|x64.Build.0 = Debug|Any CPU
+		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD}.Debug|x86.Build.0 = Debug|Any CPU
+		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD}.Release|x64.ActiveCfg = Release|Any CPU
+		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD}.Release|x64.Build.0 = Release|Any CPU
+		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD}.Release|x86.ActiveCfg = Release|Any CPU
+		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -749,6 +763,7 @@ Global
 		{AD4D66B9-6CAB-4729-A5D1-57A859E06801} = {AE791E26-78E1-4936-BCF4-1BF5152CBBD6}
 		{2C7D3A7A-26E2-4A9D-97D6-9AF3812F6906} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
 		{B6A55DC4-18E2-4B1B-AE7E-9B80F2ADC048} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
+		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD} = {0D9FE592-7EB7-4CEE-95E8-3379B98041C6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {32B9C883-432E-4FC8-A1BF-090EB033DD5B}

--- a/src/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
+++ b/src/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
@@ -11,7 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DotNet.Status.Web.Options;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.DotNet.AzureDevOpsTimeline;
+using Microsoft.DotNet.Internal.AzureDevOps;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Octokit;

--- a/src/DotNet.Status.Web/DotNet.Status.Web.csproj
+++ b/src/DotNet.Status.Web/DotNet.Status.Web.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <UserSecretsId>65a272ca-730a-4afd-b68b-d256719c2db2</UserSecretsId>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SignAssembly>false</SignAssembly>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
@@ -25,6 +26,6 @@
     <ProjectReference Include="..\Shared\Microsoft.DotNet.GitHub.Authentication\Microsoft.DotNet.GitHub.Authentication.csproj" />
     <ProjectReference Include="..\Shared\Microsoft.DotNet.Services.Utility\Microsoft.DotNet.Services.Utility.csproj" />
     <ProjectReference Include="..\shared\Microsoft.DotNet.Web.Authentication\Microsoft.DotNet.Web.Authentication.csproj" />
-    <ProjectReference Include="..\Telemetry\AzureDevOpsTimeline\AzureDevOpsTimeline.csproj" />
+    <ProjectReference Include="..\Telemetry\AzureDevOpsClient\AzureDevOpsClient.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Telemetry/AzureDevOpsClient/AzureDataTypes.cs
+++ b/src/Telemetry/AzureDevOpsClient/AzureDataTypes.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Newtonsoft.Json;
 
-namespace Microsoft.DotNet.AzureDevOpsTimeline
+namespace Microsoft.DotNet.Internal.AzureDevOps
 {
     /// <summary>
     ///     https://docs.microsoft.com/en-us/rest/api/azure/devops/build/builds/list?view=azure-devops-rest-5.0#build

--- a/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
+++ b/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.DotNet.AzureDevOpsTimeline
+namespace Microsoft.DotNet.Internal.AzureDevOps
 {
     public sealed class AzureDevOpsClient
     {

--- a/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.csproj
+++ b/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RootNamespace>Microsoft.DotNet.Internal.AzureDevOps</RootNamespace>
+    <AssemblyName>Microsoft.DotNet.Internal.AzureDevOps</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
@@ -14,6 +14,7 @@ using Kusto.Data.Common;
 using Kusto.Data.Exceptions;
 using Kusto.Data.Net.Client;
 using Kusto.Ingest;
+using Microsoft.DotNet.Internal.AzureDevOps;
 using Microsoft.DotNet.Kusto;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
 using Microsoft.DotNet.Services.Utility;

--- a/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.csproj
+++ b/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.csproj
@@ -33,6 +33,7 @@
     <ProjectReference Include="..\..\Microsoft.DotNet.ServiceFabric.ServiceHost\Microsoft.DotNet.ServiceFabric.ServiceHost.csproj" />
     <ProjectReference Include="..\..\Shared\Microsoft.DotNet.Kusto\Microsoft.DotNet.Kusto.csproj" />
     <ProjectReference Include="..\..\Shared\Microsoft.DotNet.Services.Utility\Microsoft.DotNet.Services.Utility.csproj" />
+    <ProjectReference Include="..\AzureDevOpsClient\AzureDevOpsClient.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This dependency causes the web site to require 64-bit, where it otherwise would not,
and there is no compelling reason for that binding to exist.