### PR TITLE
Check that metadata is present

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -834,16 +834,11 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                 Where(gf => gf.FilePath.Equals("global.json", StringComparison.OrdinalIgnoreCase)).
                 FirstOrDefault();
 
-            if (globalJsonFile != null)
+            // The list of committedFiles can contain the `global.json` file (and others) 
+            // even though no actual change was made to the file and therefore there is no 
+            // metadata for it.
+            if (globalJsonFile?.Metadata != null)
             {
-                // The list of committedFiles can contain the `global.json` file even though we
-                // actually didn't do any change to the file and therefore didn't create any
-                // metadata for it.
-                if (globalJsonFile.Metadata == null)
-                {
-                    return;
-                }
-
                 bool hasSdkVersionUpdate = globalJsonFile.Metadata.ContainsKey(GitFileMetadataName.SdkVersionUpdate);
                 bool hasToolsDotnetUpdate = globalJsonFile.Metadata.ContainsKey(GitFileMetadataName.ToolsDotNetUpdate);
 

--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -828,14 +828,22 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
             }
         }
 
-        private void UpdatePRDescriptionDueConfigFiles(List<GitFile> commitedFiles, StringBuilder globalJsonSection)
+        public static void UpdatePRDescriptionDueConfigFiles(List<GitFile> committedFiles, StringBuilder globalJsonSection)
         {
-            GitFile globalJsonFile = commitedFiles?.
+            GitFile globalJsonFile = committedFiles?.
                 Where(gf => gf.FilePath.Equals("global.json", StringComparison.OrdinalIgnoreCase)).
                 FirstOrDefault();
 
             if (globalJsonFile != null)
             {
+                // The list of committedFiles can contain the `global.json` file even though we
+                // actually didn't do any change to the file and therefore didn't create any
+                // metadata for it.
+                if (globalJsonFile.Metadata == null)
+                {
+                    return;
+                }
+
                 bool hasSdkVersionUpdate = globalJsonFile.Metadata.ContainsKey(GitFileMetadataName.SdkVersionUpdate);
                 bool hasToolsDotnetUpdate = globalJsonFile.Metadata.ContainsKey(GitFileMetadataName.ToolsDotNetUpdate);
 


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/5245

I overlooked that we add some files to the list of committed files even when we didn't do any change to it. In that case the Metadata isn't set for the file :-(

Executed the tests locally and got this PR created: https://github.com/maestro-auth-test/maestro-test2/pull/10079