### PR TITLE
Don't duplicate dependencies when computing dependency graph

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
@@ -491,7 +491,7 @@ namespace Microsoft.DotNet.DarcLib
             HashSet<DependencyGraphNode> incoherentNodes = new HashSet<DependencyGraphNode>();
             // Cache of incoherent dependencies, looked up by name
             Dictionary<string, DependencyDetail> incoherentDependenciesCache = new Dictionary<string, DependencyDetail>();
-            HashSet<DependencyDetail> incoherentDependencies = new HashSet<DependencyDetail>();
+            HashSet<DependencyDetail> incoherentDependencies = new HashSet<DependencyDetail>(new DependencyDetailComparer());
 
             while (nodesToVisit.Count > 0)
             {


### PR DESCRIPTION
Found this while working on another issue. Without using the custom dependency comparison class we'll end up with a bunch of repeated dependencies.