### PR TITLE
Fix Microsoft.DotNet.GitHub.Authentication namespace in darcbot

### DIFF
--- a/src/GitHubApps/DarcBot/AzureFunction.cs
+++ b/src/GitHubApps/DarcBot/AzureFunction.cs
@@ -6,7 +6,7 @@ using Kusto.Ingest;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.Dotnet.GitHub.Authentication;
+using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.DotNet.Kusto;
 using Microsoft.Extensions.Logging;
 using Octokit;


### PR DESCRIPTION
Fixes the build break introduced in https://github.com/dotnet/arcade-services/pull/914 due to the renaming of this namespace.