### PR TITLE
Null safe GetMergePolicyDefinitions

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -1361,7 +1361,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
         {
             RepositoryBranch repositoryBranch =
                 await Context.RepositoryBranches.FindAsync(Target.repository, Target.branch);
-            return (IReadOnlyList<MergePolicyDefinition>) repositoryBranch.PolicyObject?.MergePolicies ??
+            return (IReadOnlyList<MergePolicyDefinition>) repositoryBranch?.PolicyObject?.MergePolicies ??
                    Array.Empty<MergePolicyDefinition>();
         }
     }


### PR DESCRIPTION
Not only might the MergePolicies not exist, there might not be a branch
reference at all. This make several tests pass, so appears to be the
correct behavior.