### PR TITLE
Revert "Move from a soon-to-be-deprecated preview AzDO API (#1123)"

### DIFF
--- a/eng/create-tag.ps1
+++ b/eng/create-tag.ps1
@@ -5,7 +5,7 @@ param(
 $Commit = $env:Build.SourceVersion
 $Version = $env:VersionPrefix
 
-$uri ="$($env:System_TeamFoundationCollectionUri)/$($env:System_TeamProject)/_apis/git/repositories/$($env:Build_Repository_Name)/annotatedTags?api-version=5.0"
+$uri ="$($env:System_TeamFoundationCollectionUri)/$($env:System_TeamProject)/_apis/git/repositories/$($env:Build_Repository_Name)/annotatedTags?api-version=5.0-preview.1"
 $tag = "v$Version"
 
 if ($Commit -and $Version) {

--- a/src/Maestro/tests/Scenarios/common.ps1
+++ b/src/Maestro/tests/Scenarios/common.ps1
@@ -8,7 +8,7 @@
 [string]$azdoUser = if (-not $azdoUser) { "dotnet-maestro-bot" } else { $azdoUser }
 [string]$azdoAccount = if (-not $azdoAccount) { "dnceng" } else { $azdoAccount }
 [string]$azdoProject = if (-not $azdoProject) { "internal" } else { $azdoProject }
-[string]$azdoApiVersion = if (-not $azdoApiVersion) { "5.0" } else { $azdoApiVersion }
+[string]$azdoApiVersion = if (-not $azdoApiVersion) { "5.0-preview.1" } else { $azdoApiVersion }
 [string]$darcPackageSource = if (-not $darcPackageSource) {""} else { $darcPackageSource }
 [string]$barApiVersion = "2020-02-20"
 $global:gitHubPRsToClose = @()

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.DarcLib
 {
     public class AzureDevOpsClient : RemoteRepoBase, IGitRepo, IAzureDevOpsClient
     {
-        private const string DefaultApiVersion = "5.0";
+        private const string DefaultApiVersion = "5.0-preview.1";
 
         private static readonly string AzureDevOpsHostPattern = @"dev\.azure\.com\";
 
@@ -1067,7 +1067,7 @@ namespace Microsoft.DotNet.DarcLib
                 $"_apis/release/definitions/",
                 _logger,
                 body,
-                versionOverride: "5.0",
+                versionOverride: "5.0-preview.3",
                 baseAddressSubpath: "vsrm.");
 
             return content.ToObject<AzureDevOpsReleaseDefinition>();
@@ -1092,7 +1092,7 @@ namespace Microsoft.DotNet.DarcLib
                 $"_apis/release/releases/",
                 _logger,
                 body,
-                versionOverride: "5.0",
+                versionOverride: "5.0-preview.3",
                 baseAddressSubpath: "vsrm.");
 
             return content.GetValue("id").ToObject<int>();
@@ -1314,7 +1314,7 @@ namespace Microsoft.DotNet.DarcLib
                 projectName,
                 $"_apis/build/builds/{buildId}",
                 _logger,
-                versionOverride: "5.0");
+                versionOverride: "5.0-preview.3");
 
             return content.ToObject<AzureDevOpsBuild>();
         }
@@ -1334,7 +1334,7 @@ namespace Microsoft.DotNet.DarcLib
                 projectName,
                 $"_apis/release/definitions/{releaseDefinitionId}",
                 _logger,
-                versionOverride: "5.0",
+                versionOverride: "5.0-preview.3",
                 baseAddressSubpath: "vsrm.");
 
             return content.ToObject<AzureDevOpsReleaseDefinition>();


### PR DESCRIPTION
This reverts commit 0ef73e1030a303bcd715c4311009fa2e55b90592.

All of our requests are getting 400 "bad request" with this body:
```json
{
	"$id":"1",
	"innerException":null,
	"message":"The requested version \"5.0\" of the resource is under preview. The -preview flag must be supplied in the api-version for such requests. For example: \"5.0-preview\"",
	"typeName":"Microsoft.VisualStudio.Services.WebApi.VssInvalidPreviewVersionException, Microsoft.VisualStudio.Services.WebApi",
	"typeKey":"VssInvalidPreviewVersionException",
	"errorCode":0,
	"eventId":3000
}
```