### PR TITLE
Fix Arcade-services official build

### DIFF
--- a/src/Maestro/Maestro.Data/Migrations/20200413233357_AddBuildIncoherenciesTable.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20200413233357_AddBuildIncoherenciesTable.cs
@@ -7,12 +7,6 @@ namespace Maestro.Data.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AddColumn<bool>(
-                name: "Stable",
-                table: "Builds",
-                nullable: false,
-                defaultValue: false);
-
             migrationBuilder.CreateTable(
                 name: "BuildIncoherencies",
                 columns: table => new
@@ -46,10 +40,6 @@ namespace Maestro.Data.Migrations
         {
             migrationBuilder.DropTable(
                 name: "BuildIncoherencies");
-
-            migrationBuilder.DropColumn(
-                name: "Stable",
-                table: "Builds");
         }
     }
 }


### PR DESCRIPTION
Builds are failing with:

```
System.Data.SqlClient.SqlException (0x80131904): Column names in each table must be unique. Column name 'Stable' in table 'Builds' is specified more than once.
```

This was caused by a recent PR of mine. I think I manually removed the `Stable` column from the Builds table in my local BAR before creating the migration.. consequently the migration added the column again and now it's causing errors.