### PR TITLE
Update Maestro Client

### DIFF
--- a/src/Maestro/Client/src/Generated/MaestroApi.cs
+++ b/src/Maestro/Client/src/Generated/MaestroApi.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Maestro.Client
     public partial class MaestroApiOptions : ClientOptions
     {
         public MaestroApiOptions()
-            : this(new Uri("https://localhost:4430"))
+            : this(new Uri("https://maestro-int.westus2.cloudapp.azure.com"))
         {
         }
 
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Maestro.Client
         }
 
         public MaestroApiOptions(TokenCredential credentials)
-            : this(new Uri("https://localhost:4430"), credentials)
+            : this(new Uri("https://maestro-int.westus2.cloudapp.azure.com"), credentials)
         {
         }
 
@@ -223,6 +223,11 @@ namespace Microsoft.DotNet.Maestro.Client
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T Deserialize<T>(string value)
         {
+            if (typeof(T) == typeof(string))
+            {
+                return (T)(object)value;
+            }
+
             return JsonConvert.DeserializeObject<T>(value, SerializerSettings);
         }
 


### PR DESCRIPTION
Arcade services official builds are broken because of a bug in the Maestro.Client. The error had already been fixed but then I reverted the fix when I [merged this PR](https://github.com/dotnet/arcade-services/pull/1101/files#diff-d8dfc9d365bba862a19f59989e70418cL230).

Current PR is to re-introduce the patch.