### PR TITLE
Make Grafana notifications environment specific

### DIFF
--- a/src/DotNet.Status.Web/Controllers/AlertHookController.cs
+++ b/src/DotNet.Status.Web/Controllers/AlertHookController.cs
@@ -210,6 +210,11 @@ namespace DotNet.Status.Web.Controllers
                 issue.Labels.Add(label);
             }
 
+            foreach (string label in options.EnvironmentLabels.OrEmpty())
+            {
+                issue.Labels.Add(label);
+            }
+
             return issue;
         }
 
@@ -315,12 +320,19 @@ namespace DotNet.Status.Web.Controllers
         {
             string id = GetUniqueIdentifier(notification);
 
+            var searchedLabels = new List<string>
+            {
+                NotificationIdLabel
+            };
+
+            searchedLabels.AddRange(_githubOptions.Value.EnvironmentLabels.OrEmpty());
+
             string automationId = string.Format(BodyLabelTextFormat, id);
             var request = new SearchIssuesRequest(automationId)
             {
                 // We need to manually quote the label here, because of
                 // https://github.com/octokit/octokit.net/issues/2044
-                Labels = new[] {'"' + NotificationIdLabel + '"'},
+                Labels = searchedLabels.Select(label => '"' + label + '"'),
                 Order = SortDirection.Descending,
                 SortField = IssueSearchSort.Created,
                 Type = IssueTypeQualifier.Issue,

--- a/src/DotNet.Status.Web/Options/GitHubConnectionOptions.cs
+++ b/src/DotNet.Status.Web/Options/GitHubConnectionOptions.cs
@@ -10,6 +10,7 @@ namespace DotNet.Status.Web.Options
         public string Repository { get; set; }
         public string NotificationTarget { get; set; }
         public string[] AlertLabels { get; set; }
+        public string[] EnvironmentLabels { get; set; }
         public string TitlePrefix { get; set; }
         public string SupplementalBodyText { get; set; }
         public NotificationEpicOptions NotificationEpic { get; set; }

--- a/src/DotNet.Status.Web/appsettings.Production.json
+++ b/src/DotNet.Status.Web/appsettings.Production.json
@@ -14,7 +14,7 @@
     "Repository": "core-eng",
     "NotificationTarget": "dotnet/dnceng",
     "AlertLabels": [ "First Responder", "Critical" ],
-    "EnvironmentLabels": [],
+    "EnvironmentLabels": [ "Production" ],
     "TitlePrefix": "Production - ",
     "NotificationEpic": {
       "Repository": "core-eng",

--- a/src/DotNet.Status.Web/appsettings.Production.json
+++ b/src/DotNet.Status.Web/appsettings.Production.json
@@ -14,6 +14,7 @@
     "Repository": "core-eng",
     "NotificationTarget": "dotnet/dnceng",
     "AlertLabels": [ "First Responder", "Critical" ],
+    "EnvironmentLabels": [],
     "TitlePrefix": "Production - ",
     "NotificationEpic": {
       "Repository": "core-eng",

--- a/src/DotNet.Status.Web/appsettings.Staging.json
+++ b/src/DotNet.Status.Web/appsettings.Staging.json
@@ -13,7 +13,8 @@
     "Organization": "dotnet",
     "Repository": "core-eng",
     "NotificationTarget": "dotnet/dnceng",
-    "AlertLabels": [ "First Responder", "Staging" ],
+    "AlertLabels": [ "First Responder" ],
+    "EnvironmentLabels": [ "Staging" ],
     "TitlePrefix": "Staging - ",
     "NotificationEpic": {
       "Repository": "core-eng",


### PR DESCRIPTION
Fixes a bug where two same alerts but from different environments use the same issue while there should be two separate ones

https://github.com/dotnet/core-eng/issues/9713