### PR TITLE
Allow rollforward on Major versions for Darc

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/runtimeconfig.template.json
+++ b/src/Microsoft.DotNet.Darc/src/Darc/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
Upgrading the used SDK in Arcade to 5.0 showed that Darc currently doesn't have a rollforward policy for major versions. This should be enabled for global tools to not depend on specific runtime version.

Fixes https://github.com/dotnet/arcade/issues/5412

cc @akoeplinger @missymessa 