### PR TITLE
Small bugfixes in the RolloutScorer

### DIFF
--- a/src/RolloutScorer/RolloutScorer/RolloutScorer.cs
+++ b/src/RolloutScorer/RolloutScorer/RolloutScorer.cs
@@ -71,7 +71,7 @@ namespace RolloutScorer
                     BuildBreakdowns.Add(new ScorecardBuildBreakdown(build.ToObject<BuildSummary>()));
                 }
             }
-            BuildBreakdowns.OrderBy(x => x.BuildSummary.FinishTime);
+            BuildBreakdowns = BuildBreakdowns.OrderBy(x => x.BuildSummary.FinishTime).ToList();
             await Task.WhenAll(BuildBreakdowns.Select(b => CollectStages(b)));
         }
 

--- a/src/RolloutScorer/RolloutScorer/Utilities.cs
+++ b/src/RolloutScorer/RolloutScorer/Utilities.cs
@@ -128,7 +128,7 @@ namespace RolloutScorer
     public static class GithubLabelNames
     {
         public const string IssueLabel = "Rollout Issue";
-        public const string HotfixLabel = "Rollout Hotfix";
+        public const string HotfixLabel = "Rollout Manual Hotfix";
         public const string RollbackLabel = "Rollout Rollback";
         public const string DowntimeLabel = "Rollout Downtime";
     }

--- a/src/RolloutScorer/RolloutScorer/Utilities.cs
+++ b/src/RolloutScorer/RolloutScorer/Utilities.cs
@@ -129,7 +129,7 @@ namespace RolloutScorer
     {
         public const string IssueLabel = "Rollout Issue";
         public const string HotfixLabel = "Rollout Manual Hotfix";
-        public const string RollbackLabel = "Rollout Rollback";
+        public const string RollbackLabel = "Rollout Manual Rollback";
         public const string DowntimeLabel = "Rollout Downtime";
     }
 


### PR DESCRIPTION
1. Sort build breakdowns for real
2. Adjust for the changed hotfix label name