### PR TITLE
Pretty print unauthorized Maestro API access

### DIFF
--- a/src/Maestro/Client/src/AuthenticationException.cs
+++ b/src/Maestro/Client/src/AuthenticationException.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.DotNet.Maestro.Client
+{
+    [Serializable]
+    public class AuthenticationException : Exception
+    {
+        public AuthenticationException()
+        {
+        }
+
+        protected AuthenticationException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public AuthenticationException(string message) : base(message)
+        {
+        }
+
+        public AuthenticationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Maestro/Client/src/MaestroApi.cs
+++ b/src/Maestro/Client/src/MaestroApi.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
-using Newtonsoft.Json.Linq;
-using System.Threading.Tasks;
-
 
 namespace Microsoft.DotNet.Maestro.Client
 {
@@ -48,6 +46,11 @@ namespace Microsoft.DotNet.Maestro.Client
                 {
                     return;
                 }
+            }
+            else if (ex.Response.Status == (int)HttpStatusCode.Unauthorized)
+            {
+                throw new AuthenticationException("Unauthorized access while trying to access Maestro API. " +
+                    "Please make sure the PAT you're using is valid.");
             }
         }
     }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -5,15 +5,15 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.DotNet.Services.Utility;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Threading.Tasks;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
-using Microsoft.DotNet.Services.Utility;
-using System.Text;
+using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations
 {
@@ -134,6 +134,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 PrintSubscriptionInfo(applicableSubscriptions);
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddChannelOperation.cs
@@ -64,6 +64,11 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 return Constants.SuccessCode;
             }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
+            }
             catch (RestApiException e) when (e.Response.Status == (int) HttpStatusCode.Conflict)
             {
                 Logger.LogError($"An existing channel with name '{_options.Name}' already exists");

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddDefaultChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddDefaultChannelOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Services.Utility;
 using Microsoft.Extensions.Logging;
 using System;
@@ -38,6 +39,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 await remote.AddDefaultChannelAsync(_options.Repository, _options.Branch, _options.Channel);
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddSubscriptionOperation.cs
@@ -6,18 +6,16 @@ using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Models.PopUps;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.DotNet.Services.Utility;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Maestro.Client;
-using Newtonsoft.Json.Linq;
-using Microsoft.VisualStudio.Services.FileContainer;
-using Microsoft.Azure.KeyVault.Models;
-using Microsoft.DotNet.Services.Utility;
 
 namespace Microsoft.DotNet.Darc.Operations
 {
@@ -209,6 +207,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 }
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (RestApiException e) when (e.Response.Status == (int) System.Net.HttpStatusCode.BadRequest)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/DefaultChannelStatusOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/DefaultChannelStatusOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using System;
@@ -70,6 +71,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 Console.WriteLine($"Default channel association has been {(enabled ? "enabled" : "disabled")}.");
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteBuildFromChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteBuildFromChannelOperation.cs
@@ -5,10 +5,10 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -64,6 +64,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 Console.WriteLine($"darc trigger-subscriptions --source-repo {build.GitHubRepository ?? build.AzureDevOpsRepository} --channel {targetChannel.Name}");
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteChannelOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using System;
@@ -45,6 +46,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 Console.WriteLine($"Successfully deleted channel '{existingChannel.Name}'.");
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteDefaultChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteDefaultChannelOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using System;
@@ -36,6 +37,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 await remote.DeleteDefaultChannelAsync(resolvedChannel.Id);
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/DeleteSubscriptionsOperation.cs
@@ -97,6 +97,11 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 return Constants.SuccessCode;
             }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
+            }
             catch (Exception e)
             {
                 Logger.LogError(e, "Unexpected error while deleting subscriptions.");

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.DotNet.Services.Utility;
 using Microsoft.Extensions.Logging;
@@ -157,6 +158,11 @@ namespace Microsoft.DotNet.Darc.Operations
                     Console.WriteLine("Download successful.");
                     return Constants.SuccessCode;
                 }
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetAssetOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetAssetOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -139,6 +140,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 }
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetBuildOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetBuildOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -103,6 +104,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 }
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetChannelsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetChannelsOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -49,6 +50,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 }
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDefaultChannelsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDefaultChannelsOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using System;
@@ -61,6 +62,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 }
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -5,7 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using System;
@@ -95,6 +95,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 await LogGraphVizAsync(targetChannel, flowGraph, _options.IncludeBuildTimes);
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception exc)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyGraphOperation.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using System;
@@ -171,6 +172,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 }
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception exc)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetGoalOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetGoalOperation.cs
@@ -5,13 +5,12 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Net;
 using System.Threading.Tasks;
-using System.Linq;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.DotNet.Maestro.Client;
 
 namespace Microsoft.DotNet.Darc.Operations
 {
@@ -37,6 +36,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 Goal goalInfo = await remote.GetGoalAsync(_options.Channel, _options.DefinitionId);
                 Console.Write(goalInfo.Minutes);
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (RestApiException e) when (e.Response.Status == (int)HttpStatusCode.NotFound)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetLatestBuildOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetLatestBuildOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using System;
@@ -81,6 +82,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 }
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetRepositoryMergePoliciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetRepositoryMergePoliciesOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using System;
@@ -63,6 +64,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 }
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetSubscriptionsOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using System;
@@ -67,6 +68,11 @@ namespace Microsoft.DotNet.Darc.Operations
                     }
                 }
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/SetGoalOperations.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/SetGoalOperations.cs
@@ -5,13 +5,12 @@
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Net;
 using System.Threading.Tasks;
-using System.Linq;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.DotNet.Maestro.Client;
 
 namespace Microsoft.DotNet.Darc.Operations
 {
@@ -37,6 +36,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 Goal goalInfo = await remote.SetGoalAsync(_options.Channel, _options.DefinitionId, _options.Minutes);
                 Console.Write(goalInfo.Minutes);
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (RestApiException e) when (e.Response.Status == (int) HttpStatusCode.NotFound)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
@@ -15,7 +15,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations
@@ -146,6 +145,11 @@ namespace Microsoft.DotNet.Darc.Operations
                     repository, branch, mergePolicies);
                 Console.WriteLine($"Successfully updated merge policies for {repository}@{branch}.");
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (RestApiException e) when (e.Response.Status == (int) System.Net.HttpStatusCode.BadRequest)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/SubscriptionsStatusOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/SubscriptionsStatusOperation.cs
@@ -136,6 +136,11 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 return Constants.SuccessCode;
             }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
+            }
             catch (Exception e)
             {
                 Logger.LogError(e, $"Unexpected error while {actionStatusMessage.ToLower()} subscriptions.");

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/TriggerSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/TriggerSubscriptionsOperation.cs
@@ -101,6 +101,11 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 return Constants.SuccessCode;
             }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
+            }
             catch (Exception e)
             {
                 Logger.LogError(e, "Unexpected error while triggering subscriptions.");

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateBuildOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateBuildOperation.cs
@@ -3,18 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Models.PopUps;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations
@@ -44,6 +38,11 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 Console.WriteLine($"Updated build {_options.Id} with new information.");
                 Console.WriteLine(UxHelpers.GetTextBuildDescription(updatedBuild));
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
@@ -220,6 +220,11 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 return Constants.SuccessCode;
             }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
+            }
             catch (Exception e)
             {
                 Logger.LogError(e, "Error: Failed to update dependencies.");

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateSubscriptionOperation.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Models.PopUps;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using System;
@@ -13,9 +14,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Maestro.Client;
-using ApiError = Microsoft.DotNet.Maestro.Client.Models.ApiError;
-using Microsoft.Azure.KeyVault.Models;
 
 namespace Microsoft.DotNet.Darc.Operations
 {
@@ -113,6 +111,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 }
 
                 return Constants.SuccessCode;
+            }
+            catch (AuthenticationException e)
+            {
+                Console.WriteLine(e.Message);
+                return Constants.ErrorCode;
             }
             catch (RestApiException e) when (e.Response.Status == (int) System.Net.HttpStatusCode.BadRequest)
             {


### PR DESCRIPTION
Improve error message when access to Maestro API fail. Change from this:

```
fail: Microsoft.DotNet.Darc.Operations.Operation[0]
      Error: Failed to retrieve channels
Microsoft.DotNet.Maestro.Client.RestApiException`1[Microsoft.DotNet.Maestro.Client.Models.ApiError]: The response contained an invalid status code 401 Unauthorized

Body:
   at Microsoft.DotNet.Maestro.Client.Channels.OnListChannelsFailed(Request req, Response res) in /_/src/Maestro/Client/src/Generated/Channels.cs:line 151
   at Microsoft.DotNet.Maestro.Client.Channels.ListChannelsAsync(String classification, CancellationToken cancellationToken) in /_/src/Maestro/Client/src/Generated/Channels.cs:line 116
   at Microsoft.DotNet.DarcLib.MaestroApiBarClient.GetChannelsAsync(String classification) in /_/src/Microsoft.DotNet.Darc/src/DarcLib/MaestroApiBarClient.cs:line 382
   at Microsoft.DotNet.Darc.Operations.GetChannelsOperation.ExecuteAsync() in /_/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetChannelsOperation.cs:line 38
```

to this:

```
Unauthorized access while trying to access Maestro API. Please make sure the PAT you're using is valid.
```

I'll do a similar change to catch AzDO errors if you think this is all worth.