### PR TITLE
Have update-dependencies work with the SDK

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -733,7 +733,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                 description.AppendLine("This pull request updates the following dependencies");
                 description.AppendLine();
 
-                await CommitUpdatesAsync(requiredUpdates, description, darcRemote, targetRepository, newBranchName);
+                await CommitUpdatesAsync(requiredUpdates, description, DarcRemoteFactory, targetRepository, newBranchName);
 
                 var inProgressPr = new InProgressPullRequest
                 {
@@ -819,14 +819,14 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
         ///     A string writer that the PR description should be written to. If this an update
         ///     to an existing PR, this will contain the existing PR description.
         /// </param>
-        /// <param name="darc">Remote darc interface</param>
+        /// <param name="remoteFactory">Remote factory for generating remotes based on repo uri</param>
         /// <param name="targetRepository">Target repository that the updates should be applied to</param>
         /// <param name="newBranchName">Target branch the updates should be to</param>
         /// <returns></returns>
         private async Task CommitUpdatesAsync(
             List<(UpdateAssetsParameters update, List<DependencyUpdate> deps)> requiredUpdates,
             StringBuilder description,
-            IRemote darc,
+            IRemoteFactory remoteFactory,
             string targetRepository,
             string newBranchName)
         {
@@ -837,6 +837,8 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
             // Should max one coherency update
             (UpdateAssetsParameters update, List<DependencyUpdate> deps) coherencyUpdate =
                 requiredUpdates.Where(u => u.update.IsCoherencyUpdate).SingleOrDefault();
+
+            IRemote remote = await remoteFactory.GetRemoteAsync(targetRepository, Logger);
 
             // To keep a PR to as few commits as possible, if the number of
             // non-coherency updates is 1 then combine coherency updates with those.
@@ -855,7 +857,8 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                     dependenciesToCommit.AddRange(coherencyUpdate.deps);
                 }
 
-                List<GitFile> committedFiles = await darc.CommitUpdatesAsync(targetRepository, newBranchName, dependenciesToCommit.Select(du => du.To).ToList(), message.ToString());
+                List<GitFile> committedFiles = await remote.CommitUpdatesAsync(targetRepository, newBranchName, remoteFactory,
+                    dependenciesToCommit.Select(du => du.To).ToList(), message.ToString());
                 await CalculatePRDescription(update, deps, committedFiles, description);
             }
 
@@ -867,7 +870,8 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                 await CalculateCommitMessage(coherencyUpdate.update, coherencyUpdate.deps, message);
                 await CalculatePRDescription(coherencyUpdate.update, coherencyUpdate.deps, null, description);
 
-                await darc.CommitUpdatesAsync(targetRepository, newBranchName, coherencyUpdate.deps.Select(du => du.To).ToList(), message.ToString());
+                await remote.CommitUpdatesAsync(targetRepository, newBranchName, remoteFactory,
+                    coherencyUpdate.deps.Select(du => du.To).ToList(), message.ToString());
             }
         }
 
@@ -1078,7 +1082,7 @@ This pull request {(merged ? "has been merged" : "will be merged")} because the 
                 pr.Url);
 
             var description = new StringBuilder(pullRequest.Description);
-            await CommitUpdatesAsync(requiredUpdates, description, darcRemote, targetRepository, headBranch);
+            await CommitUpdatesAsync(requiredUpdates, description, DarcRemoteFactory, targetRepository, headBranch);
 
             pullRequest.Description = description.ToString();
             pullRequest.Title = await ComputePullRequestTitleAsync(pr, targetBranch);

--- a/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
@@ -125,6 +125,7 @@ namespace SubscriptionActorService.Tests
                     r => r.CommitUpdatesAsync(
                         TargetRepo,
                         NewBranch ?? InProgressPrHeadBranch,
+                        RemoteFactory.Object,
                         Capture.In(updatedDependencies),
                         It.IsAny<string>()));
             updatedDependencies.Should()

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -756,48 +756,51 @@ namespace Microsoft.DotNet.DarcLib
             return await GetRequiredCoherencyUpdatesAsync(currentDependencies, remoteFactory);
         }
 
+        /// <summary>
+        ///     Commit a set of updated dependencies to a repository
+        /// </summary>
+        /// <param name="repoUri">Repository to update</param>
+        /// <param name="branch">Branch of <paramref name="repoUri"/> to update.</param>
+        /// <param name="remoteFactory">Remote factory for obtaining common script files from arcade</param>
+        /// <param name="itemsToUpdate">Dependencies that need updating.</param>
+        /// <param name="message">Commit message.</param>
+        /// <returns>Async task.</returns>
         public async Task<List<GitFile>> CommitUpdatesAsync(
             string repoUri,
             string branch,
+            IRemoteFactory remoteFactory,
             List<DependencyDetail> itemsToUpdate,
             string message)
         {
+            CheckForValidGitClient();
+
             IEnumerable<DependencyDetail> oldDependencies = await GetDependenciesAsync(repoUri, branch, loadAssetLocations: true);
             await AddAssetLocationToDependenciesAsync(itemsToUpdate);
-
-            CheckForValidGitClient();
-            GitFileContentContainer fileContainer =
-                await _fileManager.UpdateDependencyFiles(itemsToUpdate, repoUri, branch, oldDependencies);
-            List<GitFile> filesToCommit = new List<GitFile>();
 
             // If we are updating the arcade sdk we need to update the eng/common files
             // and the sdk versions in global.json
             DependencyDetail arcadeItem = itemsToUpdate.FirstOrDefault(
                 i => string.Equals(i.Name, "Microsoft.DotNet.Arcade.Sdk", StringComparison.OrdinalIgnoreCase));
+            
+            SemanticVersion targetDotNetVersion = null;
+            bool mayNeedArcadeUpdate = (arcadeItem != null && repoUri != arcadeItem.RepoUri);
+            IRemote arcadeRemote = null;
 
-            if (arcadeItem != null && repoUri != arcadeItem.RepoUri)
+            if (mayNeedArcadeUpdate)
             {
-                // Files in arcade repository. All Arcade items have a GitHub repo URI by default so we need to change the
-                // URI from we are getting the eng/common files. If in an AzDO context we change the URI to that of
-                // dotnet-arcade in dnceng
+                arcadeRemote = await remoteFactory.GetRemoteAsync(arcadeItem.RepoUri, _logger);
+                targetDotNetVersion = await GetToolsDotnetVersionAsync(arcadeItem.RepoUri, arcadeItem.Commit);
+            }
 
-                string arcadeRepoUri = arcadeItem.RepoUri;
+            GitFileContentContainer fileContainer =
+                await _fileManager.UpdateDependencyFiles(itemsToUpdate, repoUri, branch, oldDependencies, targetDotNetVersion);
+            List<GitFile> filesToCommit = new List<GitFile>();
 
-                if (Uri.TryCreate(repoUri, UriKind.Absolute, out Uri parsedUri))
-                {
-                    if (parsedUri.Host == "dev.azure.com" || parsedUri.Host.EndsWith("visualstudio.com"))
-                    {
-                        arcadeRepoUri = "https://dev.azure.com/dnceng/internal/_git/dotnet-arcade";
-                    }
-                }
-
-                SemanticVersion arcadeDotnetVersion = await GetToolsDotnetVersionAsync(arcadeRepoUri, arcadeItem.Commit);
-                if (arcadeDotnetVersion != null)
-                {
-                    fileContainer.GlobalJson = UpdateDotnetVersionGlobalJson(arcadeDotnetVersion, fileContainer.GlobalJson);
-                }
-
-                List<GitFile> engCommonFiles = await GetCommonScriptFilesAsync(arcadeRepoUri, arcadeItem.Commit);
+            if (mayNeedArcadeUpdate)
+            {
+                // Files in the source arcade repo. We use the remote factory because the
+                // arcade repo may be in github while this remote is targeted at AzDO.
+                List<GitFile> engCommonFiles = await arcadeRemote.GetCommonScriptFilesAsync(arcadeItem.RepoUri, arcadeItem.Commit);
                 filesToCommit.AddRange(engCommonFiles);
 
                 // Files in the target repo
@@ -1102,7 +1105,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="repoUri">repo to get the version from</param>
         /// <param name="commit">commit sha to query</param>
         /// <returns></returns>
-        private async Task<SemanticVersion> GetToolsDotnetVersionAsync(string repoUri, string commit)
+        public async Task<SemanticVersion> GetToolsDotnetVersionAsync(string repoUri, string commit)
         {
             CheckForValidGitClient();
             _logger.LogInformation("Reading dotnet version from global.json");
@@ -1120,55 +1123,6 @@ namespace Microsoft.DotNet.DarcLib
             }
 
             return dotnetVersion;
-        }
-
-        /// <summary>
-        /// Updates the global.json entries for tools.dotnet and sdk.version if they are older than an incoming version
-        /// </summary>
-        /// <param name="incomingDotnetVersion">version to compare against</param>
-        /// <param name="repoGlobalJson">Global.Json file to update</param>
-        /// <returns>Updated global.json file if was able to update, or the unchanged global.json if unable to</returns>
-        private GitFile UpdateDotnetVersionGlobalJson(SemanticVersion incomingDotnetVersion, GitFile repoGlobalJson)
-        {
-            string repoGlobalJsonContent = repoGlobalJson.ContentEncoding == ContentEncoding.Base64 ?
-                _gitClient.GetDecodedContent(repoGlobalJson.Content) :
-                repoGlobalJson.Content;
-            try
-            {
-                JObject parsedGlobalJson = JObject.Parse(repoGlobalJsonContent);
-                if (SemanticVersion.TryParse(parsedGlobalJson.SelectToken("tools.dotnet").ToString(), out SemanticVersion repoDotnetVersion))
-                {
-                    if (repoDotnetVersion.CompareTo(incomingDotnetVersion) < 0)
-                    {
-                        Dictionary<GitFileMetadataName, string> metadata = new Dictionary<GitFileMetadataName, string>();
-
-                        parsedGlobalJson["tools"]["dotnet"] = incomingDotnetVersion.ToNormalizedString();
-                        metadata.Add(GitFileMetadataName.ToolsDotNetUpdate, incomingDotnetVersion.ToNormalizedString());
-
-                        // Also update and keep sdk.version in sync.
-                        JToken sdkVersion = parsedGlobalJson.SelectToken("sdk.version");
-                        if (sdkVersion != null)
-                        {
-                            parsedGlobalJson["sdk"]["version"] = incomingDotnetVersion.ToNormalizedString();
-                            metadata.Add(GitFileMetadataName.SdkVersionUpdate, incomingDotnetVersion.ToNormalizedString());
-                        }
-
-                        return new GitFile(VersionFiles.GlobalJson, parsedGlobalJson, metadata);
-                    }
-                    return repoGlobalJson;
-                }
-                else
-                {
-                    _logger.LogError("Could not parse the repo's dotnet version from the global.json. Skipping update to dotnet version sections");
-                    return repoGlobalJson;
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to update Dotnet version for global.json. Skipping update to version sections.");
-                return repoGlobalJson;
-            }
-
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.Maestro.Client.Models;
+using NuGet.Versioning;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -323,6 +324,14 @@ namespace Microsoft.DotNet.DarcLib
         Task<List<GitFile>> GetCommonScriptFilesAsync(string repoUri, string commit);
 
         /// <summary>
+        /// Get the tools.dotnet section of the global.json from a target repo URI
+        /// </summary>
+        /// <param name="repoUri">repo to get the version from</param>
+        /// <param name="commit">commit sha to query</param>
+        /// <returns></returns>
+        Task<SemanticVersion> GetToolsDotnetVersionAsync(string repoUri, string commit);
+
+        /// <summary>
         ///     Create a new branch in the specified repository.
         /// </summary>
         /// <param name="repoUri">Repository to create a brahc in</param>
@@ -344,10 +353,12 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         /// <param name="repoUri">Repository to update</param>
         /// <param name="branch">Branch of <paramref name="repoUri"/> to update.</param>
+        /// <param name="remoteFactory">Remote factory for obtaining common script files from arcade</param>
         /// <param name="itemsToUpdate">Dependencies that need updating.</param>
         /// <param name="message">Commit message.</param>
         /// <returns>Async task.</returns>
-        Task<List<GitFile>> CommitUpdatesAsync(string repoUri, string branch, List<DependencyDetail> itemsToUpdate, string message);
+        Task<List<GitFile>> CommitUpdatesAsync(string repoUri, string branch, IRemoteFactory remoteFactory, 
+            List<DependencyDetail> itemsToUpdate, string message);
 
         /// <summary>
         ///     Diff two commits in a repository and return information about them.

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyAddUpdateTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyAddUpdateTests.cs
@@ -448,6 +448,28 @@ namespace Microsoft.DotNet.Darc.Tests
         }
 
         /// <summary>
+        /// Update the arcade dependency to a new version, with an associated global.json update.
+        /// </summary>
+        [Fact]
+        public void UpdateArcadeDependencyWithSdkUpdate()
+        {
+            DependencyTestDriver.TestAndCompareOutput(nameof(UpdateArcadeDependencyWithSdkUpdate), async driver =>
+            {
+                await driver.UpdateDependenciesAsync(
+                    new List<DependencyDetail> {
+                        new DependencyDetail
+                        {
+                            Commit = "456",
+                            Name = "Microsoft.DotNet.Arcade.Sdk",
+                            RepoUri = "https://github.com/dotnet/arcade",
+                            Version = "2.0"
+                        }
+                    }, new NuGet.Versioning.SemanticVersion(10, 1, 1, "preview-1234"));
+                await driver.VerifyAsync();
+            });
+        }
+
+        /// <summary>
         ///     Sentinel test for checking that the normal version suffix isn't the end
         ///     of the alternate suffix. While other tests will fail if this is the case,
         ///     this makes diagnosing it easier.

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.DotNet.DarcLib;
 using Microsoft.Extensions.Logging.Abstractions;
+using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -68,13 +69,14 @@ namespace Microsoft.DotNet.Darc.Tests
                 null);
         }
 
-        public async Task UpdateDependenciesAsync(List<DependencyDetail> dependencies)
+        public async Task UpdateDependenciesAsync(List<DependencyDetail> dependencies, SemanticVersion dotNetVersion = null)
         {
             GitFileContentContainer container = await _gitFileManager.UpdateDependencyFiles(
                 dependencies,
                 TemporaryRepositoryPath,
                 null,
-                null);
+                null,
+                dotNetVersion);
             List<GitFile> filesToUpdate = container.GetFilesToCommit();
             await _gitClient.CommitFilesAsync(filesToUpdate, TemporaryRepositoryPath, null, null);
         }
@@ -88,6 +90,7 @@ namespace Microsoft.DotNet.Darc.Tests
             GitFileContentContainer container = await _gitFileManager.UpdateDependencyFiles(
                 dependencies,
                 TemporaryRepositoryPath,
+                null,
                 null,
                 null);
             List<GitFile> filesToUpdate = container.GetFilesToCommit();

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependency2/output/global.json
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependency2/output/global.json
@@ -1,1 +1,16 @@
-{}
+{
+  "sdk": {
+    "version": "3.1.200"
+  },
+  "tools": {
+    "dotnet": "3.1.200",
+    "runtimes": {
+      "dotnet": [
+        "2.1.11"
+      ]
+    }
+  },
+  "msbuild-sdks": {
+    "Microsoft.DotNet.Arcade.Sdk": "2.0"
+  }
+}

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/input/NuGet.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/input/NuGet.config
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration/>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/input/eng/Version.Details.xml
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/input/eng/Version.Details.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Dependencies>
+  <ProductDependencies>
+    <Dependency Name="Existing.Dependency" Version="1.2.3">
+      <Uri>https://foo.com/foo/baz</Uri>
+      <Sha>szdfsdfsdf</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>abc</Sha>
+    </Dependency>
+  </ProductDependencies>
+</Dependencies>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/input/eng/Versions.props
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/input/eng/Versions.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!--Package versions-->
+  <PropertyGroup>
+    <FooBarPackageVersion>0.0.0</FooBarPackageVersion>
+  </PropertyGroup>
+  <!--Package names-->
+  <PropertyGroup>
+    <FooBarPackage>Foo.bar</FooBarPackage>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/input/global.json
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/input/global.json
@@ -11,6 +11,6 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20224.11"
   }
 }

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/output/eng/Version.Details.xml
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/output/eng/Version.Details.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Dependencies>
+  <ProductDependencies>
+    <Dependency Name="Existing.Dependency" Version="1.2.3">
+      <Uri>https://foo.com/foo/baz</Uri>
+      <Sha>szdfsdfsdf</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="2.0">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>456</Sha>
+    </Dependency>
+  </ProductDependencies>
+</Dependencies>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/output/eng/Versions.props
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/output/eng/Versions.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!--Package versions-->
+  <PropertyGroup>
+    <FooBarPackageVersion>0.0.0</FooBarPackageVersion>
+  </PropertyGroup>
+  <!--Package names-->
+  <PropertyGroup>
+    <FooBarPackage>Foo.bar</FooBarPackage>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/output/global.json
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/output/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "3.1.200"
+    "version": "10.1.1-preview-1234"
   },
   "tools": {
-    "dotnet": "3.1.200",
+    "dotnet": "10.1.1-preview-1234",
     "runtimes": {
       "dotnet": [
         "2.1.11"
@@ -11,6 +11,6 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0"
+    "Microsoft.DotNet.Arcade.Sdk": "2.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/5433. The global json update
for the SDK was missed for the local flow. Refactor the code so that the
sdk update happens in UpdateDependencyFiles which is shared between Remote
and Local flows. Add tests

Other changes:
- Pass in a remote factory so we don't have to mangle the arcade repo uri.
- Fix one of the update dependencies tests which was not testing any global.json update.