### PR TITLE
Look for global.json starting from the sources directory to fix grafana metrics stage.

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -279,6 +279,7 @@ stages:
       displayName: Install Correct .NET Version
       inputs:
         useGlobalJson: true
+        workingDirectory: $(Build.SourcesDirectory)
     - script: dotnet publish $(Build.SourcesDirectory)\src\Monitoring\Sdk\Microsoft.DotNet.Monitoring.Sdk.csproj -f netcoreapp2.1
     - script: dotnet build $(Build.SourcesDirectory)\src\Monitoring\Monitoring.ArcadeServices\Monitoring.ArcadeServices.proj -t:PublishGrafana -p:GrafanaAccessToken=$(grafana-admin-api-key) -p:GrafanaHost=$(GrafanaHost) -p:GrafanaKeyVaultName=$(GrafanaKeyVault) -p:GrafanaKeyVaultAppId=2bdfceef-194a-4775-99d9-b5575c77bc6b -p:GrafanaKeyVaultAppSecret=$(key-vault-app-secret) -p:GrafanaEnvironment=$(DeploymentEnvironment) -v:normal
 


### PR DESCRIPTION
Fixes the build break seen in https://github.com/dotnet/core-eng/issues/9776 where the step is trying to install a version we specified in a test file.

```
sdk version matching: 10.1.1-preview-1234 could not be found
```

That SDK version is specified here, and seems to be picked up by the task instead of the global.json in the root of the repo:  https://github.com/dotnet/arcade-services/blob/master/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/UpdateArcadeDependencyWithSdkUpdate/output/global.json

Validated that this now picks up the correct global.json in this build: https://dev.azure.com/dnceng/internal/_build/results?buildId=636745&view=results
 