### PR TITLE
Up Azure.Core version

### DIFF
--- a/src/Maestro/Client/src/Microsoft.DotNet.Maestro.Client.csproj
+++ b/src/Maestro/Client/src/Microsoft.DotNet.Maestro.Client.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.0.1" />
+    <PackageReference Include="Azure.Core" Version="1.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.0" />


### PR DESCRIPTION
When I tried plugging the latest version of Maestro.Client into Tasks.Feed ([testing this PR](https://github.com/dotnet/arcade/pull/5414)) I found out that due to a conflict of version the tasks in Tasks.Feed was failing at runtime. This PR is to fix that.