### PR TITLE
We need this for EF migrations

### DIFF
--- a/src/Maestro/Maestro.Data/Maestro.Data.csproj
+++ b/src/Maestro/Maestro.Data/Maestro.Data.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
3.1 stopped generating runtimeconfig.json for DLLs, but it's necessary for EF migrations to be run