### PR TITLE
Filter disabled subscriptions in trigger-subscriptions

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/TriggerSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/TriggerSubscriptionsOperation.cs
@@ -71,6 +71,25 @@ namespace Microsoft.DotNet.Darc.Operations
                     subscriptionsToTrigger.AddRange(subscriptions);
                 }
 
+                // Filter away subscriptions that are disabled
+                List<Subscription> disabledSubscriptions = subscriptionsToTrigger.Where(s => !s.Enabled).ToList();
+                subscriptionsToTrigger = subscriptionsToTrigger.Where(s => s.Enabled).ToList();
+
+                if (disabledSubscriptions.Any())
+                {
+                    Console.WriteLine($"The following {disabledSubscriptions.Count} subscription(s) are disabled and will not be triggered");
+                    foreach (var subscription in disabledSubscriptions)
+                    {
+                        Console.WriteLine($"  {UxHelpers.GetSubscriptionDescription(subscription)}");
+                    }
+                }
+
+                if (!subscriptionsToTrigger.Any())
+                {
+                    Console.WriteLine("No enabled subscriptions found matching the specified criteria.");
+                    return Constants.ErrorCode;
+                }
+
                 if (!noConfirm)
                 {
                     // Print out the list of subscriptions about to be triggered.


### PR DESCRIPTION
Filter and notify the user if some subscriptions are disabled. There have been a few cases where users expected PRs to be created but they were not.