### PR TITLE
Fix lifetimes

### DIFF
--- a/src/Maestro/Maestro.Data/BuildAssetRegistryInstallationLookup.cs
+++ b/src/Maestro/Maestro.Data/BuildAssetRegistryInstallationLookup.cs
@@ -13,12 +13,12 @@ namespace Maestro.Data
             _scopeFactory = scopeFactory;
         }
 
-        public Task<long> GetInstallationId(string repositoryUrl)
+        public async Task<long> GetInstallationId(string repositoryUrl)
         {
             using (var scope = _scopeFactory.CreateScope())
             {
                 var ctx = scope.ServiceProvider.GetRequiredService<BuildAssetRegistryContext>();
-                return ctx.GetInstallationId(repositoryUrl);
+                return await ctx.GetInstallationId(repositoryUrl);
             }
         }
     }

--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/SubscriptionsController.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.ServiceFabric.Actors;
+using Newtonsoft.Json.Linq;
 using Channel = Maestro.Data.Models.Channel;
 
 namespace Maestro.Web.Api.v2018_07_16.Controllers
@@ -32,19 +33,13 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
     {
         private readonly BuildAssetRegistryContext _context;
         private readonly BackgroundQueue _queue;
-        private readonly IDependencyUpdater _dependencyUpdater;
-        private readonly IActorProxyFactory<ISubscriptionActor> _subscriptionActorFactory;
 
         public SubscriptionsController(
             BuildAssetRegistryContext context,
-            BackgroundQueue queue,
-            IDependencyUpdater dependencyUpdater,
-            IActorProxyFactory<ISubscriptionActor> subscriptionActorFactory)
+            BackgroundQueue queue)
         {
             _context = context;
             _queue = queue;
-            _dependencyUpdater = dependencyUpdater;
-            _subscriptionActorFactory = subscriptionActorFactory;
         }
 
         /// <summary>
@@ -119,22 +114,42 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
         [ValidateModelState]
         public virtual async Task<IActionResult> TriggerSubscription(Guid id)
         {
+            Data.Models.Subscription subscription = await TriggerSubscriptionCore(id);
+
+            if (subscription == null)
+                return NotFound();
+
+            return Accepted(new Subscription(subscription));
+        }
+
+        protected async Task<Data.Models.Subscription> TriggerSubscriptionCore(Guid id)
+        {
             Data.Models.Subscription subscription = await _context.Subscriptions.Include(sub => sub.LastAppliedBuild)
                 .Include(sub => sub.Channel)
                 .FirstOrDefaultAsync(sub => sub.Id == id);
 
             if (subscription == null)
             {
-                return NotFound();
+                return null;
             }
 
-            _queue.Post(
-                async () =>
-                {
-                    await _dependencyUpdater.StartSubscriptionUpdateAsync(id);
-                });
+            _queue.Post<StartSubscriptionUpdateWorkItem>(JToken.FromObject(id));
+            return subscription;
+        }
 
-            return Accepted(new Subscription(subscription));
+        private class StartSubscriptionUpdateWorkItem : IBackgroundWorkItem
+        {
+            private readonly IDependencyUpdater _dependencyUpdater;
+
+            public StartSubscriptionUpdateWorkItem(IDependencyUpdater dependencyUpdater)
+            {
+                _dependencyUpdater = dependencyUpdater;
+            }
+
+            public Task ProcessAsync(JToken argumentToken)
+            {
+                return _dependencyUpdater.StartSubscriptionUpdateAsync(argumentToken.Value<Guid>());
+            }
         }
 
         /// <summary>
@@ -145,13 +160,24 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
         [ValidateModelState]
         public virtual IActionResult TriggerDailyUpdate()
         {
-            _queue.Post(
-                async () =>
-                {
-                    await _dependencyUpdater.CheckDailySubscriptionsAsync(CancellationToken.None);
-                });
+            _queue.Post<CheckDailySubscriptionsWorkItem>();
 
             return Accepted();
+        }
+
+        private class CheckDailySubscriptionsWorkItem : IBackgroundWorkItem
+        {
+            private readonly IDependencyUpdater _dependencyUpdater;
+
+            public CheckDailySubscriptionsWorkItem(IDependencyUpdater dependencyUpdater)
+            {
+                _dependencyUpdater = dependencyUpdater;
+            }
+
+            public Task ProcessAsync(JToken ignored)
+            {
+                return _dependencyUpdater.CheckDailySubscriptionsAsync(CancellationToken.None);
+            }
         }
 
         /// <summary>
@@ -321,14 +347,45 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
                     new ApiError("That action was successful, it cannot be retried."));
             }
 
-            _queue.Post(
-                async () =>
-                {
-                    ISubscriptionActor actor = _subscriptionActorFactory.Lookup(new ActorId(subscription.Id));
-                    await actor.RunActionAsync(update.Method, update.Arguments);
-                });
+            _queue.Post<SubscriptionActorActionWorkItem>(
+                SubscriptionActorActionWorkItem.GetArguments(subscription.Id, update.Method, update.Arguments)
+            );
 
             return Accepted();
+        }
+
+        private class SubscriptionActorActionWorkItem : IBackgroundWorkItem
+        {
+            private readonly IActorProxyFactory<ISubscriptionActor> _factory;
+
+            public SubscriptionActorActionWorkItem(IActorProxyFactory<ISubscriptionActor> factory)
+            {
+                _factory = factory;
+            }
+
+            private struct Arguments
+            {
+                public Guid Subscriptionid;
+                public string Method;
+                public string MethodArguments;
+            }
+
+            public Task ProcessAsync(JToken argumentToken)
+            {
+                var args = argumentToken.ToObject<Arguments>();
+                ISubscriptionActor actor = _factory.Lookup(new ActorId(args.Subscriptionid));
+                return actor.RunActionAsync(args.Method, args.MethodArguments);
+            }
+
+            public static JToken GetArguments(Guid subscriptionId, string method, string arguments)
+            {
+                return JToken.FromObject(new Arguments
+                {
+                    Subscriptionid = subscriptionId,
+                    Method = method,
+                    MethodArguments = arguments
+                });
+            }
         }
 
         /// <summary>

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/SubscriptionsController.cs
@@ -8,13 +8,11 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using Maestro.Contracts;
 using Maestro.Data;
 using Microsoft.AspNetCore.ApiVersioning;
 using Microsoft.AspNetCore.ApiVersioning.Swashbuckle;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.ServiceFabric.Actors;
 using Maestro.Web.Api.v2019_01_16.Models;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
 
@@ -28,19 +26,13 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
     public class SubscriptionsController : v2018_07_16.Controllers.SubscriptionsController
     {
         private readonly BuildAssetRegistryContext _context;
-        private readonly BackgroundQueue _queue;
-        private readonly IDependencyUpdater _dependencyUpdater;
 
         public SubscriptionsController(
             BuildAssetRegistryContext context,
-            BackgroundQueue queue,
-            IDependencyUpdater dependencyUpdater,
-            IActorProxyFactory<ISubscriptionActor> subscriptionActorFactory)
-            : base(context, queue, dependencyUpdater, subscriptionActorFactory)
+            BackgroundQueue queue)
+            : base(context, queue)
         {
             _context = context;
-            _queue = queue;
-            _dependencyUpdater = dependencyUpdater;
         }
 
         /// <summary>

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/SubscriptionsController.cs
@@ -115,21 +115,10 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
         [ValidateModelState]
         public override async Task<IActionResult> TriggerSubscription(Guid id)
         {
-            Data.Models.Subscription subscription = await _context.Subscriptions.Include(sub => sub.LastAppliedBuild)
-                .Include(sub => sub.Channel)
-                .FirstOrDefaultAsync(sub => sub.Id == id);
+            Data.Models.Subscription subscription = await TriggerSubscriptionCore(id);
 
             if (subscription == null)
-            {
                 return NotFound();
-            }
-
-            _queue.Post(
-                async () =>
-                {
-                    await _dependencyUpdater.StartSubscriptionUpdateAsync(id);
-                });
-
             return Accepted(new Subscription(subscription));
         }
 

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
@@ -115,20 +115,10 @@ namespace Maestro.Web.Api.v2020_02_20.Controllers
         [ValidateModelState]
         public override async Task<IActionResult> TriggerSubscription(Guid id)
         {
-            Data.Models.Subscription subscription = await _context.Subscriptions.Include(sub => sub.LastAppliedBuild)
-                .Include(sub => sub.Channel)
-                .FirstOrDefaultAsync(sub => sub.Id == id);
+            Data.Models.Subscription subscription = await TriggerSubscriptionCore(id);
 
             if (subscription == null)
-            {
                 return NotFound();
-            }
-
-            _queue.Post(
-                async () =>
-                {
-                    await _dependencyUpdater.StartSubscriptionUpdateAsync(id);
-                });
 
             return Accepted(new Subscription(subscription));
         }

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
@@ -8,7 +8,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using Maestro.Contracts;
 using Maestro.Data;
 using Microsoft.AspNetCore.ApiVersioning;
 using Microsoft.AspNetCore.ApiVersioning.Swashbuckle;
@@ -28,19 +27,13 @@ namespace Maestro.Web.Api.v2020_02_20.Controllers
     public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsController
     {
         private readonly BuildAssetRegistryContext _context;
-        private readonly BackgroundQueue _queue;
-        private readonly IDependencyUpdater _dependencyUpdater;
 
         public SubscriptionsController(
             BuildAssetRegistryContext context,
-            BackgroundQueue queue,
-            IDependencyUpdater dependencyUpdater,
-            IActorProxyFactory<ISubscriptionActor> subscriptionActorFactory)
-            : base(context, queue, dependencyUpdater, subscriptionActorFactory)
+            BackgroundQueue queue)
+            : base(context, queue)
         {
             _context = context;
-            _queue = queue;
-            _dependencyUpdater = dependencyUpdater;
         }
 
         /// <summary>


### PR DESCRIPTION
Fix lifetime of BackgroundQueue

The BackgroundQueue took a callback, which caused almost every caller
to pass a lambda that contained a bunch of bound objects with
unpredictable lifetimes.  Since the background queue runs
asynchronously, this means that often the items complete after
the caller has returns and disposed all the bound objects,
resulting in unpredictable behavior.

Change the contract of the queue so it's no longer to
flow lifetimes into the queue.

Make the BackgroundQueue create a scope (so that various items aren't
sharing the global scoped DbContext) for each item to manage
the lifetimes appropriately, and to resolve any dependencies.