### PR TITLE
Fix 2 issues related to DI scopeing and DB Context lifetimes

### DIFF
--- a/arcade-services.sln
+++ b/arcade-services.sln
@@ -159,6 +159,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Internal.D
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Maestro.Data.Tests", "src\Maestro\Maestro.Data.Tests\Maestro.Data.Tests.csproj", "{B3912147-0659-4960-83EE-BACCC24AFB6D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Internal.DependencyInjection", "src\Shared\Microsoft.DotNet.Internal.DependencyInjection\Microsoft.DotNet.Internal.DependencyInjection.csproj", "{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Internal.DependencyInjection.Tests", "src\Shared\Microsoft.DotNet.Internal.DependencyInjection.Tests\Microsoft.DotNet.Internal.DependencyInjection.Tests.csproj", "{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -789,6 +793,30 @@ Global
 		{B3912147-0659-4960-83EE-BACCC24AFB6D}.Release|x64.Build.0 = Release|Any CPU
 		{B3912147-0659-4960-83EE-BACCC24AFB6D}.Release|x86.ActiveCfg = Release|Any CPU
 		{B3912147-0659-4960-83EE-BACCC24AFB6D}.Release|x86.Build.0 = Release|Any CPU
+		{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11}.Debug|x86.Build.0 = Debug|Any CPU
+		{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11}.Release|x64.Build.0 = Release|Any CPU
+		{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11}.Release|x86.Build.0 = Release|Any CPU
+		{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1}.Debug|x64.Build.0 = Debug|Any CPU
+		{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1}.Debug|x86.Build.0 = Debug|Any CPU
+		{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1}.Release|x64.ActiveCfg = Release|Any CPU
+		{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1}.Release|x64.Build.0 = Release|Any CPU
+		{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1}.Release|x86.ActiveCfg = Release|Any CPU
+		{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -837,6 +865,8 @@ Global
 		{B9BA1250-C36F-4390-AAB2-D1A7A67889FD} = {0D9FE592-7EB7-4CEE-95E8-3379B98041C6}
 		{44CAFA8A-345D-4386-9EB2-69E08BFE2209} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
 		{B3912147-0659-4960-83EE-BACCC24AFB6D} = {AE791E26-78E1-4936-BCF4-1BF5152CBBD6}
+		{A1E8D5BD-B3E3-41A7-8FC0-590543FE1F11} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
+		{4E0ECB6F-7DE1-45AD-9582-62219C1D61A1} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {32B9C883-432E-4FC8-A1BF-090EB033DD5B}

--- a/src/Maestro/Maestro.Web/Controllers/WebHooksController.cs
+++ b/src/Maestro/Maestro.Web/Controllers/WebHooksController.cs
@@ -66,7 +66,7 @@ namespace Maestro.Web.Controllers
 
         private async Task RemoveInstallationRepositoriesAsync(long installationId)
         {
-            foreach (Data.Models.Repository repo in Context.Repositories.Where(r => r.InstallationId == installationId))
+            foreach (Data.Models.Repository repo in await Context.Repositories.Where(r => r.InstallationId == installationId).ToListAsync())
             {
                 Context.Update(repo);
                 repo.InstallationId = 0;

--- a/src/Maestro/Maestro.Web/Maestro.Web.csproj
+++ b/src/Maestro/Maestro.Web/Maestro.Web.csproj
@@ -40,6 +40,7 @@
     <ProjectReference Include="..\..\Microsoft.DotNet.Darc\src\DarcLib\Microsoft.DotNet.DarcLib.csproj" />
     <ProjectReference Include="..\..\Microsoft.DotNet.ServiceFabric.ServiceHost\Microsoft.DotNet.ServiceFabric.ServiceHost.csproj" />
     <ProjectReference Include="..\..\Shared\Microsoft.DotNet.GitHub.Authentication\Microsoft.DotNet.GitHub.Authentication.csproj" />
+    <ProjectReference Include="..\..\Shared\Microsoft.DotNet.Internal.DependencyInjection\Microsoft.DotNet.Internal.DependencyInjection.csproj" />
     <ProjectReference Include="..\..\Shared\Microsoft.DotNet.Kusto\Microsoft.DotNet.Kusto.csproj" />
     <ProjectReference Include="..\..\Shared\Microsoft.DotNet.Services.Utility\Microsoft.DotNet.Services.Utility.csproj" />
     <ProjectReference Include="..\..\shared\Microsoft.DotNet.Web.Authentication\Microsoft.DotNet.Web.Authentication.csproj" />

--- a/src/Maestro/Maestro.Web/Startup.cs
+++ b/src/Maestro/Maestro.Web/Startup.cs
@@ -44,6 +44,7 @@ using Newtonsoft.Json;
 using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.DotNet.Kusto;
 using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.DotNet.Internal.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
@@ -263,6 +264,8 @@ namespace Maestro.Web
 
             services.AddScoped<IRemoteFactory, DarcRemoteFactory>();
             services.AddSingleton(typeof(IActorProxyFactory<>), typeof(ActorProxyFactory<>));
+
+            services.EnableLazy();
 
             services.AddMergePolicies();
 

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Builds.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Builds.cs
@@ -8,6 +8,7 @@ using NUnit.Framework.Internal;
 namespace Maestro.ScenarioTests
 {
     [TestFixture]
+    [Category("ScenarioTest")]
     public class ScenarioTests_Builds : MaestroScenarioTestBase
     {
         private string repoUrl;

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Channels.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Channels.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 namespace Maestro.ScenarioTests
 {
     [TestFixture]
+    [Category("ScenarioTest")]
     public class ScenarioTests_Channels : MaestroScenarioTestBase
     {
         private TestParameters _parameters;

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_DefaultChannels.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_DefaultChannels.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 namespace Maestro.ScenarioTests
 {
     [TestFixture]
+    [Category("ScenarioTest")]
     public class ScenarioTests_DefaultChannels : MaestroScenarioTestBase
     {
         private readonly string repoName = "maestro-test1";

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Dependencies.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Dependencies.cs
@@ -8,6 +8,7 @@ using NUnit.Framework.Internal;
 namespace Maestro.ScenarioTests
 {
     [TestFixture]
+    [Category("ScenarioTest")]
     public class ScenarioTests_Dependencies : MaestroScenarioTestBase
     {
 

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
@@ -5,6 +5,7 @@ using NUnit.Framework.Internal;
 namespace Maestro.ScenarioTests
 {
     [TestFixture]
+    [Category("ScenarioTest")]
     public class ScenarioTests_RepoPolicies : MaestroScenarioTestBase
     {
         private readonly string repoName = "maestro-test1";

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
@@ -10,6 +10,7 @@ using Octokit;
 namespace Maestro.ScenarioTests
 {
     [TestFixture]
+    [Category("ScenarioTest")]
     public class ScenarioTests_SdkUpdate : MaestroScenarioTestBase
     {
         private TestParameters _parameters;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
@@ -425,7 +425,7 @@ namespace Microsoft.DotNet.DarcLib
             string testPath)
         {
             List<DependencyDetail> rootDependencyList = rootDependencies?.ToList();
-            List<string> remotesList = remotesMap.ToList();
+            List<string> remotesList = remotesMap?.ToList();
             ValidateBuildOptions(remoteFactory,
                 rootDependencyList,
                 repoUri,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
@@ -424,14 +424,24 @@ namespace Microsoft.DotNet.DarcLib
             IEnumerable<string> remotesMap,
             string testPath)
         {
-            ValidateBuildOptions(remoteFactory, rootDependencies, repoUri, commit,
-                options, remote, logger, reposFolder, remotesMap, testPath);
+            List<DependencyDetail> rootDependencyList = rootDependencies?.ToList();
+            List<string> remotesList = remotesMap.ToList();
+            ValidateBuildOptions(remoteFactory,
+                rootDependencyList,
+                repoUri,
+                commit,
+                options,
+                remote,
+                logger,
+                reposFolder,
+                remotesList,
+                testPath);
 
             if (rootDependencies != null)
             {
-                logger.LogInformation($"Starting build of graph from {rootDependencies.Count()} root dependencies " +
+                logger.LogInformation($"Starting build of graph from {rootDependencyList.Count} root dependencies " +
                     $"({repoUri}@{commit})");
-                foreach (DependencyDetail dependency in rootDependencies)
+                foreach (DependencyDetail dependency in rootDependencyList)
                 {
                     logger.LogInformation($"  {dependency.Name}@{dependency.Version}");
                 }
@@ -449,19 +459,19 @@ namespace Microsoft.DotNet.DarcLib
             }
 
             List<LinkedList<DependencyGraphNode>> cycles = new List<LinkedList<DependencyGraphNode>>();
-            Dictionary<string, Task<IEnumerable<Build>>> buildLookupTasks = null;
+            Dictionary<string, List<Build>> buildLookups = null;
 
             if (options.LookupBuilds)
             {
-                buildLookupTasks = new Dictionary<string, Task<IEnumerable<Build>>>();
+                buildLookups = new Dictionary<string, List<Build>>();
 
                 // Look up the dependency and get the creating build.
-                buildLookupTasks.Add($"{repoUri}@{commit}", barOnlyRemote.GetBuildsAsync(repoUri, commit));
+                buildLookups.Add($"{repoUri}@{commit}", (await barOnlyRemote.GetBuildsAsync(repoUri, commit)).ToList());
             }
 
             // Create the root node and add the repo to the visited bit vector.
             List<Build> allContributingBuilds = null;
-            DependencyGraphNode rootGraphNode = new DependencyGraphNode(repoUri, commit, rootDependencies, null);
+            DependencyGraphNode rootGraphNode = new DependencyGraphNode(repoUri, commit, rootDependencyList, null);
             rootGraphNode.VisitedNodes.Add(repoUri);
             // Nodes to visit is a queue, so that the evaluation order
             // of the graph is breadth first.
@@ -490,8 +500,10 @@ namespace Microsoft.DotNet.DarcLib
             Dictionary<string, DependencyGraphNode> visitedRepoUriNodes = new Dictionary<string, DependencyGraphNode>();
             HashSet<DependencyGraphNode> incoherentNodes = new HashSet<DependencyGraphNode>();
             // Cache of incoherent dependencies, looked up by name
-            Dictionary<string, DependencyDetail> incoherentDependenciesCache = new Dictionary<string, DependencyDetail>();
-            HashSet<DependencyDetail> incoherentDependencies = new HashSet<DependencyDetail>(new LooseDependencyDetailComparer());
+            Dictionary<string, DependencyDetail> incoherentDependenciesCache =
+                new Dictionary<string, DependencyDetail>();
+            HashSet<DependencyDetail> incoherentDependencies =
+                new HashSet<DependencyDetail>(new LooseDependencyDetailComparer());
 
             while (nodesToVisit.Count > 0)
             {
@@ -499,7 +511,7 @@ namespace Microsoft.DotNet.DarcLib
 
                 logger.LogInformation($"Visiting {node.Repository}@{node.Commit}");
 
-                IEnumerable<DependencyDetail> dependencies;
+                List<DependencyDetail> dependencies;
                 // In case of the root node which is initially put on the stack,
                 // we already have the set of dependencies to start at (this may have been
                 // filtered by the caller). So no need to get the dependencies again.
@@ -511,7 +523,7 @@ namespace Microsoft.DotNet.DarcLib
                 {
                     logger.LogInformation($"Getting dependencies at {node.Repository}@{node.Commit}");
 
-                    dependencies = await GetDependenciesAsync(
+                    dependencies = (await GetDependenciesAsync(
                         remoteFactory,
                         remote,
                         logger,
@@ -519,9 +531,9 @@ namespace Microsoft.DotNet.DarcLib
                         node.Repository,
                         node.Commit,
                         options.IncludeToolset,
-                        remotesMap,
+                        remotesList,
                         reposFolder,
-                        testPath);
+                        testPath)).ToList();
                     // Set the dependencies on the current node.
                     node.Dependencies = dependencies;
                 }
@@ -542,9 +554,11 @@ namespace Microsoft.DotNet.DarcLib
 
                         if (options.LookupBuilds)
                         {
-                            if (!buildLookupTasks.ContainsKey($"{dependency.RepoUri}@{dependency.Commit}"))
+                            if (!buildLookups.ContainsKey($"{dependency.RepoUri}@{dependency.Commit}"))
                             {
-                                buildLookupTasks.Add($"{dependency.RepoUri}@{dependency.Commit}", barOnlyRemote.GetBuildsAsync(dependency.RepoUri, dependency.Commit));
+                                buildLookups.Add($"{dependency.RepoUri}@{dependency.Commit}",
+                                    (await barOnlyRemote.GetBuildsAsync(dependency.RepoUri, dependency.Commit))
+                                    .ToList());
                             }
                         }
 
@@ -560,13 +574,15 @@ namespace Microsoft.DotNet.DarcLib
                                 var newCycles = ComputeCyclePaths(node, dependency.RepoUri);
                                 cycles.AddRange(newCycles);
                             }
+
                             continue;
                         }
 
                         // Add the individual dependency to the set of unique dependencies seen
                         // in the whole graph.
                         uniqueDependencyDetails.Add(dependency);
-                        if (incoherentDependenciesCache.TryGetValue(dependency.Name, out DependencyDetail existingDependency))
+                        if (incoherentDependenciesCache.TryGetValue(dependency.Name,
+                            out DependencyDetail existingDependency))
                         {
                             incoherentDependencies.Add(existingDependency);
                             incoherentDependencies.Add(dependency);
@@ -578,9 +594,11 @@ namespace Microsoft.DotNet.DarcLib
 
                         // We may have visited this node before.  If so, add it as a child and avoid additional walks.
                         // Update the list of contributing builds.
-                        if (nodeCache.TryGetValue($"{dependency.RepoUri}@{dependency.Commit}", out DependencyGraphNode existingNode))
+                        if (nodeCache.TryGetValue($"{dependency.RepoUri}@{dependency.Commit}",
+                            out DependencyGraphNode existingNode))
                         {
-                            logger.LogInformation($"Node {dependency.RepoUri}@{dependency.Commit} has already been created, adding as child");
+                            logger.LogInformation(
+                                $"Node {dependency.RepoUri}@{dependency.Commit} has already been created, adding as child");
                             node.AddChild(existingNode, dependency);
                             continue;
                         }
@@ -617,9 +635,10 @@ namespace Microsoft.DotNet.DarcLib
 
             if (options.LookupBuilds)
             {
-                allContributingBuilds = await ComputeContributingBuildsAsync(buildLookupTasks,
-                                                                             nodeCache.Values,
-                                                                             logger);
+                allContributingBuilds = ComputeContributingBuilds(
+                    buildLookups,
+                    nodeCache.Values,
+                    logger);
             }
 
             switch (options.NodeDiff)
@@ -636,24 +655,25 @@ namespace Microsoft.DotNet.DarcLib
             }
 
             return new DependencyGraph(rootGraphNode,
-                                       uniqueDependencyDetails,
-                                       incoherentDependencies,
-                                       nodeCache.Values,
-                                       incoherentNodes,
-                                       allContributingBuilds,
-                                       cycles);
+                uniqueDependencyDetails,
+                incoherentDependencies,
+                nodeCache.Values,
+                incoherentNodes,
+                allContributingBuilds,
+                cycles);
         }
 
         /// <summary>
         /// Compute which builds contribute to each node in the graph, as well as the overall graph
         /// </summary>
-        /// <param name="buildLookupTasks">Set of tasks that are looking up builds</param>
+        /// <param name="buildLookups">Set of tasks that are looking up builds</param>
         /// <param name="allNodes">All nodes in the graph</param>
         /// <param name="logger">Logger</param>
         /// <returns></returns>
-        private static async Task<List<Build>> ComputeContributingBuildsAsync(Dictionary<string, Task<IEnumerable<Build>>> buildLookupTasks,
-                                                                              IEnumerable<DependencyGraphNode> allNodes,
-                                                                              ILogger logger)
+        private static List<Build> ComputeContributingBuilds(
+            Dictionary<string, List<Build>> buildLookups,
+            IEnumerable<DependencyGraphNode> allNodes,
+            ILogger logger)
         {
             logger.LogInformation("Computing contributing builds");
 
@@ -662,13 +682,13 @@ namespace Microsoft.DotNet.DarcLib
             foreach (DependencyGraphNode node in allNodes)
             {
                 node.ContributingBuilds = new HashSet<Build>(new BuildComparer());
-                IEnumerable<Build> potentiallyContributingBuilds = await buildLookupTasks[$"{node.Repository}@{node.Commit}"];
+                IEnumerable<Build> potentiallyContributingBuilds = buildLookups[$"{node.Repository}@{node.Commit}"];
 
                 // Filter down. The parent nodes of this node may have specific dependency versions that narrow down
                 // which potential builds this could be.  For instance, if sha A was built twice, producing asset B.1 and B.2,
                 // we wouldn't know which by a simple query. But we can narrow the potential
                 // builds by any of those that produced assets that match any parent's dependency name+version
-                foreach (var potentialContributingBuild in potentiallyContributingBuilds)
+                foreach (Build potentialContributingBuild in potentiallyContributingBuilds)
                 {
                     if (BuildContributesToNode(node, potentialContributingBuild))
                     {
@@ -682,7 +702,7 @@ namespace Microsoft.DotNet.DarcLib
 
             return allContributingBuilds;
         }
-        
+
         /// <summary>
         /// Determines whether a build contributes to a given node by looking at the parents'
         /// input dependencies. If there are no parents, then we assume that the build could contribute. This
@@ -730,16 +750,16 @@ namespace Microsoft.DotNet.DarcLib
             // Find all parents who have a path to the root node.  This set might also
             // be the root node, since the root node has itself marked in VisitedNodes.
             // After reaching the root along all paths, this set will be empty
-            var parentsInCycles = currentNode.Parents.Where(p => p.VisitedNodes.Contains(repoCycleRoot));
+            var parentsInCycles = currentNode.Parents.Where(p => p.VisitedNodes.Contains(repoCycleRoot)).ToList();
 
             if (parentsInCycles.Any())
             {
                 // Recurse into each parent, combining the returned cycles together and
                 // appending on the current node.
-                foreach (var parent in parentsInCycles)
+                foreach (DependencyGraphNode parent in parentsInCycles)
                 {
-                    var cyclesRootedAtParentNode = ComputeCyclePaths(parent, repoCycleRoot);
-                    foreach (var cycleRootedAtNode in cyclesRootedAtParentNode)
+                    List<LinkedList<DependencyGraphNode>> cyclesRootedAtParentNode = ComputeCyclePaths(parent, repoCycleRoot);
+                    foreach (LinkedList<DependencyGraphNode> cycleRootedAtNode in cyclesRootedAtParentNode)
                     {
                         cycleRootedAtNode.AddLast(currentNode);
                         allCyclesRootedAtNode.Add(cycleRootedAtNode);
@@ -749,7 +769,7 @@ namespace Microsoft.DotNet.DarcLib
             else
             {
                 // Create a segment containing just this node and return that
-                LinkedList<DependencyGraphNode> newCycleSegment = new LinkedList<DependencyGraphNode>();
+                var newCycleSegment = new LinkedList<DependencyGraphNode>();
                 allCyclesRootedAtNode.Add(newCycleSegment);
                 newCycleSegment.AddFirst(currentNode);
             }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraphNode.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraphNode.cs
@@ -11,23 +11,24 @@ namespace Microsoft.DotNet.DarcLib
 {
     public class DependencyGraphNode
     {
-        public DependencyGraphNode(string repoUri,
-                                   string commit,
-                                   IEnumerable<DependencyDetail> dependencies,
-                                   HashSet<Build> contributingBuilds)
+        public DependencyGraphNode(
+            string repoUri,
+            string commit,
+            List<DependencyDetail> dependencies,
+            HashSet<Build> contributingBuilds)
             : this(
-                  repoUri,
-                  commit,
-                  dependencies,
-                  new HashSet<string>(StringComparer.OrdinalIgnoreCase),
-                  contributingBuilds)
+                repoUri,
+                commit,
+                dependencies,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                contributingBuilds)
         {
         }
 
         public DependencyGraphNode(
             string repoUri,
             string commit,
-            IEnumerable<DependencyDetail> dependencies,
+            List<DependencyDetail> dependencies,
             HashSet<string> visitedNodes,
             HashSet<Build> contributingBuilds)
         {
@@ -60,7 +61,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <summary>
         ///     Dependencies of the node at RepoUri and Commit.
         /// </summary>
-        public IEnumerable<DependencyDetail> Dependencies { get; set; }
+        public List<DependencyDetail> Dependencies { get; set; }
 
         /// <summary>
         ///     Unique set of repositories that this node is dependent on.

--- a/src/Shared/Microsoft.DotNet.Internal.DependencyInjection.Tests/LazyTests.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.DependencyInjection.Tests/LazyTests.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.DotNet.Internal.DependencyInjection.Tests
+{
+    public class LazyTests
+    {
+        [Fact]
+        public void UnresolvedNoCreation()
+        {
+            Tracker tracker = new Tracker();
+            ServiceCollection collection = new ServiceCollection();
+            collection.AddSingleton(_ => tracker.Create());
+            collection.EnableLazy();
+            using (ServiceProvider provider = collection.BuildServiceProvider())
+            {
+                Assert.Equal(0, tracker.Created);
+            }
+        }
+
+        [Fact]
+        public void ResolvedNoValueNoCreation()
+        {
+            Tracker tracker = new Tracker();
+            ServiceCollection collection = new ServiceCollection();
+            collection.AddSingleton(_ => tracker.Create());
+            collection.EnableLazy();
+            using (ServiceProvider provider = collection.BuildServiceProvider())
+            {
+                Lazy<Tracked> lazy = provider.GetRequiredService<Lazy<Tracked>>();
+                Assert.Equal(0, tracker.Created);
+            }
+        }
+
+        [Fact]
+        public void ResolvedCreatesValue()
+        {
+            Tracker tracker = new Tracker();
+            ServiceCollection collection = new ServiceCollection();
+            collection.AddSingleton(_ => tracker.Create());
+            collection.EnableLazy();
+            using (ServiceProvider provider = collection.BuildServiceProvider())
+            {
+                Lazy<Tracked> lazy = provider.GetRequiredService<Lazy<Tracked>>();
+                Assert.Equal(0, tracker.Created);
+                Tracked t = lazy.Value;
+                Assert.Equal(1, tracker.Created);
+                Assert.Equal(1, t.Id);
+            }
+        }
+
+        [Fact]
+        public void SingletonDisposes()
+        {
+            Tracker tracker = new Tracker();
+            ServiceCollection collection = new ServiceCollection();
+            collection.AddSingleton(_ => tracker.Create());
+            collection.EnableLazy();
+            Tracked t;
+            using (ServiceProvider provider = collection.BuildServiceProvider())
+            {
+                Lazy<Tracked> lazy = provider.GetRequiredService<Lazy<Tracked>>();
+                t = lazy.Value;
+                Assert.False(t.Disposed, "Not disposed before provider is");
+            }
+            Assert.True(t.Disposed, "Disposed with provider");
+        }
+
+        [Fact]
+        public void SingletonNotDisposedBetweenScopes()
+        {
+            Tracker tracker = new Tracker();
+            ServiceCollection collection = new ServiceCollection();
+            collection.AddSingleton(_ => tracker.Create());
+            collection.EnableLazy();
+            using (ServiceProvider provider = collection.BuildServiceProvider())
+            {
+                Tracked a1;
+                using (provider.CreateScope())
+                {
+                    Lazy<Tracked> a = provider.GetRequiredService<Lazy<Tracked>>();
+                    a1 = a.Value;
+                    Assert.Equal(1, tracker.Created);
+                }
+                Assert.False(a1.Disposed);
+            }
+        }
+
+        [Fact]
+        public void ScopedDisposedBetweenScopes()
+        {
+            Tracker tracker = new Tracker();
+            ServiceCollection collection = new ServiceCollection();
+            collection.AddScoped(_ => tracker.Create());
+            collection.EnableLazy();
+            using (ServiceProvider provider = collection.BuildServiceProvider())
+            {
+                Tracked a1;
+                using (IServiceScope scope = provider.CreateScope())
+                {
+                    Lazy<Tracked> a = scope.ServiceProvider.GetRequiredService<Lazy<Tracked>>();
+                    a1 = a.Value;
+                    Assert.Equal(1, tracker.Created);
+                }
+                Assert.True(a1.Disposed);
+            }
+        }
+
+        [Fact]
+        public void ResolvesDifferentLazy()
+        {
+            Tracker tracker = new Tracker();
+            ServiceCollection collection = new ServiceCollection();
+            collection.AddSingleton(_ => tracker.Create());
+            collection.EnableLazy();
+            using (ServiceProvider provider = collection.BuildServiceProvider())
+            {
+                Lazy<Tracked> a = provider.GetRequiredService<Lazy<Tracked>>();
+                Lazy<Tracked> b = provider.GetRequiredService<Lazy<Tracked>>();
+                Assert.NotSame(a, b);
+            }
+        }
+
+        [Fact]
+        public void LazyResolutionIsLazy()
+        {
+            Tracker tracker = new Tracker();
+            ServiceCollection collection = new ServiceCollection();
+            collection.AddSingleton(_ => tracker.Create());
+            collection.EnableLazy();
+            using (ServiceProvider provider = collection.BuildServiceProvider())
+            {
+                Lazy<Tracked> a = provider.GetRequiredService<Lazy<Tracked>>();
+                Assert.False(a.IsValueCreated);
+                var a1 = a.Value;
+                var a2 = a.Value;
+                Assert.Same(a1, a2);
+                Assert.Equal(1, tracker.Created);
+            }
+        }
+
+        [Fact]
+        public void ResolvesSameObject()
+        {
+            Tracker tracker = new Tracker();
+            ServiceCollection collection = new ServiceCollection();
+            collection.AddSingleton(_ => tracker.Create());
+            collection.EnableLazy();
+            using (ServiceProvider provider = collection.BuildServiceProvider())
+            {
+                Lazy<Tracked> a = provider.GetRequiredService<Lazy<Tracked>>();
+                Tracked a1 = a.Value;
+                Lazy<Tracked> b = provider.GetRequiredService<Lazy<Tracked>>();
+                Tracked b1 = b.Value;
+                Assert.Same(a1, b1);
+                Assert.Equal(1, tracker.Created);
+            }
+        }
+
+        [Fact]
+        public void ScopeResolutionIsIndependent()
+        {
+            Tracker tracker = new Tracker();
+            ServiceCollection collection = new ServiceCollection();
+            collection.AddScoped(_ => tracker.Create());
+            collection.EnableLazy();
+            using (ServiceProvider provider = collection.BuildServiceProvider())
+            {
+                Tracked a1, b1;
+                using (IServiceScope scope = provider.CreateScope())
+                {
+                    Lazy<Tracked> a = scope.ServiceProvider.GetRequiredService<Lazy<Tracked>>();
+                    a1 = a.Value;
+                    Assert.Equal(1, tracker.Created);
+                }
+                Assert.True(a1.Disposed);
+                using (IServiceScope scope =provider.CreateScope())
+                {
+                    Lazy<Tracked> b = scope.ServiceProvider.GetRequiredService<Lazy<Tracked>>();
+                    b1 = b.Value;
+                    Assert.Equal(2, tracker.Created);
+                }
+                Assert.True(b1.Disposed);
+                Assert.NotSame(a1, b1);
+            }
+        }
+
+        [Fact]
+        public void SingletonSharedBetweenScopes()
+        {
+            Tracker tracker = new Tracker();
+            ServiceCollection collection = new ServiceCollection();
+            collection.AddSingleton(_ => tracker.Create());
+            collection.EnableLazy();
+            using (ServiceProvider provider = collection.BuildServiceProvider())
+            {
+                Tracked a1, b1;
+                using (IServiceScope scope =provider.CreateScope())
+                {
+                    Lazy<Tracked> a = scope.ServiceProvider.GetRequiredService<Lazy<Tracked>>();
+                    a1 = a.Value;
+                    Assert.Equal(1, tracker.Created);
+                }
+                using (IServiceScope scope =provider.CreateScope())
+                {
+                    Lazy<Tracked> b = scope.ServiceProvider.GetRequiredService<Lazy<Tracked>>();
+                    b1 = b.Value;
+                    Assert.Equal(1, tracker.Created);
+                }
+                Assert.Same(a1, b1);
+            }
+        }
+
+        [Fact]
+        public void TransientIsUniqueAndDisposed()
+        {
+            Tracker tracker = new Tracker();
+            ServiceCollection collection = new ServiceCollection();
+            collection.AddTransient(_ => tracker.Create());
+            collection.EnableLazy();
+            Tracked a1, b1;
+            using (ServiceProvider provider = collection.BuildServiceProvider())
+            {
+                using (IServiceScope scope =provider.CreateScope())
+                {
+                    Lazy<Tracked> a = scope.ServiceProvider.GetRequiredService<Lazy<Tracked>>();
+                    a1 = a.Value;
+                    Assert.Equal(1, tracker.Created);
+                    Lazy<Tracked> b = scope.ServiceProvider.GetRequiredService<Lazy<Tracked>>();
+                    b1 = b.Value;
+                    Assert.Equal(2, tracker.Created);
+                    Assert.NotSame(a1,b1);
+                }
+                Assert.True(a1.Disposed);
+                Assert.True(b1.Disposed);
+            }
+        }
+
+        public class Tracker
+        {
+            public int Created;
+
+            public Tracked Create()
+            {
+                int value = Interlocked.Increment(ref Created);
+                return new Tracked(value);
+            }
+        }
+
+        public class Tracked : IDisposable
+        {
+            public int Id { get; }
+            public bool Disposed { get; private set; }
+
+            public Tracked(int id)
+            {
+                Id = id;
+            }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+        }
+    }
+}

--- a/src/Shared/Microsoft.DotNet.Internal.DependencyInjection.Tests/Microsoft.DotNet.Internal.DependencyInjection.Tests.csproj
+++ b/src/Shared/Microsoft.DotNet.Internal.DependencyInjection.Tests/Microsoft.DotNet.Internal.DependencyInjection.Tests.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.Internal.DependencyInjection\Microsoft.DotNet.Internal.DependencyInjection.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Shared/Microsoft.DotNet.Internal.DependencyInjection/Microsoft.DotNet.Internal.DependencyInjection.csproj
+++ b/src/Shared/Microsoft.DotNet.Internal.DependencyInjection/Microsoft.DotNet.Internal.DependencyInjection.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+</Project>

--- a/src/Shared/Microsoft.DotNet.Internal.DependencyInjection/ResolvingLazy.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.DependencyInjection/ResolvingLazy.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.DotNet.Internal.DependencyInjection
+{
+    internal class ResolvingLazy<T> : Lazy<T>
+    {
+        public ResolvingLazy(IServiceProvider services) : base(services.GetRequiredService<T>)
+        {
+        }
+    }
+}

--- a/src/Shared/Microsoft.DotNet.Internal.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.DotNet.Internal.DependencyInjection
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection EnableLazy(this IServiceCollection services)
+        {
+            return services.AddTransient(typeof(Lazy<>), typeof(ResolvingLazy<>));
+        }
+    }
+}


### PR DESCRIPTION
Allow Lazy<T> resolution in DI.

Also, be sure to enumate DBContext lists and await all DBContext tasks, otherwise
there are multithreading issues.