### PR TITLE
I want to spam myself when more pipelines fail

### DIFF
--- a/src/DotNet.Status.Web/appsettings.json
+++ b/src/DotNet.Status.Web/appsettings.json
@@ -23,7 +23,7 @@
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\helix-service\\dotnet-helix-service-CI",
-          "Branches": ["master", "production"],
+          "Branches": [ "master", "production" ],
           "Assignee": "ChrisBoh"
         },
         {
@@ -35,6 +35,12 @@
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\arcade-validation\\dotnet-arcade-validation-official",
+          "Branches": [ "master" ],
+          "Assignee": "missymessa"
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet\\arcade-validation\\dotnet-arcade-validation-for-promotion",
           "Branches": [ "master" ],
           "Assignee": "missymessa"
         },


### PR DESCRIPTION
Configuring Build Monitor to assign me issues when `\\dotnet\arcade-validation\\dotnet-arcade-validation-for-promotion` fails. 