### PR TITLE
Disable System.Net.Http.EnableActivityPropagation

### DIFF
--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
@@ -67,6 +67,11 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
         /// </summary>
         public static void Run(Action<ServiceHost> configure)
         {
+            // Because of this issue, the activity tracking causes
+            // arbitrarily HttpClient calls to crash, so disable it until
+            // it is fixed
+            // https://github.com/dotnet/runtime/issues/36908
+            AppContext.SetSwitch("ystem.Net.Http.EnableActivityPropagation", false);
             CodePackageActivationContext packageActivationContext = FabricRuntime.GetActivationContext();
             try
             {


### PR DESCRIPTION
Because of https://github.com/dotnet/runtime/issues/36908,
this is causing arbitrary http requests to crash with "FormatExceptions".

Activity information is being injected by services outside our control, so
we can't force a safe format, so our only choice to disable it.