### PR TITLE
Make us do all testing only once

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,9 +127,9 @@ stages:
         - script: eng\common\cibuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
-            -p:Test=false
             $(_InternalBuildArgs)
             $(_ProductionArgs)
+            /p:Test=false
           name: Build
           displayName: Build / Publish
           condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,6 +127,7 @@ stages:
         - script: eng\common\cibuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
+            -p:Test=false
             $(_InternalBuildArgs)
             $(_ProductionArgs)
           name: Build

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -3,7 +3,7 @@ steps:
 - task: VSTest@2
   inputs:
     searchFolder: $(Build.SourcesDirectory)/artifacts/bin
-    testAssemblyVer2: '**.\*.Tests.dll'
+    testAssemblyVer2: '**\*.Tests.dll'
     testFiltercriteria: Category!=ScenarioTest
     codeCoverageEnabled: true
     configuration: $(_BuildConfig)

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -13,9 +13,22 @@ steps:
       --settings:CodeCoverage.runsettings
       --filter "TestCategory!=PostDeployment&TestCategory!=Nightly&TestCategory!=PreDeployment"
       --no-build
+      --logger "trx;LogFilePrefix=TestResults-"
+      --
+      "RunConfiguration.ResultsDirectory=$(Build.ArtifactStagingDirectory)\TestResults"
   env:
     NUGET_PACKAGES: '$(Build.SourcesDirectory)/.packages'
   condition: succeededOrFailed()
+
+- task: PublishTestResults@2
+  displayName: Publish Core Test Results
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '**/TestResults-*' 
+    searchFolder: $(Build.ArtifactStagingDirectory)\TestResults
+    testRunTitle: Basic Tests
+    buildConfiguration: $(_BuildConfig)
 
 - task: Powershell@2
   inputs: 

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -30,7 +30,10 @@ steps:
     testResultsFiles: '**/TestResults-*' 
     searchFolder: $(Build.ArtifactStagingDirectory)\TestResults
     testRunTitle: Basic Tests
-    mergeTestResults: true
+    # This seems to cause a null ref inside the PublishTestResults
+    # https://github.com/microsoft/azure-pipelines-tasks/issues/13007
+    # Disable it for now... we'll have a bunch of "XUnit_7" test runs
+    #mergeTestResults: true
     buildConfiguration: $(_BuildConfig)
 
 - task: Powershell@2

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -28,20 +28,21 @@ steps:
     testResultsFiles: '**/TestResults-*' 
     searchFolder: $(Build.ArtifactStagingDirectory)\TestResults
     testRunTitle: Basic Tests
+    mergeTestResults: true
     buildConfiguration: $(_BuildConfig)
 
 - task: Powershell@2
   inputs: 
     targetType: 'filePath'
     filePath: eng\convert-codecoveragetoxml.ps1
-    arguments: -Path "$(system.defaultworkingdirectory)" -NugetPackagesPath "$(Build.SourcesDirectory)\.packages"
+    arguments: -Path "$(Build.ArtifactStagingDirectory)\TestResults" -NugetPackagesPath "$(Build.SourcesDirectory)\.packages"
   displayName: Convert Code Coverage to XML (powershell)
 
 - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
   displayName: ReportGenerator
   inputs:
-    reports: '$(system.defaultworkingdirectory)\codecoverage.coveragexml'
-    targetdir: '$(Build.SourcesDirectory)\CodeCoverage'
+    reports: '$(Build.ArtifactStagingDirectory)\TestResults\codecoverage.coveragexml'
+    targetdir: '$(Build.ArtifactStagingDirectory)\CodeCoverage'
     reporttypes: 'HtmlInline_AzurePipelines;Cobertura'
     sourcedirs: '$(Build.SourcesDirectory)'
 
@@ -49,7 +50,7 @@ steps:
   displayName: 'Publish Code Coverage'
   inputs:
     codeCoverageTool: Cobertura
-    summaryFileLocation: '$(Build.SourcesDirectory)\CodeCoverage\Cobertura.xml'
+    summaryFileLocation: $(Build.ArtifactStagingDirectory)\CodeCoverage\Cobertura.xml'
     pathToSources: '$(Build.SourcesDirectory)'
     publishRunAttachments: true
 

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -1,44 +1,12 @@
 steps: 
 
-- task: DotNetCoreCLI@2
-  displayName: Test C# (dotnet test)
+- task: VSTest@2
   inputs:
-    command: 'custom'
-    projects: |
-      src/**/*.Tests.csproj
-    custom: 'test'
-    arguments: > 
-      --configuration $(_BuildConfig)
-      --collect:"Code Coverage"
-      --settings:CodeCoverage.runsettings
-      --filter "Category!=ScenarioTest"
-      --no-build
-  env:
-    NUGET_PACKAGES: '$(Build.SourcesDirectory)/.packages'
-  condition: succeededOrFailed()
-
-- task: Powershell@2
-  inputs: 
-    targetType: 'filePath'
-    filePath: eng\convert-codecoveragetoxml.ps1
-    arguments: -Path "$(system.defaultworkingdirectory)" -NugetPackagesPath "$(Build.SourcesDirectory)\.packages"
-  displayName: Convert Code Coverage to XML (powershell)
-
-- task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
-  displayName: ReportGenerator
-  inputs:
-    reports: '$(system.defaultworkingdirectory)\codecoverage.coveragexml'
-    targetdir: '$(Build.SourcesDirectory)\CodeCoverage'
-    reporttypes: 'HtmlInline_AzurePipelines;Cobertura'
-    sourcedirs: '$(Build.SourcesDirectory)'
-
-- task: PublishCodeCoverageResults@1
-  displayName: 'Publish Code Coverage'
-  inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: '$(Build.SourcesDirectory)\CodeCoverage\Cobertura.xml'
-    pathToSources: '$(Build.SourcesDirectory)'
-    publishRunAttachments: true
+    searchFolder: $(Build.SourcesDirectory)/artifacts/bin
+    testSelector: '**.\*.Tests.dll'
+    testFiltercriteria: Category!=ScenarioTest
+    codeCoverageEnabled: true
+    configuration: $(_BuildConfig)
 
 - script: echo export const token = ''; > src/environments/token.ts
   workingDirectory: $(Build.SourcesDirectory)/src/Maestro/maestro-angular

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -50,7 +50,7 @@ steps:
   displayName: 'Publish Code Coverage'
   inputs:
     codeCoverageTool: Cobertura
-    summaryFileLocation: $(Build.ArtifactStagingDirectory)\CodeCoverage\Cobertura.xml'
+    summaryFileLocation: $(Build.ArtifactStagingDirectory)\CodeCoverage\Cobertura.xml
     pathToSources: '$(Build.SourcesDirectory)'
     publishRunAttachments: true
 

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -11,7 +11,7 @@ steps:
       --configuration $(_BuildConfig)
       --collect:"Code Coverage"
       --settings:CodeCoverage.runsettings
-      --filter "TestCategory!=PostDeployment&TestCategory!=Nightly&TestCategory!=PreDeployment"
+      --filter "Category!=ScenarioTest"
       --no-build
   env:
     NUGET_PACKAGES: '$(Build.SourcesDirectory)/.packages'

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -1,12 +1,44 @@
 steps: 
 
-- task: VSTest@2
+- task: DotNetCoreCLI@2
+  displayName: Test C# (dotnet test)
   inputs:
-    searchFolder: $(Build.SourcesDirectory)/artifacts/bin
-    testAssemblyVer2: '**\*.Tests.dll'
-    testFiltercriteria: Category!=ScenarioTest
-    codeCoverageEnabled: true
-    configuration: $(_BuildConfig)
+    command: 'custom'
+    projects: |
+      src/**/*.Tests.csproj
+    custom: 'test'
+    arguments: > 
+      --configuration $(_BuildConfig)
+      --collect:"Code Coverage"
+      --settings:CodeCoverage.runsettings
+      --filter "TestCategory!=PostDeployment&TestCategory!=Nightly&TestCategory!=PreDeployment"
+      --no-build
+  env:
+    NUGET_PACKAGES: '$(Build.SourcesDirectory)/.packages'
+  condition: succeededOrFailed()
+
+- task: Powershell@2
+  inputs: 
+    targetType: 'filePath'
+    filePath: eng\convert-codecoveragetoxml.ps1
+    arguments: -Path "$(system.defaultworkingdirectory)" -NugetPackagesPath "$(Build.SourcesDirectory)\.packages"
+  displayName: Convert Code Coverage to XML (powershell)
+
+- task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
+  displayName: ReportGenerator
+  inputs:
+    reports: '$(system.defaultworkingdirectory)\codecoverage.coveragexml'
+    targetdir: '$(Build.SourcesDirectory)\CodeCoverage'
+    reporttypes: 'HtmlInline_AzurePipelines;Cobertura'
+    sourcedirs: '$(Build.SourcesDirectory)'
+
+- task: PublishCodeCoverageResults@1
+  displayName: 'Publish Code Coverage'
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: '$(Build.SourcesDirectory)\CodeCoverage\Cobertura.xml'
+    pathToSources: '$(Build.SourcesDirectory)'
+    publishRunAttachments: true
 
 - script: echo export const token = ''; > src/environments/token.ts
   workingDirectory: $(Build.SourcesDirectory)/src/Maestro/maestro-angular

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -30,7 +30,6 @@ steps:
     testResultsFiles: '**/TestResults-*' 
     searchFolder: $(Build.ArtifactStagingDirectory)\TestResults
     testRunTitle: Basic Tests
-    mergeTestResults: true
     buildConfiguration: $(_BuildConfig)
 
 - task: PublishCodeCoverageResults@1

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -3,10 +3,10 @@ steps:
 - task: DotNetCoreCLI@2
   displayName: Test C# (dotnet test)
   inputs:
-    command: 'custom'
+    command: custom
     projects: |
       src/**/*.Tests.csproj
-    custom: 'test'
+    custom: test
     arguments: > 
       --configuration $(_BuildConfig)
       --collect:"Code Coverage"
@@ -14,10 +14,12 @@ steps:
       --filter "TestCategory!=PostDeployment&TestCategory!=Nightly&TestCategory!=PreDeployment"
       --no-build
       --logger "trx;LogFilePrefix=TestResults-"
+      -v normal
       --
       "RunConfiguration.ResultsDirectory=$(Build.ArtifactStagingDirectory)\TestResults"
+      RunConfiguration.MapCpuCount=4
   env:
-    NUGET_PACKAGES: '$(Build.SourcesDirectory)/.packages'
+    NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
   condition: succeededOrFailed()
 
 - task: PublishTestResults@2
@@ -31,9 +33,17 @@ steps:
     mergeTestResults: true
     buildConfiguration: $(_BuildConfig)
 
+- task: PublishCodeCoverageResults@1
+  displayName: Publish Code Coverage
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: $(Build.ArtifactStagingDirectory)\CodeCoverage\Cobertura.xml
+    pathToSources: $(Build.SourcesDirectory)
+    publishRunAttachments: true
+
 - task: Powershell@2
   inputs: 
-    targetType: 'filePath'
+    targetType: filePath
     filePath: eng\convert-codecoveragetoxml.ps1
     arguments: -Path "$(Build.ArtifactStagingDirectory)\TestResults" -NugetPackagesPath "$(Build.SourcesDirectory)\.packages"
   displayName: Convert Code Coverage to XML (powershell)
@@ -41,18 +51,10 @@ steps:
 - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
   displayName: ReportGenerator
   inputs:
-    reports: '$(Build.ArtifactStagingDirectory)\TestResults\codecoverage.coveragexml'
-    targetdir: '$(Build.ArtifactStagingDirectory)\CodeCoverage'
-    reporttypes: 'HtmlInline_AzurePipelines;Cobertura'
-    sourcedirs: '$(Build.SourcesDirectory)'
-
-- task: PublishCodeCoverageResults@1
-  displayName: 'Publish Code Coverage'
-  inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: $(Build.ArtifactStagingDirectory)\CodeCoverage\Cobertura.xml
-    pathToSources: '$(Build.SourcesDirectory)'
-    publishRunAttachments: true
+    reports: $(Build.ArtifactStagingDirectory)\TestResults\codecoverage.coveragexml
+    targetdir: $(Build.ArtifactStagingDirectory)\CodeCoverage
+    reporttypes: HtmlInline_AzurePipelines;Cobertura
+    sourcedirs: $(Build.SourcesDirectory)
 
 - script: echo export const token = ''; > src/environments/token.ts
   workingDirectory: $(Build.SourcesDirectory)/src/Maestro/maestro-angular

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -33,14 +33,6 @@ steps:
     mergeTestResults: true
     buildConfiguration: $(_BuildConfig)
 
-- task: PublishCodeCoverageResults@1
-  displayName: Publish Code Coverage
-  inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: $(Build.ArtifactStagingDirectory)\CodeCoverage\Cobertura.xml
-    pathToSources: $(Build.SourcesDirectory)
-    publishRunAttachments: true
-
 - task: Powershell@2
   inputs: 
     targetType: filePath
@@ -55,6 +47,14 @@ steps:
     targetdir: $(Build.ArtifactStagingDirectory)\CodeCoverage
     reporttypes: HtmlInline_AzurePipelines;Cobertura
     sourcedirs: $(Build.SourcesDirectory)
+
+- task: PublishCodeCoverageResults@1
+  displayName: Publish Code Coverage
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: $(Build.ArtifactStagingDirectory)\CodeCoverage\Cobertura.xml
+    pathToSources: $(Build.SourcesDirectory)
+    publishRunAttachments: true
 
 - script: echo export const token = ''; > src/environments/token.ts
   workingDirectory: $(Build.SourcesDirectory)/src/Maestro/maestro-angular

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -30,6 +30,7 @@ steps:
     testResultsFiles: '**/TestResults-*' 
     searchFolder: $(Build.ArtifactStagingDirectory)\TestResults
     testRunTitle: Basic Tests
+    mergeTestResults: true
     buildConfiguration: $(_BuildConfig)
 
 - task: PublishCodeCoverageResults@1

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -3,7 +3,7 @@ steps:
 - task: VSTest@2
   inputs:
     searchFolder: $(Build.SourcesDirectory)/artifacts/bin
-    testSelector: '**.\*.Tests.dll'
+    testAssemblyVer2: '**.\*.Tests.dll'
     testFiltercriteria: Category!=ScenarioTest
     codeCoverageEnabled: true
     configuration: $(_BuildConfig)

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -22,19 +22,15 @@ steps:
     NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
   condition: succeededOrFailed()
 
-- task: PublishTestResults@2
+- task: PublishTestResults@1
   displayName: Publish Core Test Results
   condition: succeededOrFailed()
   inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '**/TestResults-*' 
-    searchFolder: $(Build.ArtifactStagingDirectory)\TestResults
+    testRunner: VSTest
+    testResultsFiles: $(Build.ArtifactStagingDirectory)\TestResults\**\TestResults-*
     testRunTitle: Basic Tests
-    # This seems to cause a null ref inside the PublishTestResults
-    # https://github.com/microsoft/azure-pipelines-tasks/issues/13007
-    # Disable it for now... we'll have a bunch of "XUnit_7" test runs
-    #mergeTestResults: true
-    buildConfiguration: $(_BuildConfig)
+    mergeTestResults: true
+    configuration: $(_BuildConfig)
 
 - task: Powershell@2
   inputs: 

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -22,16 +22,6 @@ steps:
     NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
   condition: succeededOrFailed()
 
-- task: PublishTestResults@1
-  displayName: Publish Core Test Results
-  condition: succeededOrFailed()
-  inputs:
-    testRunner: VSTest
-    testResultsFiles: $(Build.ArtifactStagingDirectory)\TestResults\**\TestResults-*
-    testRunTitle: Basic Tests
-    mergeTestResults: true
-    configuration: $(_BuildConfig)
-
 - task: Powershell@2
   inputs: 
     targetType: filePath
@@ -46,6 +36,17 @@ steps:
     targetdir: $(Build.ArtifactStagingDirectory)\CodeCoverage
     reporttypes: HtmlInline_AzurePipelines;Cobertura
     sourcedirs: $(Build.SourcesDirectory)
+
+- task: PublishTestResults@2
+  displayName: Publish Core Test Results
+  condition: succeededOrFailed()
+  inputs:
+    testRunner: VSTest
+    testResultsFiles: '**/TestResults-*' 
+    searchFolder: $(Build.ArtifactStagingDirectory)\TestResults
+    testRunTitle: Basic Tests
+    mergeTestResults: true
+    configuration: $(_BuildConfig)
 
 - task: PublishCodeCoverageResults@1
   displayName: Publish Code Coverage


### PR DESCRIPTION
Exclude the categories we use.

Also, since we run "dotnet test", don't have the build also do the test,
since those results aren't uploaded, it's 100% impossible to see what even failed.