### PR TITLE
Specify If Retries Allowed For GitHubClient And AzureDevOpsClient 

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -41,9 +41,6 @@ namespace Microsoft.DotNet.DarcLib
 
         // Azure DevOps uses this id when creating a new branch as well as when deleting a branch
         private static readonly string BaseObjectId = "0000000000000000000000000000000000000000";
-
-        private bool _allowRetries = true;
-
         private readonly ILogger _logger;
         private readonly string _personalAccessToken;
         private readonly JsonSerializerSettings _serializerSettings;
@@ -70,7 +67,7 @@ namespace Microsoft.DotNet.DarcLib
             };
         }
 
-        public bool AllowRetries { get => _allowRetries; set => _allowRetries = value; }
+        public bool AllowRetries { get; set; } = true;
 
         /// <summary>
         /// Retrieve the contents of a text file in a repo on a specific branch
@@ -782,7 +779,7 @@ namespace Microsoft.DotNet.DarcLib
             string baseAddressSubpath = null,
             int retryCount = 15)
         {
-            if (!_allowRetries)
+            if (!AllowRetries)
             {
                 retryCount = 0;
             }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -42,6 +42,8 @@ namespace Microsoft.DotNet.DarcLib
         // Azure DevOps uses this id when creating a new branch as well as when deleting a branch
         private static readonly string BaseObjectId = "0000000000000000000000000000000000000000";
 
+        private bool _allowRetries = true;
+
         private readonly ILogger _logger;
         private readonly string _personalAccessToken;
         private readonly JsonSerializerSettings _serializerSettings;
@@ -67,6 +69,8 @@ namespace Microsoft.DotNet.DarcLib
                 NullValueHandling = NullValueHandling.Ignore
             };
         }
+
+        public bool AllowRetries { get => _allowRetries; set => _allowRetries = value; }
 
         /// <summary>
         /// Retrieve the contents of a text file in a repo on a specific branch
@@ -778,6 +782,10 @@ namespace Microsoft.DotNet.DarcLib
             string baseAddressSubpath = null,
             int retryCount = 15)
         {
+            if (!_allowRetries)
+            {
+                retryCount = 0;
+            }
             using (HttpClient client = CreateHttpClient(accountName, projectName, versionOverride, baseAddressSubpath))
             {
                 HttpRequestManager requestManager = new HttpRequestManager(client,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -41,7 +41,6 @@ namespace Microsoft.DotNet.DarcLib
         private readonly string _personalAccessToken;
         private readonly JsonSerializerSettings _serializerSettings;
         private readonly string _userAgent = $"DarcLib-{DarcLibVersion}";
-        private bool _allowRetries = true;
 
         static GitHubClient()
         {
@@ -66,7 +65,7 @@ namespace Microsoft.DotNet.DarcLib
 
         public virtual Octokit.IGitHubClient Client => _lazyClient.Value;
 
-        public bool AllowRetries { get => _allowRetries; set => _allowRetries = value; }
+        public bool AllowRetries { get; set; } = true;
 
         /// <summary>
         ///     Retrieve the contents of a repository file as a string
@@ -527,7 +526,7 @@ namespace Microsoft.DotNet.DarcLib
             int retryCount = 15,
             bool logFailure = true)
         {
-            if (!_allowRetries)
+            if (!AllowRetries)
             {
                 retryCount = 0;
             }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -41,6 +41,7 @@ namespace Microsoft.DotNet.DarcLib
         private readonly string _personalAccessToken;
         private readonly JsonSerializerSettings _serializerSettings;
         private readonly string _userAgent = $"DarcLib-{DarcLibVersion}";
+        private bool _allowRetries = true;
 
         static GitHubClient()
         {
@@ -64,6 +65,8 @@ namespace Microsoft.DotNet.DarcLib
         }
 
         public virtual Octokit.IGitHubClient Client => _lazyClient.Value;
+
+        public bool AllowRetries { get => _allowRetries; set => _allowRetries = value; }
 
         /// <summary>
         ///     Retrieve the contents of a repository file as a string
@@ -524,6 +527,10 @@ namespace Microsoft.DotNet.DarcLib
             int retryCount = 15,
             bool logFailure = true)
         {
+            if (!_allowRetries)
+            {
+                retryCount = 0;
+            }
             using (HttpClient client = CreateHttpClient())
             {
                 var requestManager = new HttpRequestManager(client, method, requestUri, logger, body, versionOverride, logFailure);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -10,6 +10,10 @@ namespace Microsoft.DotNet.DarcLib
 {
     public interface IGitRepo
     {
+        /// <summary>
+        /// Specifies whether functions with a retry field should employ retries
+        /// Should default to true
+        /// </summary>
         public bool AllowRetries { get; set; }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -10,6 +10,8 @@ namespace Microsoft.DotNet.DarcLib
 {
     public interface IGitRepo
     {
+        public bool AllowRetries { get; set; }
+
         /// <summary>
         /// Checks that a repository exists
         /// </summary>


### PR DESCRIPTION
I encountered an issue for tests involving DarcLib where it was taking 8 minutes for a test to retry a function that was expected to fail.  This PR is to add the option to specify that Client functions employing retries should not use them.