### PR TITLE
Minor patches in gather-drop

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -1636,7 +1636,7 @@ namespace Microsoft.DotNet.Darc.Operations
             }
             catch (OperationCanceledException e)
             {
-                errors.Add($"The download operation was cancelled: {e.Message}");
+                errors.Add($"While trying to download from {sourceUri} the download operation was cancelled: {e.Message}");
             }
             finally
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("max-downloads", Default = 4, HelpText = "Maximum concurrent downloads.")]
         public int MaxConcurrentDownloads { get; set; }
 
-        [Option("download-timeout", Default = 30, HelpText = "Timeout in seconds for downloading each asset.")]
+        [Option("download-timeout", Default = 180, HelpText = "Timeout in seconds for downloading each asset.")]
         public int AssetDownloadTimeoutInSeconds { get; set; }
 
         [Option('f', "full", HelpText = "Gather the full drop (build and all input builds).")]


### PR DESCRIPTION
After debugging errors reported by @lukas-lansky on the release pipeline ([see sample here](https://dev.azure.com/dnceng/internal/_build/results?buildId=654620&view=results)) I noticed the download of some assets is being cancelled because the current default timeout is too low and also the error message doesn't tell sufficient information about what happened. This PR is to increase the default timeout and also improve the error message.