### PR TITLE
Make ApiPagination Packable and revert roslyn version in Analyzer

### DIFF
--- a/src/Maestro/Microsoft.AspNetCore.ApiPagination/Microsoft.AspNetCore.ApiPagination.csproj
+++ b/src/Maestro/Microsoft.AspNetCore.ApiPagination/Microsoft.AspNetCore.ApiPagination.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    </PropertyGroup>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App"/>

--- a/src/Maestro/Microsoft.AspNetCore.ApiVersioning.Analyzers/DoNotUseUnversionedTypesInVersionedApis.cs
+++ b/src/Maestro/Microsoft.AspNetCore.ApiVersioning.Analyzers/DoNotUseUnversionedTypesInVersionedApis.cs
@@ -68,14 +68,14 @@ namespace Microsoft.AspNetCore.ApiVersioning.Analyzers
             public override void VisitClassDeclaration(ClassDeclarationSyntax node)
             {
                 IImmutableList<ITypeSymbol> baseTypes = SemanticModel.GetAllBaseTypeSymbols(node);
-                bool isController = baseTypes.Any(t => SymbolEqualityComparer.Default.Equals(t, KnownTypes.Controller));
+                bool isController = baseTypes.Any(t => t.Equals(KnownTypes.Controller));
                 if (!isController)
                 {
                     return;
                 }
 
                 IImmutableList<AttributeUsageInfo> attributeInfo = SemanticModel.GetAttributeInfo(node.AttributeLists);
-                bool isVersioned = attributeInfo.Any(info => SymbolEqualityComparer.Default.Equals(info.AttributeType, KnownTypes.ApiVersionAttribute));
+                bool isVersioned = attributeInfo.Any(info => info.AttributeType.Equals(KnownTypes.ApiVersionAttribute));
                 if (!isVersioned)
                 {
                     return;
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.ApiVersioning.Analyzers
                     List<(ExpressionSyntax expression, ITypeSymbol type)> typeParameters =
                         parameters.Select(
                                 p => (expression: p.Expression, type: SemanticModel.GetTypeSymbol(p.Expression)))
-                            .Where(p => SymbolEqualityComparer.Default.Equals(p.type, KnownTypes.Type))
+                            .Where(p => p.type.Equals(KnownTypes.Type))
                             .ToList();
                     if (typeParameters.Count == 0)
                     {

--- a/src/Maestro/Microsoft.AspNetCore.ApiVersioning.Analyzers/Microsoft.AspNetCore.ApiVersioning.Analyzers.csproj
+++ b/src/Maestro/Microsoft.AspNetCore.ApiVersioning.Analyzers/Microsoft.AspNetCore.ApiVersioning.Analyzers.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" VersionOverride="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="2.0.0" PrivateAssets="All" />
     <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
The version bump made the analyzer unloadable by any compiler that isn't as new or newer than 3.5.0.