### PR TITLE
Count cancelled builds as failed

### DIFF
--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
@@ -293,7 +293,8 @@ export class BuildComponent implements OnInit, OnChanges {
             mostRecentFailureLink = undefined;
           } else {
             isMostRecent = false;
-            const recentFailure = newerBuilds.find(b => b.result == "failed");
+            // Yes, it's "canceled".
+            const recentFailure = newerBuilds.find(b => (b.result == "failed" || b.result == "canceled") );
             if (recentFailure) {
               mostRecentFailureLink = this.getBuildLinkFromAzdo(build.azureDevOpsAccount as string, build.azureDevOpsProject as string, recentFailure.id);
             } else {


### PR DESCRIPTION
Builds that were aborted because jobs didn't start should be counted as failed