### PR TITLE
Fix deserialization

### DIFF
--- a/src/DotNet.Status.Web/Controllers/GitHubHookController.cs
+++ b/src/DotNet.Status.Web/Controllers/GitHubHookController.cs
@@ -207,69 +207,35 @@ For help filling out this form, see the [Root Cause Analysis](https://github.com
 
     public class IssuesHookData
     {
-        public string Action { get; }
-        public IssuesHookIssue Issue { get; }
-        public IssuesHookUser Sender { get; }
-        public IssuesHookRepository Repository { get; }
-        public IssuesHookLabel Label { get; }
-        
-        public IssuesHookData(string action, IssuesHookIssue issue, IssuesHookUser sender, IssuesHookRepository repository, IssuesHookLabel label)
-        {
-            Action = action;
-            Issue = issue;
-            Sender = sender;
-            Repository = repository;
-            Label = label;
-        }
+        public string Action { get; set; }
+        public IssuesHookIssue Issue { get; set; }
+        public IssuesHookUser Sender { get; set; }
+        public IssuesHookRepository Repository { get; set; }
+        public IssuesHookLabel Label { get; set; }
     }
 
     public class IssuesHookRepository
     {
-        public string Name { get; }
-        public IssuesHookUser Owner { get; }
-
-        public IssuesHookRepository(string name, IssuesHookUser owner)
-        {
-            Name = name;
-            Owner = owner;
-        }
+        public string Name { get; set; }
+        public IssuesHookUser Owner { get; set; }
     }
 
     public class IssuesHookIssue
     {
-        public int Number { get; }
-        public string Title { get; }
-        public IssuesHookUser Assignee { get; }
+        public int Number { get; set; }
+        public string Title { get; set; }
+        public IssuesHookUser Assignee { get; set; }
         public ImmutableArray<IssuesHookLabel> Labels { get; set; }
-        public ItemState State { get; }
-
-        public IssuesHookIssue(int number, string title, IssuesHookUser assignee, ImmutableArray<IssuesHookLabel> labels, ItemState state)
-        {
-            Number = number;
-            Title = title;
-            Assignee = assignee;
-            Labels = labels;
-            State = state;
-        }
+        public ItemState State { get; set; }
     }
 
     public class IssuesHookLabel
     {
-        public string Name { get; }
-
-        public IssuesHookLabel(string name)
-        {
-            Name = name;
-        }
+        public string Name { get; set; }
     }
 
     public class IssuesHookUser
     {
-        public string Login { get; }
-
-        public IssuesHookUser(string login)
-        {
-            Login = login;
-        }
+        public string Login { get; set; }
     }
 }

--- a/src/DotNet.Status.Web/Controllers/GrafanaNotification.cs
+++ b/src/DotNet.Status.Web/Controllers/GrafanaNotification.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,36 +8,14 @@ namespace DotNet.Status.Web.Controllers
 {
     public class GrafanaNotification
     {
-        public GrafanaNotification(
-            string title,
-            int ruleId,
-            string ruleName,
-            string ruleUrl,
-            string state,
-            string imageUrl,
-            string message,
-            IImmutableList<GrafanaNotificationMatch> evalMatches,
-            ImmutableDictionary<string, string> tags)
-        {
-            Title = title;
-            RuleId = ruleId;
-            RuleName = ruleName;
-            RuleUrl = ruleUrl;
-            State = state;
-            ImageUrl = imageUrl;
-            Message = message;
-            EvalMatches = evalMatches;
-            Tags = tags;
-        }
-
-        public string Title { get; }
-        public int RuleId { get; }
-        public string RuleName { get; }
-        public string RuleUrl { get; }
-        public string State { get; }
-        public string ImageUrl { get; }
-        public string Message { get; }
-        public IImmutableList<GrafanaNotificationMatch> EvalMatches { get; }
-        public ImmutableDictionary<string, string> Tags { get; }
+        public string Title { get; set; }
+        public int RuleId { get; set; }
+        public string RuleName { get; set; }
+        public string RuleUrl { get; set; }
+        public string State { get; set; }
+        public string ImageUrl { get; set; }
+        public string Message { get; set; }
+        public IImmutableList<GrafanaNotificationMatch> EvalMatches { get; set; }
+        public ImmutableDictionary<string, string> Tags { get; set; }
     }
 }

--- a/src/DotNet.Status.Web/Controllers/GrafanaNotificationMatch.cs
+++ b/src/DotNet.Status.Web/Controllers/GrafanaNotificationMatch.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,15 +8,8 @@ namespace DotNet.Status.Web.Controllers
 {
     public class GrafanaNotificationMatch
     {
-        public GrafanaNotificationMatch(string metric, ImmutableDictionary<string, string> tags, double value)
-        {
-            Metric = metric;
-            Tags = tags;
-            Value = value;
-        }
-
-        public string Metric { get; }
-        public ImmutableDictionary<string, string> Tags { get; }
-        public double Value { get; }
+        public string Metric { get; set; }
+        public ImmutableDictionary<string, string> Tags { get; set; }
+        public double Value { get; set; }
     }
 }


### PR DESCRIPTION
Moving from .NET core 2.1 to 3.1 dropped Newtonsoft.Json in favor of System.Text.Json. Now, only parameterless constructors are used for model classes. This change modifies models as needed.