### PR TITLE
Maestro Scenario Tests: Subscription test fix

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -318,6 +318,7 @@ stages:
         MAESTRO_BASEURI: $(MaestroTestEndpoint)
         MAESTRO_TOKEN: $(scenario-test-maestro-token)
         GITHUB_TOKEN: $(maestro-scenario-test-github-token)
+        AZDO_TOKEN: $(dn-bot-dnceng-build-rw-code-rw-release-rw)
         DARC_PACKAGE_SOURCE: $(Pipeline.Workspace)\PackageArtifacts
 
     - powershell: |

--- a/src/Maestro/tests/Maestro.ScenarioTests/Maestro.ScenarioTests.csproj
+++ b/src/Maestro/tests/Maestro.ScenarioTests/Maestro.ScenarioTests.csproj
@@ -20,6 +20,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Microsoft.DotNet.Darc\src\Darc\Microsoft.DotNet.Darc.csproj" />
     <ProjectReference Include="..\..\Client\src\Microsoft.DotNet.Maestro.Client.csproj" />
   </ItemGroup>
 

--- a/src/Maestro/tests/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
@@ -85,6 +85,22 @@ namespace Maestro.ScenarioTests
             return $"https://{_parameters.GitHubUser}:{_parameters.GitHubToken}@github.com/{org}/{repository}";
         }
 
+        public string GetAzDoRepoUrl(string repoName, string azdoAccount = "dnceng", string azdoProject = "internal")
+        {
+            return $"https://dev.azure.com/{azdoAccount}/{azdoProject}/_git/{repoName}";
+        }
+
+        public Task<string> RunDarcAsyncWithInput(string input, params string[] args)
+        {
+            return TestHelpers.RunExecutableAsyncWithInput(_parameters.DarcExePath, input, args.Concat(new[]
+            {
+                "-p", _parameters.MaestroToken,
+                "--bar-uri", _parameters.MaestroBaseUri,
+                "--github-pat", _parameters.GitHubToken,
+                "--azdev-pat", _parameters.AzDoToken,
+            }).ToArray());
+        }
+
         public Task<string> RunDarcAsync(params string[] args)
         {
             return TestHelpers.RunExecutableAsync(_parameters.DarcExePath, args.Concat(new[]
@@ -92,6 +108,7 @@ namespace Maestro.ScenarioTests
                 "-p", _parameters.MaestroToken,
                 "--bar-uri", _parameters.MaestroBaseUri,
                 "--github-pat", _parameters.GitHubToken,
+                "--azdev-pat", _parameters.AzDoToken,
             }).ToArray());
         }
 
@@ -153,14 +170,58 @@ namespace Maestro.ScenarioTests
             await RunDarcAsync("delete-default-channel", "--channel", testChannelName, "--repo", repoUri, "--branch", branch).ConfigureAwait(false);
         }
 
-        public async Task<AsyncDisposableValue<string>> CreateSubscriptionAsync(string sourceChannelName, string sourceRepo, string targetRepo, string targetBranch, string updateFrequency)
+        public async Task<AsyncDisposableValue<string>> CreateSubscriptionAsync(
+            string sourceChannelName,
+            string sourceRepo,
+            string targetRepo,
+            string targetBranch,
+            string updateFrequency,
+            string sourceOrg = "dotnet",
+            List<string> additionalOptions = null,
+            bool sourceIsAzDo = false,
+            bool targetIsAzDo = false)
         {
-            string output = await RunDarcAsync("add-subscription", "-q", "--no-trigger",
+            string sourceUrl = sourceIsAzDo ? GetAzDoRepoUrl(sourceRepo, azdoProject: sourceOrg) : GetRepoUrl(sourceOrg, sourceRepo);
+            string targetUrl = targetIsAzDo ? GetAzDoRepoUrl(targetRepo) : GetRepoUrl(targetRepo);
+
+            string[] command = {"add-subscription", "-q", "--no-trigger",
                 "--channel", sourceChannelName,
-                "--source-repo", GetRepoUrl("dotnet", sourceRepo),
-                "--target-repo", GetRepoUrl(targetRepo),
+                "--source-repo", sourceUrl,
+                "--target-repo", targetUrl,
                 "--target-branch", targetBranch,
-                "--update-frequency", updateFrequency).ConfigureAwait(false);
+                "--update-frequency", updateFrequency};
+
+            if (additionalOptions != null)
+            {
+                command = command.Concat(additionalOptions).ToArray();
+            }
+
+            string output = await RunDarcAsync(command).ConfigureAwait(false);
+
+            Match match = Regex.Match(output, "Successfully created new subscription with id '([a-f0-9-]+)'");
+            if (!match.Success)
+            {
+                throw new MaestroTestException("Unable to create subscription.");
+            }
+
+            string subscriptionId = match.Groups[1].Value;
+            return AsyncDisposableValue.Create(subscriptionId, async () =>
+            {
+                TestContext.WriteLine($"Cleaning up Test Subscription {subscriptionId}");
+                try
+                {
+                    await RunDarcAsync("delete-subscriptions", "--id", subscriptionId, "--quiet").ConfigureAwait(false);
+                }
+                catch (MaestroTestException)
+                {
+                    // If this throws an exception the most likely cause is that the subscription was deleted as part of the test case
+                }
+            });
+        }
+
+        public async Task<AsyncDisposableValue<string>> CreateSubscriptionAsync(string yamlDefinition)
+        {
+            string output = await RunDarcAsyncWithInput(yamlDefinition, "add-subscription", "-q", "--read-stdin", "--no-trigger").ConfigureAwait(false);
 
             Match match = Regex.Match(output, "Successfully created new subscription with id '([a-f0-9-]+)'");
             if (match.Success)
@@ -169,11 +230,58 @@ namespace Maestro.ScenarioTests
                 return AsyncDisposableValue.Create(subscriptionId, async () =>
                 {
                     TestContext.WriteLine($"Cleaning up Test Subscription {subscriptionId}");
-                    await RunDarcAsync("delete-subscriptions", "--id", subscriptionId, "--quiet").ConfigureAwait(false);
+                    try
+                    {
+                        await RunDarcAsync("delete-subscriptions", "--id", subscriptionId, "--quiet").ConfigureAwait(false);
+                    }
+                    catch (MaestroTestException)
+                    {
+                        // If this throws an exception the most likely cause is that the subscription was deleted as part of the test case
+                    }
                 });
             }
 
             throw new MaestroTestException("Unable to create subscription.");
+        }
+
+        public async Task<string> GetSubscriptionInfo(string subscriptionId)
+        {
+            return await RunDarcAsync("get-subscriptions", "--ids", subscriptionId).ConfigureAwait(false);
+        }
+
+        public async Task<string> GetSubscriptions(string channelName)
+        {
+            return await RunDarcAsync("get-subscriptions", "--channel", channelName);
+        }
+
+        public async Task ValidateSubscriptionInfo(string subscriptionId, string expectedSubscriptionInfo)
+        {
+            string subscriptionInfo = await GetSubscriptionInfo(subscriptionId);
+            StringAssert.AreEqualIgnoringCase(expectedSubscriptionInfo, subscriptionInfo);
+        }
+
+        public async Task SetSubscriptionStatus(bool enableSub, string subscriptionId = null, string channelName = null)
+        {
+            string actionToTake = enableSub ? "--enable" : "-d";
+
+            if (channelName != null)
+            {
+                await RunDarcAsync("subscription-status", actionToTake, "--channel", channelName, "--quiet").ConfigureAwait(false);
+            }
+            else
+            {
+                await RunDarcAsync("subscription-status", "--id", subscriptionId, actionToTake, "--quiet").ConfigureAwait(false);
+            }
+        }
+
+        public async Task<string> DeleteSubscriptionsForChannel(string channelName)
+        {
+            return await RunDarcAsync("delete-subscriptions", "--channel", channelName, "--quiet");
+        }
+
+        public async Task<string> DeleteSubscriptionById(string subscriptionId)
+        {
+            return await RunDarcAsync("delete-subscriptions", "--id", subscriptionId, "--quiet").ConfigureAwait(false);
         }
 
         public Task<Build> CreateBuildAsync(string repositoryUrl, string branch, string commit, string buildNumber, IImmutableList<AssetData> assets)

--- a/src/Maestro/tests/Maestro.ScenarioTests/ObjectHelpers/SubscriptionBuilder.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ObjectHelpers/SubscriptionBuilder.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.DotNet.Darc;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Newtonsoft.Json.Linq;
+
+namespace Maestro.ScenarioTests.ObjectHelpers
+{
+    public class SubscriptionBuilder
+    {
+        /// <summary>
+        /// Creates a subscription object based on a standard set of test inputs
+        /// </summary>
+        public static Subscription BuildSubscription(string repo1Uri, string repo2Uri, string targetBranch, string channelName, string subscriptionId,
+            UpdateFrequency updateFrequency, bool batchable, List<string> mergePolicyNames = null, List<string> ignoreChecks = null)
+        {
+            Subscription expectedSubscription = new Subscription(Guid.Parse(subscriptionId), true, repo1Uri, repo2Uri, targetBranch);
+            expectedSubscription.Channel = new Channel(42, channelName, "test");
+            expectedSubscription.Policy = new SubscriptionPolicy(batchable, updateFrequency);
+
+            List<MergePolicy> mergePolicies = new List<MergePolicy>();
+
+            if (mergePolicyNames == null)
+            {
+                expectedSubscription.Policy.MergePolicies = mergePolicies.ToImmutableList<MergePolicy>();
+                return expectedSubscription;
+            }
+
+            if (mergePolicyNames.Contains(Constants.StandardMergePolicyName))
+            {
+                mergePolicies.Add(new MergePolicy
+                {
+                    Name = Constants.StandardMergePolicyName
+                });
+            }
+
+            if (mergePolicyNames.Contains(Constants.NoExtraCommitsMergePolicyName))
+            {
+                mergePolicies.Add(
+                    new MergePolicy
+                    {
+                        Name = Constants.NoExtraCommitsMergePolicyName
+                    });
+            }
+
+            if (mergePolicyNames.Contains(Constants.AllCheckSuccessfulMergePolicyName) && ignoreChecks.Any())
+            {
+                mergePolicies.Add(
+                    new MergePolicy
+                    {
+                        Name = Constants.AllCheckSuccessfulMergePolicyName,
+                        Properties = ImmutableDictionary.Create<string, JToken>()
+                            .Add(Constants.IgnoreChecksMergePolicyPropertyName, JToken.FromObject(ignoreChecks))
+                    });
+            }
+
+            if (mergePolicyNames.Contains(Constants.NoRequestedChangesMergePolicyName))
+            {
+                mergePolicies.Add(
+                    new MergePolicy
+                    {
+                        Name = Constants.NoRequestedChangesMergePolicyName,
+                        Properties = ImmutableDictionary.Create<string, JToken>()
+                    });
+            }
+
+            expectedSubscription.Policy.MergePolicies = mergePolicies.ToImmutableList<MergePolicy>();
+            return expectedSubscription;
+        }
+    }
+}

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
@@ -1,0 +1,266 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Maestro.ScenarioTests.ObjectHelpers;
+using Microsoft.DotNet.Darc;
+using Microsoft.DotNet.Maestro.Client.Models;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace Maestro.ScenarioTests
+{
+    [TestFixture]
+    [Category("ScenarioTest")]
+    public class ScenarioTests_Subscriptions : MaestroScenarioTestBase
+    {
+        private TestParameters _parameters;
+
+        private string repo1Name = "maestro-test1";
+        private string repo2Name = "maestro-test2";
+        private string repo3Name = "marstro-test3";
+        private string channel1Name = "subscriptionTestChannel1";
+        private string channel2Name = "subscriptionTestChannel2";
+
+        [SetUp]
+        public async Task InitializeAsync()
+        {
+            _parameters = await TestParameters.GetAsync();
+            SetTestParameters(_parameters);
+        }
+
+        [TearDown]
+        public Task DisposeAsync()
+        {
+            _parameters.Dispose();
+            return Task.CompletedTask;
+        }
+
+        [Test]
+        [Category("ScenarioTest")]
+        public async Task Subscriptions_EndToEnd()
+        {
+            TestContext.WriteLine("Subscription management tests...");
+
+            string repo1Uri = GetRepoUrl(repo1Name);
+            string repo2Uri = GetRepoUrl(repo2Name);
+            string repo3Uri = GetRepoUrl(repo3Name);
+            string repo1AzDoUri = GetAzDoRepoUrl(repo1Name);
+            string targetBranch = "master";
+
+            TestContext.WriteLine($"Creating channels {channel1Name} and {channel2Name}");
+            await using (AsyncDisposableValue<string> channel1 = await CreateTestChannelAsync(channel1Name).ConfigureAwait(false))
+            {
+                await using (AsyncDisposableValue<string> channel2 = await CreateTestChannelAsync(channel2Name).ConfigureAwait(false))
+                {
+
+                    TestContext.WriteLine("Testing various command line parameters of add-subscription");
+                    await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionAsync(
+                        channel1Name, repo1Name, repo2Name, targetBranch, "everyWeek", "maestro-auth-test");
+
+                    Subscription expectedSubscription1 = SubscriptionBuilder.BuildSubscription(
+                        repo1Uri, 
+                        repo2Uri, 
+                        targetBranch, 
+                        channel1Name, 
+                        subscription1Id.Value, 
+                        UpdateFrequency.EveryWeek, 
+                        false);
+
+                    string expectedSubscription1Info = UxHelpers.GetTextSubscriptionDescription(expectedSubscription1, null);
+
+                    await ValidateSubscriptionInfo(subscription1Id.Value, expectedSubscription1Info);
+
+                    await using AsyncDisposableValue<string> subscription2Id = await CreateSubscriptionAsync(
+                        channel1Name, repo1Name, repo1Name, targetBranch, "none", "maestro-auth-test",
+                        new List<string>
+                        { "--all-checks-passed", "--no-extra-commits", "--no-requested-changes", "--ignore-checks", "WIP,license/cla" }, targetIsAzDo: true);
+
+                    Subscription expectedSubscription2 = SubscriptionBuilder.BuildSubscription(
+                        repo1Uri,
+                        repo1AzDoUri,
+                        targetBranch,
+                        channel1Name,
+                        subscription2Id.Value,
+                        UpdateFrequency.None,
+                        false,
+                        new List<string> { Constants.NoExtraCommitsMergePolicyName, Constants.AllCheckSuccessfulMergePolicyName, Constants.NoRequestedChangesMergePolicyName },
+                        new List<string> { "WIP", "license/cla" });
+
+                    string expectedSubscription2Info = UxHelpers.GetTextSubscriptionDescription(expectedSubscription2, null);
+
+                    await ValidateSubscriptionInfo(subscription2Id.Value, expectedSubscription2Info);
+
+                    await using AsyncDisposableValue<string> subscription3Id = await CreateSubscriptionAsync(
+                        channel2Name, repo1Name, repo2Name, targetBranch, "none", "maestro-auth-test",
+                        new List<string>
+                        { "--all-checks-passed", "--no-extra-commits", "--no-requested-changes", "--ignore-checks", "WIP,license/cla" });
+
+                    Subscription expectedSubscription3 = SubscriptionBuilder.BuildSubscription(
+                        repo1Uri,
+                        repo2Uri,
+                        targetBranch,
+                        channel2Name,
+                        subscription3Id.Value,
+                        UpdateFrequency.None,
+                        false,
+                        new List<string> { Constants.NoExtraCommitsMergePolicyName, Constants.AllCheckSuccessfulMergePolicyName, Constants.NoRequestedChangesMergePolicyName },
+                        new List<string> { "WIP", "license/cla" });
+
+                    string expectedSubscription3Info = UxHelpers.GetTextSubscriptionDescription(expectedSubscription3, null);
+
+                    await ValidateSubscriptionInfo(subscription3Id.Value, expectedSubscription3Info);
+
+                    // Disable the first two subscriptions, but not the third.
+                    TestContext.WriteLine("Disable the subscriptions for test channel 1");
+                    await SetSubscriptionStatus(false, channelName: channel1Name);
+
+                    // Disable one by id (classic usage) to make sure that works
+                    TestContext.WriteLine("Disable the third subscription by id");
+                    await SetSubscriptionStatus(false, subscriptionId: subscription3Id.Value);
+
+                    // Re-enable
+                    TestContext.WriteLine("Enable the third subscription by id");
+                    await SetSubscriptionStatus(true, subscriptionId: subscription3Id.Value);
+                    StringAssert.Contains("Enabled: True", await GetSubscriptionInfo(subscription3Id.Value), $"Expected subscription {subscription3Id} to be enabled");
+
+                    // Mass delete the subscriptions. Delete the first two but not the third.
+                    TestContext.WriteLine("Delete the subscriptions for test channel 1");
+                    string message = await DeleteSubscriptionsForChannel(channel1Name);
+
+                    // Check that there are no subscriptions against channel1 now
+                    TestContext.WriteLine("Verify that there are no subscriptions in test channel 1");
+                    Assert.ThrowsAsync<MaestroTestException>(async () => await GetSubscriptions(channel1Name), "Subscriptions for channel 1 were not deleted.");
+
+                    // Validate the third subscription, which should still exist
+                    TestContext.WriteLine("Verify that the third subscription still exists, then delete it");
+                    await ValidateSubscriptionInfo(subscription3Id.Value, expectedSubscription3Info);
+                    string message2 = await DeleteSubscriptionById(subscription3Id.Value);
+
+                    // Attempt to create a batchable subscription with merge policies.
+                    // Should fail, merge policies are set separately for batched subs
+                    TestContext.WriteLine("Attempt to create a batchable subscription with merge policies");
+                    Assert.ThrowsAsync<MaestroTestException>(async () =>
+                        await CreateSubscriptionAsync(channel1Name, repo1Name, repo2Name, "master", "none", additionalOptions: new List<string> { "--standard-automerge", "--batchable" }),
+                        "Attempt to create a batchable subscription with merge policies");
+
+                    // Create a batchable subscription
+                    TestContext.WriteLine("Create a batchable subscription");
+                    await using AsyncDisposableValue<string> batchSubscriptionId = await CreateSubscriptionAsync(
+                        channel1Name, repo1Name, repo2Name, targetBranch, "everyWeek", "maestro-auth-test", additionalOptions: new List<string> { "--batchable" });
+
+                    Subscription expectedBatchedSubscription = SubscriptionBuilder.BuildSubscription(
+                        repo1Uri, 
+                        repo2Uri, 
+                        targetBranch, 
+                        channel1Name, 
+                        batchSubscriptionId.Value, 
+                        UpdateFrequency.EveryWeek, 
+                        true);
+
+                    string expectedBatchedSubscriptionInfo = UxHelpers.GetTextSubscriptionDescription(expectedBatchedSubscription, null);
+
+                    await ValidateSubscriptionInfo(batchSubscriptionId.Value, expectedBatchedSubscriptionInfo);
+                    await DeleteSubscriptionById(batchSubscriptionId.Value);
+
+                    TestContext.WriteLine("Testing YAML for darc add-subscription");
+
+                    string yamlDefinition = $@"
+                    Channel: {channel1Name}
+                    Source Repository URL: {repo1Uri}
+                    Target Repository URL: {repo2Uri}
+                    Target Branch: master
+                    Update Frequency: everyWeek
+                    Batchable: False
+                    Merge Policies:
+                    - Name: Standard
+                    ";
+
+                    await using AsyncDisposableValue<string> yamlSubscriptionId = await CreateSubscriptionAsync(yamlDefinition);
+
+                    Subscription expectedYamlSubscription = SubscriptionBuilder.BuildSubscription(
+                        repo1Uri, 
+                        repo2Uri, 
+                        targetBranch, 
+                        channel1Name, 
+                        yamlSubscriptionId.Value, 
+                        UpdateFrequency.EveryWeek, 
+                        false, 
+                        new List<string> { Constants.StandardMergePolicyName });
+
+                    string expectedYamlSubscriptionInfo = UxHelpers.GetTextSubscriptionDescription(expectedYamlSubscription, null);
+
+                    await ValidateSubscriptionInfo(yamlSubscriptionId.Value, expectedYamlSubscriptionInfo);
+                    await DeleteSubscriptionById(yamlSubscriptionId.Value);
+
+                    TestContext.WriteLine("Change casing of the various properties. Expecting no changes.");
+
+                    string yamlDefinition2 = $@"
+                    Channel: {channel1Name}
+                    Source Repository URL: {repo1Uri}
+                    Target Repository URL: {repo2Uri}
+                    Target Branch: master
+                    Update Frequency: everyweek
+                    Batchable: False
+                    Merge Policies:
+                    - Name: standard
+                    ";
+
+                    await using AsyncDisposableValue<string> yamlSubscription2Id = await CreateSubscriptionAsync(yamlDefinition2);
+
+                    Subscription expectedYamlSubscription2 = SubscriptionBuilder.BuildSubscription(
+                        repo1Uri, 
+                        repo2Uri,
+                        targetBranch, 
+                        channel1Name, 
+                        yamlSubscription2Id.Value, 
+                        UpdateFrequency.EveryWeek, false, 
+                        new List<string> { Constants.StandardMergePolicyName });
+
+                    string expectedYamlSubscriptionInfo2 = UxHelpers.GetTextSubscriptionDescription(expectedYamlSubscription2, null);
+
+                    await ValidateSubscriptionInfo(yamlSubscription2Id.Value, expectedYamlSubscriptionInfo2);
+                    await DeleteSubscriptionById(yamlSubscription2Id.Value);
+
+                    TestContext.WriteLine("Attempt to add multiple of the same merge policy checks. Should fail.");
+
+                    string yamlDefinition3 = $@"
+                    Channel: {channel1Name}
+                    Source Repository URL: {repo1Uri}
+                    Target Repository URL: {repo2Uri}
+                    Target Branch: master
+                    Update Frequency: everyweek
+                    Batchable: False
+                    Merge Policies:
+                    - Name: AllChecksSuccessful
+                      Properties:
+                        ignoreChecks:
+                        - WIP
+                        - license/cla
+                    - Name: AllChecksSuccessful
+                      Properties:
+                        ignoreChecks:
+                        - WIP
+                        - MySpecialCheck";
+
+                    Assert.ThrowsAsync<MaestroTestException>(async () =>
+                        await CreateSubscriptionAsync(yamlDefinition3), "Attempt to create a subscription with multiples of the same merge policy.");
+
+                    TestContext.WriteLine("Testing duplicate subscription handling...");
+                    AsyncDisposableValue<string> yamlSubscription3Id = await CreateSubscriptionAsync(channel1Name, repo1Name, repo2Name, targetBranch, "everyWeek", "maestro-auth-test");
+
+                    Assert.ThrowsAsync<MaestroTestException>(async () =>
+                        await CreateSubscriptionAsync(channel1Name, repo1Name, repo2Name, targetBranch, "everyWeek", "maestro-auth-test"),
+                        "Attempt to create a subscription with the same values as an existing subscription.");
+
+                    Assert.ThrowsAsync<MaestroTestException>(async () =>
+                        await CreateSubscriptionAsync(channel1Name, repo1Name, repo2Name, targetBranch, "everyweek", "maestro-auth-test"),
+                        "Attempt to create a subscription with the same values as an existing subscription (except for the casing of one parameter.");
+
+                    await DeleteSubscriptionById(yamlSubscription3Id.Value);
+
+                    TestContext.WriteLine("End of test case. Starting clean up.");
+
+                }
+            }
+        }
+    }
+}

--- a/src/Maestro/tests/Maestro.ScenarioTests/TestHelpers.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/TestHelpers.cs
@@ -13,6 +13,11 @@ namespace Maestro.ScenarioTests
     {
         public static async Task<string> RunExecutableAsync(string executable, params string[] args)
         {
+            return await RunExecutableAsyncWithInput(executable, "", args);
+        }
+
+        public static async Task<string> RunExecutableAsyncWithInput(string executable, string input, params string[] args)
+        {
             TestContext.WriteLine(FormatExecutableCall(executable, args));
             var output = new StringBuilder();
 
@@ -30,7 +35,10 @@ namespace Maestro.ScenarioTests
             {
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                RedirectStandardInput = true,
+                UseShellExecute = false
             };
+
             foreach (string arg in args)
             {
                 psi.ArgumentList.Add(arg);
@@ -40,15 +48,17 @@ namespace Maestro.ScenarioTests
             {
                 StartInfo = psi
             };
+
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             process.EnableRaisingEvents = true;
             process.Exited += (s, e) => { tcs.TrySetResult(true); };
             process.Start();
 
             Task<bool> exitTask = tcs.Task;
+            Task stdin = Task.Run(() => { process.StandardInput.Write(input); process.StandardInput.Close(); });
             Task<string> stdout = process.StandardOutput.ReadLineAsync();
             Task<string> stderr = process.StandardError.ReadLineAsync();
-            var list = new List<Task> { exitTask, stdout, stderr };
+            var list = new List<Task> { exitTask, stdout, stderr, stdin };
             while (list.Count != 0)
             {
                 var done = await Task.WhenAny(list);
@@ -77,6 +87,12 @@ namespace Maestro.ScenarioTests
                     {
                         list.Add(stderr = process.StandardError.ReadLineAsync());
                     }
+                    continue;
+                }
+
+                if (done == stdin)
+                {
+                    await stdin;
                     continue;
                 }
 

--- a/src/Maestro/tests/Maestro.ScenarioTests/TestHelpers.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/TestHelpers.cs
@@ -41,7 +41,16 @@ namespace Maestro.ScenarioTests
 
             foreach (string arg in args)
             {
-                psi.ArgumentList.Add(arg);
+                // The string append used by Process will accept null params 
+                // and then throw without identifying the param, so we need to handle it here to get logging
+                if (arg != null)
+                {
+                    psi.ArgumentList.Add(arg);
+                }
+                else
+                {
+                    WriteOutput("Null parameter encountered while constructing command string.");
+                }
             }
 
             using var process = new Process

--- a/src/Maestro/tests/Maestro.ScenarioTests/TestParameters.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/TestParameters.cs
@@ -25,6 +25,7 @@ namespace Maestro.ScenarioTests
             string maestroToken = Environment.GetEnvironmentVariable("MAESTRO_TOKEN") ?? userSecrets["MAESTRO_TOKEN"];
             string githubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? userSecrets["GITHUB_TOKEN"];
             string darcPackageSource = Environment.GetEnvironmentVariable("DARC_PACKAGE_SOURCE");
+            string azdoToken = Environment.GetEnvironmentVariable("AZDO_TOKEN") ?? userSecrets["AZDO_TOKEN"];
 
             using var testDir = Shareable.Create(TemporaryDirectory.Get());
 
@@ -57,10 +58,10 @@ namespace Maestro.ScenarioTests
                     new ProductHeaderValue(assembly.GetName().Name, assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion),
                     new InMemoryCredentialStore(new Credentials(githubToken)));
 
-            return new TestParameters(darcExe, await TestHelpers.Which("git"), maestroBaseUri, maestroToken!, githubToken, maestroApi, githubApi, testDir.TryTake()!);
+            return new TestParameters(darcExe, await TestHelpers.Which("git"), maestroBaseUri, maestroToken!, githubToken, maestroApi, githubApi, testDir.TryTake()!, azdoToken);
         }
 
-        private TestParameters(string darcExePath, string gitExePath, string maestroBaseUri, string maestroToken, string gitHubToken, IMaestroApi maestroApi, GitHubClient gitHubApi, TemporaryDirectory dir)
+        private TestParameters(string darcExePath, string gitExePath, string maestroBaseUri, string maestroToken, string gitHubToken, IMaestroApi maestroApi, GitHubClient gitHubApi, TemporaryDirectory dir, string azdoToken)
         {
             _dir = dir;
             DarcExePath = darcExePath;
@@ -70,11 +71,12 @@ namespace Maestro.ScenarioTests
             GitHubToken = gitHubToken;
             MaestroApi = maestroApi;
             GitHubApi = gitHubApi;
+            AzDoToken = azdoToken;
         }
 
         public string DarcExePath { get; }
 
-        public string GitExePath { get;  }
+        public string GitExePath { get; }
 
         public string GitHubUser { get; } = "dotnet-maestro-bot";
 
@@ -97,6 +99,8 @@ namespace Maestro.ScenarioTests
         public string AzureDevOpsAccount { get; } = "dnceng";
 
         public string AzureDevOpsProject { get; } = "internal";
+
+        public string AzDoToken { get; }
 
         public void Dispose()
         {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
@@ -198,6 +198,28 @@ namespace Microsoft.DotNet.Darc
             return builder.ToString();
         }
 
+        public static string GetTextSubscriptionDescription(Subscription subscription, IEnumerable<MergePolicy> mergePolicies = null)
+        {
+            StringBuilder subInfo = new StringBuilder();
+            subInfo.AppendLine($"{subscription.SourceRepository} ({subscription.Channel.Name}) ==> '{subscription.TargetRepository}' ('{subscription.TargetBranch}')");
+            subInfo.AppendLine($"  - Id: {subscription.Id}");
+            subInfo.AppendLine($"  - Update Frequency: {subscription.Policy.UpdateFrequency}");
+            subInfo.AppendLine($"  - Enabled: {subscription.Enabled}");
+            subInfo.AppendLine($"  - Batchable: {subscription.Policy.Batchable}");
+
+            IEnumerable<MergePolicy> policies = mergePolicies ?? subscription.Policy.MergePolicies;
+            subInfo.Append(UxHelpers.GetMergePoliciesDescription(policies, "  "));
+
+            // Currently the API only returns the last applied build for requests to specific subscriptions.
+            // This will be fixed, but for now, don't print the last applied build otherwise.
+            if (subscription.LastAppliedBuild != null)
+            {
+                subInfo.AppendLine($"  - Last Build: {subscription.LastAppliedBuild.AzureDevOpsBuildNumber} ({subscription.LastAppliedBuild.Commit})");
+            }
+
+            return subInfo.ToString();
+        }
+
         public static string GetSimpleRepoName(string repoUri)
         {
             int lastSlash = repoUri.LastIndexOf("/");

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetSubscriptionsOperation.cs
@@ -2,16 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations
 {
@@ -46,11 +46,6 @@ namespace Microsoft.DotNet.Darc.Operations
                 foreach (var subscription in subscriptions.OrderBy(subscription =>
                                             $"{subscription.SourceRepository}{subscription.Channel}{subscription.TargetRepository}{subscription.TargetBranch}"))
                 {
-                    Console.WriteLine($"{subscription.SourceRepository} ({subscription.Channel.Name}) ==> '{subscription.TargetRepository}' ('{subscription.TargetBranch}')");
-                    Console.WriteLine($"  - Id: {subscription.Id}");
-                    Console.WriteLine($"  - Update Frequency: {subscription.Policy.UpdateFrequency}");
-                    Console.WriteLine($"  - Enabled: {subscription.Enabled}");
-                    Console.WriteLine($"  - Batchable: {subscription.Policy.Batchable}");
                     // If batchable, the merge policies come from the repository
                     IEnumerable<MergePolicy> mergePolicies = subscription.Policy.MergePolicies;
                     if (subscription.Policy.Batchable == true)
@@ -58,14 +53,8 @@ namespace Microsoft.DotNet.Darc.Operations
                         mergePolicies = await remote.GetRepositoryMergePoliciesAsync(subscription.TargetRepository, subscription.TargetBranch);
                     }
 
-                    Console.Write(UxHelpers.GetMergePoliciesDescription(mergePolicies, "  "));
-
-                    // Currently the API only returns the last applied build for requests to specific subscriptions.
-                    // This will be fixed, but for now, don't print the last applied build otherwise.
-                    if (subscription.LastAppliedBuild != null)
-                    {
-                        Console.WriteLine($"  - Last Build: {subscription.LastAppliedBuild.AzureDevOpsBuildNumber} ({subscription.LastAppliedBuild.Commit})");
-                    }
+                    string subscriptionInfo = UxHelpers.GetTextSubscriptionDescription(subscription, mergePolicies);
+                    Console.Write(subscriptionInfo);
                 }
                 return Constants.SuccessCode;
             }


### PR DESCRIPTION
This is the same code as was previous reviewed with two additions - defining the AZDO_TOKEN variable in deploy.yaml and adding a null check to TestParameters (so that we can catch and log the exception before the Process string builder turns it into a null ref exception with no information about what was null). I'll add comments to the new additions to make them easier to find.