### PR TITLE
Target the solution instead of the csproj for tests

### DIFF
--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -17,7 +17,7 @@ steps:
       --configuration $(_BuildConfig)
       --collect:"Code Coverage"
       --settings:CodeCoverage.runsettings
-      --filter "TestCategory!=ScenarioTest"
+      --filter "TestCategory!=PostDeployment&TestCategory!=Nightly&TestCategory!=PreDeployment"
       --no-build
       --logger "trx;LogFilePrefix=TestResults-"
       -v normal

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -11,13 +11,13 @@ steps:
   inputs:
     command: custom
     projects: |
-      src/**/*.Tests.csproj
+      $(Build.SourcesDirectory)\arcade-services.sln
     custom: test
     arguments: > 
       --configuration $(_BuildConfig)
       --collect:"Code Coverage"
       --settings:CodeCoverage.runsettings
-      --filter "TestCategory!=PostDeployment&TestCategory!=Nightly&TestCategory!=PreDeployment"
+      --filter "TestCategory!=ScenarioTest"
       --no-build
       --logger "trx;LogFilePrefix=TestResults-"
       -v normal

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Builds.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Builds.cs
@@ -8,7 +8,7 @@ using NUnit.Framework.Internal;
 namespace Maestro.ScenarioTests
 {
     [TestFixture]
-    [Category("ScenarioTest")]
+    [Category("PostDeployment")]
     public class ScenarioTests_Builds : MaestroScenarioTestBase
     {
         private string repoUrl;

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Channels.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Channels.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace Maestro.ScenarioTests
 {
     [TestFixture]
-    [Category("ScenarioTest")]
+    [Category("PostDeployment")]
     public class ScenarioTests_Channels : MaestroScenarioTestBase
     {
         private TestParameters _parameters;

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_DefaultChannels.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_DefaultChannels.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace Maestro.ScenarioTests
 {
     [TestFixture]
-    [Category("ScenarioTest")]
+    [Category("PostDeployment")]
     public class ScenarioTests_DefaultChannels : MaestroScenarioTestBase
     {
         private readonly string repoName = "maestro-test1";

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Dependencies.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Dependencies.cs
@@ -8,7 +8,7 @@ using NUnit.Framework.Internal;
 namespace Maestro.ScenarioTests
 {
     [TestFixture]
-    [Category("ScenarioTest")]
+    [Category("PostDeployment")]
     public class ScenarioTests_Dependencies : MaestroScenarioTestBase
     {
 

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
@@ -5,7 +5,7 @@ using NUnit.Framework.Internal;
 namespace Maestro.ScenarioTests
 {
     [TestFixture]
-    [Category("ScenarioTest")]
+    [Category("PostDeployment")]
     public class ScenarioTests_RepoPolicies : MaestroScenarioTestBase
     {
         private readonly string repoName = "maestro-test1";

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
@@ -10,7 +10,7 @@ using Octokit;
 namespace Maestro.ScenarioTests
 {
     [TestFixture]
-    [Category("ScenarioTest")]
+    [Category("PostDeployment")]
     public class ScenarioTests_SdkUpdate : MaestroScenarioTestBase
     {
         private TestParameters _parameters;


### PR DESCRIPTION
This allows the tests to be run in parallel, which significantly increases
the throughput of the tests (instead of 5 minutes, it's closer to 20 seconds).

The "projects" value is expaned by Azure DevOps and the call is made
one project at a time.  "dotnet test" has parallelism built in, but when
targeting a single project, it can't do much.