### PR TITLE
Revert "Forward target publishing infra version to the promote pipeli…

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -78,12 +78,6 @@ namespace Microsoft.DotNet.Darc.Operations
                     return Constants.ErrorCode;
                 }
 
-                if (_options.PublishingInfraVersion < 2 || _options.PublishingInfraVersion > 3)
-                {
-                    Console.WriteLine($"Publishing version '{_options.PublishingInfraVersion}' is not configured. The following versions are available: 2, 3");
-                    return Constants.ErrorCode;
-                }
-
                 List<Channel> targetChannels = new List<Channel>();
 
                 if (!string.IsNullOrEmpty(_options.Channel))
@@ -232,7 +226,6 @@ namespace Microsoft.DotNet.Darc.Operations
 
             var queueTimeVariables = $"{{" +
                 $"\"BARBuildId\": \"{ build.Id }\", " +
-                $"\"PublishingInfraVersion\": \"{ _options.PublishingInfraVersion }\", " +
                 $"\"PromoteToChannelIds\": \"{ string.Join(",", targetChannels.Select(tch => tch.Id)) }\", " +
                 $"\"EnableSigningValidation\": \"{ _options.DoSigningValidation }\", " +
                 $"\"SigningValidationAdditionalParameters\": \"{ _options.SigningValidationAdditionalParameters }\", " +

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
@@ -13,9 +13,6 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("id", Required = true, HelpText = "BAR id of build to assign to channel.")]
         public int Id { get; set; }
 
-        [Option("publishing-infra-version", Default = 2, Required = true, HelpText = "Which version of the publishing infrastructure should be used.")]
-        public int PublishingInfraVersion { get; set; }
-
         [Option("channel", HelpText = "Channel to assign build to. Required if --default-channels is not specified.")]
         public string Channel { get; set; }
 


### PR DESCRIPTION
…ne (#1261)"

This reverts commit b1730f246d51d97a88ce3133c82ea0dfd8685412.

This change broke the scenario tests, and will block our progress in getting everything fixed for rollout.

see https://dev.azure.com/dnceng/internal/_build/results?buildId=702743&view=results and https://github.com/dotnet/core-eng/issues/10137