### PR TITLE
Fix AzureFunctionsVersion

### DIFF
--- a/src/GitHubApps/DarcBot/DarcBot.csproj
+++ b/src/GitHubApps/DarcBot/DarcBot.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <Platforms>x64</Platforms>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>

--- a/src/RolloutScorer/RolloutScorerAzureFunction/RolloutScorerAzureFunction.csproj
+++ b/src/RolloutScorer/RolloutScorerAzureFunction/RolloutScorerAzureFunction.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
   <PropertyGroup>
-    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <FileUpgradeFlags>40</FileUpgradeFlags>
     <SignAssembly>false</SignAssembly>
     <OldToolsVersion>2.0</OldToolsVersion>


### PR DESCRIPTION
We moved to netcoreapp3.1, but didn't update AzureFunctionsVersion to v3. This fixes that in DarcBot and RolloutScorer.

Fixes https://github.com/dotnet/core-eng/issues/10196