### PR TITLE
[HOTFIX] Do not call ToList() when dependencies are null

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyGraph.cs
@@ -533,7 +533,7 @@ namespace Microsoft.DotNet.DarcLib
                         options.IncludeToolset,
                         remotesList,
                         reposFolder,
-                        testPath)).ToList();
+                        testPath))?.ToList();
                     // Set the dependencies on the current node.
                     node.Dependencies = dependencies;
                 }


### PR DESCRIPTION
The semantics of LINQ here mean that you can't call it with a null input set.
GetDependenciesAsync returns null if a repo@sha does not have a version details file.
This exists in a single place (very old corefx dependency).

Add '?'