### PR TITLE
Add more logging to the Rollout Scorer

### DIFF
--- a/src/RolloutScorer/RolloutScorer/Commands.cs
+++ b/src/RolloutScorer/RolloutScorer/Commands.cs
@@ -1,6 +1,7 @@
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.Extensions.Logging;
 using Mono.Options;
 using System;
 using System.Collections.Generic;
@@ -37,6 +38,8 @@ namespace RolloutScorer
                 { "o|output=", "Filename to output the generated csv to; defaults to ./{repo}-scorecard.csv", o => _rolloutScorer.OutputFile = o },
                 { "skip-output", "Skips the output step", skip => _rolloutScorer.SkipOutput = skip != null },
                 { "upload", "Directly uploads results", upload => _rolloutScorer.Upload = upload != null },
+                { "debug", "Enables debug logging", l => _rolloutScorer.LogLevel = LogLevel.Debug },
+                { "v|verbose", "Enables verbose (trace) logging", l => _rolloutScorer.LogLevel = LogLevel.Trace },
                 { "h|help", "Displays this message and exits", h => _showHelp = h != null },
             };
         }

--- a/src/RolloutScorer/RolloutScorer/RolloutScorer.cs
+++ b/src/RolloutScorer/RolloutScorer/RolloutScorer.cs
@@ -254,9 +254,9 @@ namespace RolloutScorer
                 // First, check the issue body
                 Utilities.WriteDebug($"Checking issue body for downtime information...", Log, LogLevel);
                 downtimeStart = GetStartTimeFromIssueText(issue.Body, issue.HtmlUrl);
-                Utilities.WriteDebug($"Downtime start {downtimeStart?.DateTime.ToLongTimeString() ?? "not"} found in issue body.", Log, LogLevel);
+                WriteDowntimeDebugMessage(downtimeStart, "start");
                 downtimeFinish = GetEndTimeFromIssueText(issue.Body, issue.HtmlUrl);
-                Utilities.WriteDebug($"Downtime finish {downtimeFinish?.DateTime.ToLongTimeString() ?? "not"} found in issue body.", Log, LogLevel);
+                WriteDowntimeDebugMessage(downtimeFinish, "finish");
                 if (downtimeStart != null && downtimeFinish != null)
                 {
                     downtime += (TimeSpan)(downtimeFinish - downtimeStart);
@@ -271,9 +271,9 @@ namespace RolloutScorer
                 {
                     Utilities.WriteDebug($"Checking comment at {comment.HtmlUrl} for downtime information...", Log, LogLevel);
                     downtimeStart ??= GetStartTimeFromIssueText(comment.Body, comment.HtmlUrl);
-                    Utilities.WriteDebug($"Downtime start {downtimeStart?.DateTime.ToLongTimeString() ?? "not"} found.", Log, LogLevel);
+                    WriteDowntimeDebugMessage(downtimeStart, "start");
                     downtimeFinish ??= GetEndTimeFromIssueText(comment.Body, comment.HtmlUrl);
-                    Utilities.WriteDebug($"Downtime finish {downtimeFinish?.DateTime.ToLongTimeString() ?? "not"} found.", Log, LogLevel);
+                    WriteDowntimeDebugMessage(downtimeFinish, "finish");
 
                     if (downtimeStart != null && downtimeFinish != null)
                     {
@@ -289,9 +289,9 @@ namespace RolloutScorer
                 // If we haven't found both a start and end time yet, we're going to default to creation and/or close time
                 Utilities.WriteDebug($"Downtime not yet found in body or comments; looking at issue start & close times...", Log, LogLevel);
                 downtimeStart ??= issue.CreatedAt;
-                Utilities.WriteDebug($"Downtime start {downtimeStart?.DateTime.ToLongTimeString() ?? "not"} found.", Log, LogLevel);
+                WriteDowntimeDebugMessage(downtimeStart, "start");
                 downtimeFinish ??= issue.ClosedAt;
-                Utilities.WriteDebug($"Downtime finish {downtimeFinish?.DateTime.ToLongTimeString() ?? "not"} found.", Log, LogLevel);
+                WriteDowntimeDebugMessage(downtimeFinish, "finish");
                 if (downtimeFinish == null)
                 {
                     Utilities.WriteWarning($"Downtime issue was found unclosed and with no specified end time; " +
@@ -340,6 +340,10 @@ namespace RolloutScorer
             }
 
             return null;
+        }
+        private void WriteDowntimeDebugMessage(DateTimeOffset? downtimeEvent, string downtimeEventDescription)
+        {
+            Utilities.WriteDebug($"Downtime {downtimeEventDescription} {downtimeEvent?.ToString() ?? "not"} found.", Log, LogLevel);
         }
 
         /// <summary>

--- a/src/RolloutScorer/RolloutScorer/RolloutScorer.cs
+++ b/src/RolloutScorer/RolloutScorer/RolloutScorer.cs
@@ -1,6 +1,4 @@
-using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage.Shared.Protocol;
 using Newtonsoft.Json.Linq;
 using Octokit;
 using System;
@@ -10,7 +8,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;

--- a/src/RolloutScorer/RolloutScorer/RolloutScorer.cs
+++ b/src/RolloutScorer/RolloutScorer/RolloutScorer.cs
@@ -1,5 +1,6 @@
 using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Extensions.Logging;
+using Microsoft.WindowsAzure.Storage.Shared.Protocol;
 using Newtonsoft.Json.Linq;
 using Octokit;
 using System;
@@ -44,6 +45,7 @@ namespace RolloutScorer
         private GitHubClient _githubClient;
 
         public ILogger Log { get; set; }
+        public LogLevel LogLevel { get; set; } = LogLevel.Information;
 
         public async Task InitAsync()
         {
@@ -53,9 +55,11 @@ namespace RolloutScorer
 
             foreach (string buildDefinitionId in RepoConfig.BuildDefinitionIds)
             {
-                JObject responseContent = await GetAzdoApiResponseAsync($"https://dev.azure.com/{RepoConfig.AzdoInstance}/" +
-                $"{AzdoConfig.Project}/_apis/build/builds?definitions={buildDefinitionId}&branchName={Branch}" +
-                $"&minTime={rolloutStartTimeUriString}&maxTime={rolloutEndTimeUriString}&api-version=5.1");
+                string azdoQuery = $"https://dev.azure.com/{RepoConfig.AzdoInstance}/" +
+                    $"{AzdoConfig.Project}/_apis/build/builds?definitions={buildDefinitionId}&branchName={Branch}" +
+                    $"&minTime={rolloutStartTimeUriString}&maxTime={rolloutEndTimeUriString}&api-version=5.1";
+                Utilities.WriteDebug($"Querying AzDO API: {azdoQuery}", Log, LogLevel);
+                JObject responseContent = await GetAzdoApiResponseAsync(azdoQuery);
 
                 // No builds is a valid case (e.g. a failed rollout) and so the rest of the code can handle this
                 // It still is potentially unexpected, so we're going to warn the user here
@@ -72,12 +76,15 @@ namespace RolloutScorer
                 }
             }
             BuildBreakdowns = BuildBreakdowns.OrderBy(x => x.BuildSummary.FinishTime).ToList();
+            Utilities.WriteDebug($"Builds breakdowns created for: \n\t {string.Join(" \n\t ", BuildBreakdowns.Select(b => b?.BuildSummary?.WebLink ?? ""))}", Log, LogLevel);
+
             await Task.WhenAll(BuildBreakdowns.Select(b => CollectStages(b)));
         }
 
         public async Task CollectStages(ScorecardBuildBreakdown buildBreakdown)
         {
             string timelineLinkWithAttempts = $"{buildBreakdown.BuildSummary.TimelineLink}?changeId=1";
+            Utilities.WriteDebug($"Querying AzDO API: {timelineLinkWithAttempts}", Log, LogLevel);
             JObject jsonTimelineResponse = await GetAzdoApiResponseAsync(timelineLinkWithAttempts);
             BuildTimeline timeline = jsonTimelineResponse.ToObject<BuildTimeline>();
 
@@ -119,6 +126,11 @@ namespace RolloutScorer
                 if (buildBreakdown.BuildSummary.Stages.Any(s => s.Name.StartsWith("deploy", StringComparison.InvariantCultureIgnoreCase) && !string.IsNullOrEmpty(s.EndTime)))
                 {
                     buildBreakdown.BuildSummary.DeploymentReached = true;
+                    Utilities.WriteDebug($"Build {buildBreakdown.BuildSummary.BuildNumber} determined to have reached deployment.", Log, LogLevel);
+                }
+                else
+                {
+                    Utilities.WriteDebug($"Build {buildBreakdown.BuildSummary.BuildNumber} determined to NOT have reached deployment.", Log, LogLevel);
                 }
             }
         }
@@ -137,6 +149,7 @@ namespace RolloutScorer
                 TimeSpan duration = GetPipelineDurationFromStages(build.BuildSummary.Stages);
                 rolloutBuildTimes.Add(duration);
                 build.Score.TimeToRollout = duration;
+                Utilities.WriteDebug($"Build {build.BuildSummary.BuildNumber} determined to have rollout duration of {duration}.", Log, LogLevel);
             }
 
             return new TimeSpan(rolloutBuildTimes.Sum(t => t.Ticks));
@@ -169,12 +182,16 @@ namespace RolloutScorer
                 {
                     numRollbacks++;
                     build.Score.Rollbacks = 1;
+                    Utilities.WriteDebug($"Build {build.BuildSummary.BuildNumber} determined to be a ROLLBACK with commit message '{source.Comment}'", Log, LogLevel);
+                    Utilities.WriteDebug($"Web link: {build.BuildSummary.WebLink}", Log, LogLevel);
                 }
                 // if we're assuming no tags, every deployment after the first is assumed to be a hotfix; otherwise we need to look specifically for the hotfix tag
                 else if (AssumeNoTags || source.Comment.Contains(AzureDevOpsCommitTags.HotfixTag, StringComparison.InvariantCultureIgnoreCase))
                 {
                     numHotfixes++;
                     build.Score.Hotfixes = 1;
+                    Utilities.WriteDebug($"Build {build.BuildSummary.BuildNumber} determined to be a HOTFIX with commit message '{source.Comment}'", Log, LogLevel);
+                    Utilities.WriteDebug($"Web link: {build.BuildSummary.WebLink}", Log, LogLevel);
                 }
                 // if none of these caught this deployment, then there's an untagged deployment when tags should be present; we'll warn the user about this
                 else if (!source.Comment.Contains(AzureDevOpsCommitTags.RolloutTag, StringComparison.InvariantCultureIgnoreCase))
@@ -185,25 +202,33 @@ namespace RolloutScorer
             }
             numHotfixes += ManualHotfixes;
             numRollbacks += ManualRollbacks;
+            Utilities.WriteDebug($"Detected {numHotfixes} hotfixes ({ManualHotfixes} manual) and {numRollbacks} rollbacks ({ManualRollbacks} manual).", Log, LogLevel);
 
             return (numHotfixes, numRollbacks);
         }
 
         public bool DetermineFailure()
         {
+            Utilities.WriteDebug($"Determining failure for {Repo}...", Log, LogLevel);
             if (BuildBreakdowns.Count == 0)
             {
+                Utilities.WriteDebug($"No builds found for {Repo} this rollout; rollout marked as FAILED.", Log, LogLevel);
                 return true;
             }
 
-            string lastBuildResult = BuildBreakdowns.Last().BuildSummary.Result;
+            ScorecardBuildBreakdown lastBuild = BuildBreakdowns.Last();
+            Utilities.WriteDebug($"Last build is for {Repo} is {lastBuild.BuildSummary.BuildNumber} ({lastBuild.BuildSummary.WebLink})", Log, LogLevel);
+            string lastBuildResult = lastBuild.BuildSummary.Result;
+            Utilities.WriteDebug($"Build {lastBuild.BuildSummary.BuildNumber} has result '{lastBuildResult}'", Log, LogLevel);
             switch (lastBuildResult)
             {
                 case "succeeded":
                 case "partiallySucceeded":
+                    Utilities.WriteDebug($"Last build determined successful.", Log, LogLevel);
                     return false;
 
                 default:
+                    Utilities.WriteDebug($"Last build determined unsuccessful; rollout marked as FAILED.", Log, LogLevel);
                     return true;
             }
         }
@@ -217,16 +242,21 @@ namespace RolloutScorer
         {
             TimeSpan downtime = TimeSpan.Zero;
             IEnumerable<Issue> downtimeIssues = githubIssues
-                .Where(i => Utilities.IssueContainsRelevantLabels(i, GithubLabelNames.DowntimeLabel, RepoConfig.GithubIssueLabel, Log));
+                .Where(i => Utilities.IssueContainsRelevantLabels(i, GithubLabelNames.DowntimeLabel, RepoConfig.GithubIssueLabel, Log, LogLevel));
 
             foreach (Issue issue in downtimeIssues)
             {
+                Utilities.WriteDebug($"Determining downtime from issue {issue.Number}...", Log, LogLevel);
+
                 DateTimeOffset? downtimeStart;
                 DateTimeOffset? downtimeFinish;
 
                 // First, check the issue body
+                Utilities.WriteDebug($"Checking issue body for downtime information...", Log, LogLevel);
                 downtimeStart = GetStartTimeFromIssueText(issue.Body, issue.HtmlUrl);
+                Utilities.WriteDebug($"Downtime start {downtimeStart?.DateTime.ToLongTimeString() ?? "not"} found in issue body.", Log, LogLevel);
                 downtimeFinish = GetEndTimeFromIssueText(issue.Body, issue.HtmlUrl);
+                Utilities.WriteDebug($"Downtime finish {downtimeFinish?.DateTime.ToLongTimeString() ?? "not"} found in issue body.", Log, LogLevel);
                 if (downtimeStart != null && downtimeFinish != null)
                 {
                     downtime += (TimeSpan)(downtimeFinish - downtimeStart);
@@ -234,12 +264,16 @@ namespace RolloutScorer
                 }
 
                 // Next, we're going to check all the comments on the issue
+                Utilities.WriteDebug($"Checking issue comments for downtime information...", Log, LogLevel);
                 IEnumerable<IssueComment> comments = (await _githubClient.Issue.Comment
                     .GetAllForIssue(GithubConfig.ScorecardsGithubOrg, GithubConfig.ScorecardsGithubRepo, issue.Number));
                 foreach (IssueComment comment in comments)
                 {
+                    Utilities.WriteDebug($"Checking comment at {comment.HtmlUrl} for downtime information...", Log, LogLevel);
                     downtimeStart ??= GetStartTimeFromIssueText(comment.Body, comment.HtmlUrl);
+                    Utilities.WriteDebug($"Downtime start {downtimeStart?.DateTime.ToLongTimeString() ?? "not"} found.", Log, LogLevel);
                     downtimeFinish ??= GetEndTimeFromIssueText(comment.Body, comment.HtmlUrl);
+                    Utilities.WriteDebug($"Downtime finish {downtimeFinish?.DateTime.ToLongTimeString() ?? "not"} found.", Log, LogLevel);
 
                     if (downtimeStart != null && downtimeFinish != null)
                     {
@@ -253,8 +287,11 @@ namespace RolloutScorer
                 }
 
                 // If we haven't found both a start and end time yet, we're going to default to creation and/or close time
+                Utilities.WriteDebug($"Downtime not yet found in body or comments; looking at issue start & close times...", Log, LogLevel);
                 downtimeStart ??= issue.CreatedAt;
+                Utilities.WriteDebug($"Downtime start {downtimeStart?.DateTime.ToLongTimeString() ?? "not"} found.", Log, LogLevel);
                 downtimeFinish ??= issue.ClosedAt;
+                Utilities.WriteDebug($"Downtime finish {downtimeFinish?.DateTime.ToLongTimeString() ?? "not"} found.", Log, LogLevel);
                 if (downtimeFinish == null)
                 {
                     Utilities.WriteWarning($"Downtime issue was found unclosed and with no specified end time; " +
@@ -265,6 +302,7 @@ namespace RolloutScorer
                 downtime += (TimeSpan)(downtimeFinish - downtimeStart);
             }
 
+            Utilities.WriteDebug($"Downtime calculated as {downtime}.", Log, LogLevel);
             return downtime;
         }
 
@@ -297,7 +335,7 @@ namespace RolloutScorer
                 }
                 else
                 {
-                    Utilities.WriteWarning($"Failed to parse specified downtime in issue or comment {issueUri})", Log);
+                    Utilities.WriteWarning($"Failed to parse specified downtime in issue or comment {issueUri} (date/time string: '{dateTimeString}')", Log);
                 }
             }
 
@@ -311,6 +349,8 @@ namespace RolloutScorer
         /// <returns>A list of GitHub issues filed during the rollout window containing string-tags in the title marking them as critical issues, hotfixes, and/or rollbacks</returns>
         public async Task<List<Issue>> GetRolloutIssuesFromGithubAsync()
         {
+            Utilities.WriteDebug($"Getting rollout issues for {Repo} (searching issues in {GithubConfig.ScorecardsGithubOrg}/{GithubConfig.ScorecardsGithubRepo} "
+                + $"from {RolloutStartDate} to {RolloutEndDate})", Log, LogLevel);
             SearchIssuesRequest searchIssuesRequest = new SearchIssuesRequest
             {
                 Created = new DateRange(RolloutStartDate, RolloutEndDate),
@@ -318,12 +358,13 @@ namespace RolloutScorer
             searchIssuesRequest.Repos.Add(GithubConfig.ScorecardsGithubOrg, GithubConfig.ScorecardsGithubRepo);
 
             List<Issue> issueSearchResults = await GetAllIssuesFromSearchAsync(searchIssuesRequest);
+            Utilities.WriteDebug($"Found {issueSearchResults.Count} issues in given time range.", Log, LogLevel);
 
             return issueSearchResults.Where(issue =>
                 Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.IssueLabel, RepoConfig.GithubIssueLabel, Log) ||
-                Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.HotfixLabel, RepoConfig.GithubIssueLabel, Log) ||
-                Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.RollbackLabel, RepoConfig.GithubIssueLabel, Log) ||
-                Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.DowntimeLabel, RepoConfig.GithubIssueLabel, Log)
+                Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.HotfixLabel, RepoConfig.GithubIssueLabel, Log, LogLevel) ||
+                Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.RollbackLabel, RepoConfig.GithubIssueLabel, Log, LogLevel) ||
+                Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.DowntimeLabel, RepoConfig.GithubIssueLabel, Log, LogLevel)
                 ).ToList();
         }
 
@@ -386,6 +427,7 @@ namespace RolloutScorer
 
         public void SetupHttpClient(string azdoPat)
         {
+            Utilities.WriteInformation("Setting up HTTP client...", Log);
             _httpClient.DefaultRequestHeaders.Accept.Clear();
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _httpClient.DefaultRequestHeaders.UserAgent.Add(Program.GetProductInfoHeaderValue());
@@ -395,6 +437,7 @@ namespace RolloutScorer
 
         public void SetupGithubClient(string githubPat)
         {
+            Utilities.WriteInformation("Setting up GitHub client...", Log);
             _githubClient = Utilities.GetGithubClient(githubPat);
         }
 

--- a/src/RolloutScorer/RolloutScorer/Scorecard.cs
+++ b/src/RolloutScorer/RolloutScorer/Scorecard.cs
@@ -42,11 +42,11 @@ namespace RolloutScorer
                 Date = rolloutScorer.RolloutStartDate,
                 TimeToRollout = rolloutScorer.CalculateTimeToRollout(),
                 CriticalIssues = githubIssues
-                    .Count(issue => Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.IssueLabel, repoLabel, rolloutScorer.Log)),
+                    .Count(issue => Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.IssueLabel, repoLabel, rolloutScorer.Log, rolloutScorer.LogLevel)),
                 Hotfixes = numHotfixes + githubIssues
-                    .Count(issue => Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.HotfixLabel, repoLabel, rolloutScorer.Log)),
+                    .Count(issue => Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.HotfixLabel, repoLabel, rolloutScorer.Log, rolloutScorer.LogLevel)),
                 Rollbacks = numRollbacks + githubIssues
-                    .Count(issue => Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.RollbackLabel, repoLabel, rolloutScorer.Log)),
+                    .Count(issue => Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.RollbackLabel, repoLabel, rolloutScorer.Log, rolloutScorer.LogLevel)),
                 Downtime = await rolloutScorer.CalculateDowntimeAsync(githubIssues) + rolloutScorer.Downtime,
                 Failure = rolloutScorer.DetermineFailure() || rolloutScorer.Failed,
                 BuildBreakdowns = rolloutScorer.BuildBreakdowns,
@@ -64,7 +64,7 @@ namespace RolloutScorer
                 ScorecardBuildBreakdown firstDeployment = scorecard.BuildBreakdowns.First();
                 firstDeployment.Score.CriticalIssues += scorecard.CriticalIssues;
                 firstDeployment.Score.GithubIssues.AddRange(scorecard.GithubIssues
-                    .Where(issue => Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.IssueLabel, repoLabel, rolloutScorer.Log)));
+                    .Where(issue => Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.IssueLabel, repoLabel, rolloutScorer.Log, rolloutScorer.LogLevel)));
 
                 // Hotfixes & rollbacks are assumed to have taken place in the last deployment
                 // This is likely incorrect given >2 deployments but can be manually adjusted if necessary
@@ -73,8 +73,8 @@ namespace RolloutScorer
                 lastDeployment.Score.Rollbacks += rolloutScorer.ManualRollbacks;
                 lastDeployment.Score.GithubIssues.AddRange(scorecard.GithubIssues
                     .Where(issue => 
-                    Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.HotfixLabel, repoLabel, rolloutScorer.Log) ||
-                    Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.RollbackLabel, repoLabel, rolloutScorer.Log)));
+                    Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.HotfixLabel, repoLabel, rolloutScorer.Log, rolloutScorer.LogLevel) ||
+                    Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.RollbackLabel, repoLabel, rolloutScorer.Log, rolloutScorer.LogLevel)));
             }
 
             return scorecard;

--- a/src/RolloutScorer/RolloutScorer/Utilities.cs
+++ b/src/RolloutScorer/RolloutScorer/Utilities.cs
@@ -16,7 +16,7 @@ namespace RolloutScorer
         public const string KeyVaultUri = "https://engkeyvault.vault.azure.net";
         public const string GitHubPatSecretName = "BotAccount-dotnet-bot-repo-PAT";
 
-        public static bool IssueContainsRelevantLabels(Issue issue, string issueLabel, string repoLabel, ILogger log = null)
+        public static bool IssueContainsRelevantLabels(Issue issue, string issueLabel, string repoLabel, ILogger log = null, Microsoft.Extensions.Logging.LogLevel logLevel = Microsoft.Extensions.Logging.LogLevel.Information)
         {
             if (issue == null)
             {
@@ -24,7 +24,15 @@ namespace RolloutScorer
                 return false;
             }
 
-            return issue.Labels.Any(l => l.Name == issueLabel) && issue.Labels.Any(l => l.Name == repoLabel);
+            WriteTrace($"Issue {issue.Number} has labels {string.Join(", ", issue.Labels.Select(l => $"'{l.Name}'"))}", log, logLevel);
+
+            bool isIssueLabel = issue.Labels.Any(l => l.Name == issueLabel) && issue.Labels.Any(l => l.Name == repoLabel);
+            if (isIssueLabel)
+            {
+                WriteDebug($"Issue {issue.Number} determined to be {issueLabel} for {repoLabel}", log, logLevel);
+            }
+
+            return isIssueLabel;
         }
 
         public static Config ParseConfig()
@@ -87,6 +95,7 @@ namespace RolloutScorer
 
         public static void WriteError(string message, ILogger log = null)
         {
+            message = $"ERROR: {message}";
             if (log == null)
             {
                 WriteColoredMessage(message, ConsoleColor.Red);
@@ -99,6 +108,7 @@ namespace RolloutScorer
 
         public static void WriteWarning(string message, ILogger log)
         {
+            message = $"WARNING: {message}";
             if (log == null)
             {
                 WriteColoredMessage(message, ConsoleColor.Yellow);
@@ -106,6 +116,44 @@ namespace RolloutScorer
             else
             {
                 log.LogWarning(message);
+            }
+        }
+        public static void WriteInformation(string message, ILogger log)
+        {
+            message = $"INFO: {message}";
+            if (log == null)
+            {
+                WriteColoredMessage(message, ConsoleColor.White);
+            }
+            else
+            {
+                log.LogInformation(message);
+            }
+        }
+
+        public static void WriteDebug(string message, ILogger log, Microsoft.Extensions.Logging.LogLevel logLevel)
+        {
+            message = $"DEBUG: {message}";
+            if (log != null)
+            {
+                log.LogInformation(message);
+            }
+            else if (logLevel <= Microsoft.Extensions.Logging.LogLevel.Debug)
+            {
+                WriteColoredMessage(message, ConsoleColor.Gray);
+            }    
+        }
+
+        public static void WriteTrace(string message, ILogger log, Microsoft.Extensions.Logging.LogLevel logLevel)
+        {
+            message = $"TRACE: {message}";
+            if (log != null)
+            {
+                log.LogInformation(message);
+            }
+            else if (logLevel <= Microsoft.Extensions.Logging.LogLevel.Trace)
+            {
+                WriteColoredMessage(message, ConsoleColor.DarkGray);
             }
         }
 

--- a/src/RolloutScorer/RolloutScorer/config.json
+++ b/src/RolloutScorer/RolloutScorer/config.json
@@ -17,7 +17,7 @@
       "ExcludeStages": [ "Validate", "Cleanup", "Validate_OnPrem" ]
     },
     {
-      "Repo": "dotnet-arcade-services",
+      "Repo": "arcade-services",
       "BuildDefinitionIds": [ "252", "728" ],
       "AzdoInstance": "dnceng",
       "GithubIssueLabel": "Rollout Arcade-Services",

--- a/src/RolloutScorer/RolloutScorerAzureFunction/RolloutScorerFunction.cs
+++ b/src/RolloutScorer/RolloutScorerAzureFunction/RolloutScorerFunction.cs
@@ -23,15 +23,15 @@ namespace RolloutScorerAzureFunction
             AzureServiceTokenProvider tokenProvider = new AzureServiceTokenProvider();
 
             string deploymentEnvironment = Environment.GetEnvironmentVariable("DeploymentEnvironment") ?? "Staging";
-            log.LogInformation($"Deployment Environment: {deploymentEnvironment}");
+            log.LogInformation($"INFO: Deployment Environment: {deploymentEnvironment}");
 
-            log.LogInformation("Getting storage account keys from KeyVault...");
+            log.LogInformation("INFO: Getting storage account keys from KeyVault...");
             SecretBundle scorecardsStorageAccountKey = await GetStorageAccountKeyAsync(tokenProvider,
                 Utilities.KeyVaultUri, ScorecardsStorageAccount.KeySecretName);
             SecretBundle deploymentTableSasToken = await GetStorageAccountKeyAsync(tokenProvider,
                 "https://DotNetEng-Status-Prod.vault.azure.net", "deployment-table-sas-token");
 
-            log.LogInformation("Getting cloud tables...");
+            log.LogInformation("INFO: Getting cloud tables...");
             CloudTable scorecardsTable = Utilities.GetScorecardsCloudTable(scorecardsStorageAccountKey.Value);
             CloudTable deploymentsTable = new CloudTable(
                 new Uri($"https://dotnetengstatusprod.table.core.windows.net/deployments{deploymentTableSasToken.Value}"));
@@ -42,24 +42,24 @@ namespace RolloutScorerAzureFunction
             List<AnnotationEntity> deploymentEntries =
                 await GetAllTableEntriesAsync<AnnotationEntity>(deploymentsTable);
             deploymentEntries.Sort((x, y) => (x.Ended ?? DateTimeOffset.MaxValue).CompareTo(y.Ended ?? DateTimeOffset.MaxValue));
-            log.LogInformation($"Found {scorecardEntries?.Count ?? -1} scorecard table entries and {deploymentEntries?.Count ?? -1} deployment table entries." +
+            log.LogInformation($"INFO: Found {scorecardEntries?.Count ?? -1} scorecard table entries and {deploymentEntries?.Count ?? -1} deployment table entries." +
                 $"(-1 indicates that null was returned.)");
 
             // The deployments we care about are ones that occurred after the last scorecard
             IEnumerable<AnnotationEntity> relevantDeployments =
                 deploymentEntries.Where(d => (d.Ended ?? DateTimeOffset.MaxValue) > scorecardEntries.Last().Date.AddDays(ScoringBufferInDays));
-            log.LogInformation($"Found {relevantDeployments?.Count() ?? -1} relevant deployments (deployments which occurred " +
+            log.LogInformation($"INFO: Found {relevantDeployments?.Count() ?? -1} relevant deployments (deployments which occurred " +
                 $"after the last scorecard). (-1 indicates that null was returned.)");
 
             if (relevantDeployments.Count() > 0)
             {
-                log.LogInformation("Checking to see if the most recent deployment occurred more than two days ago...");
+                log.LogInformation("INFO: Checking to see if the most recent deployment occurred more than two days ago...");
                 // We have only want to score if the buffer period has elapsed since the last deployment
-                if ((relevantDeployments.Last().Ended ?? DateTimeOffset.MaxValue) < DateTimeOffset.UtcNow - TimeSpan.FromDays(ScoringBufferInDays))
+                if (true || (relevantDeployments.Last().Ended ?? DateTimeOffset.MaxValue) < DateTimeOffset.UtcNow - TimeSpan.FromDays(ScoringBufferInDays))
                 {
                     var scorecards = new List<Scorecard>();
 
-                    log.LogInformation("Rollouts will be scored. Fetching GitHub PAT...");
+                    log.LogInformation("INFO: Rollouts will be scored. Fetching GitHub PAT...");
                     SecretBundle githubPat;
                     using (KeyVaultClient kv = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(tokenProvider.KeyVaultTokenCallback)))
                     {
@@ -69,7 +69,7 @@ namespace RolloutScorerAzureFunction
                     // We'll score the deployments by service
                     foreach (var deploymentGroup in relevantDeployments.GroupBy(d => d.Service))
                     {
-                        log.LogInformation($"Scoring {deploymentGroup?.Count() ?? -1} rollouts for repo '{deploymentGroup.Key}'");
+                        log.LogInformation($"INFO: Scoring {deploymentGroup?.Count() ?? -1} rollouts for repo '{deploymentGroup.Key}'");
                         RolloutScorer.RolloutScorer rolloutScorer = new RolloutScorer.RolloutScorer
                         {
                             Repo = deploymentGroup.Key,
@@ -78,16 +78,15 @@ namespace RolloutScorerAzureFunction
                             GithubConfig = Configs.DefaultConfig.GithubConfig,
                             Log = log,
                         };
-                        log.LogInformation($"Finding repo config for {rolloutScorer.Repo}...");
+                        log.LogInformation($"INFO: Finding repo config for {rolloutScorer.Repo}...");
                         rolloutScorer.RepoConfig = Configs.DefaultConfig.RepoConfigs
                             .Find(r => r.Repo == rolloutScorer.Repo);
-                        log.LogInformation($"Repo config: {rolloutScorer.RepoConfig.Repo}");
-                        log.LogInformation($"Finding AzDO config... for {rolloutScorer.RepoConfig.AzdoInstance}");
+                        log.LogInformation($"INFO: Repo config: {rolloutScorer.RepoConfig.Repo}");
+                        log.LogInformation($"INFO: Finding AzDO config for {rolloutScorer.RepoConfig.AzdoInstance}...");
                         rolloutScorer.AzdoConfig = Configs.DefaultConfig.AzdoInstanceConfigs
                             .Find(a => a.Name == rolloutScorer.RepoConfig.AzdoInstance);
-                        log.LogInformation($"AzdoConfig: {rolloutScorer.AzdoConfig.Name}");
 
-                        log.LogInformation($"Fetching AzDO PAT from KeyVault...");
+                        log.LogInformation($"INFO: Fetching AzDO PAT from KeyVault...");
                         using (KeyVaultClient kv = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(tokenProvider.KeyVaultTokenCallback)))
                         {
                             rolloutScorer.SetupHttpClient(
@@ -95,37 +94,37 @@ namespace RolloutScorerAzureFunction
                         }
                         rolloutScorer.SetupGithubClient(githubPat.Value);
 
-                        log.LogInformation($"Attempting to initialize RolloutScorer...");
+                        log.LogInformation($"INFO: Attempting to initialize RolloutScorer...");
                         try
                         {
                             await rolloutScorer.InitAsync();
                         }
                         catch (ArgumentException e)
                         {
-                            log.LogError($"Error while processing {rolloutScorer.RolloutStartDate} rollout of {rolloutScorer.Repo}.");
-                            log.LogError(e.Message);
+                            log.LogError($"ERROR: Error while processing {rolloutScorer.RolloutStartDate} rollout of {rolloutScorer.Repo}.");
+                            log.LogError($"ERROR: {e.Message}");
                             continue;
                         }
 
-                        log.LogInformation($"Creating rollout scorecard...");
+                        log.LogInformation($"INFO: Creating rollout scorecard...");
                         scorecards.Add(await Scorecard.CreateScorecardAsync(rolloutScorer));
-                        log.LogInformation($"Successfully created scorecard for {rolloutScorer.RolloutStartDate.Date} rollout of {rolloutScorer.Repo}.");
+                        log.LogInformation($"INFO: Successfully created scorecard for {rolloutScorer.RolloutStartDate.Date} rollout of {rolloutScorer.Repo}.");
                     }
 
-                    log.LogInformation($"Uploading results for {string.Join(", ", scorecards.Select(s => s.Repo))}");
+                    log.LogInformation($"INFO: Uploading results for {string.Join(", ", scorecards.Select(s => s.Repo))}");
                     await RolloutUploader.UploadResultsAsync(scorecards, Utilities.GetGithubClient(githubPat.Value),
                         scorecardsStorageAccountKey.Value, Configs.DefaultConfig.GithubConfig, skipPr: deploymentEnvironment != "Production");
                 }
                 else
                 {
-                    log.LogInformation(relevantDeployments.Last().Ended.HasValue ? $"Most recent rollout occurred less than two days ago " +
+                    log.LogInformation(relevantDeployments.Last().Ended.HasValue ? $"INFO: Most recent rollout occurred less than two days ago " +
                         $"({relevantDeployments.Last().Service} on {relevantDeployments.Last().Ended.Value}); waiting to score." :
                         $"Most recent rollout ({relevantDeployments.Last().Service}) is still in progress.");
                 }
             }
             else
             {
-                log.LogInformation($"Found no rollouts which occurred after last recorded rollout " +
+                log.LogInformation($"INFO: Found no rollouts which occurred after last recorded rollout " +
                     $"({(scorecardEntries.Count > 0 ? $"date {scorecardEntries.Last().Date}" : "no rollouts in table")})");
             }
         }

--- a/src/RolloutScorer/RolloutScorerAzureFunction/RolloutScorerFunction.cs
+++ b/src/RolloutScorer/RolloutScorerAzureFunction/RolloutScorerFunction.cs
@@ -55,7 +55,7 @@ namespace RolloutScorerAzureFunction
             {
                 log.LogInformation("INFO: Checking to see if the most recent deployment occurred more than two days ago...");
                 // We have only want to score if the buffer period has elapsed since the last deployment
-                if (true || (relevantDeployments.Last().Ended ?? DateTimeOffset.MaxValue) < DateTimeOffset.UtcNow - TimeSpan.FromDays(ScoringBufferInDays))
+                if ((relevantDeployments.Last().Ended ?? DateTimeOffset.MaxValue) < DateTimeOffset.UtcNow - TimeSpan.FromDays(ScoringBufferInDays))
                 {
                     var scorecards = new List<Scorecard>();
 


### PR DESCRIPTION
I was not able to locally reproduce the Rollout Scorer not picking up issues like it has on a few scorecards (per #10188) -- both the rollout scorer console app and the Azure Function (run locally) produce the correct results. This suggests that the issue purely lies in the function when running in Azure. The best way to determine this, however, is to run the app in staging.

This PR adds a *ton* of AppInsights logging to the rollout scorer to help with debugging these things in prod & staging. This should make debugging much easier.

Logging added:
* Raw AzDO queries (uris, no auth or headers)
* Hotfix & rollback detection (from commit messages)
* GitHub API query & number of issues returned
* [TRACE] Logs looping over every issue noting labels for all
* Rollout issue/hotfix/rollback/downtime detection form GitHub issues
* Build time to rollout calculation
* [TRACE] Start/end/approval times for builds
* Downtime calculation
* Failure detection -- logs last build w/ link & its result status