### PR TITLE
Forward target publishing infra version to the promote pipeline

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -78,6 +78,12 @@ namespace Microsoft.DotNet.Darc.Operations
                     return Constants.ErrorCode;
                 }
 
+                if (_options.PublishingInfraVersion < 2 || _options.PublishingInfraVersion > 3)
+                {
+                    Console.WriteLine($"Publishing version '{_options.PublishingInfraVersion}' is not configured. The following versions are available: 2, 3");
+                    return Constants.ErrorCode;
+                }
+
                 List<Channel> targetChannels = new List<Channel>();
 
                 if (!string.IsNullOrEmpty(_options.Channel))

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -226,6 +226,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
             var queueTimeVariables = $"{{" +
                 $"\"BARBuildId\": \"{ build.Id }\", " +
+                $"\"PublishingInfraVersion\": \"{ _options.PublishingInfraVersion }\", " +
                 $"\"PromoteToChannelIds\": \"{ string.Join(",", targetChannels.Select(tch => tch.Id)) }\", " +
                 $"\"EnableSigningValidation\": \"{ _options.DoSigningValidation }\", " +
                 $"\"SigningValidationAdditionalParameters\": \"{ _options.SigningValidationAdditionalParameters }\", " +

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("id", Required = true, HelpText = "BAR id of build to assign to channel.")]
         public int Id { get; set; }
 
-        [Option("publishing-infra-version", Default = 2, Required = true, HelpText = "Which version of the publishing infrastructure should be used.")]
+        [Option("publishing-infra-version", Default = 2, Required = false, HelpText = "Which version of the publishing infrastructure should be used.")]
         public int PublishingInfraVersion { get; set; }
 
         [Option("channel", HelpText = "Channel to assign build to. Required if --default-channels is not specified.")]

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
@@ -13,6 +13,9 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("id", Required = true, HelpText = "BAR id of build to assign to channel.")]
         public int Id { get; set; }
 
+        [Option("publishing-infra-version", Default = 2, Required = true, HelpText = "Which version of the publishing infrastructure should be used.")]
+        public int PublishingInfraVersion { get; set; }
+
         [Option("channel", HelpText = "Channel to assign build to. Required if --default-channels is not specified.")]
         public string Channel { get; set; }
 


### PR DESCRIPTION
Build failed -> https://dev.azure.com/dnceng/internal/_build/results?buildId=702743&view=results 

So the following change was reverted -> https://github.com/dotnet/arcade-services/pull/1261

The change here is making is reintroducing publishing-infra-version to add-build-to-channel and also making it optional.

The change has already been validated by Cesar here -> https://dnceng.visualstudio.com/internal/_build/results?buildId=700742&view=results