### PR TITLE
A pretty simple telemetry solution for darc.exe

### DIFF
--- a/.angulardoc.json
+++ b/.angulardoc.json
@@ -1,0 +1,4 @@
+{
+  "repoId": "75a8ee52-698f-48e1-986c-5c99e6b50e58",
+  "lastSync": 0
+}

--- a/.angulardoc.json
+++ b/.angulardoc.json
@@ -1,4 +1,0 @@
-{
-  "repoId": "75a8ee52-698f-48e1-986c-5c99e6b50e58",
-  "lastSync": 0
-}

--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder
 .mfractor/
+
+# angular stuff
+.angulardoc.json

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/Operations.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/Operations.cs
@@ -7,11 +7,10 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Console;
 
 namespace Microsoft.DotNet.Darc.Operations
 {
-    internal abstract class Operation : IDisposable
+    public abstract class Operation : IDisposable
     {
         private readonly ServiceProvider _provider;
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DotNet.Darc.Options
     internal class AddBuildToChannelCommandLineOptions : CommandLineOptions
     {
         [Option("id", Required = true, HelpText = "BAR id of build to assign to channel.")]
+        [RedactFromLogging]
         public int Id { get; set; }
 
         [Option("publishing-infra-version", Default = 2, Required = false, HelpText = "Which version of the publishing infrastructure should be used.")]
@@ -26,6 +27,7 @@ namespace Microsoft.DotNet.Darc.Options
         public string SourceBranch { get; set; }
 
         [Option("source-sha", HelpText = "SHA that should be used as base for the promotion build.")]
+        [RedactFromLogging]
         public string SourceSHA { get; set; }
 
         [Option("validate-signing", HelpText = "Perform signing validation.")]
@@ -50,9 +52,11 @@ namespace Microsoft.DotNet.Darc.Options
         public string SDLValidationContinueOnError { get; set; }
 
         [Option("symbol-publishing-parameters", HelpText = "Additional (MSBuild) properties to be passed to symbol publishing")]
+        [RedactFromLogging]
         public string SymbolPublishingAdditionalParameters { get; set; }
 
         [Option("artifact-publishing-parameters", HelpText = "Additional (MSBuild) properties to be passed to asset publishing.")]
+        [RedactFromLogging]
         public string ArtifactPublishingAdditionalParameters { get; set; }
 
         [Option("publish-installers-and-checksums", HelpText = "Whether installers and checksums should be published.")]

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/CloneCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/CloneCommandLineOptions.cs
@@ -19,9 +19,11 @@ namespace Microsoft.DotNet.Darc.Options
         public string Version { get; set; }
 
         [Option("repos-folder", HelpText = @"Full path to folder where all the repos will be cloned to, e.g. C:\repos.  Default: current directory.")]
+        [RedactFromLogging]
         public string ReposFolder { get; set; }
 
         [Option("git-dir-folder", HelpText = @"Advanced: Full path to folder where .git folders will be stored, e.g. C:\myrepos\.git\modules.  Default: each repo's folder.")]
+        [RedactFromLogging]
         public string GitDirFolder { get; set; }
 
         [Option("include-toolset", HelpText = "Include toolset dependencies.")]

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/CommandLineOptions.cs
@@ -7,15 +7,18 @@ using Microsoft.DotNet.Darc.Operations;
 
 namespace Microsoft.DotNet.Darc.Options
 {
-    abstract class CommandLineOptions
+    public abstract class CommandLineOptions
     {
         [Option('p', "password", HelpText = "BAR password.")]
+        [RedactFromLogging]
         public string BuildAssetRegistryPassword { get; set; }
 
         [Option("github-pat", HelpText = "Token used to authenticate GitHub.")]
+        [RedactFromLogging]
         public string GitHubPat { get; set; }
 
         [Option("azdev-pat", HelpText = "Token used to authenticate to Azure DevOps.")]
+        [RedactFromLogging]
         public string AzureDevOpsPat { get; set; }
 
         [Option("bar-uri", HelpText = "URI of the build asset registry service to use.")]
@@ -28,6 +31,7 @@ namespace Microsoft.DotNet.Darc.Options
         public bool Debug { get; set; }
 
         [Option("git-location", Default = "git", HelpText = "Location of git executable used for internal commands.")]
+        [RedactFromLogging]
         public string GitLocation { get; set; }
 
         [Option("output-format", Default = DarcOutputType.text,

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/DeleteBuildFromChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/DeleteBuildFromChannelCommandLineOptions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Darc.Options
     internal class DeleteBuildFromChannelCommandLineOptions : CommandLineOptions
     {
         [Option("id", Required = true, HelpText = "BAR id of build to assign to channel.")]
+        [RedactFromLogging]
         public int Id { get; set; }
 
         [Option("channel", Required = true, HelpText = "Channel to remove the build from.")]

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
@@ -12,15 +12,18 @@ namespace Microsoft.DotNet.Darc.Options
     internal class GatherDropCommandLineOptions : CommandLineOptions
     {
         [Option('i', "id", Separator = ',', HelpText = "BAR ID(s) of the root build(s) that we want to gather. comma separated.")]
+        [RedactFromLogging]
         public IEnumerable<int> RootBuildIds { get; set; }
 
         [Option('r', "repo", HelpText = "Gather a build drop for a build of this repo. Requires --commit or --channel.")]
         public string RepoUri { get; set; }
 
         [Option('c', "commit", HelpText = "Commit to gather a drop for.")]
+        [RedactFromLogging]
         public string Commit { get; set; }
 
         [Option('o',"output-dir", Required = true, HelpText = "Output directory to place build drop.")]
+        [RedactFromLogging]
         public string OutputDirectory { get; set; }
 
         [Option("max-downloads", Default = 4, HelpText = "Maximum concurrent downloads.")]
@@ -67,6 +70,7 @@ namespace Microsoft.DotNet.Darc.Options
 
         [Option("sas-suffixes", Separator = ',', HelpText = "List of potential uri suffixes that can be used if anonymous " +
             "access to a blob uri fails. Appended directly to the end of the URI (use full SAS suffix starting with '?'.")]
+        [RedactFromLogging]
         public IEnumerable<string> SASSuffixes { get; set; }
 
         [Option("asset-filter", HelpText = "Only download assets matching the given regex filter")]

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GetBuildCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GetBuildCommandLineOptions.cs
@@ -11,15 +11,18 @@ namespace Microsoft.DotNet.Darc.Options
     internal class GetBuildCommandLineOptions : CommandLineOptions
     {
         [Option("id", HelpText = "Build id.")]
+        [RedactFromLogging]
         public int Id { get; set; }
 
         [Option("uri", HelpText = "Uri of the build.")]
+        [RedactFromLogging]
         public string BuildUri { get; set; }
 
         [Option("repo", HelpText = "Full url of the repository that was built")]
         public string Repo { get; set; }
 
         [Option("commit", HelpText = "Full commit sha that was built")]
+        [RedactFromLogging]
         public string Commit { get; set; }
 
         public override Operation GetOperation()

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GetDependencyFlowGraphCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GetDependencyFlowGraphCommandLineOptions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotNet.Darc.Options
     internal class GetDependencyFlowGraphCommandLineOptions : CommandLineOptions
     {
         [Option("graphviz", HelpText = @"Writes the flow graph in GraphViz (dot) form, into the specified file.")]
+        [RedactFromLogging]
         public string GraphVizOutputFile { get; set; }
 
         [Option("include-disabled-subscriptions", HelpText = @"Include edges that have disabled subscriptions")]

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GetDependencyGraphCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GetDependencyGraphCommandLineOptions.cs
@@ -19,12 +19,14 @@ namespace Microsoft.DotNet.Darc.Options
         public string RepoUri { get; set; }
 
         [Option('v', "version", HelpText = "Branch, commit or tag to look up if looking up version information remotely.")]
+        [RedactFromLogging]
         public string Version { get; set; }
 
         [Option("asset-name", HelpText = "Get the graph based on a single asset and not the whole Version.Details.xml contents.")]
         public string AssetName { get; set; }
 
         [Option("repos-folder", HelpText = @"Full path to folder where all the repos are locally stored. i.e. C:\repos")]
+        [RedactFromLogging]
         public string ReposFolder { get; set; }
 
         [Option("remotes-map", Separator = ';', HelpText = @"';' separated key value pair defining the remote to local path mapping. i.e 'https://github.com/dotnet/arcade,C:\repos\arcade;'"
@@ -35,9 +37,11 @@ namespace Microsoft.DotNet.Darc.Options
         public bool Flat { get; set; }
 
         [Option("graphviz", HelpText = @"Writes the repository graph in GraphViz (dot) form, into the specified file.")]
+        [RedactFromLogging]
         public string GraphVizOutputFile { get; set; }
 
         [Option("output-file", HelpText = @"Writes the non-GraphViz (dot) output to the specified file into the specified file.")]
+        [RedactFromLogging]
         public string OutputFile { get; set; }
 
         [Option("include-toolset", HelpText = "Include toolset dependencies.")]

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/RedactFromLoggingAttribute.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/RedactFromLoggingAttribute.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.DotNet.Darc.Options
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class RedactFromLoggingAttribute : Attribute{ }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/RedactFromLoggingAttribute.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/RedactFromLoggingAttribute.cs
@@ -6,6 +6,14 @@ using System;
 
 namespace Microsoft.DotNet.Darc.Options
 {
+    /// <summary>
+    /// This attribute indicates that the value of this option should be redacted
+    /// from any logging utilities. Either because it contains secrets or because
+    /// it's local paths that provide little use on the server, or because it's a value
+    /// that is different every invocation, and not interesting for analytics
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
-    public class RedactFromLoggingAttribute : Attribute{ }
+    public class RedactFromLoggingAttribute : Attribute
+    {
+    }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateDependenciesCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateDependenciesCommandLineOptions.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DotNet.Darc.Options
     class UpdateDependenciesCommandLineOptions : CommandLineOptions
     {
         [Option("id", HelpText = "Optional BAR id of build to be used instead of the latest build in the channel.")]
+        [RedactFromLogging]
         public int BARBuildId { get; set; }
 
         [Option('c', "channel", HelpText = "Channel to pull dependencies from.")]
@@ -28,6 +29,7 @@ namespace Microsoft.DotNet.Darc.Options
 
         [Option("packages-folder", HelpText = "An optional path to a folder which contains the NuGet " +
             "packages whose versions will be used to update existing dependencies.")]
+        [RedactFromLogging]
         public string PackagesFolder { get; set; }
 
         [Option("dry-run", HelpText = "Show what will be updated, but make no changes.")]

--- a/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
@@ -6,16 +6,95 @@ using CommandLine;
 using Microsoft.DotNet.Darc.Operations;
 using Microsoft.DotNet.Darc.Options;
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.DependencyCollector;
+using Microsoft.ApplicationInsights.Extensibility;
 
 namespace Microsoft.DotNet.Darc
 {
-    class Program
+    internal static class Program
     {
-        static int Main(string[] args)
+        private static TelemetryClient s_telemetryClient;
+
+        private static int Main(string[] args)
         {
-            return Parser.Default.ParseArguments(args, GetOptions())
-                .MapResult( (CommandLineOptions opts) => RunOperation(opts),
-                    (errs => 1));
+            InitializeTelemetry();
+
+            try
+            {
+                return Parser.Default.ParseArguments(args, GetOptions())
+                    .MapResult(
+                        (CommandLineOptions opts) => RunOperation(opts),
+                        RecordFailedCommand
+                    );
+            }
+            finally
+            {
+                s_telemetryClient.Flush();
+            }
+        }
+
+        private static int RecordFailedCommand(IEnumerable<Error> errors)
+        {
+            foreach (Error error in errors)
+            {
+                switch (error)
+                {
+                    case NamedError named:
+                        s_telemetryClient.TrackTrace(
+                            $"Command line parsing error: {named.Tag}, name '{named.NameInfo.LongName}'",
+                            SeverityLevel.Error,
+                            new Dictionary<string, string>
+                            {
+                                {"errorTag", named.Tag.ToString()},
+                                {"errorName", named.NameInfo.LongName},
+                            }
+                        );
+                        break;
+                    case TokenError token:
+                        s_telemetryClient.TrackTrace(
+                            $"Command line parsing error: {token.Tag}, token '{token.Token}'",
+                            SeverityLevel.Error,
+                            new Dictionary<string, string>
+                            {
+                                {"errorTag", token.Tag.ToString()},
+                                {"errorToken", token.Token},
+                            }
+                        );
+                        break;
+                    default:
+                        s_telemetryClient.TrackTrace(
+                            $"Command line parsing error: {error.Tag}",
+                            SeverityLevel.Error,
+                            new Dictionary<string, string>
+                            {
+                                {"errorTag", error.Tag.ToString()}
+                            }
+                        );
+                        break;
+                    case HelpRequestedError _:
+                    case HelpVerbRequestedError _:
+                        s_telemetryClient.TrackTrace(
+                            "Verb chosen: help",
+                            SeverityLevel.Information,
+                            new Dictionary<string, string>
+                            {
+                                {"verb", "help"}
+                            }
+                        );
+                        return 0;
+                    case VersionRequestedError _:
+                        ReportVerb();
+                        return 0;
+                }
+            }
+
+            return 1;
         }
 
         /// <summary>
@@ -30,16 +109,25 @@ namespace Microsoft.DotNet.Darc
         {
             try
             {
-                Operation operation = opts.GetOperation();
-
-                int returnValue = operation.ExecuteAsync().GetAwaiter().GetResult();
-                operation.Dispose();
-                return returnValue;
+                using (Operation operation = opts.GetOperation())
+                {
+                    Stopwatch stopwatch = Stopwatch.StartNew();
+                    try
+                    {
+                        return operation.ExecuteAsync().GetAwaiter().GetResult();
+                    }
+                    finally
+                    {
+                        stopwatch.Stop();
+                        ReportInvocation(opts, stopwatch.Elapsed);
+                    }
+                }
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Unhandled exception while running {typeof(Operation).Name}");
+                Console.WriteLine("Unhandled exception encountered");
                 Console.WriteLine(e);
+                s_telemetryClient.TrackException(e);
                 return Constants.ErrorCode;
             }
         }
@@ -85,6 +173,99 @@ namespace Microsoft.DotNet.Darc
                     typeof(SetGoalCommandLineOptions),
                     typeof(GetGoalCommandLineOptions)
                 };
+        }
+
+        private static void InitializeTelemetry()
+        {
+            var isDebugging = Debugger.IsAttached;
+            var config = TelemetryConfiguration.CreateDefault();
+            if (!isDebugging)
+            {
+                config.InstrumentationKey = "9fcef3c7-f401-41c7-9e91-1f6029c8dcc3";
+            }
+
+            var dependencyTracking = new DependencyTrackingTelemetryModule();
+            dependencyTracking.ExcludeComponentCorrelationHttpHeadersOnDomains.Add("core.windows.net");
+            dependencyTracking.Initialize(config);
+
+            config.TelemetryInitializers.Add(new HttpDependenciesParsingTelemetryInitializer());
+            var channel = new InMemoryChannel {DeveloperMode = isDebugging};
+            config.TelemetryChannel = channel;
+
+            s_telemetryClient = new TelemetryClient(config);
+        }
+
+        private static void ReportVerb()
+        {
+            s_telemetryClient.TrackTrace(
+                "Verb chosen: version",
+                SeverityLevel.Information,
+                new Dictionary<string, string>
+                {
+                    {"verb", "version"}
+                }
+            );
+        }
+
+        private static void ReportInvocation(CommandLineOptions options, TimeSpan stopwatchElapsed)
+        {
+            Type optionType = options.GetType();
+            string verb = optionType.GetCustomAttribute<VerbAttribute>()?.Name;
+            if (string.IsNullOrEmpty(verb))
+            {
+                s_telemetryClient.TrackTrace($"Unrecognized options/verb detected: {optionType.Name}");
+                return;
+            }
+
+            Dictionary<string,string> arguments = new Dictionary<string, string>();
+            Dictionary<Type, object> defaultValueCache = new Dictionary<Type, object>();
+            foreach (var prop in optionType.GetProperties(BindingFlags.FlattenHierarchy | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                var optionAttribute = prop.GetCustomAttribute<OptionAttribute>();
+                if (optionAttribute == null)
+                {
+                    // Whatever this property is, it's not an option, ignore it
+                    continue;
+                }
+
+                var value = prop.GetValue(options);
+                if (value == null)
+                {
+                    // This argument wasn't passed, just ignore it
+                    continue;
+                }
+
+                if (prop.PropertyType.IsValueType)
+                {
+                    // Value types, like "int", are hard, because they aren't null
+                    // So we need to Activator.CreateInstance one to get the "default"
+                    // value, and then compare to that.
+                    if (!defaultValueCache.TryGetValue(prop.PropertyType, out var defaultValue))
+                    {
+                        defaultValueCache.Add(prop.PropertyType, defaultValue = Activator.CreateInstance(prop.PropertyType));
+                    }
+
+                    if (defaultValue.Equals(value))
+                    {
+                        continue;
+                    }
+                }
+
+                if (prop.GetCustomAttribute<RedactFromLoggingAttribute>() != null)
+                {
+                    value = "<<REDACTED>>";
+                }
+
+                arguments.Add(optionAttribute.LongName, value.ToString());
+            }
+
+            s_telemetryClient.TrackEvent("CommandExecuted",
+                arguments,
+                new Dictionary<string, double>
+                {
+                    {"duration", stopwatchElapsed.TotalMilliseconds}
+                }
+            );
         }
     }
 }


### PR DESCRIPTION
It reports:
* any command line parsing error as a LogError with relevant information
* any exception that bubbles out to Main
* every verb executed including any options passed and their values
* sensitive options can be redacted with `[RedactFromLogging]`, which record they were specified, but not the values passed