### PR TITLE
Maestro failed requests granularity

### DIFF
--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -3466,7 +3466,7 @@
     "list": []
   },
   "time": {
-    "from": "now-90d",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {

--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -21,7 +21,6 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 2,
   "links": [],
   "panels": [
     {
@@ -63,7 +62,6 @@
         "x": 7,
         "y": 0
       },
-      "hiddenSeries": false,
       "id": 44,
       "legend": {
         "avg": false,
@@ -467,7 +465,6 @@
         "x": 19,
         "y": 0
       },
-      "hiddenSeries": false,
       "id": 48,
       "legend": {
         "alignAsTable": false,
@@ -888,7 +885,6 @@
         "x": 7,
         "y": 8
       },
-      "hiddenSeries": false,
       "id": 42,
       "legend": {
         "avg": false,
@@ -1293,7 +1289,6 @@
         "x": 19,
         "y": 8
       },
-      "hiddenSeries": false,
       "id": 49,
       "legend": {
         "alignAsTable": false,
@@ -1442,7 +1437,6 @@
         "x": 0,
         "y": 16
       },
-      "hiddenSeries": false,
       "id": 12,
       "legend": {
         "avg": false,
@@ -2084,7 +2078,6 @@
         "x": 19,
         "y": 16
       },
-      "hiddenSeries": false,
       "id": 50,
       "legend": {
         "alignAsTable": false,
@@ -2274,7 +2267,6 @@
         "x": 0,
         "y": 24
       },
-      "hiddenSeries": false,
       "id": 3,
       "legend": {
         "avg": false,
@@ -2888,7 +2880,6 @@
         "x": 19,
         "y": 24
       },
-      "hiddenSeries": false,
       "id": 52,
       "legend": {
         "alignAsTable": false,
@@ -2974,8 +2965,7 @@
             "resourceGroup": "select",
             "resourceName": "select",
             "timeGrain": "auto",
-            "timeGrains": [],
-            "top": "10"
+            "timeGrains": []
           },
           "queryType": "Application Insights",
           "refId": "A"
@@ -3459,7 +3449,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 22,
+  "schemaVersion": 20,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -3485,7 +3475,5 @@
     ]
   },
   "timezone": "",
-  "title": "Service Availability",
-  "uid": "arcadeAvailability",
-  "version": 44
+  "title": "Service Availability"
 }

--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -21,6 +21,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
+  "id": 2,
   "links": [],
   "panels": [
     {
@@ -62,6 +63,7 @@
         "x": 7,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 44,
       "legend": {
         "avg": false,
@@ -465,6 +467,7 @@
         "x": 19,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 48,
       "legend": {
         "alignAsTable": false,
@@ -885,6 +888,7 @@
         "x": 7,
         "y": 8
       },
+      "hiddenSeries": false,
       "id": 42,
       "legend": {
         "avg": false,
@@ -1289,6 +1293,7 @@
         "x": 19,
         "y": 8
       },
+      "hiddenSeries": false,
       "id": 49,
       "legend": {
         "alignAsTable": false,
@@ -1437,6 +1442,7 @@
         "x": 0,
         "y": 16
       },
+      "hiddenSeries": false,
       "id": 12,
       "legend": {
         "avg": false,
@@ -2078,6 +2084,7 @@
         "x": 19,
         "y": 16
       },
+      "hiddenSeries": false,
       "id": 50,
       "legend": {
         "alignAsTable": false,
@@ -2267,6 +2274,7 @@
         "x": 0,
         "y": 24
       },
+      "hiddenSeries": false,
       "id": 3,
       "legend": {
         "avg": false,
@@ -2880,6 +2888,7 @@
         "x": 19,
         "y": 24
       },
+      "hiddenSeries": false,
       "id": 52,
       "legend": {
         "alignAsTable": false,
@@ -2946,11 +2955,11 @@
             ],
             "metricName": "requests/count",
             "rawQuery": true,
-            "rawQueryString": "let r = requests | where $__timeFilter();\nlet f = toscalar(r | summarize min(timestamp));\nlet t = toscalar(r | summarize max(timestamp));\nr\n| where success == false and toint(resultCode) >= 500\n| make-series valueCount=count() default=0 on timestamp in range(f, t, 1m) by resultCode\n| mvexpand timestamp, valueCount\n| project timestamp=todatetime(timestamp), valueCount=toint(valueCount), resultCode",
+            "rawQueryString": "let r = requests | where $__timeFilter();\r\nlet f = toscalar(r | summarize min(timestamp));\r\nlet t = toscalar(r | summarize max(timestamp));\r\nlet span=(t - f)/60;\r\nlet interval=case(span >= 1d, bin(span, 1d), span >= 1h, bin(span, 1h), 15m);\r\nlet intervalHours = interval / 1h;\r\nr\r\n| where success == false and toint(resultCode) >= 500\r\n| make-series valueCount=count() default=0 on timestamp in range(f, t, interval) by resultCode\r\n| mv-expand timestamp, valueCount\r\n| project timestamp=todatetime(timestamp), failuresCount=todouble(valueCount)/intervalHours, resultCode",
             "segmentColumn": "resultCode",
             "timeColumn": "timestamp",
             "timeGrain": "auto",
-            "valueColumn": "valueCount"
+            "valueColumn": "failuresCount"
           },
           "azureLogAnalytics": {
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
@@ -2965,17 +2974,35 @@
             "resourceGroup": "select",
             "resourceName": "select",
             "timeGrain": "auto",
-            "timeGrains": []
+            "timeGrains": [],
+            "top": "10"
           },
           "queryType": "Application Insights",
           "refId": "A"
         }
       ],
-      "thresholds": [],
+      "thresholds": [
+        {
+          "colorMode": "warning",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 5,
+          "yaxis": "left"
+        },
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 10,
+          "yaxis": "left"
+        }
+      ],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Maestro Failed Requests",
+      "title": "Maestro Failed Requests/Hour",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -3432,14 +3459,14 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 20,
+  "schemaVersion": 22,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-90d",
     "to": "now"
   },
   "timepicker": {
@@ -3458,5 +3485,7 @@
     ]
   },
   "timezone": "",
-  "title": "Service Availability"
+  "title": "Service Availability",
+  "uid": "arcadeAvailability",
+  "version": 44
 }


### PR DESCRIPTION
Now it shows data always in units reqs/hour and dynamically change granularity. 
I have also set thresholds to5 failed-reqs/hours warning, 10 critical