### PR TITLE
Use the package URI to check for packages in nuget.org instead of the registration URI 

### DIFF
--- a/src/Maestro/FeedCleanerService/FeedCleanerService.cs
+++ b/src/Maestro/FeedCleanerService/FeedCleanerService.cs
@@ -324,11 +324,10 @@ namespace FeedCleanerService
             string packageContentsUri = $"{FeedConstants.NuGetOrgPackageBaseUrl}{name.ToLower()}/{version}/{name.ToLower()}.{version}.nupkg";
             try
             {
-                using (HttpRequestMessage headRequest = new HttpRequestMessage(HttpMethod.Head, new Uri(packageContentsUri)))
-                using (HttpResponseMessage response = await _httpClient.SendAsync(headRequest))
-                {
-                    response.EnsureSuccessStatusCode();
-                }
+                using HttpRequestMessage headRequest = new HttpRequestMessage(HttpMethod.Head, new Uri(packageContentsUri));
+                using HttpResponseMessage response = await _httpClient.SendAsync(headRequest);
+
+                response.EnsureSuccessStatusCode();
                 Logger.LogInformation($"Found {name}.{version} in nuget.org URI: {packageContentsUri}");
                 return true;
             }

--- a/src/Maestro/FeedCleanerService/FeedCleanerService.cs
+++ b/src/Maestro/FeedCleanerService/FeedCleanerService.cs
@@ -314,24 +314,27 @@ namespace FeedCleanerService
 
         /// <summary>
         /// Checks whether a package is available in NuGet.org
-        /// by using the package registration URL for a given package + version combination.
+        /// by making a HEAD request to the package contents URI.
         /// </summary>
         /// <param name="name">Package to search for</param>
         /// <param name="version">Version to search for</param>
-        /// <returns>True if the package is available in the NuGet.org registry, false if not</returns>
+        /// <returns>True if the package is available in NuGet.org, false if not</returns>
         private async Task<bool> IsPackageAvailableInNugetOrgAsync(string name, string version)
         {
+            string packageContentsUri = $"{FeedConstants.NuGetOrgPackageBaseUrl}{name.ToLower()}/{version}/{name.ToLower()}.{version}.nupkg";
             try
             {
-                using (HttpResponseMessage response = await _httpClient.GetAsync($"{FeedConstants.NuGetOrgRegistrationBaseUrl}/{name.ToLower()}/{version}.json"))
+                using (HttpRequestMessage headRequest = new HttpRequestMessage(HttpMethod.Head, new Uri(packageContentsUri)))
+                using (HttpResponseMessage response = await _httpClient.SendAsync(headRequest))
                 {
                     response.EnsureSuccessStatusCode();
                 }
+                Logger.LogInformation($"Found {name}.{version} in nuget.org URI: {packageContentsUri}");
                 return true;
             }
             catch (HttpRequestException e) when (e.Message.Contains("404 (Not Found)"))
             {
-                Logger.LogInformation($"Unable to find {name}.{version} in nuget.org.");
+                Logger.LogInformation($"Unable to find {name}.{version} in nuget.org URI: {packageContentsUri}");
                 return false;
             }
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/FeedConstants.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/FeedConstants.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.DarcLib.Helpers
         public static readonly string AzureStorageProxyFeedPattern =
             @"https://([a-z-]+).azurewebsites.net/container/([^/]+)/sig/\w+/se/([0-9]{4}-[0-9]{2}-[0-9]{2})/" + MaestroManagedFeedNamePattern + "/index.json";
 
-        public static readonly string NuGetOrgRegistrationBaseUrl = "https://api.nuget.org/v3/registration3-gz-semver2";
+        public static readonly string NuGetOrgPackageBaseUrl = "https://api.nuget.org/v3-flatcontainer/";
         public static readonly string NuGetOrgLocation = "https://api.nuget.org/v3/index.json";
     }
 }


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/5823

We previously missed cleaning up ~15k package versions since February as the registration URL we were previously using got replaced. I was under a misunderstanding that all nuget v3 registrations would use the same URI. This should ensure the cleaner looks up the right spot going forward.

Also adds additional logging so it's easier to find the last time we found a package in Nuget.org, as I had to poke in the DB to find out when this stopped working.
