### PR TITLE
Maestro Scenario Tests - RepoPolicy test bug fix

### DIFF
--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
@@ -49,12 +49,13 @@ namespace Maestro.ScenarioTests
             TestContext.WriteLine("Setting repository merge policy to all checks successful");
             await SetRepositoryPolicies(repoUrl, branchName, new string[] { "--all-checks-passed", "--ignore-checks", "A,B" });
             string allChecksPolicies = await GetRepositoryPolicies(repoUrl, branchName);
+            string actualPolicy = TestHelpers.ParseOutSpecificRepoPolicy(allChecksPolicies, repoUrl +  $" @ {branchName}");
             string expectedAllChecksPolicies = $"{repoUrl} @ {branchName}\r\n- Merge Policies:\r\n  AllChecksSuccessful\r\n    ignoreChecks = \r\n" +
                 "                   [\r\n" +
                 "                     \"A\",\r\n" +
                 "                     \"B\"\r\n" +
                 "                   ]\r\n";
-            StringAssert.AreEqualIgnoringCase(expectedAllChecksPolicies, allChecksPolicies, "Repository policy is incorrect for all checks successful case");
+            StringAssert.AreEqualIgnoringCase(expectedAllChecksPolicies, actualPolicy, "Repository policy is incorrect for all checks successful case");
         }
     }
 }

--- a/src/Maestro/tests/Maestro.ScenarioTests/TestHelpers.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/TestHelpers.cs
@@ -152,6 +152,14 @@ namespace Maestro.ScenarioTests
 
             return output.ToString();
         }
+
+        public static string ParseOutSpecificRepoPolicy(string allReturnedPolicies, string repoUrlAndBranch)
+        {
+            int startingIndex = allReturnedPolicies.IndexOf(repoUrlAndBranch);
+            string removeEarlierPolicies = allReturnedPolicies.Substring(startingIndex);
+            string[] removeLaterPolicies = removeEarlierPolicies.Split(']');
+            return removeLaterPolicies[0] + ']';
+        }
     }
 
     public class MaestroTestException : Exception

--- a/src/Maestro/tests/Maestro.ScenarioTests/TestHelpersTest.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/TestHelpersTest.cs
@@ -27,5 +27,118 @@ namespace Maestro.ScenarioTests
 
             Assert.AreEqual("darc.exe \"-p\" \"***\" \"add-channel\" \"--github-pat\" \"***\" \"--name\" \"what-a-channel\"", formatted);
         }
+
+        [Test]
+        public void ParseOutSpecificRepoPolicy_ExactMatch()
+        {
+            string exactMatchPolicy =
+                @"https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_DESKTOP-8VPP7ON
+                    -Merge Policies:
+                    AllChecksSuccessful
+                      ignoreChecks =
+          
+                                     [
+                                       ""A"",
+                                       ""B""
+                                     ]";
+
+            string parsedPolicy = TestHelpers.ParseOutSpecificRepoPolicy(exactMatchPolicy,
+               "https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_DESKTOP-8VPP7ON");
+
+            string expectedPolicy =
+                $"RepoPoliciesTestBranch_DESKTOP-8VPP7ON\r\n- Merge Policies:\r\n  AllChecksSuccessful\r\n    ignoreChecks = \r\n" +
+                "                   [\r\n" +
+                "                     \"A\",\r\n" +
+                "                     \"B\"\r\n" +
+                "                   ]\r\n";
+
+            StringAssert.AreNotEqualIgnoringCase(expectedPolicy, parsedPolicy);
+        }
+
+        [Test]
+        public void ParseOutSpecificRepoPolicy_MultipleResults_Last()
+        {
+            string extraPolicies = @"https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch
+                - Merge Policies:[]
+            https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_2
+                -Merge Policies:
+                AllChecksSuccessful
+                  ignoreChecks =
+          
+                                 [
+                                   ""A"",
+                                   ""B""
+                                 ]";
+
+            string parsedPolicy = TestHelpers.ParseOutSpecificRepoPolicy(extraPolicies, 
+                "https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_2");
+
+            string expectedPolicy =
+                            $"RepoPoliciesTestBranch_2\r\n- Merge Policies:\r\n  AllChecksSuccessful\r\n    ignoreChecks = \r\n" +
+                "                   [\r\n" +
+                "                     \"A\",\r\n" +
+                "                     \"B\"\r\n" +
+                "                   ]\r\n";
+
+            StringAssert.AreNotEqualIgnoringCase(expectedPolicy, parsedPolicy);
+        }
+
+        [Test]
+        public void ParseOutSpecificRepoPolicy_MultipleResults_First()
+        {
+            string extraPolicies = @"https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch
+                - Merge Policies:[]
+            https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_2
+                -Merge Policies:
+                AllChecksSuccessful
+                  ignoreChecks =
+          
+                                 [
+                                   ""A"",
+                                   ""B""
+                                 ]";
+
+            string parsedPolicy = TestHelpers.ParseOutSpecificRepoPolicy(extraPolicies,
+                "https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch");
+
+            string expectedPolicy =
+                            $"RepoPoliciesTestBranch\r\n- Merge Policies:\r\n  AllChecksSuccessful\r\n    ignoreChecks = \r\n" +
+                "                   [\r\n" +
+                "                     \"A\",\r\n" +
+                "                     \"B\"\r\n" +
+                "                   ]\r\n";
+
+            StringAssert.AreNotEqualIgnoringCase(expectedPolicy, parsedPolicy);
+        }
+
+        [Test]
+        public void ParseOutSpecificRepoPolicy_MultipleResults_Middle()
+        {
+            string extraPolicies = @"https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch
+                - Merge Policies:[]
+            https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_2
+                - Merge Policies:[]
+            https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_3
+                -Merge Policies:
+                AllChecksSuccessful
+                  ignoreChecks =
+          
+                                 [
+                                   ""A"",
+                                   ""B""
+                                 ]";
+
+            string parsedPolicy = TestHelpers.ParseOutSpecificRepoPolicy(extraPolicies,
+                "https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_2");
+
+            string expectedPolicy =
+                            $"RepoPoliciesTestBranch_2\r\n- Merge Policies:\r\n  AllChecksSuccessful\r\n    ignoreChecks = \r\n" +
+                "                   [\r\n" +
+                "                     \"A\",\r\n" +
+                "                     \"B\"\r\n" +
+                "                   ]\r\n";
+
+            StringAssert.AreNotEqualIgnoringCase(expectedPolicy, parsedPolicy);
+        }
     }
 }

--- a/src/Maestro/tests/Maestro.ScenarioTests/TestHelpersTest.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/TestHelpersTest.cs
@@ -36,7 +36,6 @@ namespace Maestro.ScenarioTests
                     -Merge Policies:
                     AllChecksSuccessful
                       ignoreChecks =
-          
                                      [
                                        ""A"",
                                        ""B""
@@ -46,13 +45,16 @@ namespace Maestro.ScenarioTests
                "https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_DESKTOP-8VPP7ON");
 
             string expectedPolicy =
-                $"RepoPoliciesTestBranch_DESKTOP-8VPP7ON\r\n- Merge Policies:\r\n  AllChecksSuccessful\r\n    ignoreChecks = \r\n" +
-                "                   [\r\n" +
-                "                     \"A\",\r\n" +
-                "                     \"B\"\r\n" +
-                "                   ]\r\n";
+                @"https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_DESKTOP-8VPP7ON
+                    -Merge Policies:
+                    AllChecksSuccessful
+                      ignoreChecks =
+                                     [
+                                       ""A"",
+                                       ""B""
+                                     ]";
 
-            StringAssert.AreNotEqualIgnoringCase(expectedPolicy, parsedPolicy);
+            StringAssert.AreEqualIgnoringCase(expectedPolicy, parsedPolicy);
         }
 
         [Test]
@@ -64,7 +66,6 @@ namespace Maestro.ScenarioTests
                 -Merge Policies:
                 AllChecksSuccessful
                   ignoreChecks =
-          
                                  [
                                    ""A"",
                                    ""B""
@@ -74,13 +75,16 @@ namespace Maestro.ScenarioTests
                 "https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_2");
 
             string expectedPolicy =
-                            $"RepoPoliciesTestBranch_2\r\n- Merge Policies:\r\n  AllChecksSuccessful\r\n    ignoreChecks = \r\n" +
-                "                   [\r\n" +
-                "                     \"A\",\r\n" +
-                "                     \"B\"\r\n" +
-                "                   ]\r\n";
+                @"https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_2
+                -Merge Policies:
+                AllChecksSuccessful
+                  ignoreChecks =
+                                 [
+                                   ""A"",
+                                   ""B""
+                                 ]";
 
-            StringAssert.AreNotEqualIgnoringCase(expectedPolicy, parsedPolicy);
+            StringAssert.AreEqualIgnoringCase(expectedPolicy, parsedPolicy);
         }
 
         [Test]
@@ -92,7 +96,6 @@ namespace Maestro.ScenarioTests
                 -Merge Policies:
                 AllChecksSuccessful
                   ignoreChecks =
-          
                                  [
                                    ""A"",
                                    ""B""
@@ -101,14 +104,10 @@ namespace Maestro.ScenarioTests
             string parsedPolicy = TestHelpers.ParseOutSpecificRepoPolicy(extraPolicies,
                 "https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch");
 
-            string expectedPolicy =
-                            $"RepoPoliciesTestBranch\r\n- Merge Policies:\r\n  AllChecksSuccessful\r\n    ignoreChecks = \r\n" +
-                "                   [\r\n" +
-                "                     \"A\",\r\n" +
-                "                     \"B\"\r\n" +
-                "                   ]\r\n";
+            string expectedPolicy = @"https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch
+                - Merge Policies:[]";
 
-            StringAssert.AreNotEqualIgnoringCase(expectedPolicy, parsedPolicy);
+            StringAssert.AreEqualIgnoringCase(expectedPolicy, parsedPolicy);
         }
 
         [Test]
@@ -131,14 +130,10 @@ namespace Maestro.ScenarioTests
             string parsedPolicy = TestHelpers.ParseOutSpecificRepoPolicy(extraPolicies,
                 "https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_2");
 
-            string expectedPolicy =
-                            $"RepoPoliciesTestBranch_2\r\n- Merge Policies:\r\n  AllChecksSuccessful\r\n    ignoreChecks = \r\n" +
-                "                   [\r\n" +
-                "                     \"A\",\r\n" +
-                "                     \"B\"\r\n" +
-                "                   ]\r\n";
+            string expectedPolicy = @"https://github.com/maestro-auth-test/maestro-test1 @ RepoPoliciesTestBranch_2
+                - Merge Policies:[]";
 
-            StringAssert.AreNotEqualIgnoringCase(expectedPolicy, parsedPolicy);
+            StringAssert.AreEqualIgnoringCase(expectedPolicy, parsedPolicy);
         }
     }
 }


### PR DESCRIPTION
Add code to parse the repo policy response down to the specific branch that the test case is comparing.

Note: It contains a silly number of unit tests because if I run it to test the fix it'll break int builds again (and I don't have a way to run Maestro locally on my personal machine).