### PR TITLE
Update DevGuide - ngrok redirection

### DIFF
--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -24,8 +24,10 @@
     1. 
         - Repository: https://github.com/maestro-auth-test/maestro-test3
         - Installation Id: 289474
+1. Install ngrok from  https://ngrok.com/ or `choco install ngrok`
+1. (optional - when darc is used) Run `ngrok http 8080` and then use the reported ngrok url for the --bar-uri darc argument
 
-After successfully running `bootstrap.ps1` running the `MaestroApplication` project via F5 in VS (launch as elevated) will run the application on `http://localhost:8080`. However, for running some local debuginng using darc, such as scenario tests, darc http client library requires SSL (https) endpoint when calling it with Bearer token. One solution is to use ngrok for redirection. Install it from  https://ngrok.com/ or `choco install ngrok`, do ngrok http 8080 and then use the ngrok url for the --bar-uri.
+After successfully running `bootstrap.ps1` running the `MaestroApplication` project via F5 in VS (launch as elevated) will run the application on `http://localhost:8080`.
 
 ## Azure AppConfiguration
 

--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -25,7 +25,7 @@
         - Repository: https://github.com/maestro-auth-test/maestro-test3
         - Installation Id: 289474
 
-After successfully running `bootstrap.ps1` running the `MaestroApplication` project via F5 in VS (launch as elevated) will run the application on `http://localhost:8080`
+After successfully running `bootstrap.ps1` running the `MaestroApplication` project via F5 in VS (launch as elevated) will run the application on `http://localhost:8080`. However, for running some local debuginng using darc, such as scenario tests, darc http client library requires SSL (https) endpoint when calling it with Bearer token. One solution is to use ngrok for redirection. Install it from  https://ngrok.com/ or `choco install ngrok`, do ngrok http 8080 and then use the ngrok url for the --bar-uri.
 
 ## Azure AppConfiguration
 


### PR DESCRIPTION
We use ngrok to satisfy azure.core requirement SSL when Bearer token is used.