### PR TITLE
Add regex support for default channel 'branch' values

### DIFF
--- a/src/Maestro/Maestro.Web.Tests/DefaultChannelsController20200220Tests.cs
+++ b/src/Maestro/Maestro.Web.Tests/DefaultChannelsController20200220Tests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,9 +41,9 @@ namespace Maestro.Web.Tests
             Channel channel1, channel2;
             {
                 var result = await data.ChannelsController.CreateChannel($"{channelName}-1", classification);
-                channel1 = (Channel)((ObjectResult)result).Value;
+                channel1 = (Channel) ((ObjectResult) result).Value;
                 result = await data.ChannelsController.CreateChannel($"{channelName}-2", classification);
-                channel2 = (Channel)((ObjectResult)result).Value;
+                channel2 = (Channel) ((ObjectResult) result).Value;
             }
 
             DefaultChannel defaultChannel;
@@ -52,17 +56,17 @@ namespace Maestro.Web.Tests
                     Repository = repository
                 };
                 var result = await data.DefaultChannelsController.Create(testDefaultChannelData);
-                defaultChannel = (DefaultChannel)((ObjectResult)result).Value;
+                defaultChannel = (DefaultChannel) ((ObjectResult) result).Value;
             }
 
             DefaultChannel singleChannelGetDefaultChannel;
             {
                 IActionResult result = await data.DefaultChannelsController.Get(defaultChannel.Id);
                 result.Should().BeAssignableTo<ObjectResult>();
-                var objResult = (ObjectResult)result;
-                objResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+                var objResult = (ObjectResult) result;
+                objResult.StatusCode.Should().Be((int) HttpStatusCode.OK);
                 objResult.Value.Should().BeAssignableTo<DefaultChannel>();
-                singleChannelGetDefaultChannel = ((DefaultChannel)objResult.Value);
+                singleChannelGetDefaultChannel = ((DefaultChannel) objResult.Value);
             }
             singleChannelGetDefaultChannel.Id.Should().Be(defaultChannel.Id);
 
@@ -70,10 +74,10 @@ namespace Maestro.Web.Tests
             {
                 IActionResult result = data.DefaultChannelsController.List(repository, branch, channel2.Id);
                 result.Should().BeAssignableTo<ObjectResult>();
-                var objResult = (ObjectResult)result;
-                objResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+                var objResult = (ObjectResult) result;
+                objResult.StatusCode.Should().Be((int) HttpStatusCode.OK);
                 objResult.Value.Should().BeAssignableTo<IEnumerable<DefaultChannel>>();
-                listOfInsertedDefaultChannels = ((IEnumerable<DefaultChannel>)objResult.Value).ToList();
+                listOfInsertedDefaultChannels = ((IEnumerable<DefaultChannel>) objResult.Value).ToList();
             }
 
             listOfInsertedDefaultChannels.Should().ContainSingle();
@@ -92,9 +96,9 @@ namespace Maestro.Web.Tests
             Channel channel1, channel2;
             {
                 var result = await data.ChannelsController.CreateChannel($"{channelName}-1", classification);
-                channel1 = (Channel)((ObjectResult)result).Value;
+                channel1 = (Channel) ((ObjectResult) result).Value;
                 result = await data.ChannelsController.CreateChannel($"{channelName}-2", classification);
-                channel2 = (Channel)((ObjectResult)result).Value;
+                channel2 = (Channel) ((ObjectResult) result).Value;
             }
 
             DefaultChannel defaultChannel;
@@ -107,7 +111,7 @@ namespace Maestro.Web.Tests
                     Repository = repository
                 };
                 var result = await data.DefaultChannelsController.Create(testDefaultChannelData);
-                defaultChannel = (DefaultChannel)((ObjectResult)result).Value;
+                defaultChannel = (DefaultChannel) ((ObjectResult) result).Value;
             }
 
             DefaultChannel updatedDefaultChannel;
@@ -120,17 +124,17 @@ namespace Maestro.Web.Tests
                     Repository = $"NEW-{repository}"
                 };
                 var result = await data.DefaultChannelsController.Update(defaultChannel.Id, defaultChannelUpdateData);
-                updatedDefaultChannel = (DefaultChannel)((ObjectResult)result).Value;
+                updatedDefaultChannel = (DefaultChannel) ((ObjectResult) result).Value;
             }
 
             List<DefaultChannel> defaultChannels;
             {
                 IActionResult result = data.DefaultChannelsController.List($"NEW-{repository}", $"{branch}-UPDATED", channel2.Id, false);
                 result.Should().BeAssignableTo<ObjectResult>();
-                var objResult = (ObjectResult)result;
-                objResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+                var objResult = (ObjectResult) result;
+                objResult.StatusCode.Should().Be((int) HttpStatusCode.OK);
                 objResult.Value.Should().BeAssignableTo<IEnumerable<DefaultChannel>>();
-                defaultChannels = ((IEnumerable<DefaultChannel>)objResult.Value).ToList();
+                defaultChannels = ((IEnumerable<DefaultChannel>) objResult.Value).ToList();
             }
 
             defaultChannels.Should().ContainSingle();
@@ -149,7 +153,7 @@ namespace Maestro.Web.Tests
             Channel channel;
             {
                 var result = await data.ChannelsController.CreateChannel($"{channelName}", classification);
-                channel = (Channel)((ObjectResult)result).Value;
+                channel = (Channel) ((ObjectResult) result).Value;
             }
 
             DefaultChannel defaultChannel;
@@ -162,7 +166,7 @@ namespace Maestro.Web.Tests
                     Repository = repository
                 };
                 var result = await data.DefaultChannelsController.Create(testDefaultChannelData);
-                defaultChannel = (DefaultChannel)((ObjectResult)result).Value;
+                defaultChannel = (DefaultChannel) ((ObjectResult) result).Value;
             }
 
             string[] branchesThatMatch = new string[] { "FAKE-BRANCH-REGEX-", "FAKE-BRANCH-REGEX-RELEASE-BRANCH-1", "FAKE-BRANCH-REGEX-RELEASE-BRANCH-2" };
@@ -174,10 +178,10 @@ namespace Maestro.Web.Tests
                 {
                     IActionResult result = data.DefaultChannelsController.List(repository, branchName, channel.Id);
                     result.Should().BeAssignableTo<ObjectResult>();
-                    var objResult = (ObjectResult)result;
-                    objResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+                    var objResult = (ObjectResult) result;
+                    objResult.StatusCode.Should().Be((int) HttpStatusCode.OK);
                     objResult.Value.Should().BeAssignableTo<IEnumerable<DefaultChannel>>();
-                    defaultChannels = ((IEnumerable<DefaultChannel>)objResult.Value).ToList();
+                    defaultChannels = ((IEnumerable<DefaultChannel>) objResult.Value).ToList();
                 }
                 defaultChannels.Should().ContainSingle();
                 defaultChannels.Single().Channel.Id.Should().Be(channel.Id);
@@ -189,10 +193,10 @@ namespace Maestro.Web.Tests
                 {
                     IActionResult result = data.DefaultChannelsController.List(repository, branchName, channel.Id);
                     result.Should().BeAssignableTo<ObjectResult>();
-                    var objResult = (ObjectResult)result;
-                    objResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+                    var objResult = (ObjectResult) result;
+                    objResult.StatusCode.Should().Be((int) HttpStatusCode.OK);
                     objResult.Value.Should().BeAssignableTo<IEnumerable<DefaultChannel>>();
-                    defaultChannels = ((IEnumerable<DefaultChannel>)objResult.Value).ToList();
+                    defaultChannels = ((IEnumerable<DefaultChannel>) objResult.Value).ToList();
                 }
                 defaultChannels.Should().BeEmpty();
             }
@@ -240,7 +244,7 @@ namespace Maestro.Web.Tests
             Channel channel;
             {
                 var result = await data.ChannelsController.CreateChannel(channelName, classification);
-                channel = (Channel)((ObjectResult)result).Value;
+                channel = (Channel) ((ObjectResult) result).Value;
             }
 
             DefaultChannel defaultChannel;
@@ -253,7 +257,7 @@ namespace Maestro.Web.Tests
                     Repository = repository
                 };
                 var result = await data.DefaultChannelsController.Create(testDefaultChannelData);
-                defaultChannel = (DefaultChannel)((ObjectResult)result).Value;
+                defaultChannel = (DefaultChannel) ((ObjectResult) result).Value;
             }
 
             DefaultChannelUpdateData defaultChannelUpdateData = new DefaultChannelUpdateData()
@@ -308,7 +312,7 @@ namespace Maestro.Web.Tests
                 collection.AddSingleton(typeof(IBackgroundQueue), _backgroundQueueType);
                 ServiceProvider provider = collection.BuildServiceProvider();
 
-                var clock = (TestClock)provider.GetRequiredService<ISystemClock>();
+                var clock = (TestClock) provider.GetRequiredService<ISystemClock>();
 
                 return new TestData(provider, clock);
             }

--- a/src/Maestro/Maestro.Web.Tests/DefaultChannelsController20200220Tests.cs
+++ b/src/Maestro/Maestro.Web.Tests/DefaultChannelsController20200220Tests.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Maestro.Data;
+using Maestro.Web.Api.v2020_02_20.Controllers;
+using Maestro.Web.Api.v2020_02_20.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Internal.Testing.Utility;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using static Maestro.Web.Api.v2020_02_20.Models.DefaultChannel;
+
+namespace Maestro.Web.Tests
+{
+    [TestFixture]
+    public class DefaultChannelsController20200220Tests
+    {
+        [Test]
+        public async Task CreateAndGetDefaultChannel()
+        {
+            using TestData data = await BuildDefaultAsync();
+            string channelName = "TEST-CHANNEL-LIST-REPOSITORIES";
+            string classification = "TEST-CLASSIFICATION";
+            string repository = "FAKE-REPOSITORY";
+            string branch = "FAKE-BRANCH";
+
+            Channel channel1, channel2;
+            {
+                var result = await data.ChannelsController.CreateChannel($"{channelName}-1", classification);
+                channel1 = (Channel)((ObjectResult)result).Value;
+                result = await data.ChannelsController.CreateChannel($"{channelName}-2", classification);
+                channel2 = (Channel)((ObjectResult)result).Value;
+            }
+
+            DefaultChannel defaultChannel;
+            {
+                DefaultChannelCreateData testDefaultChannelData = new DefaultChannelCreateData()
+                {
+                    Branch = branch,
+                    ChannelId = channel2.Id,
+                    Enabled = true,
+                    Repository = repository
+                };
+                var result = await data.DefaultChannelsController.Create(testDefaultChannelData);
+                defaultChannel = (DefaultChannel)((ObjectResult)result).Value;
+            }
+
+            DefaultChannel singleChannelGetDefaultChannel;
+            {
+                IActionResult result = await data.DefaultChannelsController.Get(defaultChannel.Id);
+                result.Should().BeAssignableTo<ObjectResult>();
+                var objResult = (ObjectResult)result;
+                objResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+                objResult.Value.Should().BeAssignableTo<DefaultChannel>();
+                singleChannelGetDefaultChannel = ((DefaultChannel)objResult.Value);
+            }
+            singleChannelGetDefaultChannel.Id.Should().Be(defaultChannel.Id);
+
+            List<DefaultChannel> listOfInsertedDefaultChannels;
+            {
+                IActionResult result = data.DefaultChannelsController.List(repository, branch, channel2.Id);
+                result.Should().BeAssignableTo<ObjectResult>();
+                var objResult = (ObjectResult)result;
+                objResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+                objResult.Value.Should().BeAssignableTo<IEnumerable<DefaultChannel>>();
+                listOfInsertedDefaultChannels = ((IEnumerable<DefaultChannel>)objResult.Value).ToList();
+            }
+
+            listOfInsertedDefaultChannels.Should().ContainSingle();
+            listOfInsertedDefaultChannels.Single().Channel.Id.Should().Be(channel2.Id, "Only fake channel #2's id should show up as a default channel");
+        }
+
+        [Test]
+        public async Task UpdateDefaultChannel()
+        {
+            using TestData data = await BuildDefaultAsync();
+            string channelName = "TEST-CHANNEL-TO-UPDATE";
+            string classification = "TEST-CLASSIFICATION";
+            string repository = "FAKE-REPOSITORY";
+            string branch = "FAKE-BRANCH";
+
+            Channel channel1, channel2;
+            {
+                var result = await data.ChannelsController.CreateChannel($"{channelName}-1", classification);
+                channel1 = (Channel)((ObjectResult)result).Value;
+                result = await data.ChannelsController.CreateChannel($"{channelName}-2", classification);
+                channel2 = (Channel)((ObjectResult)result).Value;
+            }
+
+            DefaultChannel defaultChannel;
+            {
+                DefaultChannelCreateData testDefaultChannelData = new DefaultChannelCreateData()
+                {
+                    Branch = branch,
+                    ChannelId = channel1.Id,
+                    Enabled = true,
+                    Repository = repository
+                };
+                var result = await data.DefaultChannelsController.Create(testDefaultChannelData);
+                defaultChannel = (DefaultChannel)((ObjectResult)result).Value;
+            }
+
+            DefaultChannel updatedDefaultChannel;
+            {
+                DefaultChannelUpdateData defaultChannelUpdateData = new DefaultChannelUpdateData()
+                {
+                    Branch = $"{branch}-UPDATED",
+                    ChannelId = channel2.Id,
+                    Enabled = false,
+                    Repository = $"NEW-{repository}"
+                };
+                var result = await data.DefaultChannelsController.Update(defaultChannel.Id, defaultChannelUpdateData);
+                updatedDefaultChannel = (DefaultChannel)((ObjectResult)result).Value;
+            }
+
+            List<DefaultChannel> defaultChannels;
+            {
+                IActionResult result = data.DefaultChannelsController.List($"NEW-{repository}", $"{branch}-UPDATED", channel2.Id, false);
+                result.Should().BeAssignableTo<ObjectResult>();
+                var objResult = (ObjectResult)result;
+                objResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+                objResult.Value.Should().BeAssignableTo<IEnumerable<DefaultChannel>>();
+                defaultChannels = ((IEnumerable<DefaultChannel>)objResult.Value).ToList();
+            }
+
+            defaultChannels.Should().ContainSingle();
+            defaultChannels.Single().Channel.Id.Should().Be(channel2.Id, "Only fake channel #2's id should show up as a default channel");
+        }
+
+        [Test]
+        public async Task DefaultChannelRegularExpressionMatching()
+        {
+            using TestData data = await BuildDefaultAsync();
+            string channelName = "TEST-CHANNEL-REGEX-FOR-DEFAULT";
+            string classification = "TEST-CLASSIFICATION";
+            string repository = "FAKE-REPOSITORY";
+            string branch = "-regex:FAKE-BRANCH-REGEX-.*";
+
+            Channel channel;
+            {
+                var result = await data.ChannelsController.CreateChannel($"{channelName}", classification);
+                channel = (Channel)((ObjectResult)result).Value;
+            }
+
+            DefaultChannel defaultChannel;
+            {
+                DefaultChannelCreateData testDefaultChannelData = new DefaultChannelCreateData()
+                {
+                    Branch = branch,
+                    ChannelId = channel.Id,
+                    Enabled = true,
+                    Repository = repository
+                };
+                var result = await data.DefaultChannelsController.Create(testDefaultChannelData);
+                defaultChannel = (DefaultChannel)((ObjectResult)result).Value;
+            }
+
+            string[] branchesThatMatch = new string[] { "FAKE-BRANCH-REGEX-", "FAKE-BRANCH-REGEX-RELEASE-BRANCH-1", "FAKE-BRANCH-REGEX-RELEASE-BRANCH-2" };
+            string[] branchesThatDontMatch = new string[] { "I-DONT-MATCH", "REAL-BRANCH-REGEX" };
+
+            foreach (string branchName in branchesThatMatch)
+            {
+                List<DefaultChannel> defaultChannels;
+                {
+                    IActionResult result = data.DefaultChannelsController.List(repository, branchName, channel.Id);
+                    result.Should().BeAssignableTo<ObjectResult>();
+                    var objResult = (ObjectResult)result;
+                    objResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+                    objResult.Value.Should().BeAssignableTo<IEnumerable<DefaultChannel>>();
+                    defaultChannels = ((IEnumerable<DefaultChannel>)objResult.Value).ToList();
+                }
+                defaultChannels.Should().ContainSingle();
+                defaultChannels.Single().Channel.Id.Should().Be(channel.Id);
+            }
+
+            foreach (string branchName in branchesThatDontMatch)
+            {
+                List<DefaultChannel> defaultChannels;
+                {
+                    IActionResult result = data.DefaultChannelsController.List(repository, branchName, channel.Id);
+                    result.Should().BeAssignableTo<ObjectResult>();
+                    var objResult = (ObjectResult)result;
+                    objResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+                    objResult.Value.Should().BeAssignableTo<IEnumerable<DefaultChannel>>();
+                    defaultChannels = ((IEnumerable<DefaultChannel>)objResult.Value).ToList();
+                }
+                defaultChannels.Should().BeEmpty();
+            }
+        }
+
+        [Test]
+        public async Task TryToAddNonExistentChannel()
+        {
+            using TestData data = await BuildDefaultAsync();
+            string repository = "FAKE-REPOSITORY";
+            string branch = "FAKE-BRANCH";
+
+            DefaultChannelCreateData testDefaultChannelData = new DefaultChannelCreateData()
+            {
+                Branch = branch,
+                ChannelId = 404,
+                Enabled = true,
+                Repository = repository
+            };
+            var result = await data.DefaultChannelsController.Create(testDefaultChannelData);
+            result.Should().BeOfType<NotFoundObjectResult>("Asking for a non-existent channel should give a not-found-object type result");
+        }
+
+        [Test]
+        public async Task TryToGetOrUpdateNonExistentChannel()
+        {
+            string channelName = "TEST-CHANNEL-TO-UPDATE";
+            string classification = "TEST-CLASSIFICATION";
+            string repository = "FAKE-NON-EXISTENT-REPOSITORY-MISSING-CHANNEL-UPDATE";
+            string branch = "FAKE-BRANCH-MISSING-CHANNEL-UPDATE";
+
+            using TestData data = await BuildDefaultAsync();
+            DefaultChannelUpdateData defaultChannelThatDoesntExistUpdateData = new DefaultChannelUpdateData()
+            {
+                Branch = branch,
+                ChannelId = 404,
+                Enabled = false,
+                Repository = repository
+            };
+            // First: non-existent default channel
+            var expectedFailResult = await data.DefaultChannelsController.Update(404, defaultChannelThatDoesntExistUpdateData);
+            expectedFailResult.Should().BeOfType<NotFoundResult>("Asking for a non-existent channel should give a not-found type result");
+
+            // Second: Extant default, non-existent channel.
+            Channel channel;
+            {
+                var result = await data.ChannelsController.CreateChannel(channelName, classification);
+                channel = (Channel)((ObjectResult)result).Value;
+            }
+
+            DefaultChannel defaultChannel;
+            {
+                DefaultChannelCreateData testDefaultChannelData = new DefaultChannelCreateData()
+                {
+                    Branch = branch,
+                    ChannelId = channel.Id,
+                    Enabled = true,
+                    Repository = repository
+                };
+                var result = await data.DefaultChannelsController.Create(testDefaultChannelData);
+                defaultChannel = (DefaultChannel)((ObjectResult)result).Value;
+            }
+
+            DefaultChannelUpdateData defaultChannelUpdateData = new DefaultChannelUpdateData()
+            {
+                Branch = $"{branch}-UPDATED",
+                ChannelId = 404,
+                Enabled = false,
+                Repository = $"NEW-{repository}"
+            };
+            var secondExpectedFailResult = await data.DefaultChannelsController.Update(defaultChannel.Id, defaultChannelUpdateData);
+            secondExpectedFailResult.Should().BeOfType<NotFoundObjectResult>("Updating a default channel for a non-existent channel should give a not-found type result");
+            // Try to get a default channel that just doesn't exist at all.
+            var thirdExpectedFailResult = await data.DefaultChannelsController.Get(404);
+            thirdExpectedFailResult.Should().BeOfType<NotFoundResult>("Getting a default channel for a non-existent default channel should give a not-found type result");
+        }
+
+        private Task<TestData> BuildDefaultAsync()
+        {
+            return new TestDataBuilder().BuildAsync();
+        }
+
+        private sealed class TestDataBuilder
+        {
+            private Type _backgroundQueueType = typeof(NeverBackgroundQueue);
+
+            public TestDataBuilder WithImmediateBackgroundQueue()
+            {
+                _backgroundQueueType = typeof(ImmediateBackgroundQueue);
+                return this;
+            }
+
+            public async Task<TestData> BuildAsync()
+            {
+                string connectionString = await SharedData.Database.GetConnectionString();
+
+                var collection = new ServiceCollection();
+                collection.AddLogging(l => l.AddProvider(new NUnitLogger()));
+                collection.AddSingleton<IHostEnvironment>(new HostingEnvironment
+                {
+                    EnvironmentName = Environments.Development
+                });
+                collection.AddBuildAssetRegistry(options =>
+                {
+                    options.UseSqlServer(connectionString);
+                    options.EnableServiceProviderCaching(false);
+                });
+                collection.AddSingleton<DefaultChannelsController>();
+                collection.AddSingleton<ChannelsController>();
+                collection.AddSingleton<BuildsController>();
+                collection.AddSingleton<ISystemClock, TestClock>();
+                collection.AddSingleton(Mock.Of<IRemoteFactory>());
+                collection.AddSingleton(typeof(IBackgroundQueue), _backgroundQueueType);
+                ServiceProvider provider = collection.BuildServiceProvider();
+
+                var clock = (TestClock)provider.GetRequiredService<ISystemClock>();
+
+                return new TestData(provider, clock);
+            }
+        }
+
+        private sealed class TestData : IDisposable
+        {
+            private readonly ServiceProvider _provider;
+            public TestClock Clock { get; }
+
+            public TestData(ServiceProvider provider, TestClock clock)
+            {
+                _provider = provider;
+                Clock = clock;
+            }
+
+            public DefaultChannelsController DefaultChannelsController => _provider.GetRequiredService<DefaultChannelsController>();
+            public ChannelsController ChannelsController => _provider.GetRequiredService<ChannelsController>();
+            public BuildsController BuildsController => _provider.GetRequiredService<BuildsController>();
+
+            public void Dispose()
+            {
+                _provider.Dispose();
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
@@ -338,6 +338,16 @@ namespace Microsoft.DotNet.Darc
         /// <returns>True if the branch exists, prompting is not desired, or if the user confirms that they want to continue. False otherwise.</returns>
         public static async Task<bool> VerifyAndConfirmBranchExistsAsync(IRemote remote, string repo, string branch, bool prompt)
         {
+            const string regexPrefix = "-regex:";
+            // IRemote doesn't currently provide a way for enumerating all branches in a repo, and the purpose of supporting regex is to allow new ones to match
+            // So in this case we'll just prompt 
+            if (branch.StartsWith(regexPrefix, StringComparison.InvariantCultureIgnoreCase))
+            {
+                Console.WriteLine($"Warning: Regular expression '{branch.Substring(regexPrefix.Length)}' will be used to match on branches in '{repo}'.");
+                Console.WriteLine("To ensure dependency updates (where desired), please verify all branches matching this pattern contain an eng/Version.Details.xml file.");
+                return !prompt || PromptForYesNo("Continue?");
+            }
+
             try
             {
                 branch = GitHelpers.NormalizeBranchName(branch);

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddDefaultChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddDefaultChannelOperation.cs
@@ -28,7 +28,8 @@ namespace Microsoft.DotNet.Darc.Operations
             {
                 IRemote remote = RemoteFactory.GetRemote(_options, _options.Repository, Logger);
 
-                _options.Branch = GitHelpers.NormalizeBranchName(_options.Branch);
+                // Users can ignore the flag and pass in -regex: but to prevent typos we'll avoid that.
+                _options.Branch = _options.UseBranchAsRegex ? $"-regex:{_options.Branch}" : GitHelpers.NormalizeBranchName(_options.Branch);
 
                 if (!(await UxHelpers.VerifyAndConfirmBranchExistsAsync(remote, _options.Repository, _options.Branch, !_options.NoConfirmation)))
                 {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddDefaultChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddDefaultChannelCommandLineOptions.cs
@@ -13,11 +13,14 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("channel", Required = true, HelpText = "Name of channel that a build of 'branch' and 'repo' should be applied to.")]
         public string Channel { get; set; }
 
-        [Option("branch", Required = true, HelpText = "Build of 'repo' on this branch will be automatically applied to 'channel'")]
+        [Option("branch", Required = true, HelpText = "Builds of 'repo' on this branch will be automatically applied to 'channel'.  Use with '--regex' to match on multiple branch names")]
         public string Branch { get; set; }
 
-        [Option("repo", Required = true, HelpText = "Build of this repo repo on 'branch' will be automatically applied to 'channel'")]
+        [Option("repo", Required = true, HelpText = "Builds of this repo on 'branch' will be automatically applied to 'channel'")]
         public string Repository { get; set; }
+
+        [Option("regex", Required = false, HelpText = "If specified, the value of the 'branch' option will be treated as a regular expression for matching branch names.", Default = false)]
+        public bool UseBranchAsRegex { get; set; }
 
         [Option('q', "quiet", HelpText = "Do not prompt if the target repository/branch does not exist.")]
         public bool NoConfirmation { get; set; }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -312,7 +312,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <summary>
         ///     Create a new branch in the specified repository.
         /// </summary>
-        /// <param name="repoUri">Repository to create a brahc in</param>
+        /// <param name="repoUri">Repository to create a branch in</param>
         /// <param name="baseBranch">Branch to create <paramref name="newBranch"/> off of</param>
         /// <param name="newBranch">New branch name.</param>
         /// <returns>Async task</returns>


### PR DESCRIPTION
With this change, default channel entries can include the prefix '-regex:', which when encountered (real branch names can never start with '-') is used to match on branch names.

Add some DefaultChannelsController tests.  See https://github.com/dotnet/arcade/issues/5131 for context