### PR TITLE
Offer a lighter weight LogginScope

### DIFF
--- a/src/Maestro/Maestro.Web.Tests/LoggingConfigurationTests.cs
+++ b/src/Maestro/Maestro.Web.Tests/LoggingConfigurationTests.cs
@@ -114,7 +114,7 @@ namespace Maestro.Web.Tests
         [Test]
         public void LoggingScopeDoesNotDisposeScopedDependencies()
         {
-            TestData data = Setup();
+            using TestData data = Setup();
             TrackedDisposable toDispose;
             using (var op = data.OperationManager.BeginLoggingScope("TEST-SCOPE:{TEST_KEY}", "TEST_VALUE"))
             {

--- a/src/Maestro/Maestro.Web.Tests/LoggingConfigurationTests.cs
+++ b/src/Maestro/Maestro.Web.Tests/LoggingConfigurationTests.cs
@@ -174,7 +174,7 @@ namespace Maestro.Web.Tests
         [Test]
         public void LoggingWithFullScopes()
         {
-            TestData data = Setup();
+            using TestData data = Setup();
             using (data.TelemetryClient.StartOperation<RequestTelemetry>("Fake operation"))
             {
                 data.Logger.LogError("Outside");

--- a/src/Maestro/Maestro.Web.Tests/LoggingConfigurationTests.cs
+++ b/src/Maestro/Maestro.Web.Tests/LoggingConfigurationTests.cs
@@ -18,52 +18,177 @@ using NUnit.Framework;
 
 namespace Maestro.Web.Tests
 {
-    [TestFixture]
+    [TestFixture, NonParallelizable]
     public class LoggingConfigurationTests
     {
-        [Test]
-        public void LoggingWithScopes()
+        private class TestData
+            : IDisposable
+        {
+            private readonly ServiceProvider _outerProvider;
+            public ILogger Logger { get; }
+            public OperationManager OperationManager { get; }
+            public TelemetryClient TelemetryClient { get; }
+            public List<ITelemetry> TelemetryLogged { get; }
+            public ServiceProvider Provider { get; }
+
+            public TestData(
+                ILogger logger,
+                OperationManager operationManager,
+                TelemetryClient telemetryClient,
+                List<ITelemetry> telemetryLogged,
+                ServiceProvider provider,
+                ServiceProvider outerProvider)
+            {
+                _outerProvider = outerProvider;
+                Logger = logger;
+                OperationManager = operationManager;
+                TelemetryClient = telemetryClient;
+                TelemetryLogged = telemetryLogged;
+                Provider = provider;
+            }
+
+            public void Dispose()
+            {
+                Provider.Dispose();
+                _outerProvider.Dispose();
+            }
+        }
+
+        private sealed class TrackedDisposable : IDisposable
+        {
+            public bool Disposed { get; private set; }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+        }
+
+        private static TestData Setup()
         {
             Environment.SetEnvironmentVariable("ENVIRONMENT", Environments.Development);
-            Mock<ITelemetryChannel> channel = new Mock<ITelemetryChannel>();
-            List<ITelemetry> telemetry = new List<ITelemetry>();
+            var channel = new Mock<ITelemetryChannel>();
+            var telemetry = new List<ITelemetry>();
             channel.Setup(s => s.Send(Capture.In(telemetry)));
 
             var config = new ConfigurationBuilder();
             var collection = new ServiceCollection();
             collection.AddSingleton(channel.Object);
             collection.AddSingleton<OperationManager>();
+            collection.AddScoped<TrackedDisposable>();
             // The only scenario we are worried about is when running in the ServiceHost
             ServiceHost.ConfigureDefaultServices(collection);
 
             collection.AddSingleton<IConfiguration>(config.Build());
             collection.AddSingleton<Startup>();
-            using ServiceProvider outerProvider = collection.BuildServiceProvider();
+            ServiceProvider outerProvider = collection.BuildServiceProvider();
             var startup = outerProvider.GetRequiredService<Startup>();
             startup.ConfigureServices(collection);
 
-            using ServiceProvider innerProvider = collection.BuildServiceProvider();
+            ServiceProvider innerProvider = collection.BuildServiceProvider();
             var logger = innerProvider.GetRequiredService<ILogger<DependencyRegistrationTests>>();
             var operations = innerProvider.GetRequiredService<OperationManager>();
             var tc = innerProvider.GetRequiredService<TelemetryClient>();
+
             Activity.Current = null;
             // AppInsights behaves very oddly if the ActivityId is W3C
             // It's not ideal for a test to mess with static state, but we need to ensure this works correctly
             Activity.DefaultIdFormat = ActivityIdFormat.Hierarchical;
-            using (tc.StartOperation<RequestTelemetry>("Fake operation"))
-            {
-                logger.LogError("Outside");
-                using (operations.BeginOperation("TEST-SCOPE:{TEST_KEY}", "TEST_VALUE"))
-                {
-                    logger.LogError("Something: {TEST_SOMETHING_KEY}", "TEST_SOMETHING_VALUE");
-                    logger.LogError("Else");
-                }
 
-                logger.LogError("Outside again");
+            return new TestData(logger, operations, tc, telemetry, innerProvider, outerProvider);
+        }
+        
+        [Test]
+        public void FullScopeDisposesScopedDependencies()
+        {
+            using TestData data = Setup();
+            TrackedDisposable toDispose;
+            using (var op = data.OperationManager.BeginOperation("TEST-SCOPE:{TEST_KEY}", "TEST_VALUE"))
+            {
+                toDispose = op.ServiceProvider.GetRequiredService<TrackedDisposable>();
             }
 
-            innerProvider.GetRequiredService<TelemetryClient>().Flush();
-            List<TraceTelemetry> traces = telemetry.OfType<TraceTelemetry>().ToList();
+            toDispose.Disposed.Should().BeTrue();
+        }
+        
+        [Test]
+        public void LoggingScopeDoesNotDisposeScopedDependencies()
+        {
+            TestData data = Setup();
+            TrackedDisposable toDispose;
+            using (var op = data.OperationManager.BeginLoggingScope("TEST-SCOPE:{TEST_KEY}", "TEST_VALUE"))
+            {
+                toDispose = op.ServiceProvider.GetRequiredService<TrackedDisposable>();
+            }
+
+            toDispose.Disposed.Should().BeFalse();
+        }
+
+        [Test]
+        public void LoggingWithLoggingScopes()
+        {
+            TestData data = Setup();
+            using (data.TelemetryClient.StartOperation<RequestTelemetry>("Fake operation"))
+            {
+                data.Logger.LogError("Outside");
+                using (var op = data.OperationManager.BeginLoggingScope("TEST-SCOPE:{TEST_KEY}", "TEST_VALUE"))
+                {
+                    data.Logger.LogError("Something: {TEST_SOMETHING_KEY}", "TEST_SOMETHING_VALUE");
+                    data.Logger.LogError("Else");
+                }
+
+                data.Logger.LogError("Outside again");
+            }
+
+            data.TelemetryClient.Flush();
+            List<TraceTelemetry> traces = data.TelemetryLogged.OfType<TraceTelemetry>().ToList();
+            traces.Should().HaveCount(4);
+
+            {
+                // The operation id should stay constant, it's the root
+                string[] opIds = traces.Select(t => t.Context?.Operation?.Id).ToArray();
+                opIds[0].Should().NotBeNull();
+                opIds[1].Should().Be(opIds[0]);
+                opIds[2].Should().Be(opIds[1]);
+                opIds[3].Should().Be(opIds[2]);
+            }
+
+            {
+                // The parent ids should flow with the operation start/stop
+                var parentIds = traces.Select(t => t.Context?.Operation?.ParentId).ToArray();
+                parentIds[0].Should().NotBeNull();
+                parentIds[1].Should().NotBe(parentIds[0]);
+                parentIds[1].Should().StartWith(parentIds[0]);
+                parentIds[2].Should().Be(parentIds[1]);
+                parentIds[3].Should().NotBe(parentIds[2]);
+                parentIds[3].Should().Be(parentIds[0]);
+            }
+
+            // The things in the operation should flow the properties from the BeginOperation
+            traces[1].Properties.GetValueOrDefault("TEST_KEY").Should().Be("TEST_VALUE");
+
+            // The things outside the operation should not have those properties
+            traces[3].Properties.Should().NotContainKey("TEST_VALUE");
+        }
+
+        [Test]
+        public void LoggingWithFullScopes()
+        {
+            TestData data = Setup();
+            using (data.TelemetryClient.StartOperation<RequestTelemetry>("Fake operation"))
+            {
+                data.Logger.LogError("Outside");
+                using (var op = data.OperationManager.BeginOperation("TEST-SCOPE:{TEST_KEY}", "TEST_VALUE"))
+                {
+                    data.Logger.LogError("Something: {TEST_SOMETHING_KEY}", "TEST_SOMETHING_VALUE");
+                    data.Logger.LogError("Else");
+                }
+
+                data.Logger.LogError("Outside again");
+            }
+
+            data.TelemetryClient.Flush();
+            List<TraceTelemetry> traces = data.TelemetryLogged.OfType<TraceTelemetry>().ToList();
             traces.Should().HaveCount(4);
 
             {

--- a/src/Maestro/Maestro.Web.Tests/LoggingConfigurationTests.cs
+++ b/src/Maestro/Maestro.Web.Tests/LoggingConfigurationTests.cs
@@ -127,7 +127,7 @@ namespace Maestro.Web.Tests
         [Test]
         public void LoggingWithLoggingScopes()
         {
-            TestData data = Setup();
+            using TestData data = Setup();
             using (data.TelemetryClient.StartOperation<RequestTelemetry>("Fake operation"))
             {
                 data.Logger.LogError("Outside");

--- a/src/Shared/MIcrosoft.DotNet.Internal.Logging/OperationManager.cs
+++ b/src/Shared/MIcrosoft.DotNet.Internal.Logging/OperationManager.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Internal.Logging
         }
 
         /// <summary>
-        /// Bing an operation.  This will create a logging scope (including setting Activity.Id)
+        /// Begin an operation.  This will create a logging scope (including setting Activity.Id)
         /// as well as create a new scoped IServiceProvider (available on the return value <see cref="Operation.ServiceProvider"/>)
         /// </summary>
         /// <param name="name">Logging format string for scope. <example><code>Processing message {messageId}</code></example></param>

--- a/src/Shared/MIcrosoft.DotNet.Internal.Logging/OperationManager.cs
+++ b/src/Shared/MIcrosoft.DotNet.Internal.Logging/OperationManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -8,19 +9,29 @@ namespace Microsoft.DotNet.Internal.Logging
     public class OperationManager
     {
         private readonly IOptions<OperationManagerOptions> _options;
+        private readonly IServiceProvider _serviceProvider;
         private readonly IServiceScopeFactory _scope;
         private readonly ILogger<OperationManager> _logger;
 
         public OperationManager(
             IOptions<OperationManagerOptions> options,
+            IServiceProvider serviceProvider,
             IServiceScopeFactory scope,
             ILogger<OperationManager> logger = null)
         {
             _options = options;
+            _serviceProvider = serviceProvider;
             _scope = scope;
             _logger = logger;
         }
 
+        /// <summary>
+        /// Bing an operation.  This will create a logging scope (including setting Activity.Id)
+        /// as well as create a new scoped IServiceProvider (available on the return value <see cref="Operation.ServiceProvider"/>)
+        /// </summary>
+        /// <param name="name">Logging format string for scope. <example><code>Processing message {messageId}</code></example></param>
+        /// <param name="args">Optional parameters to format the logging message. <example>message.Id will set the {messageId} in the name example</example></param>
+        /// <returns>A new operation that exposes the <see cref="IServiceProvider"/>, and, when disposed, will end the operation and all resulting scopes</returns>
         public Operation BeginOperation(string name, params object[] args)
         {
             string formatted = FormattableStringFormatter.Format(name, args);
@@ -33,6 +44,30 @@ namespace Microsoft.DotNet.Internal.Logging
             }
 
             o.TrackDisposable(scope);
+
+            if (_options.Value.ShouldCreateLoggingScope && _logger != null)
+            {
+                o.TrackDisposable(_logger.BeginScope(name, args));
+            }
+
+            return o;
+        }
+        
+        /// <summary>
+        /// The same as <see cref="BeginOperation"/> except this does not create a new ServiceProvider scope.
+        /// In general, BeginOperation should be preferred, to ensure proper cleanup of scoped dependencies,
+        /// but for tight loops where performance is a concern, this is a lighter weight alternative.
+        /// </summary>
+        /// <seealso cref="BeginOperation"/>
+        public Operation BeginLoggingScope(string name, params object[] args)
+        {
+            string formatted = FormattableStringFormatter.Format(name, args);
+            var o = new Operation(_serviceProvider);
+            if (_options.Value.ShouldStartActivity)
+            {
+                var activity = new Activity(formatted);
+                o.TrackActivity(activity.Start());
+            }
 
             if (_options.Value.ShouldCreateLoggingScope && _logger != null)
             {


### PR DESCRIPTION
There are a few places that want all the logging goodness,
but can't afford to create and dispose entire ServiceProviders,
(like the Sql processor, which processes millions of messages).

So offer a new method that doesn't do the service scope stuff.