### PR TITLE
Move StartBuildAsync to use the new run pipeline API and fix darc-add-build-to-channel for v3 promotion

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -84,6 +84,12 @@ namespace Microsoft.DotNet.Darc.Operations
                     return Constants.ErrorCode;
                 }
 
+                if (_options.PublishingInfraVersion > 2 && _options.DoSDLValidation)
+                {
+                    Console.WriteLine($"Publishing version '{_options.PublishingInfraVersion}' does not support running SDL when adding a build to a channel");
+                    return Constants.ErrorCode;
+                }
+
                 List<Channel> targetChannels = new List<Channel>();
 
                 if (!string.IsNullOrEmpty(_options.Channel))
@@ -249,13 +255,17 @@ namespace Microsoft.DotNet.Darc.Operations
                 { "SigningValidationAdditionalParameters", _options.SigningValidationAdditionalParameters },
                 { "EnableNugetValidation", _options.DoNuGetValidation.ToString() },
                 { "EnableSourceLinkValidation", _options.DoSourcelinkValidation.ToString() },
-                { "EnableSDLValidation", _options.DoSDLValidation.ToString() },
-                { "SDLValidationCustomParams", _options.SDLValidationParams },
-                { "SDLValidationContinueOnError", _options.SDLValidationContinueOnError },
                 { "PublishInstallersAndChecksums", _options.PublishInstallersAndChecksums.ToString() },
                 { "SymbolPublishingAdditionalParameters", _options.SymbolPublishingAdditionalParameters },
                 { "ArtifactsPublishingAdditionalParameters", _options.ArtifactPublishingAdditionalParameters }
             };
+
+            if (_options.DoSDLValidation)
+            {
+                promotionPipelineVariables.Add("EnableSDLValidation", _options.DoSDLValidation.ToString());
+                promotionPipelineVariables.Add("SDLValidationCustomParams", _options.SDLValidationParams);
+                promotionPipelineVariables.Add("SDLValidationContinueOnError", _options.SDLValidationContinueOnError);
+            }
 
             int azdoBuildId = await azdoClient.StartNewBuildAsync(build.AzureDevOpsAccount,
                 promotionPipelineInformation.project,

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -267,6 +267,8 @@ namespace Microsoft.DotNet.Darc.Operations
                 promotionPipelineVariables.Add("SDLValidationContinueOnError", _options.SDLValidationContinueOnError);
             }
 
+            // Pass the same values to the variables and pipeline parameters so this works with the
+            // v2 and v3 versions of the promotion pipeline.
             int azdoBuildId = await azdoClient.StartNewBuildAsync(build.AzureDevOpsAccount,
                 promotionPipelineInformation.project,
                 promotionPipelineInformation.pipelineId,

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("validate-signing", HelpText = "Perform signing validation.")]
         public bool DoSigningValidation { get; set; }
 
-        [Option("signing-validation-parameters", HelpText = "Additional (MSBuild) properties to be passed to signing validation.")]
+        [Option("signing-validation-parameters", Default ="''", HelpText = "Additional (MSBuild) properties to be passed to signing validation.")]
         public string SigningValidationAdditionalParameters { get; set; }
 
         [Option("validate-nuget", HelpText = "Perform NuGet metadata validation.")]
@@ -45,17 +45,17 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("validate-SDL", HelpText = "Perform SDL validation.")]
         public bool DoSDLValidation { get; set; }
 
-        [Option("sdl-validation-parameters", HelpText = "Custom parameters for SDL validation.")]
+        [Option("sdl-validation-parameters", Default = "''", HelpText = "Custom parameters for SDL validation.")]
         public string SDLValidationParams { get; set; }
 
         [Option("sdl-validation-continue-on-error", HelpText = "Ignore SDL validation errors.")]
         public string SDLValidationContinueOnError { get; set; }
 
-        [Option("symbol-publishing-parameters", HelpText = "Additional (MSBuild) properties to be passed to symbol publishing")]
+        [Option("symbol-publishing-parameters", Default = "''", HelpText = "Additional (MSBuild) properties to be passed to symbol publishing")]
         [RedactFromLogging]
         public string SymbolPublishingAdditionalParameters { get; set; }
 
-        [Option("artifact-publishing-parameters", HelpText = "Additional (MSBuild) properties to be passed to asset publishing.")]
+        [Option("artifact-publishing-parameters", Default = "''", HelpText = "Additional (MSBuild) properties to be passed to asset publishing.")]
         [RedactFromLogging]
         public string ArtifactPublishingAdditionalParameters { get; set; }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/AzureDevOps/AzureDevOpsPipelineRunDefinition.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/AzureDevOps/AzureDevOpsPipelineRunDefinition.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.DarcLib.Models.AzureDevOps
+{
+    public class AzureDevOpsPipelineRunDefinition
+    {
+        public AzureDevOpsRunResourcesParameters Resources { get; set; }
+
+        public Dictionary<string, string> TemplateParameters { get; set; }
+
+        public Dictionary<string, AzureDevOpsVariable> Variables { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/AzureDevOps/AzureDevOpsRepositoryResourceParameter.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/AzureDevOps/AzureDevOpsRepositoryResourceParameter.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.DarcLib.Models.AzureDevOps
+{
+    public class AzureDevOpsRepositoryResourceParameter
+    {
+        public string RefName { get; set; }
+        public string Version { get; set; }
+
+        public AzureDevOpsRepositoryResourceParameter(string refName, string version)
+        {
+            RefName = refName;
+            Version = version;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/AzureDevOps/AzureDevOpsRunResourcesParameters.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/AzureDevOps/AzureDevOpsRunResourcesParameters.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.DarcLib.Models.AzureDevOps
+{
+    public class AzureDevOpsRunResourcesParameters
+    {
+        public Dictionary<string, AzureDevOpsRepositoryResourceParameter> Repositories { get; set; }
+
+        public AzureDevOpsRunResourcesParameters()
+        {
+            Repositories = new Dictionary<string, AzureDevOpsRepositoryResourceParameter>();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/AzureDevOps/AzureDevOpsVariable.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/AzureDevOps/AzureDevOpsVariable.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.DarcLib.Models.AzureDevOps
+{
+    public class AzureDevOpsVariable
+    {
+        public bool IsSecret { get; set; }
+        public string Value { get; set; }
+
+        public AzureDevOpsVariable(string value, bool isSecret = false)
+        {
+            Value = value;
+            IsSecret = isSecret;
+        }
+    }
+}


### PR DESCRIPTION
This lets us queue pipelines with both template parameters and variables.

Add-build-to-channel just passes the same values for both for backwards compatibility.

The new pipeline definition pending in https://github.com/dotnet/arcade/pull/5896 removes some SDL variables / parameters. I'm keeping them until we've decided what to do with those, as this change also keeps things working for older builds.

V2 publishing build promoted using these changes: https://dnceng.visualstudio.com/internal/_build/results?buildId=771120&view=results (published to general testing)

related to https://github.com/dotnet/arcade/issues/5942. 

~We will either need a follow-up here to not pass the SDL parameters to v3 publishing, or we'll need to adjust the yaml of the promotion pipeline itself to support SDL before we can use this completely for v3.~

I updated the PR, for now publishing v3 does not allow running SDL with add-build-to-channel