### PR TITLE
Remove auto fixture

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -4,8 +4,6 @@
     <DotNetAssemblyVersion>3.1.3</DotNetAssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Update="AutoFixture" Version="4.13.0" />
-    <PackageReference Update="AutoFixture.NUnit3" Version="4.13.0" />
     <PackageReference Update="Azure.Core" Version="1.0.2" /> 
     <PackageReference Update="Azure.Data.AppConfiguration" Version="1.0.0" />
     <PackageReference Update="Azure.Identity" Version="1.1.1" /> 

--- a/src/DotNet.Status.Web.Tests/DotNet.Status.Web.Tests.csproj
+++ b/src/DotNet.Status.Web.Tests/DotNet.Status.Web.Tests.csproj
@@ -23,8 +23,6 @@
     <EmbeddedResource Include="Files\triage-items-with-multi-builds.body.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AutoFixture" />
-    <PackageReference Include="AutoFixture.NUnit3" />
     <PackageReference Include="Moq" />
   </ItemGroup>
   <ItemGroup>

--- a/src/DotNet.Status.Web.Tests/Files/triage-items-with-diff-cat.expected.json
+++ b/src/DotNet.Status.Web.Tests/Files/triage-items-with-diff-cat.expected.json
@@ -3,18 +3,18 @@
     "BuildId": 666778,
     "RecordId": "6c5bbe10-d41c-5008-b9b3-09c7d6d8c0b3",
     "Index": 0,
-    "UpdatedCategory": "Pool provider",
+    "UpdatedCategory": "Pool provider"
   },
   {
     "BuildId": 674578,
     "RecordId": "4ec48297-f0d4-5d6c-7d7c-174fafbbae1c",
     "Index": 1,
-    "UpdatedCategory": "Test",
+    "UpdatedCategory": "Test"
   },
   {
     "BuildId": 688348,
     "RecordId": "3b5945b0-87a7-52cf-843a-406c21a8e27e",
     "Index": 2,
-    "UpdatedCategory": "Helix",
+    "UpdatedCategory": "Helix"
   }
 ]

--- a/src/DotNet.Status.Web.Tests/Files/triage-items-with-invalid.expected.json
+++ b/src/DotNet.Status.Web.Tests/Files/triage-items-with-invalid.expected.json
@@ -3,6 +3,6 @@
     "BuildId": 674578,
     "RecordId": "4ec48297-f0d4-5d6c-7d7c-174fafbbae1c",
     "Index": 1,
-    "UpdatedCategory": "Test",
+    "UpdatedCategory": "Test"
   }
 ]

--- a/src/DotNet.Status.Web.Tests/Files/triage-items-with-multi-builds.expected.json
+++ b/src/DotNet.Status.Web.Tests/Files/triage-items-with-multi-builds.expected.json
@@ -3,18 +3,18 @@
     "BuildId": 666778,
     "RecordId": "6c5bbe10-d41c-5008-b9b3-09c7d6d8c0b3",
     "Index": 0,
-    "UpdatedCategory": "Pool provider",
+    "UpdatedCategory": "Pool provider"
   },
   {
     "BuildId": 674578,
     "RecordId": "4ec48297-f0d4-5d6c-7d7c-174fafbbae1c",
     "Index": 0,
-    "UpdatedCategory": "Pool provider",
+    "UpdatedCategory": "Pool provider"
   },
   {
     "BuildId": 688348,
     "RecordId": "3b5945b0-87a7-52cf-843a-406c21a8e27e",
     "Index": 0,
-    "UpdatedCategory": "Pool provider",
+    "UpdatedCategory": "Pool provider"
   }
 ]


### PR DESCRIPTION
We just normalized our test dependency story, and we are trying to avoid implicit code.

Even after reading the documentation for AutoFixture,
I still can't really be sure what it's doin, and it makes the test
hard to reason over (Why are these things supposed to be different?
Where did they come from?)

We want to reduce the amount of libraries someone has to go
read about just to code review a simple test.