### PR TITLE
Add UnprocessableEntity as an expected failure for GetLastCommitShaAsync

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -770,7 +770,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="owner">Owner of repo</param>
         /// <param name="repo">Repository name</param>
         /// <param name="branch">Branch to retrieve the latest sha for</param>
-        /// <returns>Latest sha.  Throws if no commits were found.</returns>
+        /// <returns>Latest sha.  Null if no commits were found.</returns>
         private async Task<string> GetLastCommitShaAsync(string owner, string repo, string branch)
         {
             try
@@ -786,7 +786,8 @@ namespace Microsoft.DotNet.DarcLib
 
                 return content["sha"].ToString();
             }
-            catch (HttpRequestException exc) when (exc.Message.Contains(((int)HttpStatusCode.NotFound).ToString()))
+            catch (HttpRequestException exc) when (exc.Message.Contains(((int)HttpStatusCode.NotFound).ToString())
+                || exc.Message.Contains(((int)HttpStatusCode.UnprocessableEntity).ToString()))
             {
                 return null;
             }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/HttpRequestManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/HttpRequestManager.cs
@@ -46,6 +46,7 @@ namespace Microsoft.DotNet.DarcLib
 
             HttpStatusCode[] stopRetriesHttpStatusCodes = new HttpStatusCode[] {
                 HttpStatusCode.NotFound,
+                HttpStatusCode.UnprocessableEntity,
                 HttpStatusCode.BadRequest,
                 HttpStatusCode.Unauthorized,
                 HttpStatusCode.Forbidden };


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/6044.

When GetLastCommitShaAsync looks to see if there is a last commit for a branch, the github API returns an UnprocessableEntity status code when the branch does not exist, rather than NotFound, which is what GetLastCommitShaAsync assumes.

We need to update the function to also look for UnprocessableEntity, as well as update ExecuteAsync to add UnprocessableEntity as a stopRetriesHttpStatusCode.