### PR TITLE
Do not count dismissed reviews as rejected

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -834,8 +834,10 @@ namespace Microsoft.DotNet.DarcLib
                     return ReviewState.ChangesRequested;
                 case PullRequestReviewState.Commented:
                     return ReviewState.Commented;
+                // A PR comment could be dismissed by a new push, so this does not count as a rejection.
+                // Change to a comment
                 case PullRequestReviewState.Dismissed:
-                    return ReviewState.Rejected;
+                    return ReviewState.Commented;
                 case PullRequestReviewState.Pending:
                     return ReviewState.Pending;
                 default:


### PR DESCRIPTION
Some of the bots like msftbot will comment on a PR, but not reject the changes.
When a new commit is pushed, the comment is dismissed. We categorize
dismissals as rejections. Instead, classify them as comments.