### PR TITLE
Use the sourceBranch variable instead of SourceBranchName

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -278,7 +278,7 @@ stages:
         -TsaRepositoryName "Arcade-Services"
         -TsaCodebaseName "Arcade-Services"
         -TsaPublish $True'
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), in(variables['Build.SourceBranchName'], 'master', 'production'))}}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/production'))}}:
   - template: eng\deploy.yaml
     parameters:
       ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/production') }}:


### PR DESCRIPTION
This prevents blah/master and blah/production from deploying. Followup to https://github.com/dotnet/arcade-services/pull/1383 and related to dotnet/core-eng#10679

Verified this build did not trigger the deployment steps even though it comes from a `riarenas/master` branch