### PR TITLE
Maestro - Add the changes URL in update dependencies PRs

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -6,14 +6,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Reflection.Metadata;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 using Maestro.Contracts;
 using Maestro.Data;
 using Maestro.Data.Models;
-using Maestro.MergePolicies;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
 using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
@@ -245,6 +243,11 @@ namespace SubscriptionActorService
 
         protected abstract Task<IReadOnlyList<MergePolicyDefinition>> GetMergePolicyDefinitions();
 
+        private class ReferenceLinksMap
+        {
+            public Dictionary<(string from, string to), int> ShaRangeToLinkId { get; } = new Dictionary<(string from, string to), int>();
+        }
+
         private async Task<string> GetSourceRepositoryAsync(Guid subscriptionId)
         {
             Subscription subscription = await Context.Subscriptions.FindAsync(subscriptionId);
@@ -395,7 +398,7 @@ namespace SubscriptionActorService
             IRemote darc = await DarcRemoteFactory.GetRemoteAsync(targetRepository, Logger);
 
             InProgressPullRequest pr = maybePr.Value;
-            
+
             PrStatus status = await darc.GetPullRequestStatusAsync(prUrl);
             switch (status)
             {
@@ -410,9 +413,9 @@ namespace SubscriptionActorService
                         case MergePolicyCheckResult.Merged:
                             await UpdateSubscriptionsForMergedPRAsync(pr.ContainedSubscriptions);
                             await AddDependencyFlowEventsAsync(
-                                pr.ContainedSubscriptions, 
-                                DependencyFlowEventType.Completed, 
-                                DependencyFlowEventReason.AutomaticallyMerged, 
+                                pr.ContainedSubscriptions,
+                                DependencyFlowEventType.Completed,
+                                DependencyFlowEventReason.AutomaticallyMerged,
                                 checkPolicyResult.Result,
                                 prUrl);
                             await StateManager.RemoveStateAsync(PullRequest);
@@ -434,14 +437,14 @@ namespace SubscriptionActorService
                         await UpdateSubscriptionsForMergedPRAsync(pr.ContainedSubscriptions);
                     }
 
-                    DependencyFlowEventReason reason = status == PrStatus.Merged ? 
-                        DependencyFlowEventReason.ManuallyMerged : 
+                    DependencyFlowEventReason reason = status == PrStatus.Merged ?
+                        DependencyFlowEventReason.ManuallyMerged :
                         DependencyFlowEventReason.ManuallyClosed;
 
                     await AddDependencyFlowEventsAsync(
-                        pr.ContainedSubscriptions, 
-                        DependencyFlowEventType.Completed, 
-                        reason, 
+                        pr.ContainedSubscriptions,
+                        DependencyFlowEventType.Completed,
+                        reason,
                         pr.MergePolicyResult,
                         prUrl);
                     await StateManager.RemoveStateAsync(PullRequest);
@@ -474,7 +477,7 @@ namespace SubscriptionActorService
                 pr,
                 darc,
                 policyDefinitions);
-            
+
             await UpdateMergeStatusAsync(darc, pr.Url, result.Results);
             if (result.Failed || result.Pending)
             {
@@ -534,13 +537,13 @@ namespace SubscriptionActorService
         }
 
         private async Task AddDependencyFlowEventsAsync(
-            IEnumerable<SubscriptionPullRequestUpdate> subscriptionPullRequestUpdates, 
-            DependencyFlowEventType flowEvent, 
-            DependencyFlowEventReason reason, 
+            IEnumerable<SubscriptionPullRequestUpdate> subscriptionPullRequestUpdates,
+            DependencyFlowEventType flowEvent,
+            DependencyFlowEventReason reason,
             MergePolicyCheckResult policy,
             string prUrl)
         {
-            
+
             foreach (SubscriptionPullRequestUpdate update in subscriptionPullRequestUpdates)
             {
                 ISubscriptionActor actor = SubscriptionActorFactory.Lookup(new ActorId(update.SubscriptionId));
@@ -758,9 +761,9 @@ namespace SubscriptionActorService
                     inProgressPr.Url = prUrl;
 
                     await AddDependencyFlowEventsAsync(
-                        inProgressPr.ContainedSubscriptions, 
-                        DependencyFlowEventType.Created, 
-                        DependencyFlowEventReason.New, 
+                        inProgressPr.ContainedSubscriptions,
+                        DependencyFlowEventType.Created,
+                        DependencyFlowEventReason.New,
                         MergePolicyCheckResult.PendingPolicies,
                         prUrl);
 
@@ -776,9 +779,9 @@ namespace SubscriptionActorService
 
                 // If we did not create a PR, then mark the dependency flow as completed as nothing to do.
                 await AddDependencyFlowEventsAsync(
-                        inProgressPr.ContainedSubscriptions, 
-                        DependencyFlowEventType.Completed, 
-                        DependencyFlowEventReason.NothingToDo, 
+                        inProgressPr.ContainedSubscriptions,
+                        DependencyFlowEventType.Completed,
+                        DependencyFlowEventReason.NothingToDo,
                         MergePolicyCheckResult.PendingPolicies,
                         null);
 
@@ -832,6 +835,7 @@ namespace SubscriptionActorService
                 var message = new StringBuilder();
                 List<DependencyUpdate> dependenciesToCommit = deps;
                 await CalculateCommitMessage(update, deps, message);
+
 
                 if (combineCoherencyWithNonCoherency && coherencyUpdate.update != null)
                 {
@@ -978,10 +982,35 @@ namespace SubscriptionActorService
                 subscriptionSection.AppendLine();
                 subscriptionSection.AppendLine($"- **Updates**:");
 
+                ReferenceLinksMap dependencyMapObject = new ReferenceLinksMap();
+
+                int referenceLinkId = 1;
                 foreach (DependencyUpdate dep in deps)
                 {
-                    subscriptionSection.AppendLine($"  - **{dep.To.Name}**: from {dep.From.Version} to {dep.To.Version}");
+                    if (!dependencyMapObject.ShaRangeToLinkId.ContainsKey((dep.From.Commit, dep.To.Commit)))
+                    {
+                        dependencyMapObject.ShaRangeToLinkId.Add((dep.From.Commit, dep.To.Commit), referenceLinkId++);
+                    }
                 }
+
+                foreach (DependencyUpdate dep in deps)
+                {
+                    subscriptionSection.AppendLine($"  - **{dep.To.Name}**: [from {dep.From.Version} to {dep.To.Version}][{dependencyMapObject.ShaRangeToLinkId[(dep.From.Commit, dep.To.Commit)]}]");
+                }
+
+                subscriptionSection.AppendLine();
+                for (int i = 1; i <= referenceLinkId; i++)
+                {
+                    foreach (KeyValuePair<(string, string), int> entry in dependencyMapObject.ShaRangeToLinkId)
+                    {
+                        if (entry.Value == i)
+                        {
+                            DependencyDetail to = deps.Find(d => d.To.Commit == entry.Key.Item1).To;
+                            subscriptionSection.AppendLine($"[{i}]: {GetChangesURI(to.RepoUri, entry.Key.Item1, entry.Key.Item2)}");
+                        }
+                    }
+                }
+
                 subscriptionSection.AppendLine();
                 subscriptionSection.AppendLine(DependencyUpdateEnd);
                 subscriptionSection.AppendLine();
@@ -1002,13 +1031,35 @@ namespace SubscriptionActorService
 
             if (sectionStartIndex != -1 && sectionEndIndex != -1)
             {
-                sectionEndIndex+= sectionEndMarker.Length;
+                sectionEndIndex += sectionEndMarker.Length;
                 description.Remove(sectionStartIndex, sectionEndIndex - sectionStartIndex);
                 return sectionStartIndex;
             }
             // if either marker is missing, just append at end and don't remove anything
             // from the description
             return description.Length;
+        }
+
+        private string GetChangesURI(string repoURI, string from, string to)
+        {
+            if (repoURI == null)
+            {
+                throw new ArgumentNullException(nameof(repoURI));
+            }
+            if (from == null)
+            {
+                throw new ArgumentNullException(nameof(from));
+            }
+            if (to == null)
+            {
+                throw new ArgumentNullException(nameof(to));
+            }
+
+            if (repoURI.Contains("github.com"))
+            {
+                return $"{repoURI}/compare/{from.Substring(0, 7)}...{to.Substring(0, 7)}";
+            }
+            return $"{repoURI}/branches?baseVersion=GC{from.Substring(0, 7)}&targetVersion=GC{to.Substring(0, 7)}&_a=files";
         }
 
         private async Task UpdatePullRequestAsync(InProgressPullRequest pr, List<UpdateAssetsParameters> updates)
@@ -1043,14 +1094,14 @@ namespace SubscriptionActorService
             // At this point, pr.ContainedSubscriptions only containes the subscriptions that were not updated,
             // so everything that is in the previous list but not in the current list were updated.
             await AddDependencyFlowEventsAsync(
-                previousSubscriptions.Except(pr.ContainedSubscriptions), 
-                DependencyFlowEventType.Updated, 
-                DependencyFlowEventReason.FailedUpdate, 
+                previousSubscriptions.Except(pr.ContainedSubscriptions),
+                DependencyFlowEventType.Updated,
+                DependencyFlowEventReason.FailedUpdate,
                 pr.MergePolicyResult,
                 pr.Url);
-                        
+
             pr.ContainedSubscriptions.AddRange(requiredUpdates
-                .Where( u => !u.update.IsCoherencyUpdate)
+                .Where(u => !u.update.IsCoherencyUpdate)
                 .Select(
                     u => new SubscriptionPullRequestUpdate
                     {
@@ -1061,9 +1112,9 @@ namespace SubscriptionActorService
             // Mark any new dependency updates as Created. Any subscriptions that are in pr.ContainedSubscriptions
             // but were not in the previous list of subscripitons are new
             await AddDependencyFlowEventsAsync(
-                pr.ContainedSubscriptions.Except(previousSubscriptions), 
-                DependencyFlowEventType.Created, 
-                DependencyFlowEventReason.New, 
+                pr.ContainedSubscriptions.Except(previousSubscriptions),
+                DependencyFlowEventType.Created,
+                DependencyFlowEventReason.New,
                 MergePolicyCheckResult.PendingPolicies,
                 pr.Url);
 
@@ -1177,7 +1228,7 @@ namespace SubscriptionActorService
             {
                 RepositoryBranch repoBranch = await GetRepositoryBranch(repo, branch);
                 Context.RepositoryBranchUpdates.Add(
-                    update = new RepositoryBranchUpdate {RepositoryBranch = repoBranch});
+                    update = new RepositoryBranchUpdate { RepositoryBranch = repoBranch });
             }
             else
             {
@@ -1296,7 +1347,7 @@ namespace SubscriptionActorService
         protected override async Task<IReadOnlyList<MergePolicyDefinition>> GetMergePolicyDefinitions()
         {
             Subscription subscription = await GetSubscription();
-            return (IReadOnlyList<MergePolicyDefinition>) subscription.PolicyObject.MergePolicies ??
+            return (IReadOnlyList<MergePolicyDefinition>)subscription.PolicyObject.MergePolicies ??
                    Array.Empty<MergePolicyDefinition>();
         }
 
@@ -1351,7 +1402,7 @@ namespace SubscriptionActorService
         {
             RepositoryBranch repositoryBranch =
                 await Context.RepositoryBranches.FindAsync(Target.repository, Target.branch);
-            return (IReadOnlyList<MergePolicyDefinition>) repositoryBranch?.PolicyObject?.MergePolicies ??
+            return (IReadOnlyList<MergePolicyDefinition>)repositoryBranch?.PolicyObject?.MergePolicies ??
                    Array.Empty<MergePolicyDefinition>();
         }
     }

--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -1005,7 +1005,7 @@ namespace SubscriptionActorService
                     {
                         if (entry.Value == i)
                         {
-                            DependencyDetail to = deps.Find(d => d.To.Commit == entry.Key.Item1).To;
+                            DependencyDetail to = deps.Find(d => d.To.Commit == entry.Key.Item2).To;
                             subscriptionSection.AppendLine($"[{i}]: {GetChangesURI(to.RepoUri, entry.Key.Item1, entry.Key.Item2)}");
                         }
                     }
@@ -1055,11 +1055,14 @@ namespace SubscriptionActorService
                 throw new ArgumentNullException(nameof(to));
             }
 
+            string fromSha = from.Length > 7 ? from.Substring(0, 7) : from;
+            string toSha = to.Length > 7 ? to.Substring(0, 7) : to;
+
             if (repoURI.Contains("github.com"))
             {
-                return $"{repoURI}/compare/{from.Substring(0, 7)}...{to.Substring(0, 7)}";
+                return $"{repoURI}/compare/{fromSha}...{toSha}";
             }
-            return $"{repoURI}/branches?baseVersion=GC{from.Substring(0, 7)}&targetVersion=GC{to.Substring(0, 7)}&_a=files";
+            return $"{repoURI}/branches?baseVersion=GC{fromSha}&targetVersion=GC{toSha}&_a=files";
         }
 
         private async Task UpdatePullRequestAsync(InProgressPullRequest pr, List<UpdateAssetsParameters> updates)

--- a/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
@@ -163,6 +163,14 @@ namespace SubscriptionActorService.Tests
                     }
                 },
                 options => options.Excluding(pr => pr.Title).Excluding(pr => pr.Description));
+
+            ValidatePRDescriptionContainsLinks(pullRequests[0]);
+        }
+
+        private void ValidatePRDescriptionContainsLinks(PullRequest pr)
+        {
+            pr.Description.Should().Contain("][1]");
+            pr.Description.Should().Contain("[1]:");
         }
 
         private void CreatePullRequestShouldReturnAValidValue()

--- a/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
@@ -140,6 +140,8 @@ namespace SubscriptionActorService.Tests
                                 {
                                     Name = a.Name,
                                     Version = a.Version,
+                                    RepoUri = withUpdatesFromBuild.GitHubRepository,
+                                    Commit = "sha3"
                                 })
                             .ToList()
                     });
@@ -225,12 +227,16 @@ namespace SubscriptionActorService.Tests
                                     From = new DependencyDetail
                                     {
                                         Name = d.Name,
-                                        Version = d.Version
+                                        Version = d.Version,
+                                        RepoUri = sourceRepo,
+                                        Commit = sourceSha
                                     },
                                     To = new DependencyDetail
                                     {
                                         Name = d.Name,
-                                        Version = d.Version
+                                        Version = d.Version,
+                                        RepoUri = sourceRepo,
+                                        Commit = "sha3"
                                     },
                                 })
                             .ToList();


### PR DESCRIPTION
As described [on this issue](https://github.com/dotnet/arcade/issues/5961), we are adding the URL of the changes (diff between 2 versions of a repo) in the body of the initial comment created by Maestro.