### PR TITLE
Use the dev.azure.com url for promotion message.

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -278,7 +278,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 promotionPipelineVariables
                 ).ConfigureAwait(false);
 
-            string promotionBuildUrl = $"https://{build.AzureDevOpsAccount}.visualstudio.com/{promotionPipelineInformation.project}/_build/results?buildId={azdoBuildId}";
+            string promotionBuildUrl = $"https://dev.azure.com/{build.AzureDevOpsAccount}/{promotionPipelineInformation.project}/_build/results?buildId={azdoBuildId}";
 
             Console.WriteLine($"Build {build.Id} will be assigned to target channel(s) once this build finishes publishing assets: {promotionBuildUrl}");
 


### PR DESCRIPTION
The visualstudio url is a legacy url.