### PR TITLE
Fixing checks scenario test

### DIFF
--- a/src/Maestro/tests/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
@@ -439,7 +439,7 @@ namespace Maestro.ScenarioTests
         {
             using (ChangeDirectory(repoPath))
             {
-                await RunDarcAsync(new string[] { "add-dependency", "--name", name, "--type", isToolset ? "toolset" : "product", "--repo", repoUri });
+                await RunDarcAsync(new string[] { "add-dependency", "--name", name, "--type", isToolset ? "toolset" : "product", "--repo", repoUri, "--version", "0.0.1" });
             }
         }
         public async Task<string> GetTestChannelsAsync()
@@ -884,7 +884,7 @@ namespace Maestro.ScenarioTests
                 if (checkRun.ExternalId.StartsWith(MergePolicyConstants.MaestroMergePolicyCheckRunPrefix))
                 {
                     cnt++;
-                    if (checkRun.Status != "completed")
+                    if (checkRun.Status != "completed" && !checkRun.Output.Title.Contains("Waiting for checks."))
                     {
                         return false;
                     }


### PR DESCRIPTION
After the recent changes, the AllChecksSuccessful check was pending (and not failing) as there are no other checks than the merge policies check in the scenario tests (WIP is ignored).

So at the end of the scenario test, we were expecting all the checks to be completed which is not the case anymore.