### PR TITLE
Adding copy buttons to BARViz 

### DIFF
--- a/src/Maestro/maestro-angular/src/app/app.module.ts
+++ b/src/Maestro/maestro-angular/src/app/app.module.ts
@@ -21,6 +21,7 @@ import {
   faLock,
   faRedo,
   faLockOpen,
+  faClipboard,
 } from "@fortawesome/free-solid-svg-icons";
 import {
   faQuestionCircle as farQuestionCircle,
@@ -119,6 +120,7 @@ library.add(
   faAngleRight,
   faAngleUp,
   faCheckCircle,
+  faClipboard,
   faEllipsisV,
   faExclamation,
   faExclamationTriangle,

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.html
@@ -62,8 +62,11 @@
             </div>
           </div>
           <h4>{{getRepo(build)}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>
-          <div><a class="btn btn-sm btn-info" [href]="build | commitLink" target="_blank">{{build.commit}} <fa-icon
-                icon="external-link-alt"></fa-icon></a></div>
+          <div>
+            <a class="btn btn-sm btn-primary" [href]="build | commitLink" target="_blank">{{build.commit}} <fa-icon
+                icon="external-link-alt"></fa-icon></a>
+              <button class="btn btn-sm btn-primary ml-2" aria-label="Copy" (click)="copyToClipboard(build.commit)"><fa-icon icon="clipboard"></fa-icon></button>
+          </div>
           <div>
             <mc-relative-date [value]="build.dateProduced"></mc-relative-date>
           </div>

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.html
@@ -10,7 +10,11 @@
         <fa-icon class="text-info" icon="question-circle"></fa-icon>
       </div>
       <div class="flex-grow-1">
-        <h4>{{getRepo(build)}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>
+        <h4>
+          {{getRepo(build)}} 
+          <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small>
+          <button class="btn btn-sm btn-primary ml-2" aria-label="Copy" (click)="copyToClipboard(build.azureDevOpsBuildId)">{{build.azureDevOpsBuildId}} <fa-icon icon="clipboard"></fa-icon></button>
+        </h4>
         <div>
           <span>Loading build information from Azure Pipelines</span>
           <div style="display:inline-block; vertical-align: middle;">
@@ -24,7 +28,11 @@
         <fa-icon class="text-warning" icon="exclamation-circle"></fa-icon>
       </div>
       <div class="flex-grow-1">
-        <h4>{{getRepo(build)}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>
+        <h4>
+          {{getRepo(build)}} 
+          <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small>
+          <button class="btn btn-sm btn-primary ml-2" aria-label="Copy" (click)="copyToClipboard(build.azureDevOpsBuildId)">{{build.azureDevOpsBuildId}} <fa-icon icon="clipboard"></fa-icon></button>
+        </h4>
         <div>
           <span class="text-warning" *ngIf="!haveAzDevInfo(build)">
             Cannot lookup build in Azure Pipelines. Missing required data. Update to the latest Arcade SDK to collect
@@ -61,7 +69,11 @@
               </a>
             </div>
           </div>
-          <h4>{{getRepo(build)}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>
+          <h4>
+            {{getRepo(build)}} 
+            <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small>
+            <button class="btn btn-sm btn-primary ml-2" aria-label="Copy" (click)="copyToClipboard(build.azureDevOpsBuildId)">{{build.azureDevOpsBuildId}} <fa-icon icon="clipboard"></fa-icon></button>
+          </h4>
           <div>
             <a class="btn btn-sm btn-primary" [href]="build | commitLink" target="_blank">{{build.commit}} <fa-icon
                 icon="external-link-alt"></fa-icon></a>

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
@@ -84,6 +84,7 @@ export class BuildComponent implements OnInit, OnChanges {
               self.toastVisible = false;
               observer.next(buildId);
             };
+
           },
           error(err) {
             observer.error(err);
@@ -257,6 +258,20 @@ export class BuildComponent implements OnInit, OnChanges {
            !!build.azureDevOpsBranch;
   }
 
+  public copyToClipboard(item:string): void {
+    console.log("Copying ", item, " to clipboard");
+    let selBox = document.createElement('textarea');
+    selBox.style.position = 'fixed';
+    selBox.style.left = '0';
+    selBox.style.top = '0';
+    selBox.style.opacity = '0';
+    selBox.value = item;
+    document.body.appendChild(selBox);
+    selBox.focus();
+    selBox.select();
+    document.execCommand('copy');
+    document.body.removeChild(selBox);
+  };
 
   public getBuildInfo(build: Build): Observable<AzDevBuildInfo> {
     if (!build.azureDevOpsAccount) {


### PR DESCRIPTION
As requested [on this issue](https://github.com/dotnet/arcade/issues/6137), I'm adding some extra informations on BARViz.

I'll change the UI of the maestro web app to add new info to it (+ additional features to make it easier for everyone such as a button to copy the sha). 

Changes made:
- [x] The BAR id of the build you're currently looking at (this is particuarly useful for sending builds through the release pipeline. Copy button would be extra helfpul
![image](https://user-images.githubusercontent.com/43049559/92248057-62ff7480-eec8-11ea-99fe-d7d6c0666901.png)
- [x] Add a copy button for the sha.
![image](https://user-images.githubusercontent.com/43049559/92244647-765c1100-eec3-11ea-9493-dbc4a37d8ff3.png)

