### PR TITLE
Fix analyzer TargetFramework

### DIFF
--- a/src/Maestro/Microsoft.AspNetCore.ApiVersioning.Analyzers/Microsoft.AspNetCore.ApiVersioning.Analyzers.csproj
+++ b/src/Maestro/Microsoft.AspNetCore.ApiVersioning.Analyzers/Microsoft.AspNetCore.ApiVersioning.Analyzers.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- This must stay netstandard2.0 to not break using the analyzer in VS -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IsPackable>true</IsPackable>

--- a/src/Maestro/Microsoft.AspNetCore.ApiVersioning.Analyzers/Microsoft.AspNetCore.ApiVersioning.Analyzers.csproj
+++ b/src/Maestro/Microsoft.AspNetCore.ApiVersioning.Analyzers/Microsoft.AspNetCore.ApiVersioning.Analyzers.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IsPackable>true</IsPackable>
     <!-- Build Tasks should not include any dependencies -->


### PR DESCRIPTION
This needs to target netstandard2.0 otherwise it gets the wrong references
and doesn't work in VS.