### PR TITLE
Adding a btn to access the latest ongoing build

### DIFF
--- a/src/Maestro/Maestro.Web/Controllers/AzDevController.cs
+++ b/src/Maestro/Maestro.Web/Controllers/AzDevController.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using Kusto.Cloud.Platform.Utils;
 using Maestro.AzureDevOps;
 using Microsoft.AspNetCore.Mvc;
 
@@ -33,18 +35,19 @@ namespace Maestro.Web.Controllers
         }
 
         [HttpGet("build/status/{account}/{project}/{definitionId}/{*branch}")]
-        public async Task<IActionResult> GetBuildStatus(string account, string project, int definitionId, string branch, int count)
+        public async Task<IActionResult> GetBuildStatus(string account, string project, int definitionId, string branch, int count, string status)
         {
             string token = await TokenProvider.GetTokenForAccount(account);
-            return await HttpContext.ProxyRequestAsync(
+            
+            return (await HttpContext.ProxyRequestAsync(
                 s_lazyClient.Value,
-                $"https://dev.azure.com/{account}/{project}/_apis/build/builds?api-version=5.0&definitions={definitionId}&branchName={branch}&statusFilter=completed&$top={count}",
+                $"https://dev.azure.com/{account}/{project}/_apis/build/builds?api-version=5.0&definitions={definitionId}&branchName={branch}&statusFilter={status}&$top={count}",
                 req =>
                 {
                     req.Headers.Authorization = new AuthenticationHeaderValue(
                         "Basic",
                         Convert.ToBase64String(Encoding.UTF8.GetBytes(":" + token)));
-                });
+                }));
         }
     }
 }

--- a/src/Maestro/Maestro.Web/Controllers/AzDevController.cs
+++ b/src/Maestro/Maestro.Web/Controllers/AzDevController.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
-using Kusto.Cloud.Platform.Utils;
 using Maestro.AzureDevOps;
 using Microsoft.AspNetCore.Mvc;
 
@@ -39,7 +37,7 @@ namespace Maestro.Web.Controllers
         {
             string token = await TokenProvider.GetTokenForAccount(account);
             
-            return (await HttpContext.ProxyRequestAsync(
+            return await HttpContext.ProxyRequestAsync(
                 s_lazyClient.Value,
                 $"https://dev.azure.com/{account}/{project}/_apis/build/builds?api-version=5.0&definitions={definitionId}&branchName={branch}&statusFilter={status}&$top={count}",
                 req =>
@@ -47,7 +45,7 @@ namespace Maestro.Web.Controllers
                     req.Headers.Authorization = new AuthenticationHeaderValue(
                         "Basic",
                         Convert.ToBase64String(Encoding.UTF8.GetBytes(":" + token)));
-                }));
+                });
         }
     }
 }

--- a/src/Maestro/maestro-angular/src/app/model/build-status.ts
+++ b/src/Maestro/maestro-angular/src/app/model/build-status.ts
@@ -12,6 +12,11 @@ export interface BuildStatusCompleted {
   status: "completed";
   result: "canceled" | "failed" | "none" | "partiallySucceeded" | "succeeded";
   length: number;
+  _links: {
+    web: {
+      href: string;
+    }
+  }
 }
 
 export interface BuildListResultInProgress{

--- a/src/Maestro/maestro-angular/src/app/model/build-status.ts
+++ b/src/Maestro/maestro-angular/src/app/model/build-status.ts
@@ -1,35 +1,21 @@
 // Result format of Azure DevOps api
 // https://docs.microsoft.com/en-us/rest/api/azure/devops/build/builds/list?view=azure-devops-rest-5.0
+export type BuildStatus = "all" | "cancelling" | "completed" | "inProgress" | "none" | "notStarted" | "postponed";
 
-export interface BuildListResultCompleted {
-  count: number;
-  value: BuildStatusCompleted[];
+export interface Build {
+  _links: { web: { href: string; } };
+  id: number;
+  status: BuildStatus;
 }
 
-export interface BuildStatusCompleted {
-  id: number;
-  finishTime: string;
+export interface CompletedBuild extends Build {
   status: "completed";
-  result: "canceled" | "failed" | "none" | "partiallySucceeded" | "succeeded";
+  finishTime: string;
   length: number;
-  _links: {
-    web: {
-      href: string;
-    }
-  }
+  result: "canceled" | "failed" | "none" | "partiallySucceeded" | "succeeded";
 }
 
-export interface BuildListResultInProgress{
+export interface BuildListResult<T extends Build> {
   count: number;
-  value: BuildStatusInProgress[];
-}
-
-export interface BuildStatusInProgress {
-  id: number;
-  status: "inProgress";
-  _links: {
-    web: {
-      href: string;
-    }
-  }
+  value: T[];
 }

--- a/src/Maestro/maestro-angular/src/app/model/build-status.ts
+++ b/src/Maestro/maestro-angular/src/app/model/build-status.ts
@@ -3,23 +3,18 @@
 
 export interface BuildListResult {
   count: number;
-  value: BuildStatusCompleted[] | BuildStatusInProgress[];
+  value: BuildStatus[];
 }
 
-export interface BuildStatusCompleted {
+export interface BuildStatus {
   id: number;
-  finishTime: string;
+  finishTime?: string;
   status: "all" | "cancelling" | "completed" | "inProgress" | "none" | "notStarted" | "postponed";
-  result: "canceled" | "failed" | "none" | "partiallySucceeded" | "succeeded";
-  length: number;
-}
-
-export interface BuildStatusInProgress {
-  id: number;
-  status: "all" | "cancelling" | "completed" | "inProgress" | "none" | "notStarted" | "postponed";
+  result?: "canceled" | "failed" | "none" | "partiallySucceeded" | "succeeded";
+  length?: number;
   _links: {
     web: {
       href: string;
     }
-  };
+  }
 }

--- a/src/Maestro/maestro-angular/src/app/model/build-status.ts
+++ b/src/Maestro/maestro-angular/src/app/model/build-status.ts
@@ -1,17 +1,32 @@
 // Result format of Azure DevOps api
 // https://docs.microsoft.com/en-us/rest/api/azure/devops/build/builds/list?view=azure-devops-rest-5.0
 
-export interface BuildListResult {
+export interface BuildListResultCompleted {
   count: number;
-  value: BuildStatus[];
+  value: BuildStatusCompleted[];
 }
 
-export interface BuildStatus {
+export interface BuildStatusCompleted {
   id: number;
-  finishTime?: string;
-  status: "all" | "cancelling" | "completed" | "inProgress" | "none" | "notStarted" | "postponed";
-  result?: "canceled" | "failed" | "none" | "partiallySucceeded" | "succeeded";
-  length?: number;
+  finishTime: string;
+  status: "completed";
+  result: "canceled" | "failed" | "none" | "partiallySucceeded" | "succeeded";
+  length: number;
+  _links: {
+    web: {
+      href: string;
+    }
+  }
+}
+
+export interface BuildListResultInProgress{
+  count: number;
+  value: BuildStatusInProgress[];
+}
+
+export interface BuildStatusInProgress {
+  id: number;
+  status: "inProgress";
   _links: {
     web: {
       href: string;

--- a/src/Maestro/maestro-angular/src/app/model/build-status.ts
+++ b/src/Maestro/maestro-angular/src/app/model/build-status.ts
@@ -12,11 +12,6 @@ export interface BuildStatusCompleted {
   status: "completed";
   result: "canceled" | "failed" | "none" | "partiallySucceeded" | "succeeded";
   length: number;
-  _links: {
-    web: {
-      href: string;
-    }
-  }
 }
 
 export interface BuildListResultInProgress{

--- a/src/Maestro/maestro-angular/src/app/model/build-status.ts
+++ b/src/Maestro/maestro-angular/src/app/model/build-status.ts
@@ -3,13 +3,23 @@
 
 export interface BuildListResult {
   count: number;
-  value: BuildStatus[];
+  value: BuildStatusCompleted[] | BuildStatusInProgress[];
 }
 
-export interface BuildStatus {
+export interface BuildStatusCompleted {
   id: number;
   finishTime: string;
   status: "all" | "cancelling" | "completed" | "inProgress" | "none" | "notStarted" | "postponed";
   result: "canceled" | "failed" | "none" | "partiallySucceeded" | "succeeded";
   length: number;
+}
+
+export interface BuildStatusInProgress {
+  id: number;
+  status: "all" | "cancelling" | "completed" | "inProgress" | "none" | "notStarted" | "postponed";
+  _links: {
+    web: {
+      href: string;
+    }
+  };
 }

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.html
@@ -61,9 +61,9 @@
                   Latest Failed Build <fa-icon icon="external-link-alt"></fa-icon>
                 </a>
               </span>
-              <ng-container *stateful="let azDevOnGoingInfo from azDevOnGoingBuildsInfo$;">
-                <span *ngIf="azDevOnGoingInfo">
-                  <a class="btn btn-primary btn-sm float-right text-light" [href]="azDevOnGoingInfo"
+              <ng-container *stateful="let onGoingBuildUrl from azDevOnGoingBuildUrl$;">
+                <span *ngIf="onGoingBuildUrl">
+                  <a class="btn btn-primary btn-sm float-right text-light" [href]="onGoingBuildUrl"
                     target="_blank">
                     Latest Ongoing Build <fa-icon icon="external-link-alt"></fa-icon>
                   </a>

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.html
@@ -50,15 +50,25 @@
         <div class="flex-grow-1">
           <div class="float-right">
             <div>
-              <a class="btn btn-sm btn-primary" [href]="build | buildLink" target="_blank">
+              <a class="btn btn-sm btn-primary float-right mb-2" [href]="build | buildLink" target="_blank">
                 Go to build in Azure DevOps <fa-icon icon="external-link-alt"></fa-icon>
               </a>
             </div>
-            <div *ngIf="azDevInfo.mostRecentFailureLink">
-              <a class="btn btn-danger btn-sm float-right text-light" [href]="azDevInfo.mostRecentFailureLink"
-                target="_blank">
-                Latest Failed Build <fa-icon icon="external-link-alt"></fa-icon>
-              </a>
+            <div>
+              <span *ngIf="azDevInfo.mostRecentFailureLink">
+                <a class="btn btn-danger btn-sm float-right text-light ml-2" [href]="azDevInfo.mostRecentFailureLink"
+                  target="_blank">
+                  Latest Failed Build <fa-icon icon="external-link-alt"></fa-icon>
+                </a>
+              </span>
+              <ng-container *stateful="let azDevOnGoingInfo from azDevOnGoingBuildsInfo$; loadingTemplate: loadingBuildInfo; errorTemplate: errorBuildInfo;">
+                <span *ngIf="azDevOnGoingInfo">
+                  <a class="btn btn-primary btn-sm float-right text-light" [href]="azDevOnGoingInfo"
+                    target="_blank">
+                    Latest Ongoing Build <fa-icon icon="external-link-alt"></fa-icon>
+                  </a>
+                </span>
+              </ng-container>
             </div>
           </div>
           <h4>{{getRepo(build)}} <small class="text-muted">{{build.azureDevOpsBuildNumber}}</small></h4>

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.html
@@ -61,7 +61,7 @@
                   Latest Failed Build <fa-icon icon="external-link-alt"></fa-icon>
                 </a>
               </span>
-              <ng-container *stateful="let azDevOnGoingInfo from azDevOnGoingBuildsInfo$; loadingTemplate: loadingBuildInfo; errorTemplate: errorBuildInfo;">
+              <ng-container *stateful="let azDevOnGoingInfo from azDevOnGoingBuildsInfo$;">
                 <span *ngIf="azDevOnGoingInfo">
                   <a class="btn btn-primary btn-sm float-right text-light" [href]="azDevOnGoingInfo"
                     target="_blank">

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
@@ -319,7 +319,7 @@ export class BuildComponent implements OnInit, OnChanges {
             // Yes, it's "canceled".
             const recentFailure = newerBuilds.find(b => (b.result == "failed" || b.result == "canceled") );
             if (recentFailure) {
-              mostRecentFailureLink = this.getBuildLinkFromAzdo(build.azureDevOpsAccount as string, build.azureDevOpsProject as string, recentFailure.id);
+              mostRecentFailureLink = recentFailure._links.web.href;
             } else {
               mostRecentFailureLink = undefined;
             }
@@ -351,7 +351,7 @@ export class BuildComponent implements OnInit, OnChanges {
     .pipe(
       map(builds => {
         if (builds.count > 0) {
-          return builds.value[0]["_links"]["web"]["href"];
+          return builds.value[0]._links.web.href;
         }
         return null;
       }),
@@ -360,13 +360,5 @@ export class BuildComponent implements OnInit, OnChanges {
 
   public getRepo(build: Build) {
     return build.gitHubRepository || build.azureDevOpsRepository;
-  }
-
-  public getBuildLinkFromAzdo(account: string, project: string, buildId: number): string {
-    return `https://dev.azure.com` +
-      `/${account}` +
-      `/${project}` +
-      `/_build/results` +
-      `?view=results&buildId=${buildId}`;
   }
 }

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
@@ -6,7 +6,7 @@ import { isAfter, compareAsc, parseISO } from "date-fns";
 import { BuildGraph, Build, Subscription } from 'src/maestro-client/models';
 import { Observable, of, timer, OperatorFunction } from 'rxjs';
 import { BuildStatusService } from 'src/app/services/build-status.service';
-import { BuildStatus } from 'src/app/model/build-status';
+import { BuildStatusCompleted } from 'src/app/model/build-status';
 import { statefulSwitchMap, StatefulResult, statefulPipe } from 'src/stateful';
 import { tapLog } from 'src/helpers';
 import { BuildService } from 'src/app/services/build.service';
@@ -297,20 +297,20 @@ export class BuildComponent implements OnInit, OnChanges {
     return this.buildStatusService.getBranchStatus(build.azureDevOpsAccount, build.azureDevOpsProject, build.azureDevOpsBuildDefinitionId, build.azureDevOpsBranch, 5, "completed")
       .pipe(
         map(builds => {
-          function isNewer(b: BuildStatus): boolean {
-            if (b.status === "inProgress") {
-              return false;
-            }
+          function isNewer(b: BuildStatusCompleted): boolean {
             if (b.id === build.azureDevOpsBuildId) {
               return false;
             }
             return isAfter(parseISO(b.finishTime!), build.dateProduced);
           }
+          if (!build.azureDevOpsAccount) {
+            throw new Error("azureDevOpsAccount undefined");
+          }
 
           let isMostRecent: boolean;
           let mostRecentFailureLink: string | undefined;
 
-          const newerBuilds = builds.value.filter(isNewer).sort((l, r) => compareAsc(parseISO(l.finishTime!), parseISO(r.finishTime!)));
+          const newerBuilds = builds.value.filter(isNewer).sort((l, r) => compareAsc(parseISO(l.finishTime), parseISO(r.finishTime)));
           if (!newerBuilds.length) {
             isMostRecent = true;
             mostRecentFailureLink = undefined;

--- a/src/Maestro/maestro-angular/src/app/services/build-status.service.ts
+++ b/src/Maestro/maestro-angular/src/app/services/build-status.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@angular/core";
 import { Observable, of } from "rxjs";
 import { HttpClient } from '@angular/common/http';
-import { BuildListResultInProgress, BuildListResultCompleted } from '../model/build-status';
+import { BuildStatus, CompletedBuild, BuildListResult, Build } from '../model/build-status';
 
 @Injectable({
   providedIn: "root",
@@ -10,13 +10,11 @@ export class BuildStatusService {
 
   public constructor(private http: HttpClient) { }
 
-  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number, status: "inProgress"): Observable<BuildListResultInProgress>;
-  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number, status: "completed"): Observable<BuildListResultCompleted>;
-  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number, status: string): Observable<BuildListResultInProgress | BuildListResultCompleted>;
+  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number, status: "completed"): Observable<BuildListResult<CompletedBuild>>;
+  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number, status: BuildStatus): Observable<BuildListResult<Build>>;
 
-
-  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number, status: string): Observable<BuildListResultInProgress | BuildListResultCompleted> {
-    return this.http.get<BuildListResultInProgress>(`/_/AzDev/build/status/${account}/${project}/${definitionId}/${branch}?count=${count}&status=${status}`, {
+  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number, status: string): Observable<BuildListResult<Build> | BuildListResult<CompletedBuild>> {
+    return this.http.get<BuildListResult<Build> | BuildListResult<CompletedBuild>>(`/_/AzDev/build/status/${account}/${project}/${definitionId}/${branch}?count=${count}&status=${status}`, {
       responseType: "json",
     })
   }

--- a/src/Maestro/maestro-angular/src/app/services/build-status.service.ts
+++ b/src/Maestro/maestro-angular/src/app/services/build-status.service.ts
@@ -10,8 +10,8 @@ export class BuildStatusService {
 
   public constructor(private http: HttpClient) { }
 
-  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number): Observable<BuildListResult> {
-    return this.http.get<BuildListResult>(`/_/AzDev/build/status/${account}/${project}/${definitionId}/${branch}?count=${count}`, {
+  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number, status: string): Observable<BuildListResult> {
+    return this.http.get<BuildListResult>(`/_/AzDev/build/status/${account}/${project}/${definitionId}/${branch}?count=${count}&status=${status}`, {
       responseType: "json",
     });
   }

--- a/src/Maestro/maestro-angular/src/app/services/build-status.service.ts
+++ b/src/Maestro/maestro-angular/src/app/services/build-status.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@angular/core";
 import { Observable, of } from "rxjs";
 import { HttpClient } from '@angular/common/http';
-import { BuildListResult } from '../model/build-status';
+import { BuildListResultInProgress, BuildListResultCompleted } from '../model/build-status';
 
 @Injectable({
   providedIn: "root",
@@ -10,9 +10,14 @@ export class BuildStatusService {
 
   public constructor(private http: HttpClient) { }
 
-  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number, status: string): Observable<BuildListResult> {
-    return this.http.get<BuildListResult>(`/_/AzDev/build/status/${account}/${project}/${definitionId}/${branch}?count=${count}&status=${status}`, {
+  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number, status: "inProgress"): Observable<BuildListResultInProgress>;
+  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number, status: "completed"): Observable<BuildListResultCompleted>;
+  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number, status: string): Observable<BuildListResultInProgress | BuildListResultCompleted>;
+
+
+  public getBranchStatus(account: string, project: string, definitionId: number, branch: string, count: number, status: string): Observable<BuildListResultInProgress | BuildListResultCompleted> {
+    return this.http.get<BuildListResultInProgress>(`/_/AzDev/build/status/${account}/${project}/${definitionId}/${branch}?count=${count}&status=${status}`, {
       responseType: "json",
-    });
+    })
   }
 }


### PR DESCRIPTION
As requested on this [issue](https://github.com/dotnet/arcade/issues/6150), I'm adding a button to access the latest ongoing build.

How does it look like?

- If a build is currently running
![image](https://user-images.githubusercontent.com/43049559/93098648-64d6ee00-f6a7-11ea-9b10-5f07085e9924.png)

- Otherwise (if everything is fine or we recently had a failed build)
![image](https://user-images.githubusercontent.com/43049559/93098753-820bbc80-f6a7-11ea-8d41-22c4b09d6c56.png)
![image](https://user-images.githubusercontent.com/43049559/93098690-715b4680-f6a7-11ea-8cb1-dba08e5762c2.png)

What does it do?

If you click on the link, it will redirect you to this page:
![image](https://user-images.githubusercontent.com/43049559/93098857-9cde3100-f6a7-11ea-88df-c39474949264.png)


