### PR TITLE
Fix DependencyUpdater and unify flow graph generation code

### DIFF
--- a/src/Maestro/DependencyUpdater/DependencyUpdater.cs
+++ b/src/Maestro/DependencyUpdater/DependencyUpdater.cs
@@ -258,7 +258,7 @@ namespace DependencyUpdater
 
                 foreach (var channel in channels)
                 {
-                    var flowGraph = await barOnlyRemote.GetDependencyFlowGraph(
+                    var flowGraph = await barOnlyRemote.GetDependencyFlowGraphAsync(
                         channel.Id,
                         days: 30,
                         includeArcade: false,

--- a/src/Maestro/DependencyUpdater/DependencyUpdater.cs
+++ b/src/Maestro/DependencyUpdater/DependencyUpdater.cs
@@ -266,15 +266,15 @@ namespace DependencyUpdater
                         includeDisabledSubscriptions: false,
                         includedFrequencies: frequencies);
 
-                    if (flowGraph.Nodes.Count > 0)
-                    {
-                        // Get the nodes on the longest path and order them by path time so that the
-                        // contributing repos are in the right order
-                        List<DependencyFlowNode> longestBuildPathNodes = flowGraph.Nodes
-                            .Where(n => n.OnLongestBuildPath)
-                            .OrderByDescending(n => n.BestCasePathTime)
-                            .ToList();
+                    // Get the nodes on the longest path and order them by path time so that the
+                    // contributing repos are in the right order
+                    List<DependencyFlowNode> longestBuildPathNodes = flowGraph.Nodes
+                        .Where(n => n.OnLongestBuildPath)
+                        .OrderByDescending(n => n.BestCasePathTime)
+                        .ToList();
 
+                    if (longestBuildPathNodes.Any())
+                    {
                         LongestBuildPath lbp = new LongestBuildPath()
                         {
                             ChannelId = channel.Id,
@@ -286,6 +286,10 @@ namespace DependencyUpdater
 
                         Logger.LogInformation($"Will update {channel.Name} to best case time {lbp.BestCaseTimeInMinutes} and worst case time {lbp.WorstCaseTimeInMinutes}");
                         await Context.LongestBuildPaths.AddAsync(lbp);
+                    }
+                    else
+                    {
+                        Logger.LogInformation($"Will not update {channel.Name} longest build path because no nodes have {nameof(DependencyFlowNode.OnLongestBuildPath)} flag set. Total node count = {flowGraph.Nodes.Count}");
                     }
                 }
 

--- a/src/Maestro/DependencyUpdater/DependencyUpdater.cs
+++ b/src/Maestro/DependencyUpdater/DependencyUpdater.cs
@@ -250,44 +250,24 @@ namespace DependencyUpdater
         {
             using (_operations.BeginOperation($"Updating Longest Build Path table"))
             {
-                List<Channel> channels = Context.Channels.Select(c => new Channel() { Id = c.Id, Name = c.Name }).ToList();
-
-                // Get the flow graph
                 IRemote barOnlyRemote = await RemoteFactory.GetBarOnlyRemoteAsync(Logger);
-
-                List<Microsoft.DotNet.Maestro.Client.Models.DefaultChannel> defaultChannels = (await barOnlyRemote.GetDefaultChannelsAsync()).ToList();
-                List<Microsoft.DotNet.Maestro.Client.Models.Subscription> subscriptions = (await barOnlyRemote.GetSubscriptionsAsync()).ToList();
-
-                IEnumerable<string> frequencies = new[] { "everyWeek", "twiceDaily", "everyDay", "everyBuild", "none", };
+                List<Channel> channels = Context.Channels.Select(c => new Channel() { Id = c.Id, Name = c.Name }).ToList();
+                IReadOnlyList<string> frequencies = new[] { "everyWeek", "twiceDaily", "everyDay", "everyBuild", "none", };
 
                 Logger.LogInformation($"Will update '{channels.Count}' channels");
 
                 foreach (var channel in channels)
                 {
-                    // Build, then prune out what we don't want to see if the user specified channels.
-                    DependencyFlowGraph flowGraph = await DependencyFlowGraph.BuildAsync(defaultChannels, subscriptions, barOnlyRemote, 30);
-
-                    flowGraph.PruneGraph(
-                        node => DependencyFlowGraph.IsInterestingNode(channel.Name, node), 
-                        edge => DependencyFlowGraph.IsInterestingEdge(edge, false, frequencies));
+                    var flowGraph = await barOnlyRemote.GetDependencyFlowGraph(
+                        channel.Id,
+                        days: 30,
+                        includeArcade: false,
+                        includeBuildTimes: true,
+                        includeDisabledSubscriptions: false,
+                        includedFrequencies: frequencies);
 
                     if (flowGraph.Nodes.Count > 0)
                     {
-                        var edgesWithLastBuild = flowGraph.Edges
-                            .Where(e => e.Subscription.LastAppliedBuild != null);
-
-                        foreach (var edge in edgesWithLastBuild)
-                        {
-                            edge.IsToolingOnly = !Context.IsProductDependency(
-                                edge.Subscription.LastAppliedBuild.Id,
-                                edge.To.Repository,
-                                edge.To.Branch);
-                        }
-
-                        flowGraph.MarkBackEdges();
-                        flowGraph.CalculateLongestBuildPaths();
-                        flowGraph.MarkLongestBuildPath();
-
                         // Get the nodes on the longest path and order them by path time so that the
                         // contributing repos are in the right order
                         List<DependencyFlowNode> longestBuildPathNodes = flowGraph.Nodes

--- a/src/Maestro/Maestro.DataProviders/MaestroBarClient.cs
+++ b/src/Maestro/Maestro.DataProviders/MaestroBarClient.cs
@@ -131,7 +131,10 @@ namespace Maestro.DataProviders
                 other.Classification);
         }
 
-        public Task<DependencyFlowGraph> GetDependencyFlowGraph(
+        private const int EngLatestChannelId = 2;
+        private const int Eng3ChannelId = 344;
+
+        public async Task<DependencyFlowGraph> GetDependencyFlowGraph(
             int channelId,
             int days,
             bool includeArcade,
@@ -139,7 +142,83 @@ namespace Maestro.DataProviders
             bool includeDisabledSubscriptions,
             IReadOnlyList<string> includedFrequencies)
         {
-            throw new NotImplementedException();
+            var engLatestChannel = await GetChannelAsync(EngLatestChannelId);
+            var eng3Channel = await GetChannelAsync(Eng3ChannelId);
+            var defaultChannels = (await GetDefaultChannelsAsync()).ToList();
+
+            if (includeArcade)
+            {
+                if (engLatestChannel != null)
+                {
+                    defaultChannels.Add(
+                        new DefaultChannel(0, "https://github.com/dotnet/arcade", true)
+                        {
+                            Branch = "master",
+                            Channel = engLatestChannel
+                        }
+                    );
+                }
+
+                if (eng3Channel != null)
+                {
+                    defaultChannels.Add(
+                        new DefaultChannel(0, "https://github.com/dotnet/arcade", true)
+                        {
+                            Branch = "release/3.x",
+                            Channel = eng3Channel
+                        }
+                    );
+                }
+            }
+
+            var subscriptions = (await GetSubscriptionsAsync()).ToList();
+
+            // Build, then prune out what we don't want to see if the user specified
+            // channels.
+            DependencyFlowGraph flowGraph = await DependencyFlowGraph.BuildAsync(
+                defaultChannels, 
+                subscriptions,
+                this,
+                days);
+
+            IEnumerable<string> frequencies
+                = includedFrequencies == default || includedFrequencies.Count() == 0
+                ? new string[] { "everyWeek", "twiceDaily", "everyDay", "everyBuild", "none", }
+                : includedFrequencies;
+
+            Channel targetChannel = null;
+
+            if (channelId != 0)
+            {
+                targetChannel = await GetChannelAsync(channelId);
+            }
+
+            if (targetChannel != null)
+            {
+                flowGraph.PruneGraph(
+                    node => DependencyFlowGraph.IsInterestingNode(targetChannel.Name, node),
+                    edge => DependencyFlowGraph.IsInterestingEdge(edge, includeDisabledSubscriptions, frequencies));
+            }
+
+            if (includeBuildTimes)
+            {
+                var edgesWithLastBuild = flowGraph.Edges
+                    .Where(e => e.Subscription.LastAppliedBuild != null);
+
+                foreach (var edge in edgesWithLastBuild)
+                {
+                    edge.IsToolingOnly = !_context.IsProductDependency(
+                        edge.Subscription.LastAppliedBuild.Id,
+                        edge.To.Repository,
+                        edge.To.Branch);
+                }
+
+                flowGraph.MarkBackEdges();
+                flowGraph.CalculateLongestBuildPaths();
+                flowGraph.MarkLongestBuildPath();
+            }
+
+            return flowGraph;
         }
 
         public Task<Build> GetLatestBuildAsync(string repoUri, int channelId)

--- a/src/Maestro/Maestro.DataProviders/MaestroBarClient.cs
+++ b/src/Maestro/Maestro.DataProviders/MaestroBarClient.cs
@@ -134,7 +134,7 @@ namespace Maestro.DataProviders
         private const int EngLatestChannelId = 2;
         private const int Eng3ChannelId = 344;
 
-        public async Task<DependencyFlowGraph> GetDependencyFlowGraph(
+        public async Task<DependencyFlowGraph> GetDependencyFlowGraphAsync(
             int channelId,
             int days,
             bool includeArcade,

--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/ChannelsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/ChannelsController.cs
@@ -246,9 +246,6 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
             return await Task.FromResult(StatusCode((int)HttpStatusCode.NotModified));
         }
 
-        private const int EngLatestChannelId = 2;
-        private const int Eng3ChannelId = 344;
-
         /// <summary>
         ///   Get the dependency flow graph for the specified <see cref="Channel"/>
         /// </summary>
@@ -272,78 +269,13 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
             bool includeArcade = true)
         {
             var barOnlyRemote = await _remoteFactory.GetBarOnlyRemoteAsync(Logger);
-
-            Microsoft.DotNet.Maestro.Client.Models.Channel engLatestChannel = await barOnlyRemote.GetChannelAsync(EngLatestChannelId);
-            Microsoft.DotNet.Maestro.Client.Models.Channel eng3Channel = await barOnlyRemote.GetChannelAsync(Eng3ChannelId);
-
-            List<Microsoft.DotNet.Maestro.Client.Models.DefaultChannel> defaultChannels = (await barOnlyRemote.GetDefaultChannelsAsync()).ToList();
-
-            if (includeArcade)
-            {
-                if (engLatestChannel != null)
-                {
-                    defaultChannels.Add(
-                        new Microsoft.DotNet.Maestro.Client.Models.DefaultChannel(0, "https://github.com/dotnet/arcade", true)
-                        {
-                            Branch = "master",
-                            Channel = engLatestChannel
-                        }
-                    );
-                }
-
-                if (eng3Channel != null)
-                {
-                    defaultChannels.Add(
-                        new Microsoft.DotNet.Maestro.Client.Models.DefaultChannel(0, "https://github.com/dotnet/arcade", true)
-                        {
-                            Branch = "release/3.x",
-                            Channel = eng3Channel
-                        }
-                    );
-                }
-            }
-
-            List<Microsoft.DotNet.Maestro.Client.Models.Subscription> subscriptions = (await barOnlyRemote.GetSubscriptionsAsync()).ToList();
-
-            // Build, then prune out what we don't want to see if the user specified
-            // channels.
-            DependencyFlowGraph flowGraph = await DependencyFlowGraph.BuildAsync(defaultChannels, subscriptions, barOnlyRemote, days);
-
-           IEnumerable<string> frequencies = includedFrequencies == default || includedFrequencies.Count() == 0 ? 
-                new string[] { "everyWeek", "twiceDaily", "everyDay", "everyBuild", "none", } : 
-                includedFrequencies;
-
-            Microsoft.DotNet.Maestro.Client.Models.Channel targetChannel = null;
-
-            if (channelId != 0)
-            {
-                targetChannel = await barOnlyRemote.GetChannelAsync((int) channelId);
-            }
-
-            if (targetChannel != null)
-            {
-                flowGraph.PruneGraph(
-                    node => DependencyFlowGraph.IsInterestingNode(targetChannel.Name, node), 
-                    edge => DependencyFlowGraph.IsInterestingEdge(edge, includeDisabledSubscriptions, frequencies));
-            }
-
-            if (includeBuildTimes)
-            {
-                var edgesWithLastBuild = flowGraph.Edges
-                    .Where(e => e.Subscription.LastAppliedBuild != null);
-
-                foreach (var edge in edgesWithLastBuild)
-                {
-                    edge.IsToolingOnly = !_context.IsProductDependency(
-                        edge.Subscription.LastAppliedBuild.Id,
-                        edge.To.Repository,
-                        edge.To.Branch);
-                }
-
-                flowGraph.MarkBackEdges();
-                flowGraph.CalculateLongestBuildPaths();
-                flowGraph.MarkLongestBuildPath();
-            }
+            var flowGraph = await barOnlyRemote.GetDependencyFlowGraph(
+                channelId,
+                days,
+                includeArcade,
+                includeBuildTimes,
+                includeDisabledSubscriptions,
+                includedFrequencies.ToList());
 
             // Convert flow graph to correct return type
             return Ok(FlowGraph.Create(flowGraph));

--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/ChannelsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/ChannelsController.cs
@@ -269,7 +269,7 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
             bool includeArcade = true)
         {
             var barOnlyRemote = await _remoteFactory.GetBarOnlyRemoteAsync(Logger);
-            var flowGraph = await barOnlyRemote.GetDependencyFlowGraph(
+            var flowGraph = await barOnlyRemote.GetDependencyFlowGraphAsync(
                 channelId,
                 days,
                 includeArcade,

--- a/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
+++ b/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
@@ -82,7 +82,7 @@ namespace SubscriptionActorService
             throw new NotImplementedException();
         }
 
-        public Task<DependencyFlowGraph> GetDependencyFlowGraph(
+        public Task<DependencyFlowGraph> GetDependencyFlowGraphAsync(
             int channelId,
             int days,
             bool includeArcade,

--- a/src/Maestro/tests/DependencyUpdater.Tests/DependencyUpdaterTests.cs
+++ b/src/Maestro/tests/DependencyUpdater.Tests/DependencyUpdaterTests.cs
@@ -58,7 +58,6 @@ namespace DependencyUpdater.Tests
             services.AddOperationTracking(o => { });
             Provider = services.BuildServiceProvider();
             Scope = Provider.CreateScope();
-
             _context = new Lazy<BuildAssetRegistryContext>(GetContext);
         }
 

--- a/src/Maestro/tests/DependencyUpdater.Tests/UpdateLongestBuildPathTests.cs
+++ b/src/Maestro/tests/DependencyUpdater.Tests/UpdateLongestBuildPathTests.cs
@@ -1,0 +1,149 @@
+using FluentAssertions;
+using Maestro.Data.Migrations;
+using Maestro.Data.Models;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DependencyUpdater.Tests
+{
+    [TestFixture]
+    public class UpdateLongestBuildPathTests : DependencyUpdaterTests
+    {
+        [Test]
+        public async Task ShouldSaveCorrectBestAndWorstPathTimesForEachChannel()
+        {
+            var graph1 = CreateGraph(
+                (Repo: "a", BestCaseTime: 1, WorstCaseTime: 7, OnLongestBuildPath: true),
+                (Repo: "b", BestCaseTime: 2, WorstCaseTime: 5, OnLongestBuildPath: true),
+                (Repo: "c", BestCaseTime: 9, WorstCaseTime: 9, OnLongestBuildPath: false));
+
+            var graph2 = CreateGraph(
+                (Repo: "g", BestCaseTime: 10, WorstCaseTime: 70, OnLongestBuildPath: true),
+                (Repo: "h", BestCaseTime: 20, WorstCaseTime: 50, OnLongestBuildPath: true));
+
+            SetupRemote(
+                (ChannelId: 1, Graph: graph1),
+                (ChannelId: 2, Graph: graph2));
+
+            var updater = ActivatorUtilities.CreateInstance<DependencyUpdater>(Scope.ServiceProvider);
+            await updater.UpdateLongestBuildPathAsync(CancellationToken.None);
+
+            var longestBuildPaths = Context.LongestBuildPaths.ToList();
+            longestBuildPaths.Should().HaveCount(2);
+
+            var firstChannelData = longestBuildPaths.FirstOrDefault(x => x.ChannelId == 1);
+            firstChannelData.Should().BeEquivalentTo(new LongestBuildPath
+            {
+                BestCaseTimeInMinutes = 2,
+                ChannelId = 1,
+                WorstCaseTimeInMinutes = 7,
+                ContributingRepositories = "b@main;a@main"
+            }, options => options
+                .Excluding(x => x.Channel)
+                .Excluding(x => x.Id)
+                .Excluding(x => x.ReportDate));
+
+            var secondChannelData = longestBuildPaths.FirstOrDefault(x => x.ChannelId == 2);
+            secondChannelData.Should().BeEquivalentTo(new LongestBuildPath
+            {
+                BestCaseTimeInMinutes = 20,
+                ChannelId = 2,
+                WorstCaseTimeInMinutes = 70,
+                ContributingRepositories = "h@main;g@main"
+            }, options => options
+                .Excluding(x => x.Channel)
+                .Excluding(x => x.Id)
+                .Excluding(x => x.ReportDate));
+        }
+
+        [Test]
+        public async Task ShouldNotAddLongestBuildPathRowWhenThereAreNoNodesOnLongestBuildPath()
+        {
+            var graph = CreateGraph(
+                (Repo: "a", BestCaseTime: 1, WorstCaseTime: 7, OnLongestBuildPath: false),
+                (Repo: "b", BestCaseTime: 2, WorstCaseTime: 5, OnLongestBuildPath: false));
+
+            SetupRemote(
+                (ChannelId: 1, Graph: graph));
+
+            var updater = ActivatorUtilities.CreateInstance<DependencyUpdater>(Scope.ServiceProvider);
+            await updater.UpdateLongestBuildPathAsync(CancellationToken.None);
+
+            var longestBuildPaths = Context.LongestBuildPaths.ToList();
+            longestBuildPaths.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task ShouldNotAddLongestBuildPathRowWhenGraphIsEmpty()
+        {
+            var graph = new DependencyFlowGraph(
+                new List<DependencyFlowNode>(),
+                new List<DependencyFlowEdge>());
+
+            SetupRemote(
+                (ChannelId: 1, Graph: graph));
+
+            var updater = ActivatorUtilities.CreateInstance<DependencyUpdater>(Scope.ServiceProvider);
+            await updater.UpdateLongestBuildPathAsync(CancellationToken.None);
+
+            var longestBuildPaths = Context.LongestBuildPaths.ToList();
+            longestBuildPaths.Should().BeEmpty();
+        }
+
+        private void SetupRemote(
+            params (int ChannelId, DependencyFlowGraph Graph)[] graphPerChannel)
+        {
+            var remoteMock = new Mock<IRemote>();
+
+            foreach (var item in graphPerChannel)
+            {
+                remoteMock.Setup(m => m.GetDependencyFlowGraphAsync(
+                    item.ChannelId,
+                    It.IsAny<int>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<IReadOnlyList<string>>()))
+                    .Returns(Task.FromResult(item.Graph));
+
+                Context.Channels.Add(new Channel
+                {
+                    Id = item.ChannelId,
+                    Name = $"Channel_{item.ChannelId}"
+                });
+            }
+
+            Context.SaveChanges();
+
+            RemoteFactory
+                .Setup(m => m.GetBarOnlyRemoteAsync(It.IsAny<ILogger>()))
+                .Returns(Task.FromResult(remoteMock.Object));
+        }
+
+        private DependencyFlowGraph CreateGraph(
+            params (string Repo, double BestCaseTime, double WorstCaseTime, bool OnLongestBuildPath)[] nodes)
+        {
+            var graphNodes = nodes
+                .Select((n, i) => new DependencyFlowNode(n.Repo, "main", $"Node{i}")
+                {
+                    BestCasePathTime = n.BestCaseTime,
+                    OnLongestBuildPath = n.OnLongestBuildPath,
+                    WorstCasePathTime = n.WorstCaseTime
+                })
+                .ToList();
+
+            return new DependencyFlowGraph(
+                graphNodes,
+                new List<DependencyFlowEdge>());
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Darc.Operations
                     }
                 }
 
-                var flowGraph = await barOnlyRemote.GetDependencyFlowGraph(
+                var flowGraph = await barOnlyRemote.GetDependencyFlowGraphAsync(
                     targetChannel?.Id ?? 0,
                     _options.Days,
                     includeArcade: true,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -1381,7 +1381,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="includeDisabledSubscriptions">Should disabled subscriptions be included in the graph</param>
         /// <param name="includedFrequencies">Include only subscription with specified frequencies. Leave null or empty to include all</param>
         /// <returns>Dependency flow graph for given channel</returns>
-        public async Task<DependencyFlowGraph> GetDependencyFlowGraph(
+        public async Task<DependencyFlowGraph> GetDependencyFlowGraphAsync(
             int channelId,
             int days,
             bool includeArcade,
@@ -1390,7 +1390,7 @@ namespace Microsoft.DotNet.DarcLib
             IReadOnlyList<string> includedFrequencies)
         {
             CheckForValidBarClient();
-            return await _barClient.GetDependencyFlowGraph(
+            return await _barClient.GetDependencyFlowGraphAsync(
                 channelId,
                 days,
                 includeArcade,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
@@ -189,7 +189,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns></returns>
         Task<IEnumerable<Channel>> GetChannelsAsync(string classification = null);
 
-        Task<DependencyFlowGraph> GetDependencyFlowGraph(
+        Task<DependencyFlowGraph> GetDependencyFlowGraphAsync(
             int channelId,
             int days,
             bool includeArcade,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -391,7 +391,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="includeDisabledSubscriptions">Should disabled subscriptions be included in the graph</param>
         /// <param name="includedFrequencies">Include only subscription with specified frequencies. Leave null or empty to include all</param>
         /// <returns>Dependency flow graph for given channel</returns>
-        Task<DependencyFlowGraph> GetDependencyFlowGraph(
+        Task<DependencyFlowGraph> GetDependencyFlowGraphAsync(
             int channelId,
             int days,
             bool includeArcade,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/MaestroApiBarClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/MaestroApiBarClient.cs
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.DarcLib
             return _barClient.Channels.DeleteChannelAsync(id);
         }
 
-        public async Task<DependencyFlowGraph> GetDependencyFlowGraph(
+        public async Task<DependencyFlowGraph> GetDependencyFlowGraphAsync(
             int channelId,
             int days,
             bool includeArcade,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyFlowGraph.cs
@@ -319,7 +319,7 @@ namespace Microsoft.DotNet.DarcLib
         public static async Task<DependencyFlowGraph> BuildAsync(
             List<DefaultChannel> defaultChannels,
             List<Subscription> subscriptions,
-            IRemote barOnlyRemote,
+            IBarClient barClient,
             int days)
         {
             // Dictionary of nodes. Key is the repo+branch
@@ -336,7 +336,7 @@ namespace Microsoft.DotNet.DarcLib
                 // Add the build times
                 if (channel.Id != default(int))
                 {
-                    BuildTime buildTime = await barOnlyRemote.GetBuildTimeAsync(channel.Id, days);
+                    BuildTime buildTime = await barClient.GetBuildTimeAsync(channel.Id, days);
                     flowNode.OfficialBuildTime = buildTime.OfficialBuildTime ?? 0;
                     flowNode.PrBuildTime = buildTime.PrBuildTime ?? 0;
                     flowNode.GoalTimeInMinutes = buildTime.GoalTimeInMinutes ?? 0;


### PR DESCRIPTION
Changes:
- Flow graph generation was moved from `DependencyUpdater` and `ChannelsController` into `MaestroBarClient` so that now the whole logic is in single place. Both of the classes now get the graph using `IRemote` interface.
- Added missing `Async` suffix to `IBarClient.GetDependencyFlowGraph` and `IRemote.GetDependencyFlowGraph` methods.
- Added unit tests for `DependencyUpdater.UpdateLongestBuildPathAsync`.
- Changed `DependencyUpdater` so that it does not save longest build path in the database if graph is empty or does not contain any nodes marked as `OnLongestBuildPath` (fixes https://github.com/dotnet/core-eng/issues/10809)