### PR TITLE
SafeCheckout is public

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LibGit2SharpHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LibGit2SharpHelpers.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.DarcLib.Helpers
         /// <param name="commit">Commit, tag, or branch to checkout the files at</param>
         /// <param name="options">Checkout options - mostly whether to force</param>
         /// <param name="log">Logger</param>
-        internal static void SafeCheckout(Repository repo, string commit, CheckoutOptions options, ILogger log)
+        public static void SafeCheckout(Repository repo, string commit, CheckoutOptions options, ILogger log)
         {
             try
             {


### PR DESCRIPTION
The dotnet-release repo currently uses copy-pasted code from LibGit2SharpHelpers because SafeCheckout is internal.  Making it public would remove the need for the copy-pasted code.