### PR TITLE
Adding source channels name to BARViz dependency flow graph

### DIFF
--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Models/FlowEdge.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Models/FlowEdge.cs
@@ -15,10 +15,11 @@ namespace Maestro.Web.Api.v2018_07_16.Models
             FromId = from;
         }
 
-        public FlowEdge (
+        public FlowEdge(
             string to,
             string from,
             Guid subscriptionId,
+            string channelName,
             bool onLongestBuildPath,
             bool isToolingOnly,
             bool? partOfCycle,
@@ -27,6 +28,7 @@ namespace Maestro.Web.Api.v2018_07_16.Models
             ToId = to;
             FromId = from;
             SubscriptionId = subscriptionId;
+            ChannelName = channelName;
             OnLongestBuildPath = onLongestBuildPath;
             IsToolingOnly = isToolingOnly;
             PartOfCycle = partOfCycle;
@@ -39,6 +41,7 @@ namespace Maestro.Web.Api.v2018_07_16.Models
                 other.To.Id, 
                 other.From.Id,
                 other.Subscription.Id,
+                other.Subscription.Channel.Name,
                 other.OnLongestBuildPath, 
                 other.IsToolingOnly,
                 other.PartOfCycle,
@@ -48,6 +51,7 @@ namespace Maestro.Web.Api.v2018_07_16.Models
         public string ToId { get; }
         public string FromId { get; }
         public Guid SubscriptionId { get; }
+        public string ChannelName { get; }
         public bool OnLongestBuildPath { get; }
         public bool IsToolingOnly { get; }
         public bool? PartOfCycle { get; }

--- a/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.html
@@ -3,3 +3,4 @@
 </div>
 <p>Hover over nodes for details about each node.</p>
 <p>Longest build path denoted in red ellipses connected by dashed lines.</p>
+<p>The source channels are annotated if they are different than the channel currently being viewed.</p>

--- a/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
@@ -3,7 +3,7 @@ import { ApplicationInsightsService } from 'src/app/services/application-insight
 import { graphlib, render, layout } from 'dagre-d3';
 import { select } from 'd3';
 
-import { FlowGraph, FlowRef, FlowEdge } from 'src/maestro-client/models';
+import { FlowGraph, FlowRef, FlowEdge, Channel } from 'src/maestro-client/models';
 import { RepoNamePipe } from 'src/app/pipes/repo-name.pipe';
 
 function getRepositoryShortName(repo?: string): string {
@@ -73,7 +73,7 @@ function getEdgeDescription(edge:FlowEdge, graph:FlowGraph): string {
   return description;
 }
 
-function drawFlowGraph(graph: FlowGraph, includeArcade: boolean) {
+function drawFlowGraph(graph: FlowGraph, includeArcade: boolean, channel: Channel) {
   var g = new graphlib.Graph().setGraph({
     ranksep: 25,
     ranker: 'tight-tree'
@@ -126,7 +126,7 @@ function drawFlowGraph(graph: FlowGraph, includeArcade: boolean) {
       }
 
       let edgeProperties:any = { arrowheadClass: 'arrowhead',
-                    description: getEdgeDescription(edge, graph), label: edge.channelName};
+                    description: getEdgeDescription(edge, graph), label: channel.name != edge.channelName ? edge.channelName : ""};
 
       if (edge.onLongestBuildPath) {
         edgeProperties.style = "stroke: #FD625E; stroke-width: 3px; stroke-dasharray: 5,5;";
@@ -218,6 +218,7 @@ export class ChannelGraphComponent implements OnChanges {
 
   @Input() public graph?: FlowGraph;
   @Input() public includeArcade?: boolean;
+  @Input() public channel?: Channel;
 
   constructor(private ai: ApplicationInsightsService) { }
 
@@ -232,8 +233,8 @@ export class ChannelGraphComponent implements OnChanges {
     }
 
     var includeArcade: boolean = this.includeArcade ? this.includeArcade : false;
-    if (this.graph) {
-      drawFlowGraph(this.graph, includeArcade);
+    if (this.graph && this.channel) {
+      drawFlowGraph(this.graph, includeArcade, this.channel);
     }
   }
 }

--- a/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
@@ -126,7 +126,8 @@ function drawFlowGraph(graph: FlowGraph, includeArcade: boolean, channel: Channe
       }
 
       let edgeProperties:any = { arrowheadClass: 'arrowhead',
-                    description: getEdgeDescription(edge, graph), label: channel.name != edge.channelName ? edge.channelName : ""};
+                    description: getEdgeDescription(edge, graph),
+                    label: channel.name != edge.channelName ? edge.channelName : ""};
 
       if (edge.onLongestBuildPath) {
         edgeProperties.style = "stroke: #FD625E; stroke-width: 3px; stroke-dasharray: 5,5;";

--- a/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
@@ -3,10 +3,8 @@ import { ApplicationInsightsService } from 'src/app/services/application-insight
 import { graphlib, render, layout } from 'dagre-d3';
 import { select } from 'd3';
 
-import { FlowGraph, FlowRef, FlowEdge, Subscription } from 'src/maestro-client/models';
+import { FlowGraph, FlowRef, FlowEdge } from 'src/maestro-client/models';
 import { RepoNamePipe } from 'src/app/pipes/repo-name.pipe';
-import { MaestroService } from 'src/maestro-client';
-import { map, tap } from 'rxjs/operators';
 
 function getRepositoryShortName(repo?: string): string {
   return repo && RepoNamePipe.prototype.transform(repo) || "unknown repository";
@@ -75,7 +73,7 @@ function getEdgeDescription(edge:FlowEdge, graph:FlowGraph): string {
   return description;
 }
 
-function drawFlowGraph(graph: FlowGraph, includeArcade: boolean, maestro: MaestroService) {
+function drawFlowGraph(graph: FlowGraph, includeArcade: boolean) {
   var g = new graphlib.Graph().setGraph({
     ranksep: 25,
     ranker: 'tight-tree'

--- a/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
@@ -219,7 +219,7 @@ export class ChannelGraphComponent implements OnChanges {
   @Input() public graph?: FlowGraph;
   @Input() public includeArcade?: boolean;
 
-  constructor(private ai: ApplicationInsightsService, private maestro: MaestroService) { }
+  constructor(private ai: ApplicationInsightsService) { }
 
   ngOnChanges(changes: SimpleChanges) {
     if(changes.includeArcade && (changes.includeArcade.previousValue != changes.includeArcade.currentValue))
@@ -233,7 +233,7 @@ export class ChannelGraphComponent implements OnChanges {
 
     var includeArcade: boolean = this.includeArcade ? this.includeArcade : false;
     if (this.graph) {
-      drawFlowGraph(this.graph, includeArcade, this.maestro);
+      drawFlowGraph(this.graph, includeArcade);
     }
   }
 }

--- a/src/Maestro/maestro-angular/src/app/page/channel/channel.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/channel/channel.component.html
@@ -12,7 +12,9 @@
   </span>
   <div class="container-fluid" style="height: 100%;">
     <ng-container *stateful="let graph from graph$">
-      <mc-channel-graph [graph]="graph" [includeArcade]="includeArcade"></mc-channel-graph>
+      <ng-container *stateful="let channel from channel$">
+        <mc-channel-graph [graph]="graph" [includeArcade]="includeArcade" [channel]="channel"></mc-channel-graph>
+      </ng-container>
     </ng-container>
   </div>
 </div>

--- a/src/Maestro/maestro-angular/src/app/page/channel/channel.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel/channel.component.ts
@@ -15,7 +15,7 @@ import { MaestroService } from 'src/maestro-client/maestro';
 })
 export class ChannelComponent implements OnInit {
 
-  constructor(private route: ActivatedRoute, private channelService: ChannelService, private maestroService: MaestroService) { }
+  constructor(private route: ActivatedRoute, private channelService: ChannelService) { }
 
   public graph$!: Observable<StatefulResult<FlowGraph>>;
   public channel$?: Observable<StatefulResult<Channel>>;

--- a/src/Maestro/maestro-angular/src/app/page/channel/channel.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel/channel.component.ts
@@ -6,7 +6,6 @@ import { FlowGraph, Channel} from 'src/maestro-client/models';
 import { Observable, of, timer, OperatorFunction } from 'rxjs';
 import { statefulSwitchMap, StatefulResult, statefulPipe } from 'src/stateful';
 import { ChannelService} from 'src/app/services/channel.service';
-import { MaestroService } from 'src/maestro-client/maestro';
 
 @Component({
   selector: 'mc-channel',

--- a/src/Maestro/maestro-angular/src/maestro-client/models.ts
+++ b/src/Maestro/maestro-angular/src/maestro-client/models.ts
@@ -1769,15 +1769,18 @@ export class FlowEdge {
             toId,
             fromId,
             onLongestBuildPath,
+            channelName
         }: {
             toId?: string,
             fromId?: string,
             onLongestBuildPath: boolean,
+            channelName?: string,
         }
     ) {
         this._toId = toId;
         this._fromId = fromId;
         this._onLongestBuildPath = onLongestBuildPath;
+        this._channelName = channelName;
     }
 
     private _toId?: string;
@@ -1802,6 +1805,12 @@ export class FlowEdge {
         this._onLongestBuildPath = __value;
     }
     
+    private _channelName?: string;
+
+    public get channelName(): string | undefined {
+        return this._channelName;
+    }
+
     public isValid(): boolean {
         return (
             this._onLongestBuildPath !== undefined
@@ -1809,10 +1818,12 @@ export class FlowEdge {
     }
 
     public static fromRawObject(value: any): FlowEdge {
+        console.log("value ", value);
         let result = new FlowEdge({
             toId: value["toId"] == null ? undefined : value["toId"] as any,
             fromId: value["fromId"] == null ? undefined : value["fromId"] as any,
             onLongestBuildPath: value["onLongestBuildPath"] == null ? undefined : value["onLongestBuildPath"] as any,
+            channelName: value["channelName"] == null ? undefined : value["channelName"] as any,
         });
         return result;
     }
@@ -1824,6 +1835,9 @@ export class FlowEdge {
         }
         if (value._fromId) {
             result["fromId"] = value._fromId;
+        }
+        if (value._channelName) {
+            result["channelName"] = value._channelName;
         }
         result["onLongestBuildPath"] = value._onLongestBuildPath;
         return result;
@@ -1873,6 +1887,7 @@ export class FlowGraph {
 
     public static toRawObject(value: FlowGraph): any {
         let result: any = {};
+        console.log("GRAPH RESULT: " + result);
         result["flowRefs"] = value._flowRefs.map((e: any) => FlowRef.toRawObject(e));
         result["flowEdges"] = value._flowEdges.map((e: any) => FlowEdge.toRawObject(e));
         return result;

--- a/src/Maestro/maestro-angular/src/maestro-client/models.ts
+++ b/src/Maestro/maestro-angular/src/maestro-client/models.ts
@@ -1818,7 +1818,6 @@ export class FlowEdge {
     }
 
     public static fromRawObject(value: any): FlowEdge {
-        console.log("value ", value);
         let result = new FlowEdge({
             toId: value["toId"] == null ? undefined : value["toId"] as any,
             fromId: value["fromId"] == null ? undefined : value["fromId"] as any,
@@ -1887,7 +1886,6 @@ export class FlowGraph {
 
     public static toRawObject(value: FlowGraph): any {
         let result: any = {};
-        console.log("GRAPH RESULT: " + result);
         result["flowRefs"] = value._flowRefs.map((e: any) => FlowRef.toRawObject(e));
         result["flowEdges"] = value._flowEdges.map((e: any) => FlowEdge.toRawObject(e));
         return result;


### PR DESCRIPTION
The goal of this PR is to annotate every edge with a channel (the source channel of the subscription). 

Next to each edge, we have the corresponding source channel of the subscription. We don't annotate the edges that have the same channel than the one currently being viewed.
![image](https://user-images.githubusercontent.com/43049559/94033156-f984ce80-fdc0-11ea-91a2-10acaa570cd0.png)
