### PR TITLE
Fix handling of duplicated default channel assignments

### DIFF
--- a/src/Maestro/Maestro.Web.Tests/DefaultChannelsController20200220Tests.cs
+++ b/src/Maestro/Maestro.Web.Tests/DefaultChannelsController20200220Tests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Common;
 using Maestro.Data;
 using Maestro.Web.Api.v2020_02_20.Controllers;
 using Maestro.Web.Api.v2020_02_20.Models;
@@ -272,6 +273,51 @@ namespace Maestro.Web.Tests
             // Try to get a default channel that just doesn't exist at all.
             var thirdExpectedFailResult = await data.DefaultChannelsController.Get(404);
             thirdExpectedFailResult.Should().BeOfType<NotFoundResult>("Getting a default channel for a non-existent default channel should give a not-found type result");
+        }
+
+        [Test]
+        public async Task AddDuplicateDefaultChannels()
+        {
+            using TestData data = await BuildDefaultAsync();
+            string channelName = "TEST-CHANNEL-DUPLICATE-ENTRY-SCENARIO";
+            string classification = "TEST-CLASSIFICATION";
+            string repository = "FAKE-REPOSITORY";
+            string branch = "FAKE-BRANCH";
+
+            Channel channel;
+            {
+                var result = await data.ChannelsController.CreateChannel(channelName, classification);
+                channel = (Channel) ((ObjectResult) result).Value;
+            }
+
+            DefaultChannelCreateData testDefaultChannelData = new DefaultChannelCreateData()
+            {
+                Branch = branch,
+                ChannelId = channel.Id,
+                Enabled = true,
+                Repository = repository
+            };
+
+            DefaultChannel defaultChannel;
+            {
+                var result = await data.DefaultChannelsController.Create(testDefaultChannelData);
+                defaultChannel = (DefaultChannel) ((ObjectResult) result).Value;
+            }
+
+            defaultChannel.Should().NotBeNull();
+
+            DefaultChannel defaultChannelDuplicateAdd;
+            {
+                var result = await data.DefaultChannelsController.Create(testDefaultChannelData);
+                defaultChannelDuplicateAdd = (DefaultChannel) ((ObjectResult) result).Value;
+            }
+
+            // Adding the same thing twice should succeed, as well as provide the correct object in return.
+            defaultChannelDuplicateAdd.Should().NotBeNull();
+            defaultChannelDuplicateAdd.Id.Should().Be(defaultChannel.Id);
+            defaultChannelDuplicateAdd.Branch.Should().Be(defaultChannel.Branch);
+            defaultChannelDuplicateAdd.Channel.Id.Should().Be(defaultChannel.Channel.Id);
+            defaultChannelDuplicateAdd.Repository.Should().Be(defaultChannel.Repository);
         }
 
         private Task<TestData> BuildDefaultAsync()

--- a/src/Maestro/Maestro.Web.Tests/DefaultChannelsController20200220Tests.cs
+++ b/src/Maestro/Maestro.Web.Tests/DefaultChannelsController20200220Tests.cs
@@ -313,11 +313,7 @@ namespace Maestro.Web.Tests
             }
 
             // Adding the same thing twice should succeed, as well as provide the correct object in return.
-            defaultChannelDuplicateAdd.Should().NotBeNull();
-            defaultChannelDuplicateAdd.Id.Should().Be(defaultChannel.Id);
-            defaultChannelDuplicateAdd.Branch.Should().Be(defaultChannel.Branch);
-            defaultChannelDuplicateAdd.Channel.Id.Should().Be(defaultChannel.Channel.Id);
-            defaultChannelDuplicateAdd.Repository.Should().Be(defaultChannel.Repository);
+            defaultChannelDuplicateAdd.Should().BeEquivalentTo(defaultChannel);
         }
 
         private Task<TestData> BuildDefaultAsync()


### PR DESCRIPTION
Addresses dotnet/core-eng#10721 by:

- Fixed the bug in HandleDuplicateKeyRowsAttribute (which was supposed to cause HTTP 409).  It was causing HTTP 500 since the exception type did not match (was trying to match on `System.Data.SqlClient.SqlException` while the implementation threw `Microsoft.Data.SqlClient.SqlException`; now it handles both.)
- I removed this attribute from DefaultChannels.Create() after discussing w/ @ChadNedzlek as it both makes this friendlier to retry logic and more testable.
- DefaultChannels.Create() now looks up the existing DefaultChannel object and returns that if identical parameters are returned.
- Added test for duplicate add scenario