### PR TITLE
Add Rollout Scorer support for issues labeling rollouts as failures

### DIFF
--- a/src/RolloutScorer/RolloutScorer/RolloutScorer.cs
+++ b/src/RolloutScorer/RolloutScorer/RolloutScorer.cs
@@ -205,9 +205,15 @@ namespace RolloutScorer
             return (numHotfixes, numRollbacks);
         }
 
-        public bool DetermineFailure()
+        public bool DetermineFailure(List<Issue> githubIssues)
         {
             Utilities.WriteDebug($"Determining failure for {Repo}...", Log, LogLevel);
+            if (githubIssues.Any(i => Utilities.IssueContainsRelevantLabels(i, GithubLabelNames.FailureLabel, RepoConfig.GithubIssueLabel, Log, LogLevel)))
+            {
+                Utilities.WriteDebug($"Issue with failure tag found for {Repo}; rollout marked as FAILED", Log, LogLevel);
+                return true;
+            }
+
             if (BuildBreakdowns.Count == 0)
             {
                 Utilities.WriteDebug($"No builds found for {Repo} this rollout; rollout marked as FAILED.", Log, LogLevel);
@@ -373,7 +379,8 @@ namespace RolloutScorer
                 Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.IssueLabel, RepoConfig.GithubIssueLabel, Log) ||
                 Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.HotfixLabel, RepoConfig.GithubIssueLabel, Log, LogLevel) ||
                 Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.RollbackLabel, RepoConfig.GithubIssueLabel, Log, LogLevel) ||
-                Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.DowntimeLabel, RepoConfig.GithubIssueLabel, Log, LogLevel)
+                Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.DowntimeLabel, RepoConfig.GithubIssueLabel, Log, LogLevel) ||
+                Utilities.IssueContainsRelevantLabels(issue, GithubLabelNames.FailureLabel, RepoConfig.GithubIssueLabel, Log, LogLevel)
                 ).ToList();
         }
 

--- a/src/RolloutScorer/RolloutScorer/Utilities.cs
+++ b/src/RolloutScorer/RolloutScorer/Utilities.cs
@@ -31,7 +31,10 @@ namespace RolloutScorer
             if (issueLabel == GithubLabelNames.IssueLabel)
             {
                 isIssueLabel = issue.Labels.Any(l => l.Name == repoLabel)
-                    && !issue.Labels.Any(l => l.Name == GithubLabelNames.HotfixLabel || l.Name == GithubLabelNames.RollbackLabel || l.Name == GithubLabelNames.DowntimeLabel);
+                    && !issue.Labels.Any(l => l.Name == GithubLabelNames.HotfixLabel ||
+                    l.Name == GithubLabelNames.RollbackLabel ||
+                    l.Name == GithubLabelNames.DowntimeLabel ||
+                    l.Name == GithubLabelNames.FailureLabel);
             }
             else
             {
@@ -190,6 +193,7 @@ namespace RolloutScorer
         public const string HotfixLabel = "Rollout Manual Hotfix";
         public const string RollbackLabel = "Rollout Manual Rollback";
         public const string DowntimeLabel = "Rollout Downtime";
+        public const string FailureLabel = "Rollout Failure";
     }
 
     public static class ScorecardsStorageAccount

--- a/src/RolloutScorer/RolloutScorerAzureFunction/RolloutScorerFunction.cs
+++ b/src/RolloutScorer/RolloutScorerAzureFunction/RolloutScorerFunction.cs
@@ -73,7 +73,7 @@ namespace RolloutScorerAzureFunction
                         RolloutScorer.RolloutScorer rolloutScorer = new RolloutScorer.RolloutScorer
                         {
                             Repo = deploymentGroup.Key,
-                            RolloutStartDate = deploymentGroup.First().Started.GetValueOrDefault(),
+                            RolloutStartDate = deploymentGroup.First().Started.GetValueOrDefault().Date,
                             RolloutWeightConfig = Configs.DefaultConfig.RolloutWeightConfig,
                             GithubConfig = Configs.DefaultConfig.GithubConfig,
                             Log = log,


### PR DESCRIPTION
Fixes dotnet/core-eng#11096.

If an issue in core-eng has both the **Rollout Failure** label and a rollout repo label, the rollout scorer will now mark that rollout as a failure and calculate the scorecard accordingly.

Example scorecard with this from 2020-09-24 [here](https://github.com/dotnet/core-eng/blob/master/Documentation/Rollout-Scorecards/Scorecard_2020-09-24.md) and the failure issue that I used for that is [here](https://github.com/dotnet/core-eng/issues/11097). (That scorecard was calculated from 9/24 to the present date to make sure the issue was capture automatically and then I manually removed the builds that occurred in the rollouts since 9/24 and reset the time to rollout and hotfixes accordingly.)

Corollary documentation change: https://github.com/dotnet/core-eng/pull/11099