### PR TITLE
Update VersionTools and add IsReleaseOnlyPackageVersion  

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.20228.4</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>5.0.0-beta.20426.6</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <MicrosoftDotNetGitIssueManagerVersion>5.0.0-beta.20228.4</MicrosoftDotNetGitIssueManagerVersion>
-    <MicrosoftDotNetVersionToolsVersion>5.0.0-beta.20228.4</MicrosoftDotNetVersionToolsVersion>
+    <MicrosoftDotNetVersionToolsVersion>5.0.0-beta.20506.7</MicrosoftDotNetVersionToolsVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -13,6 +13,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.46",
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20228.4"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20506.7"
   }
 }

--- a/global.json
+++ b/global.json
@@ -13,6 +13,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.46",
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20506.7"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20228.4"
   }
 }

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
@@ -37,6 +37,9 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
         [XmlAttribute(AttributeName = "PublishingVersion")]
         public int PublishingVersion { get; set; }
+        
+        [XmlAttribute(AttributeName = "IsReleaseOnlyPackageVersion")]
+        public string IsReleaseOnlyPackageVersion { get; set; } = "false";
 
         #region Properties to be used in new publishing flow
 

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/ManifestBuildData.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/ManifestBuildData.cs
@@ -26,6 +26,8 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
         public int PublishingVersion { get; set; }
 
+        public string  IsReleaseOnlyPackageVersion { get; set; }
+
         public ManifestBuildData(Manifest manifest)
         {
             InitialAssetsLocation = manifest.InitialAssetsLocation;
@@ -37,6 +39,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
             AzureDevOpsRepository = manifest.AzureDevOpsRepository;
             AzureDevOpsBranch = manifest.AzureDevOpsBranch;
             PublishingVersion = manifest.PublishingVersion;
+            IsReleaseOnlyPackageVersion = manifest.IsReleaseOnlyPackageVersion;
         }
 
         public bool Equals(ManifestBuildData manifestBuildData)

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -36,6 +36,8 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
         private bool IsStableBuild { get; set; } = false;
 
+        private bool IsReleaseOnlyPackageVersion { get; set; } = false;
+        
         public string RepoRoot { get; set; }
 
         public string AssetVersion { get; set; }
@@ -655,7 +657,9 @@ namespace Microsoft.DotNet.Maestro.Tasks
                             Branch = GetAzDevBranch(),
                             Commit = GetAzDevCommit(),
                             IsStable = IsStableBuild.ToString(),
-                            PublishingVersion = manifestBuildData.PublishingVersion.ToString()
+                            PublishingVersion = PublishingInfraVersion.Latest,
+                            IsReleaseOnlyPackageVersion = IsReleaseOnlyPackageVersion.ToString()
+
                         });
 
             foreach (AssetData data in assets)

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -657,7 +657,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                             Branch = GetAzDevBranch(),
                             Commit = GetAzDevCommit(),
                             IsStable = IsStableBuild.ToString(),
-                            PublishingVersion = PublishingInfraVersion.Latest,
+                            PublishingVersion = (PublishingInfraVersion)manifestBuildData.PublishingVersion,
                             IsReleaseOnlyPackageVersion = IsReleaseOnlyPackageVersion.ToString()
 
                         });

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -658,7 +658,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                             Commit = GetAzDevCommit(),
                             IsStable = IsStableBuild.ToString(),
                             PublishingVersion = (PublishingInfraVersion)manifestBuildData.PublishingVersion,
-                            IsReleaseOnlyPackageVersion = IsReleaseOnlyPackageVersion.ToString()
+                            IsReleaseOnlyPackageVersion =manifestBuildData.IsReleaseOnlyPackageVersion
 
                         });
 


### PR DESCRIPTION
For the IsReleaseOnlyPackageVersion  to show in the merged manifest 

First part was Arcade master change -> dotnet/arcade#6340
Release 3.x -> https://github.com/dotnet/arcade/pull/6319

For the merged manifest, we need to update the MicrosoftDotNetVersionToolsVersion to the latest version and add the IsReleaseOnlyPackageVersion  attribute in the manifest. 

Test Build from arcade-services to generated updated Maestro task -> https://dev.azure.com/dnceng/internal/_build/results?buildId=846200&view=results
Test build from arcade with the updated maestro task , arcade sdk and feeds task -> https://dev.azure.com/dnceng/internal/_build/results?buildId=846325&view=results




