### PR TITLE
Change way of finding tooling dependencies in the graph

### DIFF
--- a/src/Maestro/Maestro.DataProviders/MaestroBarClient.cs
+++ b/src/Maestro/Maestro.DataProviders/MaestroBarClient.cs
@@ -208,7 +208,8 @@ namespace Maestro.DataProviders
                 foreach (var edge in edgesWithLastBuild)
                 {
                     edge.IsToolingOnly = !_context.IsProductDependency(
-                        edge.Subscription.LastAppliedBuild.Id,
+                        edge.From.Repository,
+                        edge.From.Branch,
                         edge.To.Repository,
                         edge.To.Branch);
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/6210

After changes the logic for each graph edge is:
- Get the latest build of target node
- Find all build dependencies that were included in that build and come from source node
- If none of the dependencies have `IsProduct` set then subscription is tooling-only