### PR TITLE
Order by repo name, use begin/end comments around maestro feeds

### DIFF
--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
@@ -58,8 +58,15 @@ namespace Microsoft.DotNet.Darc.Tests
             string inputXmlContent = await File.ReadAllTextAsync(inputNugetPath);
             var inputNuGetConfigFile = GitFileManager.ReadXmlFile(inputXmlContent);
 
+            Dictionary<string, HashSet<string>> configFileUpdateData = new Dictionary<string, HashSet<string>>();
+            configFileUpdateData.Add("testKey", new HashSet<string>(managedFeeds));
+            var managedFeedsForTest = gitFileManager.FlattenLocationsAndSplitIntoGroups(configFileUpdateData);
+
+            // 'unknown' = regex failed to match and extract repo name from feed
+            managedFeedsForTest.Keys.Should().NotContain("unknown");
+
             XmlDocument updatedConfigFile =
-                gitFileManager.UpdatePackageSources(inputNuGetConfigFile, new HashSet<string>(managedFeeds));
+                gitFileManager.UpdatePackageSources(inputNuGetConfigFile, managedFeedsForTest);
 
             var outputNugetPath = Path.Combine(
                 Environment.CurrentDirectory,

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/AddFeedsToNuGetConfigWithoutManagedFeeds/NuGet.output.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/AddFeedsToNuGetConfigWithoutManagedFeeds/NuGet.output.config
@@ -4,8 +4,12 @@
   <packageSources>
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
-    <add key="darc-pub-dotnet-standard-a5b5f2e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-standard-a5b5f2e1/nuget/v3/index.json" />
+    <!--  Begin: Package sources from dotnet-corefx -->
     <add key="darc-pub-dotnet-corefx-4ac4c03" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-4ac4c036/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-corefx -->
+    <!--  Begin: Package sources from dotnet-standard -->
+    <add key="darc-pub-dotnet-standard-a5b5f2e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-standard-a5b5f2e1/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-standard -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/EnsureAppendsDisableEntryAfterLastClear/NuGet.output.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/EnsureAppendsDisableEntryAfterLastClear/NuGet.output.config
@@ -4,7 +4,9 @@
   <packageSources>
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--  Begin: Package sources from dotnet-arcade -->
     <add key="darc-int-dotnet-arcade-b043797" value="https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-arcade-b0437974/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-arcade -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
@@ -16,7 +18,9 @@
     <clear />
     <add key="nuget.org" value="true" />
     <clear />
+    <!--  Begin: Package sources from dotnet-arcade -->
     <add key="darc-int-dotnet-arcade-b043797" value="true" />
+    <!--  End: Package sources from dotnet-arcade -->
     <!-- Seems whatever wrote this config is indecisive -->
     <add key="dotnet-windowsdesktop" value="true" />
   </disabledPackageSources>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/PreserveCommentsInRightLocationsWhenReplacing/NuGet.output.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/PreserveCommentsInRightLocationsWhenReplacing/NuGet.output.config
@@ -4,8 +4,12 @@
   <packageSources>
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
-    <add key="darc-pub-dotnet-standard-a5b5f2e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-standard-a5b5f2e1/nuget/v3/index.json" />
+    <!--  Begin: Package sources from dotnet-corefx -->
     <add key="darc-pub-dotnet-corefx-4ac4c03" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-4ac4c036/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-corefx -->
+    <!--  Begin: Package sources from dotnet-standard -->
+    <add key="darc-pub-dotnet-standard-a5b5f2e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-standard-a5b5f2e1/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-standard -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!--
       'src/test/PrepareTestAssets/PrepareTestAssets.proj' generates a NuGet.config file using this

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/PreserveCommentsInRightLocationsWithNoExistingBlock/NuGet.output.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/PreserveCommentsInRightLocationsWithNoExistingBlock/NuGet.output.config
@@ -4,8 +4,12 @@
   <packageSources>
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
-    <add key="darc-pub-dotnet-corefx-4ac4c03" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-4ac4c036/nuget/v3/index.json" />
+    <!--  Begin: Package sources from dotnet-arcade -->
     <add key="darc-int-dotnet-arcade-b043797" value="https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-arcade-b0437974/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-arcade -->
+    <!--  Begin: Package sources from dotnet-corefx -->
+    <add key="darc-pub-dotnet-corefx-4ac4c03" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-4ac4c036/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-corefx -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!--
       'src/test/PrepareTestAssets/PrepareTestAssets.proj' generates a NuGet.config file using this
@@ -18,6 +22,8 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
+    <!--  Begin: Package sources from dotnet-arcade -->
     <add key="darc-int-dotnet-arcade-b043797" value="true" />
+    <!--  End: Package sources from dotnet-arcade -->
   </disabledPackageSources>
 </configuration>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/PreserveManagedFeedFromOutside/NuGet.output.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/PreserveManagedFeedFromOutside/NuGet.output.config
@@ -4,8 +4,12 @@
   <packageSources>
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
-    <add key="darc-pub-dotnet-corefx-4ac4c03" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-4ac4c036/nuget/v3/index.json" />
+    <!--  Begin: Package sources from dotnet-arcade -->
     <add key="darc-int-dotnet-arcade-b043797" value="https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-arcade-b0437974/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-arcade -->
+    <!--  Begin: Package sources from dotnet-corefx -->
+    <add key="darc-pub-dotnet-corefx-4ac4c03" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-4ac4c036/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-corefx -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!--
       'src/test/PrepareTestAssets/PrepareTestAssets.proj' generates a NuGet.config file using this
@@ -21,6 +25,8 @@
   </packageSources>
   <disabledPackageSources>
     <add key="darc-int-dotnet-arcade-c134a97" value="false" />
+    <!--  Begin: Package sources from dotnet-arcade -->
     <add key="darc-int-dotnet-arcade-b043797" value="true" />
+    <!--  End: Package sources from dotnet-arcade -->
   </disabledPackageSources>
 </configuration>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/RedisableCurrentlyEnabledIntSources/NuGet.output.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/RedisableCurrentlyEnabledIntSources/NuGet.output.config
@@ -4,7 +4,9 @@
   <packageSources>
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--  Begin: Package sources from dotnet-arcade -->
     <add key="darc-int-dotnet-arcade-b043797" value="https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-arcade-b0437974/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-arcade -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
@@ -12,6 +14,8 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
+    <!--  Begin: Package sources from dotnet-arcade -->
     <add key="darc-int-dotnet-arcade-b043797" value="true" />
+    <!--  End: Package sources from dotnet-arcade -->
   </disabledPackageSources>
 </configuration>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/ReplaceExistingFeedsWithNewOnes/NuGet.output.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/ReplaceExistingFeedsWithNewOnes/NuGet.output.config
@@ -4,7 +4,9 @@
   <packageSources>
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--  Begin: Package sources from dotnet-standard -->
     <add key="darc-pub-dotnet-standard-a5b5f2e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-standard-a5b5f2e1/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-standard -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/WhiteSpaceCorrectlyFormatted/NuGet.output.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/WhiteSpaceCorrectlyFormatted/NuGet.output.config
@@ -4,7 +4,9 @@
   <packageSources>
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--  Begin: Package sources from dotnet-core-setup -->
     <add key="darc-pub-dotnet-core-setup-7d57652" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-core-setup-7d57652f/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-core-setup -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />


### PR DESCRIPTION
This is done in an attempt to avoid merge conflicts.  See test expected outputs for what this will look like.

https://github.com/dotnet/arcade/issues/5909