### PR TITLE
Always* attempt strict coherency before using legacy coherency

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateDependenciesCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateDependenciesCommandLineOptions.cs
@@ -38,8 +38,8 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("coherency-only", HelpText = "Only do coherency updates.")]
         public bool CoherencyOnly { get; set; }
 
-        [Option("strict-coherency", HelpText = "Use strict coherency.")]
-        public bool StrictCoherency { get; set; }
+        [Option("legacy-coherency", HelpText = "Use 'legacy' coherency mode (default is 'strict')")]
+        public bool LegacyCoherency { get; set; }
 
         public override Operation GetOperation()
         {


### PR DESCRIPTION
Makes all calls to GetRequiredCoherencyUpdatesAsync() (except where Legacy is explicitly specified) default to Strict, catch the update exception, then retry with Legacy mode

Addresses https://github.com/dotnet/arcade/issues/6431