### PR TITLE
log the promotion build in the error output

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -318,7 +318,8 @@ namespace Microsoft.DotNet.Darc.Operations
             }
             else
             {
-                Console.WriteLine("The promotion build finished but the build isn't associated with at least one of the target channels. This is an error scenario. Please contact @dnceng.");
+                Console.WriteLine("The promotion build finished but the build isn't associated with at least one of the target channels. This is an error scenario.");
+                Console.WriteLine($"Details are available in the following build: {promotionBuildUrl}. For any questions, contact @dnceng");
                 return Constants.ErrorCode;
             }
         }


### PR DESCRIPTION
This logs the promotion build URL when there's a failure in order to try and make the errors from the command more self-diagnosable

https://github.com/dotnet/arcade/issues/6446