### PR TITLE
only log the updated subscriptions once, not for every subscription u…

### DIFF
--- a/src/Maestro/DependencyUpdater/DependencyUpdater.cs
+++ b/src/Maestro/DependencyUpdater/DependencyUpdater.cs
@@ -242,9 +242,9 @@ namespace DependencyUpdater
                         await UpdateSubscriptionAsync(subscription.Id, latestBuildInTargetChannel.Id);
                         subscriptionsUpdated++;
                     }
-
-                    Logger.LogInformation($"Updated '{subscriptionsUpdated}' subscriptions");
                 }
+
+                Logger.LogInformation($"Updated '{subscriptionsUpdated}' subscriptions");
             }
         }
 


### PR DESCRIPTION
…pdated

Messed up where I put this logging statement in https://github.com/dotnet/arcade-services/pull/1453. It's inside the loop right now so we log "updated 'x' subscriptions" N times, which makes for some very confusing investigations.