### PR TITLE
[Rollout] Production deployment for Nov 4th, 2020

### DIFF
--- a/src/Maestro/Client/src/Generated/Models/BuildData.cs
+++ b/src/Maestro/Client/src/Generated/Models/BuildData.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Newtonsoft.Json;
 
@@ -16,6 +16,82 @@ namespace Microsoft.DotNet.Maestro.Client.Models
             AzureDevOpsBranch = azureDevOpsBranch;
             Released = released;
             Stable = stable;
+        }
+
+        public BuildData(BuildData buildData)
+        {
+            Commit = buildData.Commit;
+            AzureDevOpsBuildId = buildData.AzureDevOpsBuildId;
+            AzureDevOpsBuildDefinitionId = buildData.AzureDevOpsBuildDefinitionId;
+            AzureDevOpsAccount = buildData.AzureDevOpsAccount;
+            AzureDevOpsProject = buildData.AzureDevOpsProject;
+            AzureDevOpsBuildNumber = buildData.AzureDevOpsBuildNumber;
+            AzureDevOpsRepository = buildData.AzureDevOpsRepository;
+            AzureDevOpsBranch = buildData.AzureDevOpsBranch;
+            GitHubRepository = buildData.GitHubRepository;
+            GitHubBranch = buildData.GitHubBranch;
+            Released = buildData.Released;
+            Stable = buildData.Stable;
+
+            // Assets deep copy
+            if (buildData.Assets != null)
+            {
+                List<AssetData> assetList = new List<AssetData>();
+
+                foreach (AssetData asset in buildData.Assets)
+                {
+                    List<AssetLocationData> locationsList = new List<AssetLocationData>();
+                    foreach (AssetLocationData location in asset.Locations)
+                    {
+                        locationsList.Add(new AssetLocationData(location.Type)
+                        {
+                            Location = location.Location,
+                        });
+                    }
+
+                    assetList.Add(new AssetData(asset.NonShipping)
+                    {
+                        Name = asset.Name,
+                        Version = asset.Version,
+                        Locations = locationsList.ToImmutableList<AssetLocationData>()
+                    });
+                }
+
+                Assets = assetList.ToImmutableList<AssetData>();
+            }
+
+            //Dependencies deep copy
+            if (buildData.Dependencies != null)
+            {
+                List<BuildRef> dependenciesList = new List<BuildRef>();
+
+                foreach (BuildRef dep in buildData.Dependencies)
+                {
+                    dependenciesList.Add(new BuildRef(dep.BuildId, dep.IsProduct, dep.TimeToInclusionInMinutes));
+                }
+
+                Dependencies = dependenciesList.ToImmutableList<BuildRef>();
+            }
+
+
+            //Incoherencies deep copy
+            if (buildData.Incoherencies != null)
+            {
+                List<BuildIncoherence> incoherenciesList = new List<BuildIncoherence>();
+
+                foreach (BuildIncoherence incoherence in buildData.Incoherencies)
+                {
+                    incoherenciesList.Add(new BuildIncoherence()
+                    {
+                        Commit = incoherence.Commit,
+                        Name = incoherence.Name,
+                        Repository = incoherence.Repository,
+                        Version = incoherence.Version
+                    });
+                }
+
+                Incoherencies = incoherenciesList.ToImmutableList<BuildIncoherence>();
+            }
         }
 
         [JsonProperty("commit")]

--- a/src/Maestro/DependencyUpdater/DependencyUpdater.cs
+++ b/src/Maestro/DependencyUpdater/DependencyUpdater.cs
@@ -242,9 +242,9 @@ namespace DependencyUpdater
                         await UpdateSubscriptionAsync(subscription.Id, latestBuildInTargetChannel.Id);
                         subscriptionsUpdated++;
                     }
-
-                    Logger.LogInformation($"Updated '{subscriptionsUpdated}' subscriptions");
                 }
+
+                Logger.LogInformation($"Updated '{subscriptionsUpdated}' subscriptions");
             }
         }
 

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/AddAssetTests.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/AddAssetTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using FluentAssertions;
 using Microsoft.DotNet.Maestro.Client.Models;
 using NUnit.Framework;
@@ -19,7 +23,7 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
 
             pushMetadata.AddAsset(assetData, expectedAssetData.Name, expectedAssetData.Version, "testLocation", LocationType.None, true);
             assetData.Count.Should().Be(1);
-            CompareAssetData(assetData[0], expectedAssetData);
+            assetData.Should().BeEquivalentTo(expectedAssetData);
         }
 
         [Test]
@@ -37,10 +41,10 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
 
             AssetData newAssetData = new AssetData(true) { Name = "testName", Version = "12345", Locations = ImmutableList<AssetLocationData>.Empty.Add(new AssetLocationData(LocationType.None) { Location = "testLocation" }) };
 
-            pushMetadata.AddAsset(assetData, newAssetData.Name, newAssetData.Version, "testLocation", LocationType.None, false);
+            pushMetadata.AddAsset(assetData, newAssetData.Name, newAssetData.Version, "testLocation", LocationType.None, true);
             assetData.Count.Should().Be(2);
-            CompareAssetData(assetData[0], existingAssetData);
-            CompareAssetData(assetData[1], newAssetData);
+            assetData[0].Should().BeEquivalentTo(existingAssetData);
+            assetData[1].Should().BeEquivalentTo(newAssetData);
         }
 
         [Test]
@@ -51,14 +55,6 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
             Action act = () =>
                 pushMetadata.AddAsset(null, "testName", "12345", "testLocation", LocationType.None, true);
             act.Should().Throw<NullReferenceException>();
-        }
-
-        // This method includes additional points of comparison that aren't used in the product code
-        private void CompareAssetData(AssetData actual, AssetData expected)
-        {
-            actual.Name.Should().Be(expected.Name);
-            actual.Version.Should().Be(expected.Version);
-            actual.Locations.Should().BeEquivalentTo(expected.Locations);
         }
     }
 }

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/MergeBuildManifestsTests.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/MergeBuildManifestsTests.cs
@@ -1,0 +1,311 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Maestro.Client.Models;
+using NUnit.Framework;
+
+namespace Microsoft.DotNet.Maestro.Tasks.Tests
+{
+    [TestFixture]
+    public class MergeBuildManifestsTests
+    {
+        private PushMetadataToBuildAssetRegistry pushMetadata;
+        public const string Commit = "e7a79ce64f0703c231e6da88b5279dd0bf681b3d";
+        public const string AzureDevOpsAccount1 = "dnceng";
+        public const int AzureDevOpsBuildDefinitionId1 = 6;
+        public const int AzureDevOpsBuildId1 = 856354;
+        public const string AzureDevOpsBranch1 = "refs/heads/master";
+        public const string AzureDevOpsBuildNumber1 = "20201016.5";
+        public const string AzureDevOpsProject1 = "internal";
+        public const string AzureDevOpsRepository1 = "https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-arcade";
+        public const string LocationString = "https://dev.azure.com/dnceng/internal/_apis/build/builds/856354/artifacts";
+
+        internal static readonly AssetData PackageAsset1 =
+    new AssetData(true)
+    {
+        Locations = ImmutableList.Create(
+            new AssetLocationData(LocationType.Container)
+            { Location = LocationString }),
+        Name = "Microsoft.Cci.Extensions",
+        Version = "6.0.0-beta.20516.5"
+    };
+
+        internal static readonly AssetData BlobAsset1 =
+            new AssetData(true)
+            {
+                Locations = ImmutableList.Create(
+                    new AssetLocationData(LocationType.Container)
+                    { Location = LocationString }),
+                Name = "assets/manifests/dotnet-arcade/6.0.0-beta.20516.5/MergedManifest.xml",
+                Version = "6.0.0-beta.20516.5"
+            };
+
+        internal static readonly AssetData PackageAsset2 =
+            new AssetData(true)
+            {
+                Locations = ImmutableList.Create(
+                    new AssetLocationData(LocationType.Container)
+                    { Location = LocationString }),
+                Name = "Microsoft.DotNet.ApiCompat",
+                Version = "6.0.0-beta.20516.5"
+            };
+
+        internal static readonly AssetData BlobAsset2 =
+            new AssetData(true)
+            {
+                Locations = ImmutableList.Create(
+                    new AssetLocationData(LocationType.Container)
+                    { Location = LocationString }),
+                Name = "assets/symbols/Microsoft.Cci.Extensions.6.0.0-beta.20516.5.symbols.nupkg",
+                Version = "6.0.0-beta.20516.5"
+            };
+
+        internal static readonly AssetData PackageAsset3 =
+            new AssetData(true)
+            {
+                Locations = ImmutableList.Create(
+                    new AssetLocationData(LocationType.Container)
+                    { Location = LocationString }),
+                Name = "Microsoft.DotNet.Arcade.Sdk",
+                Version = "6.0.0-beta.20516.5"
+            };
+
+        internal static readonly AssetData BlobAsset3 =
+            new AssetData(true)
+            {
+                Locations = ImmutableList.Create(
+                    new AssetLocationData(LocationType.Container)
+                    { Location = LocationString }),
+                Name = "assets/symbols/Microsoft.DotNet.Arcade.Sdk.6.0.0-beta.20516.5.symbols.nupkg",
+                Version = "6.0.0-beta.20516.5"
+            };
+
+        public static readonly IImmutableList<AssetData> ExpectedAssets1 =
+            ImmutableList.Create(PackageAsset1, BlobAsset1);
+
+        public static readonly IImmutableList<AssetData> ExpectedAssets2 =
+             ImmutableList.Create(PackageAsset2, BlobAsset2);
+
+        public static readonly IImmutableList<AssetData> ExpectedAssets3 =
+             ImmutableList.Create(PackageAsset3, BlobAsset3);
+
+        public static readonly IImmutableList<AssetData> ExpectedAssets1And2 =
+            ImmutableList.Create(PackageAsset1, BlobAsset1, PackageAsset2, BlobAsset2);
+
+        public static readonly IImmutableList<AssetData> ThreeExpectedAssets =
+            ImmutableList.Create(PackageAsset1, BlobAsset1, PackageAsset2, BlobAsset2, PackageAsset3, BlobAsset3);
+
+        public static readonly IImmutableList<AssetData> NoBlobExpectedAssets =
+            ImmutableList.Create(PackageAsset1);
+
+        public static readonly IImmutableList<AssetData> NoPackageExpectedAssets =
+            ImmutableList.Create(BlobAsset1);
+
+        public static readonly IImmutableList<AssetData> ExpectedPartialAssets =
+            ImmutableList.Create(PackageAsset1, BlobAsset1);
+
+        private static readonly BuildData Asset1BuildData =
+            new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+            {
+                GitHubBranch = AzureDevOpsBranch1,
+                GitHubRepository = "dotnet-arcade",
+                Assets = ExpectedAssets1,
+                AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+            };
+
+        // Other BuildData isn't modified so it can be shared between tests
+        private static readonly BuildData Asset2BuildData =
+            new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+            {
+                GitHubBranch = AzureDevOpsBranch1,
+                GitHubRepository = "dotnet-arcade",
+                Assets = ExpectedAssets2,
+                AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+            };
+
+        private static readonly BuildData Asset3BuildData =
+            new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+            {
+                GitHubBranch = AzureDevOpsBranch1,
+                GitHubRepository = "dotnet-arcade",
+                Assets = ExpectedAssets3,
+                AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+            };
+
+        private static readonly List<BuildData> twoBuildDataList =
+            new List<BuildData>() { Asset1BuildData, Asset2BuildData };
+
+        private static readonly List<BuildData> threeBuildDataList =
+            new List<BuildData>() { Asset1BuildData, Asset2BuildData, Asset3BuildData };
+
+        private static readonly BuildData ExpectedMergedBuildData =
+            new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+            {
+                GitHubBranch = AzureDevOpsBranch1,
+                GitHubRepository = "https://github.com/dotnet/arcade",
+                Assets = ExpectedAssets1And2,
+                AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+            };
+
+        private static readonly BuildData ExpectedThreeAssetsBuildData =
+            new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+            {
+                GitHubBranch = AzureDevOpsBranch1,
+                GitHubRepository = "https://github.com/dotnet/arcade",
+                Assets = ThreeExpectedAssets,
+                AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+            };
+        public static readonly BuildData ExpectedPartialAssetsBuildData =
+           new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+           {
+               GitHubBranch = AzureDevOpsBranch1,
+               GitHubRepository = "https://github.com/dotnet/arcade",
+               Assets = ExpectedPartialAssets,
+               AzureDevOpsBuildId = AzureDevOpsBuildId1,
+               AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+           };
+
+        public static readonly List<BuildData> ExpectedBuildDataIncompatibleList = new List<BuildData>()
+            {
+                new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+                {
+                    GitHubBranch = AzureDevOpsBranch1,
+                    GitHubRepository = "https://github.com/dotnet/arcade",
+                    Assets = ExpectedAssets1,
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                    AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+                },
+                new BuildData("1234567", "newAccount", "newProject", "12345", "repositoryBranch", "azureDevOpsBranch", false, false)
+                {
+                    GitHubBranch = AzureDevOpsBranch1,
+                    GitHubRepository = "dotnet-arcade",
+                    Assets = ExpectedAssets2,
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                    AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+                }
+            };
+
+        public static readonly List<BuildData> ExpectedDuplicatedAssetsBuildData = new List<BuildData>()
+        {
+            new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+            {
+                GitHubBranch = AzureDevOpsBranch1,
+                GitHubRepository = "https://github.com/dotnet/arcade",
+                Assets = ExpectedAssets1,
+                AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+            },
+            new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+            {
+                GitHubBranch = AzureDevOpsBranch1,
+                GitHubRepository = "https://github.com/dotnet/arcade",
+                Assets = ExpectedAssets1,
+                AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+            }
+        };
+
+        public static readonly List<BuildData> ExpectedNoBlobManifestMetadata = new List<BuildData>()
+            {
+                new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+                {
+                    GitHubBranch = AzureDevOpsBranch1,
+                    GitHubRepository = "dotnet-arcade",
+                    Assets = NoBlobExpectedAssets,
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                    AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+                }
+            };
+
+        public static readonly List<BuildData> ExpectedNoPackagesManifestMetadata = new List<BuildData>()
+            {
+                new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+                {
+                    GitHubBranch = AzureDevOpsBranch1,
+                    GitHubRepository = "dotnet-arcade",
+                    Assets = NoPackageExpectedAssets,
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                    AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+                }
+            };
+
+        public static readonly List<BuildData> BuildDataWithoutAssetsList = new List<BuildData>()
+            {
+                new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+                {
+                    GitHubBranch = AzureDevOpsBranch1,
+                    GitHubRepository = "dotnet-arcade",
+                    Assets = ImmutableList<AssetData>.Empty,
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                    AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+                },
+                new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+                {
+                    GitHubBranch = AzureDevOpsBranch1,
+                    GitHubRepository = "dotnet-arcade",
+                    Assets = null,
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                    AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+                }
+            };
+
+        [SetUp]
+        public void SetupMergeBuildManifestsTests()
+        {
+            pushMetadata = new PushMetadataToBuildAssetRegistry();
+        }
+
+        [Test]
+        public void TwoCompatibleBuildData()
+        {
+            BuildData mergedData = pushMetadata.MergeBuildManifests(twoBuildDataList);
+            mergedData.Should().BeEquivalentTo(ExpectedMergedBuildData);
+        }
+
+        [Test]
+        public void ThreeCompatibleBuildData()
+        {
+            BuildData mergedData = pushMetadata.MergeBuildManifests(threeBuildDataList);
+            mergedData.Should().BeEquivalentTo(ExpectedThreeAssetsBuildData);
+        }
+
+        [Test]
+        public void BuildDataWithNullAndEmptyAssets()
+        {
+            Action act = () => pushMetadata.MergeBuildManifests(BuildDataWithoutAssetsList);
+            act.Should().Throw<ArgumentNullException>().WithMessage("Value cannot be null. (Parameter 'items')");
+        }
+
+        [Test]
+        public void BuildDataWithPartiallyEmptyAssets()
+        {
+            BuildData mergedData = pushMetadata.MergeBuildManifests(ExpectedNoBlobManifestMetadata.Concat(ExpectedNoPackagesManifestMetadata).ToList());
+            mergedData.Should().BeEquivalentTo(ExpectedPartialAssetsBuildData);
+        }
+
+        [Test]
+        public void IncompatibleBuildData()
+        {
+            Action act = () => pushMetadata.MergeBuildManifests(ExpectedBuildDataIncompatibleList);
+            act.Should().Throw<Exception>().WithMessage("Can't merge if one or more manifests have different branch, build number, commit, or repository values.");
+        }
+
+        [Test]
+        public void CompatibleBuildDataWithDuplicatedAssets()
+        {
+            Action act = () => pushMetadata.MergeBuildManifests(ExpectedBuildDataIncompatibleList);
+            act.Should().Throw<Exception>().WithMessage("Can't merge if one or more manifests have different branch, build number, commit, or repository values.");
+        }
+    }
+}

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/MergeSigningInfoTests.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/MergeSigningInfoTests.cs
@@ -1,0 +1,353 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Microsoft.DotNet.Maestro.Tasks.Tests
+{
+    [TestFixture]
+    public class MergeSigningInfoTests
+    {
+        private PushMetadataToBuildAssetRegistry pushMetadata;
+
+        public const string Commit = "e7a79ce64f0703c231e6da88b5279dd0bf681b3d";
+        public const string AzureDevOpsAccount1 = "dnceng";
+        public const int AzureDevOpsBuildDefinitionId1 = 6;
+        public const int AzureDevOpsBuildId1 = 856354;
+        public const string AzureDevOpsBranch1 = "refs/heads/master";
+        public const string AzureDevOpsBuildNumber1 = "20201016.5";
+        public const string AzureDevOpsProject1 = "internal";
+        public const string AzureDevOpsRepository1 = "https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-arcade";
+        public const string LocationString = "https://dev.azure.com/dnceng/internal/_apis/build/builds/856354/artifacts";
+
+        public static readonly List<SigningInformation> ExpectedSigningInfo = new List<SigningInformation>()
+            {
+                new SigningInformation()
+                {
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1.ToString(),
+                    AzureDevOpsCollectionUri = "https://dev.azure.com/dnceng/",
+                    AzureDevOpsProject = AzureDevOpsProject1,
+                    CertificatesSignInfo = new List<CertificatesSignInfo>()
+                    {
+                        new CertificatesSignInfo()
+                        {
+                            DualSigningAllowed = true,
+                            Include = "ThisIsACert"
+                        }
+                    },
+
+                    FileExtensionSignInfos = new List<FileExtensionSignInfo>()
+                    {
+                        new FileExtensionSignInfo()
+                        {
+                            CertificateName = "ThisIsACert",
+                            Include = ".dll"
+                        }
+                    },
+
+                    FileSignInfos = new List<FileSignInfo>()
+                    {
+                        new FileSignInfo()
+                        {
+                            CertificateName = "ThisIsACert",
+                             Include = "ALibrary.dll"
+                        }
+                    },
+
+                    StrongNameSignInfos = new List<StrongNameSignInfo>()
+                    {
+                        new StrongNameSignInfo()
+                        {
+                            CertificateName = "ThisIsACert",
+                            Include = "IncludeMe",
+                            PublicKeyToken = "123456789abcde12"
+                        }
+                    },
+                    ItemsToSign = new List<ItemsToSign>()
+                }
+            };
+
+        public static readonly SigningInformation PartialSigningInfo1 = new SigningInformation()
+        {
+            AzureDevOpsBuildId = AzureDevOpsBuildId1.ToString(),
+            AzureDevOpsCollectionUri = "https://dev.azure.com/dnceng/"
+        };
+
+        public static readonly SigningInformation PartialSigningInfo2 = new SigningInformation()
+        {
+            AzureDevOpsCollectionUri = "https://dev.azure.com/dnceng/",
+            AzureDevOpsProject = AzureDevOpsProject1
+        };
+
+        public static readonly SigningInformation PartialSigningInfo3 = new SigningInformation()
+        {
+            AzureDevOpsBuildId = AzureDevOpsBuildId1.ToString(),
+            AzureDevOpsCollectionUri = "https://dev.azure.com/dnceng/",
+            AzureDevOpsProject = AzureDevOpsProject1,
+            CertificatesSignInfo = new List<CertificatesSignInfo>()
+                {
+                    new CertificatesSignInfo()
+                    {
+                        DualSigningAllowed = true,
+                        Include = "ThisIsACert"
+                    }
+                },
+
+            FileExtensionSignInfos = new List<FileExtensionSignInfo>(),
+            FileSignInfos = new List<FileSignInfo>(),
+            StrongNameSignInfos = new List<StrongNameSignInfo>(),
+            ItemsToSign = new List<ItemsToSign>()
+        };
+
+        public static readonly SigningInformation PartialSigningInfo4 = new SigningInformation()
+        {
+            AzureDevOpsBuildId = AzureDevOpsBuildId1.ToString(),
+            AzureDevOpsCollectionUri = "https://dev.azure.com/dnceng/",
+            AzureDevOpsProject = AzureDevOpsProject1,
+            CertificatesSignInfo = new List<CertificatesSignInfo>(),
+            FileExtensionSignInfos = new List<FileExtensionSignInfo>()
+                {
+                    new FileExtensionSignInfo()
+                    {
+                        CertificateName = "ThisIsACert",
+                        Include = ".dll"
+                    }
+                },
+            FileSignInfos = new List<FileSignInfo>(),
+            StrongNameSignInfos = new List<StrongNameSignInfo>(),
+            ItemsToSign = new List<ItemsToSign>()
+        };
+
+        public static readonly SigningInformation MergedPartialMetadataSigningInfos = new SigningInformation()
+        {
+            AzureDevOpsBuildId = AzureDevOpsBuildId1.ToString(),
+            AzureDevOpsCollectionUri = "https://dev.azure.com/dnceng/",
+            AzureDevOpsProject = AzureDevOpsProject1,
+            CertificatesSignInfo = new List<CertificatesSignInfo>()
+                {
+                    new CertificatesSignInfo()
+                    {
+                        DualSigningAllowed = true,
+                        Include = "ThisIsACert"
+                    }
+                },
+            FileExtensionSignInfos = new List<FileExtensionSignInfo>()
+                {
+                    new FileExtensionSignInfo()
+                    {
+                        CertificateName = "ThisIsACert",
+                        Include = ".dll"
+                    }
+                },
+            FileSignInfos = new List<FileSignInfo>(),
+            ItemsToSign = new List<ItemsToSign>(),
+            StrongNameSignInfos = new List<StrongNameSignInfo>()
+        };
+
+        public static readonly SigningInformation MergedPartialSigningInfos = new SigningInformation()
+        {
+            AzureDevOpsBuildId = AzureDevOpsBuildId1.ToString(),
+            AzureDevOpsCollectionUri = "https://dev.azure.com/dnceng/",
+            AzureDevOpsProject = AzureDevOpsProject1,
+            CertificatesSignInfo = new List<CertificatesSignInfo>()
+                {
+                    new CertificatesSignInfo()
+                    {
+                        DualSigningAllowed = true,
+                        Include = "ThisIsACert"
+                    }
+                },
+            FileExtensionSignInfos = new List<FileExtensionSignInfo>()
+                {
+                    new FileExtensionSignInfo()
+                    {
+                        CertificateName = "ThisIsACert",
+                        Include = ".dll"
+                    }
+                },
+            FileSignInfos = new List<FileSignInfo>(),
+            StrongNameSignInfos = new List<StrongNameSignInfo>(),
+            ItemsToSign = new List<ItemsToSign>()
+        };
+
+        public static readonly SigningInformation IncompatibleSigningInfo = new SigningInformation()
+        {
+            AzureDevOpsBuildId = AzureDevOpsBuildId1.ToString(),
+            AzureDevOpsCollectionUri = "https://dev.azure.com/newProject",
+            AzureDevOpsProject = AzureDevOpsProject1,
+        };
+
+        public static readonly List<SigningInformation> ExpectedSigningInfo2 = new List<SigningInformation>()
+            {
+                new SigningInformation()
+                {
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1.ToString(),
+                    AzureDevOpsCollectionUri = "https://dev.azure.com/dnceng/",
+                    AzureDevOpsProject = AzureDevOpsProject1,
+                    CertificatesSignInfo = new List<CertificatesSignInfo>()
+                    {
+                        new CertificatesSignInfo()
+                        {
+                            DualSigningAllowed = true,
+                            Include = "AnotherCert"
+                        }
+                    },
+
+                    FileExtensionSignInfos = new List<FileExtensionSignInfo>()
+                    {
+                        new FileExtensionSignInfo()
+                        {
+                            CertificateName = "None",
+                            Include = ".zip"
+                        }
+                    },
+
+                    FileSignInfos = new List<FileSignInfo>()
+                    {
+                        new FileSignInfo()
+                        {
+                            CertificateName = "AnotherCert",
+                             Include = "AnotherLibrary.dll"
+                        }
+                    },
+
+                    StrongNameSignInfos = new List<StrongNameSignInfo>()
+                    {
+                        new StrongNameSignInfo()
+                        {
+                            CertificateName = "AnotherCert",
+                            Include = "StrongName",
+                            PublicKeyToken = "123456789abcde12"
+                        }
+                    },
+                    ItemsToSign = new List<ItemsToSign>()
+                }
+            };
+
+        public static readonly SigningInformation ExpectedMergedSigningInfo =
+                new SigningInformation()
+                {
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1.ToString(),
+                    AzureDevOpsCollectionUri = "https://dev.azure.com/dnceng/",
+                    AzureDevOpsProject = AzureDevOpsProject1,
+                    CertificatesSignInfo = new List<CertificatesSignInfo>()
+                    {
+                        new CertificatesSignInfo()
+                        {
+                            DualSigningAllowed = true,
+                            Include = "ThisIsACert"
+                        },
+                        new CertificatesSignInfo()
+                        {
+                            DualSigningAllowed = true,
+                            Include = "AnotherCert"
+                        }
+                    },
+
+                    FileExtensionSignInfos = new List<FileExtensionSignInfo>()
+                    {
+                        new FileExtensionSignInfo()
+                        {
+                            CertificateName = "ThisIsACert",
+                            Include = ".dll"
+                        },
+                        new FileExtensionSignInfo()
+                        {
+                            CertificateName = "None",
+                            Include = ".zip"
+                        }
+                    },
+
+                    FileSignInfos = new List<FileSignInfo>()
+                    {
+                        new FileSignInfo()
+                        {
+                            CertificateName = "ThisIsACert",
+                             Include = "ALibrary.dll"
+                        },
+                        new FileSignInfo()
+                        {
+                            CertificateName = "AnotherCert",
+                             Include = "AnotherLibrary.dll"
+                        }
+                    },
+
+                    StrongNameSignInfos = new List<StrongNameSignInfo>()
+                    {
+                        new StrongNameSignInfo()
+                        {
+                            CertificateName = "ThisIsACert",
+                            Include = "IncludeMe",
+                            PublicKeyToken = "123456789abcde12"
+                        },
+                        new StrongNameSignInfo()
+                        {
+                            CertificateName = "AnotherCert",
+                            Include = "StrongName",
+                            PublicKeyToken = "123456789abcde12"
+                        }
+                    },
+                    ItemsToSign = new List<ItemsToSign>()
+                };
+
+        [SetUp]
+        public void SetupMergeSigningInfo()
+        {
+            pushMetadata = new PushMetadataToBuildAssetRegistry();
+        }
+
+        [Test]
+        public void GivenCompatibleSigningInfo()
+        {
+            SigningInformation actualMerged = pushMetadata.MergeSigningInfo(ExpectedSigningInfo.Concat(ExpectedSigningInfo2).ToList());
+            actualMerged.Should().BeEquivalentTo(ExpectedMergedSigningInfo);
+        }
+
+        [Test]
+        public void GivenDuplicateSigningInfo()
+        {
+            SigningInformation actualMerged = pushMetadata.MergeSigningInfo(ExpectedSigningInfo.Concat(ExpectedSigningInfo).ToList());
+            actualMerged.Should().BeEquivalentTo(ExpectedSigningInfo.First());
+        }
+
+        [Test]
+        public void GivenTwoPartialSigningInfoMetadatas()
+        {
+            Action act = () => pushMetadata.MergeSigningInfo(new List<SigningInformation> { PartialSigningInfo1, PartialSigningInfo2 });
+            act.Should().Throw<Exception>().WithMessage("Can't merge if one or more manifests have different build id, collection URI or project.");
+        }
+
+        [Test]
+        public void GivenTwoPartialSigningInfosWithEmptySections()
+        {
+            SigningInformation actualMerged = pushMetadata.MergeSigningInfo(new List<SigningInformation> { PartialSigningInfo3, PartialSigningInfo4 });
+            actualMerged.Should().BeEquivalentTo(MergedPartialMetadataSigningInfos);
+        }
+
+        [Test]
+        public void GivenIncompatibleSigningInfos()
+        {
+            Action act = () => pushMetadata.MergeSigningInfo(new List<SigningInformation> { PartialSigningInfo3, IncompatibleSigningInfo });
+            act.Should().Throw<Exception>().WithMessage("Can't merge if one or more manifests have different build id, collection URI or project.");
+        }
+
+        [Test]
+        public void GivenNullSigningInfoList()
+        {
+            Action act = () => pushMetadata.MergeSigningInfo(null);
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void GivenEmptySigningInfoList()
+        {
+            SigningInformation actualMerged = pushMetadata.MergeSigningInfo(new List<SigningInformation>());
+            actualMerged.Should().Be(null);
+        }
+    }
+}

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/Mocks/VersionIdentifierMock.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/Mocks/VersionIdentifierMock.cs
@@ -1,0 +1,23 @@
+using System;
+using Microsoft.DotNet.Maestro.Tasks.Proxies;
+
+namespace Microsoft.DotNet.Maestro.Tasks.Tests.Mocks
+{
+    internal class VersionIdentifierMock : IVersionIdentifierProxy
+    {
+        internal override string GetVersion(string assetName)
+        {
+            if (assetName == "noVersionForThisBlob")
+            {
+                return "";
+            }
+
+            return "12345";
+        }
+
+        internal override string RemoveVersions(string assetName)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
@@ -1,0 +1,486 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using FluentAssertions;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.DotNet.Maestro.Tasks.Tests.Mocks;
+using NUnit.Framework;
+
+namespace Microsoft.DotNet.Maestro.Tasks.Tests
+{
+    [TestFixture]
+    public class ParseBuildManifestMetadataTests
+    {
+        private PushMetadataToBuildAssetRegistry pushMetadata;
+
+        public const string Commit = "e7a79ce64f0703c231e6da88b5279dd0bf681b3d";
+        public const string AzureDevOpsAccount1 = "dnceng";
+        public const int AzureDevOpsBuildDefinitionId1 = 6;
+        public const int AzureDevOpsBuildId1 = 856354;
+        public const string AzureDevOpsBranch1 = "refs/heads/master";
+        public const string AzureDevOpsBuildNumber1 = "20201016.5";
+        public const string AzureDevOpsProject1 = "internal";
+        public const string AzureDevOpsRepository1 = "https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-arcade";
+        public const string LocationString = "https://dev.azure.com/dnceng/internal/_apis/build/builds/856354/artifacts";
+        private const string GitHubRepositoryName = "dotnet-arcade";
+        private const string GitHubBranch = "refs/heads/master";
+
+        #region Assets
+        internal static readonly AssetData PackageAsset1 =
+           new AssetData(true)
+           {
+               Locations = ImmutableList.Create(
+                   new AssetLocationData(LocationType.Container)
+                   { Location = LocationString }),
+               Name = "Microsoft.Cci.Extensions",
+               Version = "12345"
+           };
+
+        internal static readonly AssetData BlobAsset1 =
+            new AssetData(true)
+            {
+                Locations = ImmutableList.Create(
+                    new AssetLocationData(LocationType.Container)
+                    { Location = LocationString }),
+                Name = "assets/manifests/dotnet-arcade/6.0.0-beta.20516.5/MergedManifest.xml",
+                Version = "12345"
+            };
+
+        internal static readonly AssetData PackageAsset2 =
+            new AssetData(true)
+            {
+                Locations = ImmutableList.Create(
+                    new AssetLocationData(LocationType.Container)
+                    { Location = LocationString }),
+                Name = "Microsoft.DotNet.ApiCompat",
+                Version = "12345"
+            };
+
+        internal static readonly AssetData BlobAsset2 =
+            new AssetData(true)
+            {
+                Locations = ImmutableList.Create(
+                    new AssetLocationData(LocationType.Container)
+                    { Location = LocationString }),
+                Name = "assets/symbols/Microsoft.Cci.Extensions.6.0.0-beta.20516.5.symbols.nupkg",
+                Version = "12345"
+            };
+
+        internal static readonly AssetData PackageAsset3 =
+            new AssetData(true)
+            {
+                Locations = ImmutableList.Create(
+                    new AssetLocationData(LocationType.Container)
+                    { Location = LocationString }),
+                Name = "Microsoft.DotNet.Arcade.Sdk",
+                Version = "12345"
+            };
+
+        internal static readonly AssetData BlobAsset3 =
+            new AssetData(true)
+            {
+                Locations = ImmutableList.Create(
+                    new AssetLocationData(LocationType.Container)
+                    { Location = LocationString }),
+                Name = "assets/symbols/Microsoft.DotNet.Arcade.Sdk.6.0.0-beta.20516.5.symbols.nupkg",
+                Version = "12345"
+            };
+
+        public static readonly IImmutableList<AssetData> ExpectedAssets1 =
+            ImmutableList.Create(PackageAsset1, BlobAsset1);
+
+        public static readonly IImmutableList<AssetData> ExpectedAssets2 =
+             ImmutableList.Create(PackageAsset2, BlobAsset2);
+
+        public static readonly IImmutableList<AssetData> ExpectedAssets3 =
+             ImmutableList.Create(PackageAsset3, BlobAsset3);
+
+        public static readonly IImmutableList<AssetData> NoBlobExpectedAssets =
+           ImmutableList.Create(PackageAsset1);
+
+        public static readonly IImmutableList<AssetData> NoPackageExpectedAssets =
+            ImmutableList.Create(BlobAsset1);
+
+        public static readonly IImmutableList<AssetData> UnversionedPackageExpectedAssets =
+            ImmutableList.Create(
+                new AssetData(true)
+                {
+                    Locations = ImmutableList.Create(
+                new AssetLocationData(LocationType.Container)
+                { Location = LocationString }),
+                    Name = "Microsoft.Cci.Extensions"
+                });
+
+        public static readonly IImmutableList<AssetData> UnversionedBlobExpectedAssets =
+            ImmutableList.Create(
+                new AssetData(true)
+                {
+                    Locations = ImmutableList.Create(
+                    new AssetLocationData(LocationType.Container)
+                    { Location = LocationString }),
+                    Name = "assets/symbols/Microsoft.DotNet.Arcade.Sdk.6.0.0-beta.20516.5.symbols.nupkg"
+                });
+        #endregion
+
+        #region IndividualAssets
+        private static readonly Package package1 = new Package()
+        {
+            Id = "Microsoft.Cci.Extensions",
+            NonShipping = true,
+            Version = "12345"
+        };
+
+        private static readonly Package package2 = new Package()
+        {
+            Id = "Microsoft.DotNet.ApiCompat",
+            NonShipping = true,
+            Version = "12345"
+        };
+
+        private static readonly Package unversionedPackage = new Package()
+        {
+            Id = "Microsoft.Cci.Extensions",
+            NonShipping = true
+        };
+
+        private static readonly Blob blob1 = new Blob()
+        {
+            Id = "assets/manifests/dotnet-arcade/6.0.0-beta.20516.5/MergedManifest.xml",
+            NonShipping = true
+        };
+
+        private static readonly Blob blob2 = new Blob()
+        {
+            Id = "assets/symbols/Microsoft.Cci.Extensions.6.0.0-beta.20516.5.symbols.nupkg",
+            NonShipping = true
+        };
+
+        private static readonly Blob unversionedBlob = new Blob()
+        {
+            Id = "noVersionForThisBlob",
+            NonShipping = true
+        };
+
+        private static readonly SigningInformation signingInfo1 = new SigningInformation()
+        {
+            AzureDevOpsBuildId = AzureDevOpsBuildId1.ToString(),
+            AzureDevOpsCollectionUri = "https://dev.azure.com/dnceng/",
+            AzureDevOpsProject = AzureDevOpsProject1,
+            CertificatesSignInfo = new List<CertificatesSignInfo>()
+                    {
+                        new CertificatesSignInfo()
+                        {
+                            DualSigningAllowed = true,
+                            Include = "ThisIsACert"
+                        }
+                    },
+
+            FileExtensionSignInfos = new List<FileExtensionSignInfo>()
+                    {
+                        new FileExtensionSignInfo()
+                        {
+                            CertificateName = "ThisIsACert",
+                            Include = ".dll"
+                        }
+                    },
+
+            FileSignInfos = new List<FileSignInfo>()
+                    {
+                        new FileSignInfo()
+                        {
+                            CertificateName = "ThisIsACert",
+                             Include = "ALibrary.dll"
+                        }
+                    },
+
+            StrongNameSignInfos = new List<StrongNameSignInfo>()
+                    {
+                        new StrongNameSignInfo()
+                        {
+                            CertificateName = "ThisIsACert",
+                            Include = "IncludeMe",
+                            PublicKeyToken = "123456789abcde12"
+                        }
+                    },
+            ItemsToSign = new List<ItemsToSign>()
+        };
+
+        public static readonly SigningInformation signingInfo2 =
+            new SigningInformation()
+            {
+                AzureDevOpsBuildId = AzureDevOpsBuildId1.ToString(),
+                AzureDevOpsCollectionUri = "https://dev.azure.com/dnceng/",
+                AzureDevOpsProject = AzureDevOpsProject1,
+                CertificatesSignInfo = new List<CertificatesSignInfo>()
+                {
+                    new CertificatesSignInfo()
+                    {
+                        DualSigningAllowed = true,
+                        Include = "AnotherCert"
+                    }
+                },
+
+                FileExtensionSignInfos = new List<FileExtensionSignInfo>()
+                {
+                    new FileExtensionSignInfo()
+                    {
+                        CertificateName = "None",
+                        Include = ".zip"
+                    }
+                },
+
+                FileSignInfos = new List<FileSignInfo>()
+                {
+                    new FileSignInfo()
+                    {
+                        CertificateName = "AnotherCert",
+                            Include = "AnotherLibrary.dll"
+                    }
+                },
+
+                StrongNameSignInfos = new List<StrongNameSignInfo>()
+                {
+                    new StrongNameSignInfo()
+                    {
+                        CertificateName = "AnotherCert",
+                        Include = "StrongName",
+                        PublicKeyToken = "123456789abcde12"
+                    }
+                },
+                ItemsToSign = new List<ItemsToSign>()
+            };
+        #endregion
+
+        #region SigningInfo
+        public static readonly List<SigningInformation> ExpectedSigningInfo = new List<SigningInformation>()
+        {
+            signingInfo1
+        };
+
+        public static readonly List<SigningInformation> ExpectedSigningInfo2 = new List<SigningInformation>()
+        {
+            signingInfo2
+        };
+        #endregion
+
+        #region Manifests
+        private static readonly Manifest baseManifest = new Manifest()
+        {
+            AzureDevOpsAccount = AzureDevOpsAccount1,
+            AzureDevOpsBranch = AzureDevOpsBranch1,
+            AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1,
+            AzureDevOpsBuildId = AzureDevOpsBuildId1,
+            AzureDevOpsBuildNumber = AzureDevOpsBuildNumber1,
+            AzureDevOpsProject = AzureDevOpsProject1,
+            AzureDevOpsRepository = AzureDevOpsRepository1,
+            InitialAssetsLocation = LocationString,
+            PublishingVersion = 3,
+            Commit = Commit,
+            Name = GitHubRepositoryName,
+            Branch = GitHubBranch,
+            Packages = new List<Package>(),
+            Blobs = new List<Blob>(),
+            SigningInformation = new SigningInformation()
+        };
+
+        private static readonly Manifest manifest1 = new Manifest()
+        {
+            AzureDevOpsAccount = AzureDevOpsAccount1,
+            AzureDevOpsBranch = AzureDevOpsBranch1,
+            AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1,
+            AzureDevOpsBuildId = AzureDevOpsBuildId1,
+            AzureDevOpsBuildNumber = AzureDevOpsBuildNumber1,
+            AzureDevOpsProject = AzureDevOpsProject1,
+            AzureDevOpsRepository = AzureDevOpsRepository1,
+            InitialAssetsLocation = LocationString,
+            PublishingVersion = 3,
+            Commit = Commit,
+            Name = GitHubRepositoryName,
+            Branch = GitHubBranch,
+            Packages = new List<Package> { package1 },
+            Blobs = new List<Blob> { blob1 },
+            SigningInformation = signingInfo1
+        };
+
+        private static readonly Manifest manifest2 = new Manifest()
+        {
+            AzureDevOpsAccount = AzureDevOpsAccount1,
+            AzureDevOpsBranch = AzureDevOpsBranch1,
+            AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1,
+            AzureDevOpsBuildId = AzureDevOpsBuildId1,
+            AzureDevOpsBuildNumber = AzureDevOpsBuildNumber1,
+            AzureDevOpsProject = AzureDevOpsProject1,
+            AzureDevOpsRepository = AzureDevOpsRepository1,
+            InitialAssetsLocation = LocationString,
+            PublishingVersion = 3,
+            Commit = Commit,
+            Name = GitHubRepositoryName,
+            Branch = GitHubBranch,
+            Packages = new List<Package> { package2 },
+            Blobs = new List<Blob> { blob2 },
+            SigningInformation = signingInfo2
+        };
+
+        private static readonly ManifestBuildData baseManifestBuildData = new ManifestBuildData(baseManifest);
+        private static readonly ManifestBuildData manifest1BuildData = new ManifestBuildData(manifest1);
+
+        private static readonly List<BuildData> buildData1 = new List<BuildData>()
+            {
+                new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+                {
+                    GitHubBranch = AzureDevOpsBranch1,
+                    GitHubRepository = "dotnet-arcade",
+                    Assets = ExpectedAssets1,
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                    AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+                }
+            };
+
+        private static readonly List<BuildData> buildData2 = new List<BuildData>()
+            {
+                new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+                {
+                    GitHubBranch = AzureDevOpsBranch1,
+                    GitHubRepository = "dotnet-arcade",
+                    Assets = ExpectedAssets2,
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                    AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+                }
+            };
+
+        private static readonly List<BuildData> noBlobManifestBuildData = new List<BuildData>()
+            {
+                new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+                {
+                    GitHubBranch = AzureDevOpsBranch1,
+                    GitHubRepository = "dotnet-arcade",
+                    Assets = NoBlobExpectedAssets,
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                    AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+                }
+            };
+
+        private static readonly List<BuildData> noPackagesManifestBuildData = new List<BuildData>()
+            {
+                new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+                {
+                    GitHubBranch = AzureDevOpsBranch1,
+                    GitHubRepository = "dotnet-arcade",
+                    Assets = NoPackageExpectedAssets,
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                    AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+                }
+            };
+
+        private static readonly List<BuildData> unversionedPackagedManifestBuildData = new List<BuildData>()
+            {
+                new BuildData(Commit, AzureDevOpsAccount1, AzureDevOpsProject1, AzureDevOpsBuildNumber1, AzureDevOpsRepository1, AzureDevOpsBranch1, false, false)
+                {
+                    GitHubBranch = AzureDevOpsBranch1,
+                    GitHubRepository = "dotnet-arcade",
+                    Assets = UnversionedPackageExpectedAssets,
+                    AzureDevOpsBuildId = AzureDevOpsBuildId1,
+                    AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1
+                }
+            };
+        #endregion
+
+        [SetUp]
+        public void SetupGetBuildManifestMetadataTests()
+        {
+            pushMetadata = new PushMetadataToBuildAssetRegistry();
+            pushMetadata.versionIdentifier = new VersionIdentifierMock();
+        }
+
+        [Test]
+        public void EmptyManifestListShouldReturnEmptyObjects()
+        {
+            var (buildData, signingInformation, manifestBuildData) = pushMetadata.ParseBuildManifestsMetadata(new List<Manifest>(), CancellationToken.None);
+            buildData.Should().BeEmpty();
+            signingInformation.Should().BeEmpty();
+            manifestBuildData.Should().BeNull();
+        }
+
+        [Test]
+        public void ParseBasicManifest()
+        {
+            List<Manifest> manifests = new List<Manifest>() { manifest1 };
+            var (actualBuildData, actualSigningInformation, actualManifestBuildData) = pushMetadata.ParseBuildManifestsMetadata(manifests, CancellationToken.None);
+            actualBuildData.Should().BeEquivalentTo(buildData1);
+            actualSigningInformation.Should().BeEquivalentTo(ExpectedSigningInfo);
+            actualManifestBuildData.Should().BeEquivalentTo(manifest1BuildData);
+        }
+
+        [Test]
+        public void ParseTwoManifests()
+        {
+            List<Manifest> manifests = new List<Manifest>() { manifest1, manifest2 };
+            var (actualBuildData, actualSigningInformation, actualManifestBuildData) = pushMetadata.ParseBuildManifestsMetadata(manifests, CancellationToken.None);
+            actualBuildData.Should().BeEquivalentTo(buildData1.Concat(buildData2));
+            actualSigningInformation.Should().BeEquivalentTo(ExpectedSigningInfo.Concat(ExpectedSigningInfo2));
+            actualManifestBuildData.Should().BeEquivalentTo(baseManifestBuildData);
+            
+        }
+
+        [Test]
+        public void GivenAnEmptyManifest_ExceptionExpected()
+        {
+            Action act = () => pushMetadata.ParseBuildManifestsMetadata(new List<Manifest> { new Manifest() }, CancellationToken.None);
+            act.Should().Throw<NullReferenceException>();
+        }
+
+        [Test]
+        public void GivenManifestWithoutPackages()
+        {
+            Manifest manifestWithoutPackages = SharedMethods.GetCopyOfManifest(baseManifest);
+            manifestWithoutPackages.Blobs = new List<Blob> { blob1 };
+            var (actualBuildData, actualSigningInformation, actualManifestBuildData) = pushMetadata.ParseBuildManifestsMetadata(new List<Manifest> { manifestWithoutPackages }, CancellationToken.None);
+            actualBuildData.Should().BeEquivalentTo(noPackagesManifestBuildData);
+            actualManifestBuildData.Should().BeEquivalentTo(baseManifestBuildData);
+        }
+
+        [Test]
+        public void GivenManifestWithUnversionedPackage()
+        {
+            Manifest manifestWithUnversionedPackage = SharedMethods.GetCopyOfManifest(baseManifest);
+            manifestWithUnversionedPackage.Packages = new List<Package> { unversionedPackage };
+            var (actualBuildData, actualSigningInformation, actualManifestBuildData) = pushMetadata.ParseBuildManifestsMetadata(new List<Manifest> { manifestWithUnversionedPackage }, CancellationToken.None);
+            actualBuildData.Should().BeEquivalentTo(unversionedPackagedManifestBuildData);
+            actualManifestBuildData.Should().BeEquivalentTo(baseManifestBuildData);
+        }
+
+        [Test]
+        public void GivenManifestWithoutBlobs()
+        {
+            Manifest manifestWithoutBlobs = SharedMethods.GetCopyOfManifest(baseManifest);
+            manifestWithoutBlobs.Packages = new List<Package> { package1 };
+            var (actualBuildData, actualSigningInformation, actualManifestBuildData) = pushMetadata.ParseBuildManifestsMetadata(new List<Manifest> { manifestWithoutBlobs }, CancellationToken.None);
+            actualBuildData.Should().BeEquivalentTo(noBlobManifestBuildData);
+            actualManifestBuildData.Should().BeEquivalentTo(baseManifestBuildData);
+        }
+
+        [Test]
+        public void GivenUnversionedBlob()
+        {
+            Manifest manifestWithUnversionedBlob = SharedMethods.GetCopyOfManifest(baseManifest);
+            manifestWithUnversionedBlob.Blobs = new List<Blob> { unversionedBlob };
+            Action act = () => pushMetadata.ParseBuildManifestsMetadata(new List<Manifest> { manifestWithUnversionedBlob }, CancellationToken.None);
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [Test]
+        public void GivenTwoManifestWithDifferentAttributes_ExceptionExpected()
+        {
+            Manifest differentAttributes = SharedMethods.GetCopyOfManifest(baseManifest);
+            differentAttributes.AzureDevOpsAccount = "newAccount";
+            Action act = () => pushMetadata.ParseBuildManifestsMetadata(new List<Manifest> { baseManifest, differentAttributes }, CancellationToken.None);
+            act.Should().Throw<Exception>().WithMessage("Attributes should be the same in all manifests.");
+        }
+    }
+}

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/SharedMethods.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/SharedMethods.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.Maestro.Tasks.Tests
+{
+    public class SharedMethods
+    {
+        public static Manifest GetCopyOfManifest(Manifest manifest)
+        {
+            return new Manifest()
+            {
+                AzureDevOpsAccount = manifest.AzureDevOpsAccount,
+                AzureDevOpsBranch = manifest.AzureDevOpsBranch,
+                AzureDevOpsBuildDefinitionId = manifest.AzureDevOpsBuildDefinitionId,
+                AzureDevOpsBuildDefinitionIdString = manifest.AzureDevOpsBuildDefinitionIdString,
+                AzureDevOpsBuildId = manifest.AzureDevOpsBuildId,
+                AzureDevOpsBuildIdString = manifest.AzureDevOpsBuildIdString,
+                AzureDevOpsBuildNumber = manifest.AzureDevOpsBuildNumber,
+                AzureDevOpsProject = manifest.AzureDevOpsProject,
+                AzureDevOpsRepository = manifest.AzureDevOpsRepository,
+                Branch = manifest.Branch,
+                BuildId = manifest.BuildId,
+                Commit = manifest.Commit,
+                InitialAssetsLocation = manifest.InitialAssetsLocation,
+                IsReleaseOnlyPackageVersion = manifest.IsReleaseOnlyPackageVersion,
+                IsStable = manifest.IsStable,
+                Location = manifest.Location,
+                Name = manifest.Name,
+
+                // Note that these are shallow copies for the moment, since deep copy isn't needed for the current tests
+                Blobs = manifest.Blobs,
+                Packages = manifest.Packages,
+                PublishingVersion = manifest.PublishingVersion,
+                SigningInformation = manifest.SigningInformation
+            };
+        }
+    }
+}

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/Proxies/VersionIdentifierProxy.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/Proxies/VersionIdentifierProxy.cs
@@ -1,0 +1,23 @@
+using Microsoft.DotNet.VersionTools.BuildManifest;
+
+namespace Microsoft.DotNet.Maestro.Tasks.Proxies
+{
+    internal abstract class IVersionIdentifierProxy
+    {
+        internal abstract string GetVersion(string assetName);
+        internal abstract string RemoveVersions(string assetName);
+    }
+
+    internal class VersionIdentifierProxy : IVersionIdentifierProxy
+    {
+        internal override string GetVersion(string assetName)
+        {
+            return VersionIdentifier.GetVersion(assetName);
+        }
+
+        internal override string RemoveVersions(string assetName)
+        {
+            return VersionIdentifier.RemoveVersions(assetName);
+        }
+    }
+}

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -615,7 +615,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
         /// <returns>An AssetData with data about the merge manifest</returns>
         private AssetData GetManifestAsAsset(IImmutableList<AssetData> assets, string location, string manifestFileName)
         {
-            (string accountName, string projectName, string azDORepoName) = AzureDevOpsClient.ParseRepoUri(GetAzDevRepository());
+            string repoName = GetAzDevRepositoryName().TrimEnd('/').Replace('/','-'); 
 
             if (string.IsNullOrEmpty(AssetVersion))
             {
@@ -633,7 +633,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 {
                     Location = location,
                 }),
-                Name = $"assets/manifests/{azDORepoName}/{AssetVersion}/{manifestFileName}",
+                Name = $"assets/manifests/{repoName}/{AssetVersion}/{manifestFileName}",
                 Version = AssetVersion,
             };
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -319,7 +319,7 @@ namespace Microsoft.DotNet.Darc.Operations
             else
             {
                 Console.WriteLine("The promotion build finished but the build isn't associated with at least one of the target channels. This is an error scenario.");
-                Console.WriteLine($"Details are available in the following build: {promotionBuildUrl}. For any questions, contact @dnceng");
+                Console.WriteLine($"Details are available in the following build: {promotionBuildUrl} For any questions, contact @dnceng");
                 return Constants.ErrorCode;
             }
         }


### PR DESCRIPTION
Master build: https://dnceng.visualstudio.com/internal/_build/results?buildId=871682&view=results

The only change that affects production is https://github.com/dotnet/arcade-services/commit/5ce43c7f1a810558b77e2fe1f97b27efa7f72488, but the log that it's trying to fix log is so noisy that I believe it's worth rolling out for it.