### PR TITLE
Fix the link to the promotion build during failure

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -319,7 +319,7 @@ namespace Microsoft.DotNet.Darc.Operations
             else
             {
                 Console.WriteLine("The promotion build finished but the build isn't associated with at least one of the target channels. This is an error scenario.");
-                Console.WriteLine($"Details are available in the following build: {promotionBuildUrl}. For any questions, contact @dnceng");
+                Console.WriteLine($"Details are available in the following build: {promotionBuildUrl} For any questions, contact @dnceng");
                 return Constants.ErrorCode;
             }
         }


### PR DESCRIPTION
The final period is getting added to the link, making it invalid. See https://dev.azure.com/dnceng/internal/_build/results?buildId=874436&view=logs&j=56ebfe15-69d8-5dd1-65e4-c65998c8d8a6&t=0a9483a6-3ac1-5fd2-c450-3586b050b65b for an example