### PR TITLE
Add component governance task to build template

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,6 +137,16 @@ stages:
           displayName: Build / Publish
           condition: succeeded()
 
+        - task: ComponentGovernanceComponentDetection@0
+          inputs:
+            # `.packages` directory is used by some tools running during build.
+            # By default ComponentDetection scans this directory and sometimes reports
+            # vulnerabilities for packages that are not part of the published product.
+            # We can ignore this directory because actual vulnerabilities
+            # that we are interested in will be found by the tool
+            # when scanning .csproj and package.json files.
+            ignoreDirectories: '.packages'
+
         - template: /eng/test.yaml
 
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
As part of SDL process we are required to enable component governance in the repository. This PR adds additional task in the `Build` stage that runs the component detection. At the moment no High or Critical vulnerabilities are reported.

Example report for this feature branch can be seen here: https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-arcade-services?_a=alerts&typeId=5066156&alerts-view-option=active

Related issue: https://github.com/dotnet/core-eng/issues/11356