### PR TITLE
Make GitFileManager.UpdatePackageSources() idempotent for the same package sources

### DIFF
--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
@@ -84,6 +84,13 @@ namespace Microsoft.DotNet.Darc.Tests
             expectedOutputText = expectedOutputText.Replace(Environment.NewLine, "\n");
 
             file.Content.Should().Be(expectedOutputText);
+
+            // When this is performed via the Maestro service instead of the Darc CLI, it seemingly can 
+            // be run more than once for the same XmlDocument.  This should not impact the contents of the file; 
+            // Validate this expectation of idempotency by running the same update on the resultant file.
+            XmlDocument doubleUpdatedConfigFile = gitFileManager.UpdatePackageSources(updatedConfigFile, managedFeedsForTest);
+            GitFile doubleUpdatedfile = new GitFile(null, doubleUpdatedConfigFile);
+            doubleUpdatedfile.Content.Should().Be(expectedOutputText, "Repeated invocation of UpdatePackageSources() caused incremental changes to nuget.config");
         }
 
         [TestCase("SimpleDuplicated.props", true)]


### PR DESCRIPTION
Addresses https://github.com/dotnet/core-eng/issues/11362.  It seems that this runs multiple times in Maestro (likely its own bug, but less pressing), and previously did not clear out the existing comments when doing so.

Test coverage is added to every test case by virtue of now running UpdatePackageSources() on the XML Document we get back from the first update and ensuring the result is still identical.