### PR TITLE
[Rollout] Log which dependencies have null information and don't fail to create…

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -1006,7 +1006,14 @@ namespace SubscriptionActorService
                         if (entry.Value == i)
                         {
                             DependencyDetail to = deps.Find(d => d.To.Commit == entry.Key.Item2).To;
-                            subscriptionSection.AppendLine($"[{i}]: {GetChangesURI(to.RepoUri, entry.Key.Item1, entry.Key.Item2)}");
+                            try
+                            {
+                                subscriptionSection.AppendLine($"[{i}]: {GetChangesURI(to.RepoUri, entry.Key.Item1, entry.Key.Item2)}");
+                            }
+                            catch(ArgumentNullException e)
+                            {
+                                Logger.LogError(e, $"Failed to create SHA comparison link for dependency {to.Name} during asset update for subscription {update.SubscriptionId}");
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
… PRs if link information is not available (#1475)

Cherry picking commit ccd1c79046d2d21a95f7782c1c10b83d3de4a416 to try and diagnose and maybe, just maybe, mitigate dotnet/arcade#6577 altogether.