### PR TITLE
Show scrollbars for dependency flow graph instead of scaling it

### DIFF
--- a/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/channel-graph/channel-graph.component.ts
@@ -182,7 +182,7 @@ function drawFlowGraph(graph: FlowGraph, includeArcade: boolean, channel: Channe
   var render_graph = new render();
 
   select('svg.flowgraph').selectAll('*').remove();
-  select('svg.flowgraph').attr("viewBox", "");
+  select('svg.flowgraph').attr("viewBox", null);
 
   var svg = select("svg.flowgraph"),
       inner = svg.append("g");
@@ -204,10 +204,9 @@ function drawFlowGraph(graph: FlowGraph, includeArcade: boolean, channel: Channe
     .text(function(v:any) { return g.edge(v).description });
 
   var bbox = (svg.node() as SVGGraphicsElement).getBBox();
-  var height = bbox.height < 800 ? 810 : bbox.height+10;
-  var width = bbox.width < 800 ? 810 :bbox.width+10;
-
-  svg.attr("viewBox", `-5 -5 ${width} ${height}`);
+  svg.style('width', `${Math.ceil(bbox.width)}px`);
+  svg.style('height', `${Math.ceil(bbox.height)}px`);
+  svg.attr("viewBox", `${bbox.x} ${bbox.y} ${bbox.width} ${bbox.height}`);
 }
 
 @Component({


### PR DESCRIPTION
While making some other changes to the Maestro front-end I modified the graph display a bit so that it's not scaled to fit the whole page but is displayed at normal scale and you can move it with scrollbars. The benefits of this are that:
- It's easier to read the text on the big graphs
- The graph is correctly resized when using browser zoom - previously it couldn't be zoomed-in or out that way

There's no real requirement for this change, it was just a quick experiment so if there's a reason to keep current behavior then that's ok.

**Before:**
![maestro-before](https://user-images.githubusercontent.com/1406063/99810178-a53d6700-2b43-11eb-9f21-43a98e63819f.png)

**After:**
![maestro-after](https://user-images.githubusercontent.com/1406063/99810205-b0909280-2b43-11eb-952b-b2cd6bbf8d66.png)
