### PR TITLE
Any subscription triggers will allow an update even if the repo is currently on the latest build

### DIFF
--- a/src/Maestro/DependencyUpdater/DependencyUpdater.cs
+++ b/src/Maestro/DependencyUpdater/DependencyUpdater.cs
@@ -95,7 +95,6 @@ namespace DependencyUpdater
                          .Where(b => b.Id == buildId)
                          .FirstOrDefault()
                  where specificBuild != null
-                 where sub.LastAppliedBuildId == null || sub.LastAppliedBuildId != specificBuild.Id
                  select new
                  {
                      subscription = sub.Id,
@@ -127,7 +126,6 @@ namespace DependencyUpdater
                          .OrderByDescending(b => b.DateProduced)
                          .FirstOrDefault()
                  where latestBuild != null
-                 where sub.LastAppliedBuildId == null || sub.LastAppliedBuildId != latestBuild.Id
                  select new
                  {
                      subscription = sub.Id,


### PR DESCRIPTION
Unit tests already exist for these functions.

Previously, we would not update a repo if the build noted in the `lastAppliedBuildId` was attempting to be applied again, even if that previous attempt resulted in an error. This change will always allow a build to be applied to a repo via their subscription even if it already has been applied previously. 