### PR TITLE
Set cookie time out to max. allowed 30 minutes and added privacy footer

### DIFF
--- a/src/DotNet.Status.Web/Pages/Index.cshtml
+++ b/src/DotNet.Status.Web/Pages/Index.cshtml
@@ -1,5 +1,8 @@
 ﻿@page
 @using System.Security.Claims
+@{
+    ViewData["Title"] = "Home page";
+}
 
 .NET Engineering Status Reporting endpoint
 

--- a/src/DotNet.Status.Web/Pages/Token.cshtml
+++ b/src/DotNet.Status.Web/Pages/Token.cshtml
@@ -4,6 +4,7 @@
 @using DotNet.Status.Web
 @model DotNet.Status.Web.Pages.TokenModel
 @{
+    ViewData["Title"] = "Tokens";
     string userIdString = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
     long userId = long.TryParse(userIdString, out var temp) ? temp : 0;
 

--- a/src/DotNet.Status.Web/Pages/_Layout.cshtml
+++ b/src/DotNet.Status.Web/Pages/_Layout.cshtml
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"]</title>
+</head>
+
+<body>
+    <div>
+        @RenderBody()
+    </div>
+    <footer>
+        <hr/>
+        <div>
+            <a href="mailto:dnceng@microsoft.com">Contact Us</a>
+            &nbsp;|&nbsp;
+            <a href="https://go.microsoft.com/fwlink/?LinkId=521839">Privacy &amp; Cookies</a>
+            &nbsp;|&nbsp;
+            <a href="https://go.microsoft.com/fwlink/?LinkID=206977">Terms of Use</a>
+            &nbsp;|
+            &copy; 2020 Microsoft
+        </div>
+    </footer>
+</body>
+
+</html>

--- a/src/DotNet.Status.Web/Pages/_ViewStart.cshtml
+++ b/src/DotNet.Status.Web/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/src/DotNet.Status.Web/Startup.cs
+++ b/src/DotNet.Status.Web/Startup.cs
@@ -42,7 +42,7 @@ namespace DotNet.Status.Web
             Configuration = configuration;
             Env = env;
         }
-        
+
         public IWebHostEnvironment Env { get; }
         public IConfiguration Configuration { get; }
 
@@ -185,7 +185,7 @@ namespace DotNet.Status.Web
                 .AddCookie(IdentityConstants.ApplicationScheme,
                     o =>
                     {
-                        o.ExpireTimeSpan = TimeSpan.FromDays(7);
+                        o.ExpireTimeSpan = TimeSpan.FromMinutes(30);
                         o.SlidingExpiration = true;
                         o.Cookie.IsEssential = true;
                         o.LoginPath = "/signin";


### PR DESCRIPTION
Issue https://github.com/dotnet/core-eng/issues/11584
Cookie expiration is currently set for 7 days and it should be at most 30 minutes 
Privacy footer is missing and it should be present.