### PR TITLE
disable dotnet-status web app deployment due to failures

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -169,25 +169,26 @@ stages:
         ApplicationManifestPath: $(Pipeline.Workspace)/TelemetryApplication/projectartifacts/ApplicationPackageRoot/ApplicationManifest.xml
         ServicesSourceFolder: $(Build.SourcesDirectory)/src/Telemetry/
 
-  - job: deployStatus
-    displayName: Deploy dotnet-status web app
-    dependsOn:
-    steps:
-    - download: current
-      artifact: DotNetStatus
-    - task: AzureRmWebAppDeployment@4
-      inputs:
-        ConnectionType: AzureRM
-        azureSubscription: ${{ parameters.Subscription }}
-        appType: webApp
-        WebAppName: ${{ parameters.DotNetStatusAppName }}
-        deployToSlotOrASE: true
-        ResourceGroupName: monitoring
-        SlotName: staging
-        Package: $(Pipeline.Workspace)/DotNetStatus/DotNetStatus.zip
-        enableCustomDeployment: true
-        DeploymentType: webDeploy
-        RemoveAdditionalFilesFlag: true
+# Re-enable once https://github.com/dotnet/core-eng/issues/11634 is fixed
+#  - job: deployStatus
+#    displayName: Deploy dotnet-status web app
+#    dependsOn:
+#    steps:
+#    - download: current
+#      artifact: DotNetStatus
+#    - task: AzureRmWebAppDeployment@4
+#      inputs:
+#        ConnectionType: AzureRM
+#        azureSubscription: ${{ parameters.Subscription }}
+#        appType: webApp
+#        WebAppName: ${{ parameters.DotNetStatusAppName }}
+#        deployToSlotOrASE: true
+#        ResourceGroupName: monitoring
+#        SlotName: staging
+#        Package: $(Pipeline.Workspace)/DotNetStatus/DotNetStatus.zip
+#        enableCustomDeployment: true
+#        DeploymentType: webDeploy
+#        RemoveAdditionalFilesFlag: true
   
   - job: deployRolloutScorer
     displayName: Deploy rollout scorer azure function


### PR DESCRIPTION
Disabling this step to unblock the deployment. Once https://github.com/dotnet/core-eng/issues/11634 is understood we can re-enable