### PR TITLE
Fix a bug with deleting too many dependency flow comments

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -456,7 +456,6 @@ namespace Microsoft.DotNet.DarcLib
             }
             XmlNode insertAfterNode = null;
 
-            // Do the order backwards 
             foreach (string repoName in maestroManagedFeedsByRepo.Keys.OrderByDescending(t => t))
             {
                 var managedSources = GetManagedPackageSources(maestroManagedFeedsByRepo[repoName]).OrderByDescending(t => t.feed).ToList();
@@ -488,8 +487,8 @@ namespace Microsoft.DotNet.DarcLib
                             continue;
                         }
                         if (currentNode.NodeType == XmlNodeType.Comment &&
-                           (currentNode.Value.StartsWith(MaestroRepoSpecificBeginComment, StringComparison.OrdinalIgnoreCase) ||
-                            currentNode.Value.StartsWith(MaestroRepoSpecificEndComment, StringComparison.OrdinalIgnoreCase)))
+                           (currentNode.Value.StartsWith($"{MaestroRepoSpecificBeginComment} {repoName}", StringComparison.OrdinalIgnoreCase) ||
+                            currentNode.Value.StartsWith($"{MaestroRepoSpecificEndComment} {repoName}", StringComparison.OrdinalIgnoreCase)))
                         {
                             currentNode = RemoveCurrentNode(currentNode);
                             continue;
@@ -525,7 +524,7 @@ namespace Microsoft.DotNet.DarcLib
                     }
                 }
                 XmlComment endDisabled = nugetConfig.CreateComment($"{MaestroRepoSpecificEndComment} {repoName} ");
-                disabledSourcesNode.InsertAfter(endDisabled, insertAfterNode);
+                insertAfterNode = disabledSourcesNode.InsertAfter(endDisabled, insertAfterNode);
             }
         }
 

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
@@ -45,6 +45,11 @@ namespace Microsoft.DotNet.Darc.Tests
             "https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-arcade-b0437974/nuget/v3/index.json" })]
         [TestCase("EnsureAppendsDisableEntryAfterLastClear", new string[] { // Honor all existing disable entries and append after last found <clear/>
             "https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-arcade-b0437974/nuget/v3/index.json" })]
+        [TestCase("EnsureMultipleDisabledSourcesGetComments", new string[] { // If there are more than one disabled source, all need comments
+            "https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-arcade-b0437974/nuget/v3/index.json",
+            "https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-runtime-c13a8a85/nuget/v3/index.json"
+        })]
+        
         public async Task UpdatePackageSourcesTests(string testName, string[] managedFeeds)
         {
             GitFileManager gitFileManager = new GitFileManager(null, NullLogger.Instance);

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/EnsureMultipleDisabledSourcesGetComments/NuGet.input.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/EnsureMultipleDisabledSourcesGetComments/NuGet.input.config
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- The purpose here is to exercise an incoming new feed to a config with clear tags in its disabledPackageSources node; we need to append after clear to ensure the disable takes. -->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
+    <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <add key="dotnet-coreclr" value="true" />
+    <clear />
+    <add key="nuget.org" value="true" />
+    <clear />
+    <!-- Seems whatever wrote this config is indecisive -->
+    <add key="dotnet-windowsdesktop" value="true" />
+  </disabledPackageSources>
+</configuration>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/EnsureMultipleDisabledSourcesGetComments/NuGet.output.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/EnsureMultipleDisabledSourcesGetComments/NuGet.output.config
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- The purpose here is to exercise an incoming new feed to a config with clear tags in its disabledPackageSources node; we need to append after clear to ensure the disable takes. -->
+<configuration>
+  <packageSources>
+    <clear />
+    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--  Begin: Package sources from dotnet-arcade -->
+    <add key="darc-int-dotnet-arcade-b043797" value="https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-arcade-b0437974/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-arcade -->
+    <!--  Begin: Package sources from dotnet-runtime -->
+    <add key="darc-int-dotnet-runtime-c13a8a8" value="https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-runtime-c13a8a85/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-runtime -->
+    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
+    <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <add key="dotnet-coreclr" value="true" />
+    <clear />
+    <add key="nuget.org" value="true" />
+    <clear />
+    <!--  Begin: Package sources from dotnet-arcade -->
+    <add key="darc-int-dotnet-arcade-b043797" value="true" />
+    <!--  End: Package sources from dotnet-arcade -->
+    <!--  Begin: Package sources from dotnet-runtime -->
+    <add key="darc-int-dotnet-runtime-c13a8a8" value="true" />
+    <!--  End: Package sources from dotnet-runtime -->
+    <!-- Seems whatever wrote this config is indecisive -->
+    <add key="dotnet-windowsdesktop" value="true" />
+  </disabledPackageSources>
+</configuration>


### PR DESCRIPTION
Context: https://github.com/dotnet/arcade/issues/6685

Also adds a test that will break if this regresses.