### PR TITLE
Re-enable status site deployment

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -169,26 +169,25 @@ stages:
         ApplicationManifestPath: $(Pipeline.Workspace)/TelemetryApplication/projectartifacts/ApplicationPackageRoot/ApplicationManifest.xml
         ServicesSourceFolder: $(Build.SourcesDirectory)/src/Telemetry/
 
-# Re-enable once https://github.com/dotnet/core-eng/issues/11634 is fixed
-#  - job: deployStatus
-#    displayName: Deploy dotnet-status web app
-#    dependsOn:
-#    steps:
-#    - download: current
-#      artifact: DotNetStatus
-#    - task: AzureRmWebAppDeployment@4
-#      inputs:
-#        ConnectionType: AzureRM
-#        azureSubscription: ${{ parameters.Subscription }}
-#        appType: webApp
-#        WebAppName: ${{ parameters.DotNetStatusAppName }}
-#        deployToSlotOrASE: true
-#        ResourceGroupName: monitoring
-#        SlotName: staging
-#        Package: $(Pipeline.Workspace)/DotNetStatus/DotNetStatus.zip
-#        enableCustomDeployment: true
-#        DeploymentType: webDeploy
-#        RemoveAdditionalFilesFlag: true
+ - job: deployStatus
+   displayName: Deploy dotnet-status web app
+   dependsOn:
+   steps:
+   - download: current
+     artifact: DotNetStatus
+   - task: AzureRmWebAppDeployment@4
+     inputs:
+       ConnectionType: AzureRM
+       azureSubscription: ${{ parameters.Subscription }}
+       appType: webApp
+       WebAppName: ${{ parameters.DotNetStatusAppName }}
+       deployToSlotOrASE: true
+       ResourceGroupName: monitoring
+       SlotName: staging
+       Package: $(Pipeline.Workspace)/DotNetStatus/DotNetStatus.zip
+       enableCustomDeployment: true
+       DeploymentType: webDeploy
+       RemoveAdditionalFilesFlag: true
   
   - job: deployRolloutScorer
     displayName: Deploy rollout scorer azure function


### PR DESCRIPTION
Fixed related issue with Azure App config changes that don't seem to be represented in code anywhere. This PR is just to re-enable the deployment step.