### PR TITLE
Update the RequiredUpdates property when updating a PR's information

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -1085,6 +1085,16 @@ namespace SubscriptionActorService
                 return;
             }
 
+            pr.RequiredUpdates = requiredUpdates
+                    .SelectMany(update => update.deps)
+                    .Select(du => new DependencyUpdateSummary
+                    {
+                        DependencyName = du.To.Name,
+                        FromVersion = du.From.Version,
+                        ToVersion = du.To.Version
+                    })
+                    .ToList();
+
             PullRequest pullRequest = await darcRemote.GetPullRequestAsync(pr.Url);
             string headBranch = pullRequest.HeadBranch;
 


### PR DESCRIPTION
This fixes the broken DontAutoMergeDowngrades merge policy in https://github.com/dotnet/core-eng/issues/11718. We previously never updated the dependency update information in the internal representation of the PR that we keep in the cluster.

So far I validated that this fixes the broken merge policy, but I'd like to run some more validation.

You can see a PR without the bug that was opened by local testing of these changes here: https://github.com/maestro-auth-test/maestro-test2/pull/12797

* https://github.com/maestro-auth-test/maestro-test2/pull/12797/commits/7c8d54bd1eb18dca13d66563e1b0ba3f4c1cdd1d introduces a downgrade and the checks for it fail: https://github.com/maestro-auth-test/maestro-test2/pull/12797/checks?check_run_id=1618992323
* https://github.com/maestro-auth-test/maestro-test2/pull/12797/commits/081f474abdb2c1917b8c8e70e9b835c357e68614 fixes it and the check is now successful: https://github.com/maestro-auth-test/maestro-test2/pull/12797/checks?check_run_id=1619026951