### PR TITLE
Set login cookie lifetime to 30 minutes

### DIFF
--- a/src/Maestro/Maestro.Web/Startup.cs
+++ b/src/Maestro/Maestro.Web/Startup.cs
@@ -129,7 +129,8 @@ namespace Maestro.Web
             Configuration = configuration;
         }
 
-        public static readonly TimeSpan LoginCookieLifetime = new TimeSpan(days: 120, hours: 0, minutes: 0, seconds: 0);
+        public static readonly TimeSpan LoginCookieLifetime = new TimeSpan(hours: 0, minutes: 30, seconds: 0);
+        public static readonly TimeSpan DataProtectionKeyLifetime = new TimeSpan(days: 240, hours: 0, minutes: 0, seconds: 0);
 
         public IHostEnvironment HostingEnvironment { get; }
         public IConfiguration Configuration { get; }
@@ -139,7 +140,7 @@ namespace Maestro.Web
             if (HostingEnvironment.IsDevelopment())
             {
                 services.AddDataProtection()
-                    .SetDefaultKeyLifetime(LoginCookieLifetime * 2);
+                    .SetDefaultKeyLifetime(DataProtectionKeyLifetime);
             }
             else
             {
@@ -155,7 +156,7 @@ namespace Maestro.Web
                 services.AddDataProtection()
                     .PersistKeysToAzureBlobStorage(new Uri(dpConfig["KeyFileUri"]))
                     .ProtectKeysWithAzureKeyVault(kvClient, key.KeyIdentifier.ToString())
-                    .SetDefaultKeyLifetime(LoginCookieLifetime * 2)
+                    .SetDefaultKeyLifetime(DataProtectionKeyLifetime)
                     .SetApplicationName(typeof(Startup).FullName);
             }
 


### PR DESCRIPTION
SDL requires us to logout user from Maestro after 30 minutes of inactivity so I changed cookie configuration to use this value.

I did not modify lifetime of data protection keys. Previously it was set to `LoginCookieLifetime * 2  = 240 days` so I just statically set it to 240 days. If it should be updated as well then please let me know.

SDL work item: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1242739
Tracking issue: https://github.com/dotnet/core-eng/issues/11240.