### PR TITLE
Update the RequiredUpdates property when updating a PR's information

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -1085,6 +1085,8 @@ namespace SubscriptionActorService
                 return;
             }
 
+            pr.RequiredUpdates = MergeExistingWithIncomingUpdates(pr.RequiredUpdates, requiredUpdates);
+
             PullRequest pullRequest = await darcRemote.GetPullRequestAsync(pr.Url);
             string headBranch = pullRequest.HeadBranch;
 
@@ -1142,6 +1144,46 @@ namespace SubscriptionActorService
                 null,
                 TimeSpan.FromMinutes(5),
                 TimeSpan.FromMinutes(5));
+        }
+
+
+        /// <summary>
+        /// Merges the list of existing updates in a PR with a list of incoming udpates
+        /// </summary>
+        /// <param name="existingUpdates">pr object to update</param>
+        /// <param name="incomingUpdates">list of new incoming updates</param>
+        /// <returns>Merged list of existing updates along with the new</returns>
+        private List<DependencyUpdateSummary> MergeExistingWithIncomingUpdates(
+            List<DependencyUpdateSummary> existingUpdates,
+            List<(UpdateAssetsParameters update, List<DependencyUpdate> deps)> incomingUpdates)
+        {
+            // First project the new updates to the final list
+            List<DependencyUpdateSummary> mergedUpdates = 
+                incomingUpdates.SelectMany(update => update.deps)
+                    .Select(du => new DependencyUpdateSummary
+                    {
+                        DependencyName = du.To.Name,
+                        FromVersion = du.From.Version,
+                        ToVersion = du.To.Version
+                    }).ToList();
+
+            // Project to a form that is easy to search
+            Dictionary<string, DependencyUpdateSummary> searchableUpdates =
+                mergedUpdates.ToDictionary(u => u.DependencyName, u => u);
+
+            // Add any existing assets that weren't modified by the incoming update
+            if (existingUpdates != null)
+            {
+                foreach (DependencyUpdateSummary update in existingUpdates)
+                {
+                    if (!searchableUpdates.ContainsKey(update.DependencyName))
+                    {
+                        mergedUpdates.Add(update);
+                    }
+                }
+            }
+
+            return mergedUpdates;
         }
 
         /// <summary>

--- a/src/Maestro/maestro-angular/package-lock.json
+++ b/src/Maestro/maestro-angular/package-lock.json
@@ -4891,8 +4891,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4906,23 +4905,21 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -4935,20 +4932,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4962,7 +4956,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "deep-extend": {
@@ -4989,7 +4983,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.6.0"
+            "minipass": "2.9.0"
           }
         },
         "fs.realpath": {
@@ -5004,14 +4998,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "glob": {
@@ -5020,12 +5014,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.4",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -5040,7 +5034,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -5049,7 +5043,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -5058,15 +5052,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5078,9 +5071,8 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -5093,25 +5085,22 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.1.1"
           }
         },
         "minizlib": {
@@ -5120,14 +5109,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.9.0"
+            "minipass": "2.9.0"
           }
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5144,9 +5132,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^3.2.6",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "3.2.6",
+            "iconv-lite": "0.4.24",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -5155,16 +5143,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4.4.2"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.4.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.4.7",
+            "npmlog": "4.1.2",
+            "rc": "1.2.8",
+            "rimraf": "2.7.1",
+            "semver": "5.7.1",
+            "tar": "4.4.13"
           }
         },
         "nopt": {
@@ -5173,8 +5161,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -5183,7 +5171,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "npm-normalize-package-bin": "^1.0.1"
+            "npm-normalize-package-bin": "1.0.1"
           }
         },
         "npm-normalize-package-bin": {
@@ -5198,8 +5186,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.3",
+            "npm-bundled": "1.1.1"
           }
         },
         "npmlog": {
@@ -5208,17 +5196,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5230,9 +5217,8 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -5253,8 +5239,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -5275,10 +5261,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5295,13 +5281,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.4",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.1",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -5310,14 +5296,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.6"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5353,11 +5338,10 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -5366,16 +5350,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -5390,13 +5373,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
+            "chownr": "1.1.3",
+            "fs-minipass": "1.2.7",
+            "minipass": "2.9.0",
+            "minizlib": "1.3.3",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.1.1"
           }
         },
         "util-deprecate": {
@@ -5411,20 +5394,18 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
@@ -300,13 +300,22 @@ namespace SubscriptionActorService.Tests
                 {
                     Url = InProgressPrUrl,
                     ContainedSubscriptions = new List<SubscriptionPullRequestUpdate>
-                {
-                    new SubscriptionPullRequestUpdate
                     {
-                        BuildId = -1,
-                        SubscriptionId = Subscription.Id
+                        new SubscriptionPullRequestUpdate
+                        {
+                            BuildId = -1,
+                            SubscriptionId = Subscription.Id
+                        }
+                    },
+                    RequiredUpdates = new List<DependencyUpdateSummary>
+                    {
+                        new DependencyUpdateSummary
+                        {
+                            DependencyName = "Ham",
+                            FromVersion = "1.0.0-beta.1",
+                            ToVersion = "1.0.1-beta.1"
+                        }
                     }
-                }
                 };
                 StateManager.SetStateAsync(PullRequestActorImplementation.PullRequest, pr);
                 ExpectedActorState.Add(PullRequestActorImplementation.PullRequest, pr);


### PR DESCRIPTION
Should help fix the broken downgrade check policy: https://github.com/dotnet/core-eng/issues/11718. 

We were previously never updating the list of updates that the PR object we keep in memory had, so no matter how many new updates came in, we would never find when a downgrade was fixed.

A PR that shows this working is here:

https://github.com/maestro-auth-test/maestro-test2/pull/12838

https://github.com/maestro-auth-test/maestro-test2/commit/202fe63fd4ff7dbb844693176097318b6f9551bc introduces a downgrade, and the check fails: https://github.com/maestro-auth-test/maestro-test2/runs/1671624730

https://github.com/maestro-auth-test/maestro-test2/pull/12838/commits/fad474abdfba8735c5bbc7ccda75827bd66f8469 fixes the downgrade, and now the check succeeds: https://github.com/maestro-auth-test/maestro-test2/pull/12838/checks?check_run_id=1671636236

