### PR TITLE
Add additional hardening when downloading the git executable

### DIFF
--- a/src/Maestro/SubscriptionActorService/LocalGit.cs
+++ b/src/Maestro/SubscriptionActorService/LocalGit.cs
@@ -77,6 +77,11 @@ namespace SubscriptionActorService
 
                         _logger.LogInformation($"Downloading git from '{gitLocation}' to '{gitZipFile}'");
 
+                        if (Directory.Exists(targetPath))
+                        {
+                            Directory.Delete(targetPath, true);
+                        }
+                        
                         Directory.CreateDirectory(targetPath);
 
                         using (HttpClient client = new HttpClient())

--- a/src/Maestro/SubscriptionActorService/LocalGit.cs
+++ b/src/Maestro/SubscriptionActorService/LocalGit.cs
@@ -4,7 +4,6 @@ using System.IO.Compression;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.Internal.Logging;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;

--- a/src/Maestro/SubscriptionActorService/LocalGit.cs
+++ b/src/Maestro/SubscriptionActorService/LocalGit.cs
@@ -91,8 +91,6 @@ namespace SubscriptionActorService
                         ZipFile.ExtractToDirectory(gitZipFile, targetPath, overwriteFiles: true);
 
                         _gitExecutable = Path.Combine(targetPath, "bin", "git.exe");
-
-                        LocalHelpers.ExecuteGitCommand(_gitExecutable, "--version", _logger, Environment.CurrentDirectory);
                     }
                 }
             }
@@ -101,6 +99,8 @@ namespace SubscriptionActorService
                 _semaphoreSlim.Release();
             }
 
+            // Will throw if something is wrong with the git executable, forcing a retry
+            LocalHelpers.ExecuteGitCommand(_gitExecutable, "--version", _logger, Environment.CurrentDirectory);
             return _gitExecutable;
         }
     }

--- a/src/Maestro/SubscriptionActorService/LocalGit.cs
+++ b/src/Maestro/SubscriptionActorService/LocalGit.cs
@@ -52,9 +52,9 @@ namespace SubscriptionActorService
                     LocalHelpers.CheckGitInstallation(_gitExecutable, _logger);
                     return _gitExecutable;
                 }
-                catch (DarcException)
+                catch
                 { 
-                    _logger.LogWarning($"Something went wrong with the git executable at {_gitExecutable}. Downloading new version.");
+                    _logger.LogWarning($"Something went wrong with validating git executable at {_gitExecutable}. Downloading new version.");
                 }
             }
 

--- a/src/Maestro/SubscriptionActorService/LocalGit.cs
+++ b/src/Maestro/SubscriptionActorService/LocalGit.cs
@@ -49,7 +49,7 @@ namespace SubscriptionActorService
                 // We should also mke sure that the git executable that exists runs properly
                 try
                 {
-                    LocalHelpers.ExecuteGitCommand(_gitExecutable, "--version", _logger, Environment.CurrentDirectory);
+                    LocalHelpers.CheckGitInstallation(_gitExecutable, _logger);
                     return _gitExecutable;
                 }
                 catch (DarcException)
@@ -81,7 +81,7 @@ namespace SubscriptionActorService
                         {
                             Directory.Delete(targetPath, true);
                         }
-                        
+
                         Directory.CreateDirectory(targetPath);
 
                         using (HttpClient client = new HttpClient())
@@ -105,7 +105,7 @@ namespace SubscriptionActorService
             }
 
             // Will throw if something is wrong with the git executable, forcing a retry
-            LocalHelpers.ExecuteGitCommand(_gitExecutable, "--version", _logger, Environment.CurrentDirectory);
+            LocalHelpers.CheckGitInstallation(_gitExecutable, _logger);
             return _gitExecutable;
         }
     }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
@@ -160,12 +160,11 @@ namespace Microsoft.DotNet.DarcLib.Helpers
         /// <param name="logger">The logger</param>
         public static void CheckGitInstallation(string gitLocation, ILogger logger)
         {
-            string versionInfo = LocalHelpers.ExecuteGitCommand(gitLocation, "version --build-options", logger, Environment.CurrentDirectory);
+            string versionInfo = LocalHelpers.ExecuteCommand(gitLocation, "version --build-options", logger);
 
-            if (!versionInfo.StartsWith("git version") && !versionInfo.Contains("cpu:"))
+            if (!versionInfo.StartsWith("git version") || !versionInfo.Contains("cpu:"))
             {
-                throw new DarcException(
-                    $"Something failed when checking the git installation {gitLocation}");
+                throw new Exception($"Something failed when validating the git installation {gitLocation}");
             }
         }
 
@@ -217,7 +216,7 @@ namespace Microsoft.DotNet.DarcLib.Helpers
         /// <param name="logger">Logger</param>
         /// <param name="workingDirectory">Working directory</param>
         /// <param name="secretToMask">Mask this secret when calling the logger.</param>
-        private static string ExecuteGitCommand(string gitLocation, string arguments, ILogger logger, string workingDirectory, string secretToMask = null)
+        private static void ExecuteGitCommand(string gitLocation, string arguments, ILogger logger, string workingDirectory, string secretToMask = null)
         {
             string maskedArguments = secretToMask == null ? arguments : arguments.Replace(secretToMask, "***");
             logger.LogInformation("Executing command git {maskedArguments} in {workingDirectory}...", maskedArguments, workingDirectory);
@@ -228,8 +227,6 @@ namespace Microsoft.DotNet.DarcLib.Helpers
                 throw new DarcException(
                     $"Something failed when executing command git {maskedArguments} in {workingDirectory}");
             }
-
-            return result;
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
@@ -152,6 +152,23 @@ namespace Microsoft.DotNet.DarcLib.Helpers
             return workingDirectory;
         }
 
+        /// <summary>
+        /// Check that the git installation is valid by running git version --build-options
+        /// and checking the outputs to confirm that it is well-formed
+        /// </summary>
+        /// <param name="gitLocation">The location of git.exe</param>
+        /// <param name="logger">The logger</param>
+        public static void CheckGitInstallation(string gitLocation, ILogger logger)
+        {
+            string versionInfo = LocalHelpers.ExecuteGitCommand(gitLocation, "version --build-options", logger, Environment.CurrentDirectory);
+
+            if (!versionInfo.StartsWith("git version") && !versionInfo.Contains("cpu:"))
+            {
+                throw new DarcException(
+                    $"Something failed when checking the git installation {gitLocation}");
+            }
+        }
+
         public static string ExecuteCommand(string command, string arguments, ILogger logger, string workingDirectory = null)
         {
             if (string.IsNullOrEmpty(command))
@@ -200,7 +217,7 @@ namespace Microsoft.DotNet.DarcLib.Helpers
         /// <param name="logger">Logger</param>
         /// <param name="workingDirectory">Working directory</param>
         /// <param name="secretToMask">Mask this secret when calling the logger.</param>
-        public static void ExecuteGitCommand(string gitLocation, string arguments, ILogger logger, string workingDirectory, string secretToMask = null)
+        private static string ExecuteGitCommand(string gitLocation, string arguments, ILogger logger, string workingDirectory, string secretToMask = null)
         {
             string maskedArguments = secretToMask == null ? arguments : arguments.Replace(secretToMask, "***");
             logger.LogInformation("Executing command git {maskedArguments} in {workingDirectory}...", maskedArguments, workingDirectory);
@@ -211,6 +228,8 @@ namespace Microsoft.DotNet.DarcLib.Helpers
                 throw new DarcException(
                     $"Something failed when executing command git {maskedArguments} in {workingDirectory}");
             }
+
+            return result;
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
@@ -200,7 +200,7 @@ namespace Microsoft.DotNet.DarcLib.Helpers
         /// <param name="logger">Logger</param>
         /// <param name="workingDirectory">Working directory</param>
         /// <param name="secretToMask">Mask this secret when calling the logger.</param>
-        private static void ExecuteGitCommand(string gitLocation, string arguments, ILogger logger, string workingDirectory, string secretToMask = null)
+        public static void ExecuteGitCommand(string gitLocation, string arguments, ILogger logger, string workingDirectory, string secretToMask = null)
         {
             string maskedArguments = secretToMask == null ? arguments : arguments.Replace(secretToMask, "***");
             logger.LogInformation("Executing command git {maskedArguments} in {workingDirectory}...", maskedArguments, workingDirectory);


### PR DESCRIPTION
In LocalGit.GetPathToLocalGitAsync, we download the git executable if we haven't downloaded it before. However, this function simply tests whether or not the variable _gitExecutable is null or empty. However, that doesn't guarantee that the file that _gitExecutable points to still exists on disk (we assume it does, but never check), and it doesn't guarantee that that executable isn't corrupted. This change adds the following hardening:

1) In addition to checking the contents of the variable _gitExecutable, also make sure that the file exists.
2) Once we know that the file exists, run a basic git command (git --version), to make sure that the git executable isn't corrupted.

This helps harden against the issue described in https://github.com/dotnet/arcade/issues/5997, where we found that, though we had a path to a git executable, git was actually missing from the node. This does not solve the issue if the git executable goes missing between download and running it, however it should harden us some. We may, in the future, wish to update the remote to have its own LocalGit object, so if it finds git is missing when it runs a git command, it can download it at that time, but we are hoping that we don't have to go to that extreme.

To test this, I manually deleted the git executable on my local cluster at various points in time throughout the GetPathToLocalGitAsync function.