### PR TITLE
Fix average build time calculation on dependency flow graph

### DIFF
--- a/src/Maestro/Maestro.DataProviders/MaestroBarClient.cs
+++ b/src/Maestro/Maestro.DataProviders/MaestroBarClient.cs
@@ -458,13 +458,7 @@ namespace Maestro.DataProviders
 
             if (defaultChannel == null)
             {
-                return new BuildTime
-                {
-                    DefaultChannelId = 0,
-                    OfficialBuildTime = 0,
-                    PrBuildTime = 0,
-                    GoalTimeInMinutes = 0
-                };
+                return null;
             }
 
             MultiProjectKustoQuery queries = SharedKustoQueries.CreateBuildTimesQueries(

--- a/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildTimeController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2019_01_16/Controllers/BuildTimeController.cs
@@ -58,7 +58,11 @@ namespace Maestro.Web.Api.v2019_01_16.Controllers
                 return NotFound();
             }
 
-            MultiProjectKustoQuery queries = SharedKustoQueries.CreateBuildTimesQueries(defaultChannel.Repository, defaultChannel.Branch, days);
+            MultiProjectKustoQuery queries = SharedKustoQueries.CreateBuildTimesQueries(
+                defaultChannel.Repository,
+                defaultChannel.Branch,
+                days,
+                buildDefinitionId: null /* include all build definitions */);
 
             var results = await Task.WhenAll<IDataReader>(_kustoClientProvider.ExecuteKustoQueryAsync(queries.Internal), 
                 _kustoClientProvider.ExecuteKustoQueryAsync(queries.Public));


### PR DESCRIPTION
Reported in: https://github.com/dotnet/arcade/issues/6737

Solution implemented here is following:
- I get AzDO BuildDefinitionId for the last build of given repo in default channel
- When querying average build time in Kusto I use this ID to include only builds that have that `DefinitionId`