### PR TITLE
Fix edge case with duplicates when calculating a PRs list of updates

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -1168,15 +1168,15 @@ namespace SubscriptionActorService
                     }).ToList();
 
             // Project to a form that is easy to search
-            Dictionary<string, DependencyUpdateSummary> searchableUpdates =
-                mergedUpdates.ToDictionary(u => u.DependencyName, u => u);
+            var searchableUpdates =
+                mergedUpdates.Select( u => u.DependencyName).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
             // Add any existing assets that weren't modified by the incoming update
             if (existingUpdates != null)
             {
                 foreach (DependencyUpdateSummary update in existingUpdates)
                 {
-                    if (!searchableUpdates.ContainsKey(update.DependencyName))
+                    if (!searchableUpdates.Contains(update.DependencyName))
                     {
                         mergedUpdates.Add(update);
                     }

--- a/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestActorTests.cs
@@ -314,7 +314,13 @@ namespace SubscriptionActorService.Tests
                             DependencyName = "Ham",
                             FromVersion = "1.0.0-beta.1",
                             ToVersion = "1.0.1-beta.1"
-                        }
+                        },
+                        new DependencyUpdateSummary
+                        {
+                            DependencyName = "Ham",
+                            FromVersion = "1.0.0-beta.1",
+                            ToVersion = "1.0.1-beta.1"
+                        },
                     }
                 };
                 StateManager.SetStateAsync(PullRequestActorImplementation.PullRequest, pr);

--- a/src/Maestro/tests/SubscriptionActorService.Tests/SubscriptionOrPullRequestActorTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/SubscriptionOrPullRequestActorTests.cs
@@ -110,7 +110,7 @@ namespace SubscriptionActorService.Tests
 
         internal Build GivenANewBuild(bool addToChannel, (string name, string version, bool nonShipping)[] assets = null)
         {
-            assets = assets ?? new[] {("quail.eating.ducks", "1.1.0", false), ("quite.expensive.device", "2.0.1", true) };
+            assets = assets ?? new[] {("quail.eating.ducks", "1.1.0", false), ("quail.eating.ducks", "1.1.0", false), ("quite.expensive.device", "2.0.1", true) };
             var build = new Build
             {
                 GitHubBranch = SourceBranch,


### PR DESCRIPTION
Fixes the issue that is preventing aspnetcore's servicing branch from receiving automatic updates: https://github.com/dotnet/core-eng/issues/11878

Updated the tests to mimic this edge case, both in the existing and incoming updates.