### PR TITLE
Fix bug with dependency generation in manifest when repo has no GitHub version

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -141,7 +141,7 @@ namespace Microsoft.DotNet.Darc.Operations
         {
             string repoUri = string.IsNullOrEmpty(build.GitHubRepository) ? build.AzureDevOpsRepository : build.GitHubRepository;
             IRemote remote = RemoteFactory.GetRemote(_options, repoUri, Logger);
-            return await remote.GetDependenciesAsync(build.GitHubRepository, build.Commit);
+            return await remote.GetDependenciesAsync(repoUri, build.Commit);
         }
 
         /// <summary>


### PR DESCRIPTION
Follow up from https://github.com/dotnet/arcade/issues/6640 when trying out with a "real" build where the repo only exists in AzDO