### PR TITLE
Add "Extra Assets" regex flag to gather-drop

### DIFF
--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -49,12 +49,13 @@ If you want to run the C# scenario tests (make sure that you followed the gettin
    1. MAESTRO_TOKEN : Get a maestro bearer token (you can create one after running maestro app)
    1. DARC_PACKAGE_SOURCE : Get the path to the darc nuget package (which would be in `arcade-services\artifacts\packages\Debug\NonShipping\`, see below for getting this built)
    1. MAESTRO_BASEURI : Run ngrok and get the https url
-   
+
 Generally this is easiest if you want to debug both sides to simply have two instances of Visual Studio 2019 running. See below if you do not have the file paths mentioned for DARC_PACKAGE_SOURCE
 
 Since Visual Studio's Debug Environment variable settings do not apply to debugging tests, you'll need to set them, preferably from a command prompt:
 
 1. Start command prompt
+1. set AZDO_TOKEN=...
 1. set GITHUB_TOKEN=...
 1. set MAESTRO_TOKEN=...
 1. set DARC_PACKAGE_SOURCE=...
@@ -68,7 +69,7 @@ When debugging the tests, you can check this via the Immediate window, e.g. by r
 
 Things to try:
 - If Visual Studio hangs, edit the properties of MaestroApplication and change `Application Debug Mode` to `Remove Application`
-- If Visual Studio still hungs, under Debug->Options, uncheck "Enable Diagnostic Tools while debugging"
+- If Visual Studio still hangs, under Debug->Options, uncheck "Enable Diagnostic Tools while debugging"
 - Clean your repository before building/running. (e.g. cd to repo, `git clean -xdf`)
 - Ensure the ASP.NET Workload is installed for Visual Studio.
 - If you are using your own PATs for debugging tests, your account needs to have permissions to the repositories involved and include appropriate scopes (default is just 'public')

--- a/src/Maestro/tests/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
@@ -643,13 +643,18 @@ namespace Maestro.ScenarioTests
             }
         }
 
-        public async Task<string> GatherDrop(int buildId, string outputDir, bool includeReleased)
+        public async Task<string> GatherDrop(int buildId, string outputDir, bool includeReleased, string extraAssetsRegex)
         {
             string[] args = new[] { "gather-drop", "--id", buildId.ToString(), "--dry-run", "--output-dir", outputDir };
 
             if (includeReleased)
             {
                 args = args.Append("--include-released").ToArray();
+            }
+
+            if (!string.IsNullOrEmpty(extraAssetsRegex))
+            {
+                args = args.Append($"--always-download-asset-filters").Append(extraAssetsRegex).ToArray();
             }
 
             return await RunDarcAsync(args);

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Builds.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Builds.cs
@@ -54,7 +54,7 @@ namespace Maestro.ScenarioTests
             Build retrievedBuild = await MaestroApi.Builds.GetBuildAsync(build.Id); 
             Assert.IsFalse(retrievedBuild.Released, "Retrieved build has Released set to true when it should be false");
 
-            // Release the build; this means gather-drop would not fetch anything unless --include-released were included in its args (which the next operation does)
+            // Release the build; gather-drop does not fetch anything unless the flag '--include-released' is included in its arguments (which the next operation does set)
             Build updatedBuild = await MaestroApi.Builds.UpdateAsync(new BuildUpdate() { Released = true }, build.Id);
             Assert.IsTrue(updatedBuild.Released, "Retrieved build has Released set to false when it should be true");
 

--- a/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Builds.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/ScenarioTests_Builds.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
@@ -16,6 +17,7 @@ namespace Maestro.ScenarioTests
         private readonly string sourceBuildNumber = "654321";
         private readonly string sourceCommit = "123456";
         private readonly string sourceBranch = "master";
+        
         private readonly IImmutableList<AssetData> sourceAssets;
         private TestParameters _parameters;
 
@@ -43,51 +45,61 @@ namespace Maestro.ScenarioTests
         public async Task ArcadeBuilds_EndToEnd()
         {
             TestContext.WriteLine("Darc/Maestro build-handling tests");
+            string scenarioDirectory = _parameters._dir.Directory;
 
             repoUrl = GetRepoUrl(repoName);
 
             // Create a build for the source repo
             Build build = await CreateBuildAsync(repoUrl, sourceBranch, sourceCommit, sourceBuildNumber, sourceAssets);
-            Build retrievedBuild = await MaestroApi.Builds.GetBuildAsync(build.Id);
+            Build retrievedBuild = await MaestroApi.Builds.GetBuildAsync(build.Id); 
             Assert.IsFalse(retrievedBuild.Released, "Retrieved build has Released set to true when it should be false");
 
-            //Release the build
+            // Release the build; this means gather-drop would not fetch anything unless --include-released were included in its args (which the next operation does)
             Build updatedBuild = await MaestroApi.Builds.UpdateAsync(new BuildUpdate() { Released = true }, build.Id);
             Assert.IsTrue(updatedBuild.Released, "Retrieved build has Released set to false when it should be true");
 
             // Gather a drop with release included
-            string gatherWithReleasedDir = Path.Combine(_parameters._dir + "gather-with-released");
-            string dropOutput = "";
+            string gatherWithReleasedDir = Path.Combine(scenarioDirectory, "gather-with-released");
+            string gatherDropOutput = "";
 
-            TestContext.WriteLine("Starting 'Gather with released 1' using folder " + gatherWithReleasedDir);
+            TestContext.WriteLine("Starting 'Gather with released, where build has been set to released' using folder " + gatherWithReleasedDir);
 
-            dropOutput = await GatherDrop(build.Id, gatherWithReleasedDir, true);
+            gatherDropOutput = await GatherDrop(build.Id, gatherWithReleasedDir, true, string.Empty);
 
-            StringAssert.Contains($"Gathering drop for build {sourceBuildNumber}", dropOutput, "Gather with released 1");
-            StringAssert.Contains("Downloading asset Bar@2.1.0", dropOutput, "Gather with released 1");
-            StringAssert.Contains("Downloading asset Foo@1.1.0", dropOutput, "Gather with released 1");
+            StringAssert.Contains($"Gathering drop for build {sourceBuildNumber}", gatherDropOutput, "Gather with released 1");
+            StringAssert.Contains("Downloading asset Bar@2.1.0", gatherDropOutput, "Gather with released 1");
+            StringAssert.Contains("Downloading asset Foo@1.1.0", gatherDropOutput, "Gather with released 1");
+            StringAssert.DoesNotContain("always-download assets in build", gatherDropOutput, "Gather with released 1");
 
             // Gather with release excluded (default behavior). Gather-drop should throw an error.
             TestContext.WriteLine("Starting 'Gather with release excluded' - gather-drop should throw an error.");
 
-            string gatherWithNoReleasedDir = Path.Combine(_parameters._dir + "gather-no-released");
-            Assert.ThrowsAsync<MaestroTestException>(async () => await GatherDrop(build.Id, gatherWithNoReleasedDir, false), "Gather with release excluded");
+            string gatherWithNoReleasedDir = Path.Combine(scenarioDirectory, "gather-no-released");
+            Assert.ThrowsAsync<MaestroTestException>(async () => await GatherDrop(build.Id, gatherWithNoReleasedDir, false, string.Empty), "Gather with release excluded");
 
             // Unrelease the build
             Build unreleaseBuild = await MaestroApi.Builds.UpdateAsync(new BuildUpdate() { Released = false }, build.Id);
             Assert.IsFalse(unreleaseBuild.Released);
 
             // Gather with release excluded again (default behavior)
-            string gatherWithNoReleased2Dir = Path.Combine(_parameters._dir + "gather-no-released-2");
-            string gatherDropOutput = "";
-
+            string gatherWithNoReleased2Dir = Path.Combine(scenarioDirectory, "gather-no-released-2");
             TestContext.WriteLine("Starting 'Gather unreleased with release excluded' using folder " + gatherWithNoReleased2Dir);
-
-            gatherDropOutput = await GatherDrop(build.Id, gatherWithNoReleased2Dir, false);
+            gatherDropOutput = await GatherDrop(build.Id, gatherWithNoReleased2Dir, false, string.Empty);
 
             StringAssert.Contains($"Gathering drop for build {sourceBuildNumber}", gatherDropOutput, "Gather unreleased with release excluded");
-            StringAssert.Contains("Downloading asset Bar@2.1.0", dropOutput, "Gather unreleased with release excluded");
-            StringAssert.Contains("Downloading asset Foo@1.1.0", dropOutput, "Gather unreleased with release excluded");
+            StringAssert.Contains("Downloading asset Bar@2.1.0", gatherDropOutput, "Gather unreleased with release excluded");
+            StringAssert.Contains("Downloading asset Foo@1.1.0", gatherDropOutput, "Gather unreleased with release excluded");
+            StringAssert.DoesNotContain("always-download assets in build", gatherDropOutput, "Gather unreleased with release excluded");
+
+            // Gather with release excluded again, but specify --always-download-asset-filters
+            string gatherWithNoReleased3Dir = Path.Combine(scenarioDirectory, "gather-no-released-3");
+            TestContext.WriteLine("Starting 'Gather unreleased with release excluded' using folder " + gatherWithNoReleased3Dir);
+            gatherDropOutput = await GatherDrop(build.Id, gatherWithNoReleased3Dir, false, $"B.*r$");
+
+            StringAssert.Contains($"Gathering drop for build {sourceBuildNumber}", gatherDropOutput, "Gather unreleased with release excluded");
+            StringAssert.Contains("Downloading asset Bar@2.1.0", gatherDropOutput, "Gather unreleased with release excluded");
+            StringAssert.Contains("Downloading asset Foo@1.1.0", gatherDropOutput, "Gather unreleased with release excluded");
+            StringAssert.Contains("Found 1 always-download asset(s) in build", gatherDropOutput, "Gather unreleased with release excluded");
         }
     }
 }

--- a/src/Maestro/tests/Maestro.ScenarioTests/TestHelpers.cs
+++ b/src/Maestro/tests/Maestro.ScenarioTests/TestHelpers.cs
@@ -108,11 +108,11 @@ namespace Maestro.ScenarioTests
                 throw new InvalidOperationException("Unexpected Task completed.");
             }
 
-
-
             if (process.ExitCode != 0)
             {
-                throw new MaestroTestException($"{executable} exited with code {process.ExitCode}");
+                MaestroTestException exceptionWithConsoleLog = new MaestroTestException($"{executable} exited with code {process.ExitCode}");
+                exceptionWithConsoleLog.Data.Add("ConsoleOutput", output.ToString());
+                throw exceptionWithConsoleLog;
             }
 
             return output.ToString();

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -82,6 +82,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 Console.WriteLine();
 
                 List<DownloadedBuild> downloadedBuilds = new List<DownloadedBuild>();
+                List<DownloadedAsset> extraDownloadedAssets = new List<DownloadedAsset>();
 
                 foreach (var build in buildsToDownload.Builds)
                 {
@@ -107,12 +108,21 @@ namespace Microsoft.DotNet.Darc.Operations
                             // It may be an artificial scenario for a "root" build to have no dependencies.
                         }
                     }
+                    if (downloadedBuild.ExtraDownloadedAssets.Any())
+                    {
+                        Console.WriteLine($"Found {downloadedBuild.ExtraDownloadedAssets.Count()} always-download asset(s) in build {build.Id}:");
+                        foreach (var asset in downloadedBuild.ExtraDownloadedAssets)
+                        {
+                            Console.WriteLine($"   - {asset.Asset.Name}");
+                        }
+                        extraDownloadedAssets.AddRange(downloadedBuild.ExtraDownloadedAssets);
+                    }
 
                     downloadedBuilds.Add(downloadedBuild);
                 }
 
                 // Write the unified drop manifest
-                await WriteDropManifestAsync(downloadedBuilds, _options.OutputDirectory);
+                await WriteDropManifestAsync(downloadedBuilds, extraDownloadedAssets, _options.OutputDirectory);
 
                 // Write the release json
                 await WriteReleaseJson(downloadedBuilds, _options.OutputDirectory);
@@ -324,7 +334,7 @@ namespace Microsoft.DotNet.Darc.Operations
         private const string coreRepoCategory = "core";
         private const string aspnetCategory = "aspnet";
         private const string wcfCategory = "wcf";
-        
+
         // The following is the list of repos that should be picked up by the tooling
         // This list is effectively static, but not the full set of repos that are in the graph,
         // as our release process does not publish all of the packages (e.g. not nuget.client).
@@ -480,7 +490,7 @@ namespace Microsoft.DotNet.Darc.Operations
                     // Otherwise, if the asset is a symbol package (ends in .symbols.nupkg), then copy it to symbols
                     else if (asset.Asset.Name.EndsWith(".symbols.nupkg"))
                     {
-                        if (doNotListSymbolPackageFilenamePrefixes.Any(doNotListPrefix => 
+                        if (doNotListSymbolPackageFilenamePrefixes.Any(doNotListPrefix =>
                             Path.GetFileName(asset.ReleaseLayoutTargetLocation).StartsWith(doNotListPrefix)))
                         {
                             continue;
@@ -501,10 +511,10 @@ namespace Microsoft.DotNet.Darc.Operations
             }
 
             Directory.CreateDirectory(outputDirectory);
-            
+
             File.WriteAllText(Path.Combine(outputDirectory, allNupkgsFileName), allNupkgsFileContent.ToString());
             File.WriteAllText(Path.Combine(outputDirectory, sympkgsFileName), sympkgsFileContent.ToString());
-                
+
             // Write out for each category
             foreach (KeyValuePair<string, StringBuilder> nupkgsByCategory in nupkgFileContents)
             {
@@ -560,7 +570,7 @@ namespace Microsoft.DotNet.Darc.Operations
         ///     Write out a manifest of the items in the drop in json format.
         /// </summary>
         /// <returns></returns>
-        private async Task WriteDropManifestAsync(List<DownloadedBuild> downloadedBuilds, string specificOutputDirectory)
+        private async Task WriteDropManifestAsync(List<DownloadedBuild> downloadedBuilds, List<DownloadedAsset> extraAssets, string specificOutputDirectory)
         {
             if (_options.DryRun)
             {
@@ -574,7 +584,8 @@ namespace Microsoft.DotNet.Darc.Operations
                 File.Delete(outputPath);
             }
 
-            var manifestJson = ManifestHelper.GenerateDarcAssetJsonManifest(downloadedBuilds, 
+            var manifestJson = ManifestHelper.GenerateDarcAssetJsonManifest(downloadedBuilds,
+                                                                            extraAssets,
                                                                             _options.OutputDirectory,
                                                                             _options.UseRelativePathsInManifest);
 
@@ -656,7 +667,7 @@ namespace Microsoft.DotNet.Darc.Operations
             }
             IRemoteFactory remoteFactory = new RemoteFactory(_options);
 
-            // Flatten for convencience and remove dependencies of types that we don't want if need be.
+            // Flatten for convenience and remove dependencies of types that we don't want if need be.
             if (!_options.IncludeToolset)
             {
                 Console.WriteLine("Filtering toolset dependencies from the graph...");
@@ -691,7 +702,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 Console.WriteLine("Full set of builds in graph:");
                 foreach (var build in graph.ContributingBuilds)
                 {
-                    if ((build.GitHubRepository ?? build.AzureDevOpsRepository) == rootBuildRepository && 
+                    if ((build.GitHubRepository ?? build.AzureDevOpsRepository) == rootBuildRepository &&
                         build.Commit == rootBuild.Commit &&
                         build.Id != rootBuild.Id)
                     {
@@ -708,7 +719,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 // we'd always have it on and would probably miss some real errors. The good news is that this is basically always the
                 // same two nodes in the graph. Specifically exclude these known missing items
 
-                var nodesWithNoContributingBuilds = graph.Nodes.Where(node => !node.ContributingBuilds.Any() && 
+                var nodesWithNoContributingBuilds = graph.Nodes.Where(node => !node.ContributingBuilds.Any() &&
                     !DependenciesAlwaysMissingBuilds.Any(missingNode => node.Repository == missingNode.repo && node.Commit == missingNode.sha)).ToList();
                 if (nodesWithNoContributingBuilds.Any())
                 {
@@ -770,7 +781,6 @@ namespace Microsoft.DotNet.Darc.Operations
         {
             IRemote remote = RemoteFactory.GetBarOnlyRemote(_options, Logger);
             bool success = true;
-
             string unifiedOutputDirectory = rootOutputDirectory;
             Directory.CreateDirectory(unifiedOutputDirectory);
 
@@ -791,15 +801,25 @@ namespace Microsoft.DotNet.Darc.Operations
             Directory.CreateDirectory(releaseOutputDirectory);
 
             ConcurrentBag<DownloadedAsset> downloadedAssets = new ConcurrentBag<DownloadedAsset>();
+            ConcurrentBag<DownloadedAsset> extraDownloadedAssets = new ConcurrentBag<DownloadedAsset>();
             bool anyShipping = false;
 
             Console.WriteLine($"Gathering drop for build {build.AzureDevOpsBuildNumber} of {repoUri}");
+
+            List<Asset> mustDownloadAssets = new List<Asset>();
+            string[] alwaysDownloadRegexes = _options.AlwaysDownloadAssetPatterns.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
             using (HttpClient client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }))
             {
-                var assets = await remote.GetAssetsAsync(buildId: build.Id, nonShipping: (!_options.IncludeNonShipping ? (bool?)false : null));
+                var assets = await remote.GetAssetsAsync(buildId: build.Id, nonShipping: (!_options.IncludeNonShipping ? (bool?) false : null));
                 if (!string.IsNullOrEmpty(_options.AssetFilter))
                 {
                     assets = assets.Where(asset => Regex.IsMatch(asset.Name, _options.AssetFilter));
+                }
+
+                foreach (string nameMatchRegex in alwaysDownloadRegexes)
+                {
+                    mustDownloadAssets.AddRange(assets.Where(asset => Regex.IsMatch(Path.GetFileName(asset.Name), nameMatchRegex)));
                 }
 
                 using (var clientThrottle = new SemaphoreSlim(_options.MaxConcurrentDownloads, _options.MaxConcurrentDownloads))
@@ -836,6 +856,44 @@ namespace Microsoft.DotNet.Darc.Operations
                             clientThrottle.Release();
                         }
                     }));
+
+                    // Now download the extras (if any)
+                    if (mustDownloadAssets.Any())
+                    {
+                        string extraAssetsDirectory = Path.Join(rootOutputDirectory, "extra-assets");
+                        Directory.CreateDirectory(extraAssetsDirectory);
+
+                        await Task.WhenAll(mustDownloadAssets.Select(async asset =>
+                        {
+                            await clientThrottle.WaitAsync();
+
+                            try
+                            {
+                                DownloadedAsset downloadedAsset = await DownloadAssetAsync(client, build, asset, extraAssetsDirectory, unifiedOutputDirectory);
+                                if (downloadedAsset == null)
+                                {
+                                    // Do nothing, decided not to download.
+                                }
+                                else if (!downloadedAsset.Successful)
+                                {
+                                    success = false;
+                                    if (!_options.ContinueOnError)
+                                    {
+                                        Console.WriteLine($"Aborting download.");
+                                        return;
+                                    }
+                                }
+                                else
+                                {
+                                    extraDownloadedAssets.Add(downloadedAsset);
+                                }
+                            }
+                            finally
+                            {
+                                clientThrottle.Release();
+                            }
+                        }));
+                    }
                 }
             }
 
@@ -844,11 +902,12 @@ namespace Microsoft.DotNet.Darc.Operations
                 Successful = success,
                 Build = build,
                 DownloadedAssets = downloadedAssets,
+                ExtraDownloadedAssets = extraDownloadedAssets,
                 ReleaseLayoutOutputDirectory = releaseOutputDirectory,
                 AnyShippingAssets = anyShipping
             };
 
-            await WriteDropManifestAsync(new List<DownloadedBuild>() { newBuild }, releaseOutputDirectory);
+            await WriteDropManifestAsync(new List<DownloadedBuild>() { newBuild }, null, releaseOutputDirectory);
 
             return newBuild;
         }
@@ -974,8 +1033,8 @@ namespace Microsoft.DotNet.Darc.Operations
         /// until the asset download succeed or all locations have been tested.
         /// </summary>
         private async Task<DownloadedAsset> DownloadAssetFromAnyLocationAsync(HttpClient client,
-                                                                            Build build, 
-                                                                            Asset asset, 
+                                                                            Build build,
+                                                                            Asset asset,
                                                                             List<AssetLocation> assetLocations,
                                                                             string releaseOutputDirectory,
                                                                             string unifiedOutputDirectory,
@@ -1022,9 +1081,9 @@ namespace Microsoft.DotNet.Darc.Operations
         {
             AssetLocation latestLocation = assetLocations.OrderByDescending(al => al.Id).First();
 
-            return await DownloadAssetFromLocation(client, 
-                build, 
-                asset, 
+            return await DownloadAssetFromLocation(client,
+                build,
+                asset,
                 latestLocation,
                 releaseOutputDirectory,
                 unifiedOutputDirectory,
@@ -1431,7 +1490,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 return downloadedAsset;
             }
-            
+
             if (string.IsNullOrEmpty(assetLocation.Location))
             {
                 errors.Add($"Asset location for {asset.Name} is not available.");
@@ -1454,11 +1513,11 @@ namespace Microsoft.DotNet.Darc.Operations
         /// <param name="downloadOutput">Console output for the download.</param>
         /// <param name="errors">List of errors. Append error messages to this list if there are failures.</param>
         /// <returns>True if the download succeeded, false otherwise.</returns>
-        private async Task<bool> DownloadFileAsync(HttpClient client, 
-            string sourceUri, 
-            AuthenticationHeaderValue authHeader, 
+        private async Task<bool> DownloadFileAsync(HttpClient client,
+            string sourceUri,
+            AuthenticationHeaderValue authHeader,
             IEnumerable<string> targetFilePaths,
-            List<string> errors, 
+            List<string> errors,
             StringBuilder downloadOutput,
             CancellationToken cancellationToken)
         {
@@ -1524,11 +1583,11 @@ namespace Microsoft.DotNet.Darc.Operations
         /// <param name="errors">List of errors. Append error messages to this list if there are failures.</param>
         /// <param name="downloadOutput">Console output for the download.</param>
         /// <returns>True if the download succeeded, false otherwise.</returns>
-        private async Task<bool> DownloadFileImplAsync(HttpClient client, 
-            string sourceUri, 
-            AuthenticationHeaderValue authHeader, 
+        private async Task<bool> DownloadFileImplAsync(HttpClient client,
+            string sourceUri,
+            AuthenticationHeaderValue authHeader,
             IEnumerable<string> targetFiles,
-            List<string> errors, 
+            List<string> errors,
             StringBuilder downloadOutput,
             CancellationToken cancellationToken)
         {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
@@ -76,6 +76,9 @@ namespace Microsoft.DotNet.Darc.Options
         [RedactFromLogging]
         public IEnumerable<string> SASSuffixes { get; set; }
 
+        [Option("always-download-asset-filters", HelpText = "Comma-separated list of exact names or regexes which will always be downloaded. If not part of the usual payload, they will be downloaded to an 'extra-assets' folder.")]
+        public string AlwaysDownloadAssetPatterns { get; set; } = "";
+
         [Option("asset-filter", HelpText = "Only download assets matching the given regex filter")]
         public string AssetFilter { get; set; }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DownloadedBuild.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DownloadedBuild.cs
@@ -13,6 +13,10 @@ namespace Microsoft.DotNet.DarcLib.Models.Darc
         public bool Successful { get; set; }
         public IEnumerable<DownloadedAsset> DownloadedAssets { get; set; }
         /// <summary>
+        /// If the 'always-download-asset-filters' value is set and contains a regex which matches assets that would otherwise be skipped or ignored, they are downloaded to a parallel folder, and added to this collection.
+        /// </summary>
+        public IEnumerable<DownloadedAsset> ExtraDownloadedAssets { get; set; }
+        /// <summary>
         ///     Root output directory for this build.
         /// </summary>
         public string ReleaseLayoutOutputDirectory { get; set; }


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/6640

Allows for downloading and adding to the gather-drop manifest arbitrary assets via regex and their file name. Supports various dotnet-release scenarios while not explicitly adding (even) more understanding of these repositories to Arcade-Services.