### PR TITLE
add teams webhook notification channel and add it to the .net eng status failed requests

### DIFF
--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -3539,6 +3539,9 @@
         "notifications": [
           {
             "uid": "statusHook"
+          },
+          {
+            "uid": "teamsHook"
           }
         ]
       },

--- a/src/Monitoring/Monitoring.ArcadeServices/notifications/Production/teamsHook.notification.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/notifications/Production/teamsHook.notification.json
@@ -1,0 +1,14 @@
+{
+  "name": "Teams Alert",
+  "type": "teams",
+  "isDefault": false,
+  "sendReminder": false,
+  "disableResolveMessage": false,
+  "frequency": "",
+  "settings": {
+    "autoResolve": true,
+    "httpMethod": "POST",
+    "uploadImage": true,
+    "url": "[vault(fr-bot-notifications-teams-notification-url)]"
+  }
+}

--- a/src/Monitoring/Monitoring.ArcadeServices/notifications/Staging/teamsHook.notification.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/notifications/Staging/teamsHook.notification.json
@@ -1,0 +1,14 @@
+{
+  "name": "Teams Alert",
+  "type": "teams",
+  "isDefault": false,
+  "sendReminder": false,
+  "disableResolveMessage": false,
+  "frequency": "",
+  "settings": {
+    "autoResolve": true,
+    "httpMethod": "POST",
+    "uploadImage": true,
+    "url": "[vault(fr-bot-notifications-teams-notification-url)]"
+  }
+}


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/11371

This hooks up this one particular alert so that it posts to the FR Bot Notifications channel.

I added the respective secrets to the prod and staging vaults, and you can see an example of how the connector works [here](https://teams.microsoft.com/l/message/19:035bc5fb656b4dc8ae7f457474dabf6d@thread.skype/1612295750291?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=147df318-61de-4f04-8f7b-ecd328c256bb&parentMessageId=1612295750291&teamName=.NET%20Eng%20Services&channelName=FR%20Bot%20Notifications&createdTime=1612295750291)

