### PR TITLE
Fix HttpRequest error handling in arcade-services

### DIFF
--- a/src/Maestro/FeedCleanerService/FeedCleanerService.cs
+++ b/src/Maestro/FeedCleanerService/FeedCleanerService.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;

--- a/src/Maestro/FeedCleanerService/FeedCleanerService.cs
+++ b/src/Maestro/FeedCleanerService/FeedCleanerService.cs
@@ -332,7 +332,7 @@ namespace FeedCleanerService
                 Logger.LogInformation($"Found {name}.{version} in nuget.org URI: {packageContentsUri}");
                 return true;
             }
-            catch (HttpRequestException e) when (e.Message.Contains(((int)HttpStatusCode.NotFound).ToString())
+            catch (HttpRequestException e) when (e.Message.Contains(((int)HttpStatusCode.NotFound).ToString()))
             {
                 Logger.LogInformation($"Unable to find {name}.{version} in nuget.org URI: {packageContentsUri}");
                 return false;

--- a/src/Maestro/FeedCleanerService/FeedCleanerService.cs
+++ b/src/Maestro/FeedCleanerService/FeedCleanerService.cs
@@ -331,7 +331,7 @@ namespace FeedCleanerService
                 Logger.LogInformation($"Found {name}.{version} in nuget.org URI: {packageContentsUri}");
                 return true;
             }
-            catch (HttpRequestException e) when (e.Message.Contains("404 (Not Found)"))
+            catch (HttpRequestException e) when (e.Message.Contains(((int)HttpStatusCode.NotFound).ToString())
             {
                 Logger.LogInformation($"Unable to find {name}.{version} in nuget.org URI: {packageContentsUri}");
                 return false;

--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Runtime.Serialization;
 using System.Text;
@@ -628,7 +629,7 @@ namespace SubscriptionActorService
 
                 return ActionResult.Create<object>(null, $"Pull request '{prUrl}' created.");
             }
-            catch (HttpRequestException reqEx) when (reqEx.Message.Contains("401 (Unauthorized)"))
+            catch (HttpRequestException reqEx) when (reqEx.Message.Contains(((int) HttpStatusCode.Unauthorized).ToString()))
             {
                 // We want to preserve the HttpRequestException's information but it's not serializable
                 // We'll log the full exception object so it's in Application Insights, and strip any single quotes from the message to ensure 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -352,12 +353,12 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 return true;
             }
-            catch (HttpRequestException e) when (e.Message.Contains("404 (Not Found)"))
+            catch (HttpRequestException e) when (e.Message.Contains(((int)HttpStatusCode.NotFound).ToString()))
             {
                 Console.Write("The build that you want to add to a new channel isn't available in AzDO anymore. Aborting.");
                 return false;
             }
-            catch (HttpRequestException e) when (e.Message.Contains("401 (Unauthorized)"))
+            catch (HttpRequestException e) when (e.Message.Contains(((int)HttpStatusCode.Unauthorized).ToString()))
             {
                 Console.WriteLine("Got permission denied response while trying to retrieve target build from Azure DevOps. Aborting.");
                 Console.Write("Please make sure that your Azure DevOps PAT has the build read and execute scopes set.");

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.DarcLib
                         logFailure: false);
                     return content["content"].ToString();
                 }
-                catch (HttpRequestException reqEx) when (reqEx.Message.Contains("404 (Not Found)") || reqEx.Message.Contains("400 (Bad Request)"))
+                catch (HttpRequestException reqEx) when (reqEx.Message.Contains(((int)HttpStatusCode.NotFound).ToString()) || reqEx.Message.Contains(((int)HttpStatusCode.BadRequest).ToString()))
                 {
                     // Continue
                     lastException = reqEx;
@@ -707,7 +707,7 @@ This pull request has not been merged because Maestro++ is waiting on the follow
                     Valid = true
                 };
             }
-            catch (HttpRequestException reqEx) when (reqEx.Message.Contains("404 (Not Found)"))
+            catch (HttpRequestException reqEx) when (reqEx.Message.Contains(((int)HttpStatusCode.NotFound).ToString()))
             {
                 return GitDiff.UnknownDiff();
             }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.DarcLib
 
                 return this.GetDecodedContent(content);
             }
-            catch (HttpRequestException reqEx) when (reqEx.Message.Contains("404 (Not Found)"))
+            catch (HttpRequestException reqEx) when (reqEx.Message.Contains(((int) HttpStatusCode.NotFound).ToString()))
             {
                 throw new DependencyFileNotFoundException(filePath, $"{owner}/{repo}", branch, reqEx);
             }
@@ -1192,7 +1192,7 @@ namespace Microsoft.DotNet.DarcLib
                     Valid = true
                 };
             }
-            catch (HttpRequestException reqEx) when (reqEx.Message.Contains("404 (Not Found)"))
+            catch (HttpRequestException reqEx) when (reqEx.Message.Contains(((int) HttpStatusCode.NotFound).ToString()))
             {
                 return GitDiff.UnknownDiff();
             }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/HttpRequestManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/HttpRequestManager.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.DarcLib
                 catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
                 {
                     // For CLI users this will look normal, but translating to a DarcAuthenticationFailureException means it opts in to automated failure logging.
-                    if (ex is HttpRequestException && ex.Message.Contains("401 (Unauthorized)"))
+                    if (ex is HttpRequestException && ex.Message.Contains(((int) HttpStatusCode.Unauthorized).ToString()))
                     {
                         _logger.LogError(ex, "Non-continuable HTTP 401 error encountered while making request");
                         throw new DarcAuthenticationFailureException($"Failure to authenticate: {ex.Message}");


### PR DESCRIPTION
The message for 404 errors changed on github's side. To be safe, I've updated all of the error checking to not assume (Not Found) will be in the message.

When we move to 5.0, the HttpRequestException object also includes a StatusCode that we can reference, so we should check that instead of the message for additional safety.