### PR TITLE
[Hotfix] Fix null ref in TeamMentionForwarder 

### DIFF
--- a/src/DotNet.Status.Web/Models/TeamMentionForwarder.cs
+++ b/src/DotNet.Status.Web/Models/TeamMentionForwarder.cs
@@ -43,7 +43,7 @@ namespace DotNet.Status.Web.Models
             string team = _options.Value.WatchedTeam;
             string[] ignoredRepos = _options.Value.IgnoreRepos;
 
-            if (ignoredRepos.Contains(repo))
+            if (ignoredRepos != null && ignoredRepos.Contains(repo))
             {
                 shouldSend = false;
             }


### PR DESCRIPTION
Cherry-pick of 543d9fd42ab5a422256492d8be51695b5c1ed5e6 in order to fix https://github.com/dotnet/core-eng/issues/12630

