### PR TITLE
Fix 'anyShipping' logic for gather-drop

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -820,8 +820,9 @@ namespace Microsoft.DotNet.Darc.Operations
                 mustDownloadAssets.AddRange(assets.Where(asset => Regex.IsMatch(Path.GetFileName(asset.Name), nameMatchRegex)));
             }
 
-            (bool success, ConcurrentBag<DownloadedAsset> downloadedMainAssets) primaryAssetDownloadResult = await DownloadAssetsToDirectories(assets, build, releaseOutputDirectory, unifiedOutputDirectory);
+            (bool success, bool anyShipping, ConcurrentBag<DownloadedAsset> downloadedMainAssets) primaryAssetDownloadResult = await DownloadAssetsToDirectories(assets, build, releaseOutputDirectory, unifiedOutputDirectory);
             success &= primaryAssetDownloadResult.success;
+            anyShipping |= primaryAssetDownloadResult.anyShipping;
             downloadedAssets = primaryAssetDownloadResult.downloadedMainAssets;
             if (!success && !_options.ContinueOnError)
             {
@@ -834,8 +835,9 @@ namespace Microsoft.DotNet.Darc.Operations
                 string extraAssetsDirectory = Path.Join(rootOutputDirectory, "extra-assets");
                 Directory.CreateDirectory(extraAssetsDirectory);
 
-                (bool success, ConcurrentBag<DownloadedAsset> downloadedExtraAssets) extraAssetDownloadResult = await DownloadAssetsToDirectories(mustDownloadAssets, build, extraAssetsDirectory, unifiedOutputDirectory);
+                (bool success, bool anyShipping, ConcurrentBag<DownloadedAsset> downloadedExtraAssets) extraAssetDownloadResult = await DownloadAssetsToDirectories(mustDownloadAssets, build, extraAssetsDirectory, unifiedOutputDirectory);
                 extraDownloadedAssets = extraAssetDownloadResult.downloadedExtraAssets;
+                anyShipping |= extraAssetDownloadResult.anyShipping;
                 success &= extraAssetDownloadResult.success;
                 if (!success && !_options.ContinueOnError)
                 {
@@ -859,10 +861,11 @@ namespace Microsoft.DotNet.Darc.Operations
         }
 
 
-        private async Task<(bool success, ConcurrentBag<DownloadedAsset> downloadedAssets)> DownloadAssetsToDirectories(IEnumerable<Asset> assets, Build build, string specificAssetDirectory, string unifiedOutputDirectory)
+        private async Task<(bool success, bool anyShipping, ConcurrentBag<DownloadedAsset> downloadedAssets)> DownloadAssetsToDirectories(IEnumerable<Asset> assets, Build build, string specificAssetDirectory, string unifiedOutputDirectory)
         {
             bool success = true;
             var downloaded = new ConcurrentBag<DownloadedAsset>();
+            bool anyShipping = false;
             using (HttpClient client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }))
             {
                 using (var clientThrottle = new SemaphoreSlim(_options.MaxConcurrentDownloads, _options.MaxConcurrentDownloads))
@@ -890,6 +893,7 @@ namespace Microsoft.DotNet.Darc.Operations
                             }
                             else
                             {
+                                anyShipping |= !asset.NonShipping;
                                 downloaded.Add(downloadedAsset);
                             }
                         }
@@ -900,7 +904,7 @@ namespace Microsoft.DotNet.Darc.Operations
                     }));
                 }
             }
-            return (success, downloaded);
+            return (success, anyShipping, downloaded);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -835,9 +835,8 @@ namespace Microsoft.DotNet.Darc.Operations
                 string extraAssetsDirectory = Path.Join(rootOutputDirectory, "extra-assets");
                 Directory.CreateDirectory(extraAssetsDirectory);
 
-                (bool success, bool anyShipping, ConcurrentBag<DownloadedAsset> downloadedExtraAssets) extraAssetDownloadResult = await DownloadAssetsToDirectories(mustDownloadAssets, build, extraAssetsDirectory, unifiedOutputDirectory);
+                (bool success, bool _, ConcurrentBag<DownloadedAsset> downloadedExtraAssets) extraAssetDownloadResult = await DownloadAssetsToDirectories(mustDownloadAssets, build, extraAssetsDirectory, unifiedOutputDirectory);
                 extraDownloadedAssets = extraAssetDownloadResult.downloadedExtraAssets;
-                anyShipping |= extraAssetDownloadResult.anyShipping;
                 success &= extraAssetDownloadResult.success;
                 if (!success && !_options.ContinueOnError)
                 {


### PR DESCRIPTION
Looks like at some point the `release.json` stopped populating the products node with the paths of the shipping assets. Turns out it only adds products it thinks has shipping assets, which wasn't being bubbled up. I added the extra download assets to be considered as well, let me know if that is not right.