### PR TITLE
Fix the regex for github repos in RepositoryUrlAttribute

### DIFF
--- a/src/Maestro/Maestro.Web.Tests/RepositoryUrlAttributeTests.cs
+++ b/src/Maestro/Maestro.Web.Tests/RepositoryUrlAttributeTests.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+using FluentAssertions;
+using Microsoft.DotNet.Internal.Testing.Utility;
+using NUnit.Framework;
+
+namespace Maestro.Web.Tests
+{
+    [TestFixture]
+    public class RepositoryUrlAttributeTests
+    {
+        [TestCase("https://github.com/org/validRepo")]
+        [TestCase("https://github.com/org/valid.Repo")]
+        [TestCase("https://github.com/org/valid-Repo")]
+        [TestCase("https://github.com/org/valid-Rep.o12")]
+        [TestCase("https://dev.azure.com/org/project/_git/validRepo")]
+        [TestCase("https://dev.azure.com/org/project/_git/valid.Repo")]
+        [TestCase("https://dev.azure.com/org/project/_git/valid-Repo")]
+        [TestCase("https://dev.azure.com/org/project/_git/valid-Rep.o12")]
+        public void IsValidWithValidUrl(string url)
+        {
+            var attrib = new RepositoryUrlAttribute();
+            attrib.GetValidationResult(url, new ValidationContext(url)).Should().Be(ValidationResult.Success);
+        }
+
+        [TestCase("https://github.com/org/validRepo$")]
+        [TestCase("https://github.com/org/valid#Repo")]
+        [TestCase("https://github.com/org/valid*Repo")]
+        [TestCase("https://github.com/org/valid(Rep)o")]
+        [TestCase("https://github.com/validRepo")]
+        [TestCase("https://dev.azure.com/org/project/_git")]
+        [TestCase("https://dev.azure.com/org/_git/validRepo")]
+        [TestCase("https://dev.azure.com/_git/validRepo")]
+        [TestCase("https://dev.azure.com/org/project/validRepo")]
+        public void IsValidWithInvalidValidUrl(string url)
+        {
+            var attrib = new RepositoryUrlAttribute();
+            attrib.GetValidationResult(url, new ValidationContext(url)).Should().NotBe(ValidationResult.Success);
+        }
+    }
+}

--- a/src/Maestro/Maestro.Web/RepositoryUrlAttribute.cs
+++ b/src/Maestro/Maestro.Web/RepositoryUrlAttribute.cs
@@ -43,7 +43,7 @@ namespace Maestro.Web
         /// </summary>
         private static readonly List<Regex> _validUrlForms = new List<Regex>()
         {
-            new Regex(@"^https://github\.com/[a-zA-Z0-9-]+/[a-zA-Z0-9-]+$"),
+            new Regex(@"^https://github\.com/[a-zA-Z0-9-]+/[a-zA-Z0-9-\.]+$"),
             new Regex(@"^https://dev\.azure\.com/[a-zA-Z0-9]+/[a-zA-Z0-9-]+/_git/[a-zA-Z0-9-\.]+$")
         };
 


### PR DESCRIPTION
There are github repos that have periods (.) in them. They should be allowed.

Fixes https://github.com/dotnet/arcade/issues/7150.