### PR TITLE
Fix unit tests after master/main renaming

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
         public const string AzureDevOpsRepository1 = "https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-arcade";
         public const string LocationString = "https://dev.azure.com/dnceng/internal/_apis/build/builds/856354/artifacts";
         private const string GitHubRepositoryName = "dotnet-arcade";
-        private const string GitHubBranch = "refs/heads/master";
+        private const string GitHubBranch = "refs/heads/main";
 
         #region Assets
         internal static readonly AssetData PackageAsset1 =


### PR DESCRIPTION
Fixing these failures in internal build:
https://dev.azure.com/dnceng/internal/_build/results?buildId=1063223&view=ms.vss-test-web.build-test-results-tab&runId=32747828&resultId=100504&paneView=debug