### PR TITLE
Add retry to gather-drop when downloading assets

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -1616,26 +1616,7 @@ namespace Microsoft.DotNet.Darc.Operations
                     requestMessage = new HttpRequestMessage(HttpMethod.Get, sourceUri);
                 }
 
-                // Ensure the parent target directory has been created.
-                using (FileStream outStream = new FileStream(temporaryFileName,
-                                                      _options.Overwrite ? FileMode.Create : FileMode.CreateNew,
-                                                      FileAccess.Write))
-                {
-                    using (var response = await client.SendAsync(requestMessage))
-                    {
-                        response.EnsureSuccessStatusCode();
-
-                        using (var inStream = await response.Content.ReadAsStreamAsync())
-                        {
-                            downloadOutput.AppendLine($"    {sourceUri} =>");
-                            foreach (string targetFile in targetFiles)
-                            {
-                                downloadOutput.AppendLine($"      {targetFile}");
-                            }
-                            await inStream.CopyToAsync(outStream, cancellationToken);
-                        }
-                    }
-                }
+                DownloadFileWithRetryAsync(temporaryFileName, requestMessage, targetFiles, _options.Overwrite, downloadOutput, errors);
 
                 foreach (string targetFile in targetFiles)
                 {
@@ -1700,6 +1681,41 @@ namespace Microsoft.DotNet.Darc.Operations
                 },
                 ex => Console.WriteLine($"Failed to delete {filePath}: {ex.Message}"),
                 ex => ex is UnauthorizedAccessException);
+        }
+
+        private static async Task DownloadFileWithRetryAsync(
+            string filePath, 
+            HttpRequestMessage requestMessage, 
+            IEnumerable<string> targetFiles,
+            bool overwrite, 
+            StringBuilder downloadOutput, 
+            List<string> errors)
+        {
+            // Ensure the parent target directory has been created.
+            using (FileStream outStream = new FileStream(filePath,
+                                                    overwrite ? FileMode.Create : FileMode.CreateNew,
+                                                    FileAccess.Write))
+            {
+                var response = ExponentialRetry.Default.RetryAsync(
+                    () =>
+                    {
+                        var response = await client.SendAsync(requestMessage);
+                        response.EnsureSuccessStatusCode();
+                        return response;
+                    },
+                    ex => errors.Add($"Failed to download {sourceUri}: {ex.Message}"),
+                    ex => ex is HttpRequestException);
+
+                using (var inStream = await response.Content.ReadAsStreamAsync())
+                {
+                    downloadOutput.AppendLine($"    {sourceUri} =>");
+                    foreach (string targetFile in targetFiles)
+                    {
+                        downloadOutput.AppendLine($"      {targetFile}");
+                    }
+                    await inStream.CopyToAsync(outStream, cancellationToken);
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -1621,7 +1621,7 @@ namespace Microsoft.DotNet.Darc.Operations
                                 return response;
                             }
                         },
-                        ex => Console.WriteLine($"    Failed to download {sourceUri}: {ex.Message}. Retrying."),
+                        ex => Console.WriteLine($"    Failed to download {sourceUri}: {ex.Message} {ex.InnerException?.Message} \n{ex.StackTrace}\nRetrying."),
                         ex => ex is HttpRequestException))
                     {
                         using (var inStream = await response.Content.ReadAsStreamAsync())


### PR DESCRIPTION
Occasionally, we get various HttpRequestExceptions when downloading assets in gather-drop. Most of these are retriable, so we should have a retry on this.