### PR TITLE
Remove entry for arcade validation from notifications

### DIFF
--- a/src/DotNet.Status.Web/appsettings.json
+++ b/src/DotNet.Status.Web/appsettings.json
@@ -29,12 +29,6 @@
         },
         {
           "Project": "internal",
-          "DefinitionPath": "\\dotnet\\arcade-validation\\dotnet-arcade-validation-for-promotion",
-          "Branches": [ "main" ],
-          "Assignee": "missymessa"
-        },
-        {
-          "Project": "internal",
           "DefinitionPath": "\\dotnet-source-indexer\\dotnet-source-indexer CI",
           "Branches": [ "main" ],
           "Assignee": "alperovi"


### PR DESCRIPTION
The notifications are no longer needed as the pipeline in question will only be used in an adhoc way.

Addresses https://github.com/dotnet/arcade/issues/7110.