### PR TITLE
Add additional logging to GetPathToLocalGitAsync

### DIFF
--- a/src/Maestro/SubscriptionActorService/LocalGit.cs
+++ b/src/Maestro/SubscriptionActorService/LocalGit.cs
@@ -45,13 +45,14 @@ namespace SubscriptionActorService
             // Determine whether we need to do any downloading at all.
             if (!string.IsNullOrEmpty(_gitExecutable) && File.Exists(_gitExecutable))
             {
+                _logger.LogInformation($"Git executable found at {_gitExecutable}. Checking the installation.");
                 // We should also mke sure that the git executable that exists runs properly
                 try
                 {
                     LocalHelpers.CheckGitInstallation(_gitExecutable, _logger);
                     return _gitExecutable;
                 }
-                catch
+                catch (Exception ex)
                 { 
                     _logger.LogWarning($"Something went wrong with validating git executable at {_gitExecutable}. Downloading new version.");
                 }
@@ -78,6 +79,7 @@ namespace SubscriptionActorService
 
                         if (Directory.Exists(targetPath))
                         {
+                            _logger.LogInformation($"Target directory {targetPath} already exists. Deleting it.");
                             Directory.Delete(targetPath, true);
                         }
 

--- a/src/Maestro/SubscriptionActorService/LocalGit.cs
+++ b/src/Maestro/SubscriptionActorService/LocalGit.cs
@@ -52,7 +52,7 @@ namespace SubscriptionActorService
                     LocalHelpers.CheckGitInstallation(_gitExecutable, _logger);
                     return _gitExecutable;
                 }
-                catch (Exception ex)
+                catch
                 { 
                     _logger.LogWarning($"Something went wrong with validating git executable at {_gitExecutable}. Downloading new version.");
                 }


### PR DESCRIPTION
Add additional logging so that if we come up against https://github.com/dotnet/core-eng/issues/12752 again, we may have a clearer idea of why we are trying to download git when files that are also downloaded when downloading git exist and currently are being used/can't be deleted do so when we've found that git itself doesn't exist.