### PR TITLE
Add --separated option to gather-drop

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -798,7 +798,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 // Might contain invalid path chars, this is currently unhandled.
                 releaseOutputDirectory = Path.Combine(rootOutputDirectory, repoUri, build.AzureDevOpsBuildNumber);
             }
-            Directory.CreateDirectory(releaseOutputDirectory);
+
+            if (_options.Separated)
+            {
+                Directory.CreateDirectory(releaseOutputDirectory);
+            }
 
             ConcurrentBag<DownloadedAsset> downloadedAssets = new ConcurrentBag<DownloadedAsset>();
             ConcurrentBag<DownloadedAsset> extraDownloadedAssets = new ConcurrentBag<DownloadedAsset>();
@@ -854,7 +858,10 @@ namespace Microsoft.DotNet.Darc.Operations
                 AnyShippingAssets = anyShipping
             };
 
-            await WriteDropManifestAsync(new List<DownloadedBuild>() { newBuild }, null, releaseOutputDirectory);
+            if (_options.Separated)
+            {
+                await WriteDropManifestAsync(new List<DownloadedBuild>() { newBuild }, null, releaseOutputDirectory);
+            }
 
             return newBuild;
         }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -1168,7 +1168,14 @@ namespace Microsoft.DotNet.Darc.Operations
             string releaseFullTargetPath = Path.Combine(releaseFullSubPath, targetFileName);
             string unifiedFullTargetPath = Path.Combine(unifiedFullSubPath, targetFileName);
 
-            List<string> targetFilePaths = new List<string> { releaseFullTargetPath, unifiedFullTargetPath };
+            List<string> targetFilePaths = new List<string>();
+
+            if (_options.Separated)
+            {
+                targetFilePaths.Add(releaseFullTargetPath);
+            }
+
+            targetFilePaths.Add(unifiedFullTargetPath);
 
             DownloadedAsset downloadedAsset = new DownloadedAsset()
             {
@@ -1374,7 +1381,14 @@ namespace Microsoft.DotNet.Darc.Operations
             string releaseFullTargetPath = Path.Combine(releaseFullSubPath, normalizedAssetName);
             string unifiedFullTargetPath = Path.Combine(unifiedFullSubPath, normalizedAssetName);
 
-            List<string> targetFilePaths = new List<string> { releaseFullTargetPath, unifiedFullTargetPath };
+            List<string> targetFilePaths = new List<string>();
+            
+            if (_options.Separated)
+            {
+                targetFilePaths.Add(releaseFullTargetPath);
+            }
+            
+            targetFilePaths.Add(unifiedFullTargetPath);
 
             DownloadedAsset downloadedAsset = new DownloadedAsset()
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
@@ -68,6 +68,9 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("include-released", HelpText = "Include builds that are marked as released")]
         public bool IncludeReleased { get; set; }
 
+        [Option("separated", HelpText = "Also download files to their repo separated locations")]
+        public bool Separated { get; set; }
+
         [Option("latest-location", HelpText = "Download assets from their latest known location.")]
         public bool LatestLocation { get; set; }
 


### PR DESCRIPTION
This change adds a --separated option to gather-drop and changes the default behavior to not create the separated layout. This significantly reduces (by half) the size of a build drop, which is especially important for drops with multiple sdks, as the duplicate layout causes us to go over the 100GB available on a buildpool machine.

This does not modify the manifest.json at all, and that will need to be addressed in future work, as there are many pieces of infrastructure that assume there are 2 targets in the targets list. Once all of the infrastructure that relies on the structure of the manifest.json file is fixed, we can revisit the manifest creation to not include the separated target when we do not pass --separated.