### PR TITLE
Address https://github.com/dotnet/core-eng/issues/12911

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
                 });
         #endregion
 
-        #region IndividualAssets
+        #region Individual Assets
         private static readonly Package package1 = new Package()
         {
             Id = "Microsoft.Cci.Extensions",
@@ -193,6 +193,13 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
                         {
                             CertificateName = "ThisIsACert",
                              Include = "ALibrary.dll"
+                        },
+                        new FileSignInfo()
+                        {
+                            CertificateName = "ThisIsACertWithPKTAndTFM",
+                            Include = "ASecondLibrary.dll",
+                            PublicKeyToken = "4258675309abcdef",
+                            TargetFramework = ".NETFramework,Version=v2.0"
                         }
                     },
 
@@ -234,7 +241,14 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
                     new FileSignInfo()
                     {
                         CertificateName = "AnotherCert",
-                            Include = "AnotherLibrary.dll"
+                        Include = "AnotherLibrary.dll"
+                    },
+                    new FileSignInfo()
+                    {
+                        CertificateName = "AnotherCertWithPKTAndTFM",
+                        Include = "YetAnotherLibrary.dll",
+                        PublicKeyToken = "4258675309abcdef",
+                        TargetFramework = ".NETFramework,Version=v1.3"
                     }
                 },
 

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/XmlSerializationHelperTests.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/XmlSerializationHelperTests.cs
@@ -1,0 +1,204 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using FluentAssertions;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Maestro.Tasks.Tests
+{
+    [TestFixture]
+    public class XmlSerializationHelperTests
+    {
+        private const string Certificate1Name = "ImaginaryCert1";
+        private const string Certificate2Name = "ImaginaryCert2";
+        private const string PublicKeyToken1 = "123456789101112a";
+        private const string PublicKeyToken2 = "48151623421051aa";
+        private const string TargetFramework1 = "Bullseye.Net, Version = v1.0";
+        private const string TargetFramework2 = "Bullseye.Net, Version = v1.1";
+
+        [Test]
+        public void FileSignInfoTest()
+        {
+            var signingInformation = GetTestInfo();
+            XElement serializationResult = XmlSerializationHelper.SigningInfoToXml(signingInformation);
+
+            var fileSignInfos = serializationResult.Descendants("FileSignInfo").ToList();
+            fileSignInfos.Count().Should().Be(3);
+
+            // Validate that the PKT and TFM are only included if supplied
+            var someAssemblySignInfos = fileSignInfos.Where(x => x.Attribute("Include").Value.Equals("SomeAssembly.dll"));
+            someAssemblySignInfos.Count().Should().Be(2);
+            // In real scenarios, the assembly will be expected to share PKT across certificate / TFM
+            someAssemblySignInfos.Where(s => s.Attribute("PublicKeyToken").Value == PublicKeyToken1).Count().Should().Be(2);
+            // Make sure different cert & TFMs made it through:
+            someAssemblySignInfos.Where(s => s.Attribute("CertificateName").Value == Certificate1Name).Count().Should().Be(1);
+            someAssemblySignInfos.Where(s => s.Attribute("TargetFramework").Value == TargetFramework1).Count().Should().Be(1);
+            someAssemblySignInfos.Where(s => s.Attribute("CertificateName").Value == Certificate2Name).Count().Should().Be(1);
+            someAssemblySignInfos.Where(s => s.Attribute("TargetFramework").Value == TargetFramework2).Count().Should().Be(1);
+
+            // Eventually we need tests where this is actually checked to make sure every entry for a given assembly has
+            // both a PKT / TFM or not, to avoid ambiguity.
+            var someOtherAssemblySignInfo = fileSignInfos.Where(x => x.Attribute("Include").Value.Equals("SomeOtherAssembly.dll")).Single();
+            someOtherAssemblySignInfo.Attribute("PublicKeyToken").Should().BeNull();
+            someOtherAssemblySignInfo.Attribute("TargetFramework").Should().BeNull();
+        }
+
+        [Test]
+        public void FileExtensionSignInfoTest()
+        {
+            var signingInformation = GetTestInfo();
+            XElement serializationResult = XmlSerializationHelper.SigningInfoToXml(signingInformation);
+
+            var fileExtensionSignInfos = serializationResult.Descendants("FileExtensionSignInfo").ToList();
+            fileExtensionSignInfos.Count().Should().Be(2);
+
+            var fileExtensionSignInfo1 = fileExtensionSignInfos.Where(x => x.Attribute("Include").Value.Equals(".dll")).Single();
+            fileExtensionSignInfo1.Attribute("CertificateName").Value.Should().Be(Certificate1Name);
+
+            var fileExtensionSignInfo2 = fileExtensionSignInfos.Where(x => x.Attribute("Include").Value.Equals(".xbap")).Single();
+            fileExtensionSignInfo2.Attribute("CertificateName").Value.Should().Be(Certificate2Name);
+        }
+
+        [Test]
+        public void CertificatesSignInfoTest()
+        {
+            var signingInformation = GetTestInfo();
+            XElement serializationResult = XmlSerializationHelper.SigningInfoToXml(signingInformation);
+
+            var certificatesSignInfos = serializationResult.Descendants("CertificatesSignInfo").ToList();
+            certificatesSignInfos.Count().Should().Be(2);
+
+            var certificatesSignInfo1 = certificatesSignInfos.Where(x => x.Attribute("Include").Value.Equals(Certificate1Name)).Single();
+            certificatesSignInfo1.Attribute("DualSigningAllowed").Value.Should().Be("true");
+
+            var certificatesSignInfo2 = certificatesSignInfos.Where(x => x.Attribute("Include").Value.Equals(Certificate2Name)).Single();
+            certificatesSignInfo2.Attribute("DualSigningAllowed").Value.Should().Be("false");
+        }
+
+        [Test]
+        public void StrongNameSignInfoTest()
+        {
+            var signingInformation = GetTestInfo();
+            XElement serializationResult = XmlSerializationHelper.SigningInfoToXml(signingInformation);
+
+            var strongNameSignInfos = serializationResult.Descendants("StrongNameSignInfo").ToList();
+            strongNameSignInfos.Count().Should().Be(2);
+
+            var strongNameSignInfo1 = strongNameSignInfos.Where(x => x.Attribute("Include").Value.Equals("StrongName1")).Single();
+            strongNameSignInfo1.Attribute("PublicKeyToken").Value.Should().Be(PublicKeyToken1);
+            strongNameSignInfo1.Attribute("CertificateName").Value.Should().Be(Certificate1Name);
+
+            var strongNameSignInfo2 = strongNameSignInfos.Where(x => x.Attribute("Include").Value.Equals("StrongName2")).Single();
+            strongNameSignInfo2.Attribute("PublicKeyToken").Value.Should().Be(PublicKeyToken2);
+            strongNameSignInfo2.Attribute("CertificateName").Value.Should().Be(Certificate2Name);
+        }
+
+        [Test]
+        public void ItemsToSignTest()
+        {
+            var signingInformation = GetTestInfo();
+            XElement serializationResult = XmlSerializationHelper.SigningInfoToXml(signingInformation);
+
+            var items = serializationResult.Descendants("ItemsToSign").ToList();
+            items.Count().Should().Be(2);
+
+            items.Where(i => i.Attribute("Include").Value.Equals("SomeAssembly.dll")).Count().Should().Be(1);
+            items.Where(i => i.Attribute("Include").Value.Equals("SomeOtherAssembly.dll")).Count().Should().Be(1);
+        }
+
+        [Test]
+        public void CalledWithNullSigningInfo()
+        {
+            XElement serializationResult = XmlSerializationHelper.SigningInfoToXml(null);
+            serializationResult.Should().Be(null);
+        }
+
+        [Test]
+        public void CorrectRootElementType()
+        {
+            var signingInformation = GetTestInfo();
+            XElement serializationResult = XmlSerializationHelper.SigningInfoToXml(signingInformation);
+            serializationResult.Name.LocalName.Should().Be("SigningInformation");
+        }
+
+        private SigningInformation GetTestInfo()
+        {
+            SigningInformation signingInfo = new SigningInformation()
+            {
+                CertificatesSignInfo = new List<CertificatesSignInfo>()
+                {
+                    new CertificatesSignInfo()
+                    {
+                        DualSigningAllowed = true,
+                        Include = Certificate1Name,
+                    },
+                    new CertificatesSignInfo()
+                    {
+                        DualSigningAllowed = false,
+                        Include = Certificate2Name,
+                    },
+                },
+                FileExtensionSignInfos = new List<FileExtensionSignInfo>()
+                {
+                    new FileExtensionSignInfo()
+                    {
+                        CertificateName = Certificate1Name,
+                        Include = ".dll",
+                    },
+                    new FileExtensionSignInfo()
+                    {
+                        CertificateName = Certificate2Name,
+                        Include = ".xbap",
+                    }
+                },
+                FileSignInfos = new List<FileSignInfo>()
+                {
+                    new FileSignInfo()
+                    {
+                        CertificateName = Certificate1Name,
+                        Include = "SomeAssembly.dll",
+                        PublicKeyToken = PublicKeyToken1,
+                        TargetFramework = TargetFramework1
+                    },
+                    new FileSignInfo()
+                    {
+                        CertificateName = Certificate2Name,
+                        Include = "SomeAssembly.dll",
+                        PublicKeyToken = PublicKeyToken1,
+                        TargetFramework = TargetFramework2
+                    },
+                    new FileSignInfo()
+                    {
+                        CertificateName = Certificate2Name,
+                        Include = "SomeOtherAssembly.dll",
+                    },
+                },
+                ItemsToSign = new List<ItemsToSign>()
+                {
+                    new ItemsToSign() { Include = "SomeAssembly.dll" },
+                    new ItemsToSign() { Include = "SomeOtherAssembly.dll" },
+                },
+                StrongNameSignInfos = new List<StrongNameSignInfo>()
+                {
+                    new StrongNameSignInfo()
+                    {
+                        CertificateName = Certificate1Name,
+                        Include = "StrongName1",
+                        PublicKeyToken = PublicKeyToken1
+                    },
+                    new StrongNameSignInfo()
+                    {
+                        CertificateName = Certificate2Name,
+                        Include = "StrongName2",
+                        PublicKeyToken = PublicKeyToken2
+                    }
+                }
+            };
+            return signingInfo;
+        }
+    }
+}

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/XmlSerializationHelper.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/XmlSerializationHelper.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Xml.Linq;
 

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/XmlSerializationHelper.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/XmlSerializationHelper.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Maestro.Tasks
+{
+    static class XmlSerializationHelper
+    {
+        public static XElement SigningInfoToXml(SigningInformation signingInformation)
+        {
+            if (signingInformation == null)
+            {
+                return null;
+            }
+
+            List<XElement> signingMetadata = new List<XElement>();
+
+            foreach (FileExtensionSignInfo fileExtensionSignInfo in signingInformation.FileExtensionSignInfos)
+            {
+                signingMetadata.Add(new XElement(
+                    nameof(FileExtensionSignInfo),
+                    new XAttribute[]
+                    {
+                        new XAttribute(nameof(fileExtensionSignInfo.Include), fileExtensionSignInfo.Include),
+                        new XAttribute(nameof(fileExtensionSignInfo.CertificateName), fileExtensionSignInfo.CertificateName)
+                    }));
+            }
+
+            foreach (FileSignInfo fileSignInfo in signingInformation.FileSignInfos)
+            {
+                List<XAttribute> xAttributes = new List<XAttribute>()
+                {
+                    new XAttribute(nameof(fileSignInfo.Include), fileSignInfo.Include),
+                    new XAttribute(nameof(fileSignInfo.CertificateName), fileSignInfo.CertificateName)
+                };
+
+                if (!string.IsNullOrEmpty(fileSignInfo.PublicKeyToken))
+                {
+                    xAttributes.Add(new XAttribute(nameof(fileSignInfo.PublicKeyToken), fileSignInfo.PublicKeyToken));
+                }
+                if (!string.IsNullOrEmpty(fileSignInfo.TargetFramework))
+                {
+                    xAttributes.Add(new XAttribute(nameof(fileSignInfo.TargetFramework), fileSignInfo.TargetFramework));
+                }
+                signingMetadata.Add(new XElement(nameof(FileSignInfo), xAttributes.ToArray()));
+            }
+
+            foreach (CertificatesSignInfo certificatesSignInfo in signingInformation.CertificatesSignInfo)
+            {
+                signingMetadata.Add(new XElement(
+                    nameof(CertificatesSignInfo),
+                    new XAttribute[]
+                    {
+                        new XAttribute(nameof(certificatesSignInfo.Include), certificatesSignInfo.Include),
+                        new XAttribute(nameof(certificatesSignInfo.DualSigningAllowed), certificatesSignInfo.DualSigningAllowed)
+                    }));
+            }
+
+            foreach (ItemsToSign itemsToSign in signingInformation.ItemsToSign)
+            {
+                signingMetadata.Add(new XElement(
+                    nameof(ItemsToSign),
+                    new XAttribute[]
+                    {
+                        new XAttribute(nameof(itemsToSign.Include), itemsToSign.Include)
+                    }));
+            }
+
+            foreach (StrongNameSignInfo strongNameSignInfo in signingInformation.StrongNameSignInfos)
+            {
+                signingMetadata.Add(new XElement(
+                    nameof(StrongNameSignInfo),
+                    new XAttribute[]
+                    {
+                        new XAttribute(nameof(strongNameSignInfo.Include), strongNameSignInfo.Include),
+                        new XAttribute(nameof(strongNameSignInfo.PublicKeyToken), strongNameSignInfo.PublicKeyToken),
+                        new XAttribute(nameof(strongNameSignInfo.CertificateName), strongNameSignInfo.CertificateName)
+                    }));
+            }
+            return new XElement(nameof(SigningInformation), signingMetadata);
+        }
+    }
+}

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
@@ -150,6 +150,12 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
         [XmlAttribute(AttributeName = "CertificateName")]
         public string CertificateName { get; set; }
+
+        [XmlAttribute(AttributeName = "PublicKeyToken")]
+        public string PublicKeyToken { get; set; }
+
+        [XmlAttribute(AttributeName = "TargetFramework")]
+        public string TargetFramework { get; set; }
     }
 
     [XmlRoot(ElementName = "CertificatesSignInfo")]


### PR DESCRIPTION
PushMetadataToBuildAssetRegistry doesn't know about assemblies with PublicKeyToken or TargetFramework, leading to multi-targeting collisions when trying to publish assets later on.

- Verified the data from the build manifest now properly flows into the merged manifests with the exact changes in this.  
- Refactored the functionality that had to change (pretty boring) into a separate class to add tests
- Noted a few places that we have "parse" tests that don't seem to really parse any XML, as well as a lack of coverage for collisions / ambiguity; will file follow-up issues. 