### PR TITLE
Configure Grafana logs to allow Log Analytics capture

### DIFF
--- a/src/Monitoring/grafana-init/grafana.ini
+++ b/src/Monitoring/grafana-init/grafana.ini
@@ -77,3 +77,11 @@ container_name = grafana
 
 [snapshots]
 external_enabled = false
+
+[log]
+mode = file syslog
+
+[log.syslog]
+format = json
+facility = daemon
+tag = grafana


### PR DESCRIPTION
Configure Grafana to output JSON logs to syslogd, which can then get ingested by Azure Log Analytics. This allows logs to be inspected without SSHing into the VMs and makes it easy to enable other VM monitoring (e.g. perf counters, disk and CPU tracking).

I manually enabled in staging to verify operation. You can see the log output [here](https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/%2Fsubscriptions%2Fa4fc5514-21a9-4296-bfaf-5c7ee7fa35d1%2Fresourcegroups%2Fmonitoring%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Fgrafana/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAAwuuLM7JT%252BeqUSjPSC1KVXDOzy0oLUktUrC1VVBPL0pMS8xL1C0uSUzPzEtXh6sKKMpPTi0u9kvMTUVWCFKQX5QC1J1UqRCSmZvqnpqXWpRYkpqikJJanAyUzcnMzSxRMDQwAADTqGeudwAAAA%253D%253D/timespan/P1D).