### PR TITLE
Plumb new Subscription failure notification feature through Darc CLI

### DIFF
--- a/src/Maestro/Client/src/Generated/Models/SubscriptionData.cs
+++ b/src/Maestro/Client/src/Generated/Models/SubscriptionData.cs
@@ -6,13 +6,14 @@ namespace Microsoft.DotNet.Maestro.Client.Models
 {
     public partial class SubscriptionData
     {
-        public SubscriptionData(string channelName, string sourceRepository, string targetRepository, string targetBranch, Models.SubscriptionPolicy policy)
+        public SubscriptionData(string channelName, string sourceRepository, string targetRepository, string targetBranch, Models.SubscriptionPolicy policy, string failureNotificationTags)
         {
             ChannelName = channelName;
             SourceRepository = sourceRepository;
             TargetRepository = targetRepository;
             TargetBranch = targetBranch;
             Policy = policy;
+            PullRequestFailureNotificationTags = failureNotificationTags;
         }
 
         [JsonProperty("channelName")]

--- a/src/Maestro/Maestro.DataProviders/MaestroBarClient.cs
+++ b/src/Maestro/Maestro.DataProviders/MaestroBarClient.cs
@@ -52,7 +52,7 @@ namespace Maestro.DataProviders
         }
 
         public Task<Subscription> CreateSubscriptionAsync(string channelName, string sourceRepo, string targetRepo, string targetBranch,
-            string updateFrequency, bool batchable, List<MergePolicy> mergePolicies)
+            string updateFrequency, bool batchable, List<MergePolicy> mergePolicies, string failureNotificationTags)
         {
             throw new NotImplementedException();
         }

--- a/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
+++ b/src/Maestro/SubscriptionActorService/MaestroBarClient.cs
@@ -42,7 +42,7 @@ namespace SubscriptionActorService
         }
 
         public Task<Subscription> CreateSubscriptionAsync(string channelName, string sourceRepo, string targetRepo, string targetBranch,
-            string updateFrequency, bool batchable, List<MergePolicy> mergePolicies)
+            string updateFrequency, bool batchable, List<MergePolicy> mergePolicies, string failureNotificationTags)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
@@ -206,6 +206,7 @@ namespace Microsoft.DotNet.Darc
             subInfo.AppendLine($"  - Update Frequency: {subscription.Policy.UpdateFrequency}");
             subInfo.AppendLine($"  - Enabled: {subscription.Enabled}");
             subInfo.AppendLine($"  - Batchable: {subscription.Policy.Batchable}");
+            subInfo.AppendLine($"  - PR Failure Notification tags: {subscription.PullRequestFailureNotificationTags}");
 
             IEnumerable<MergePolicy> policies = mergePolicies ?? subscription.Policy.MergePolicies;
             subInfo.Append(UxHelpers.GetMergePoliciesDescription(policies, "  "));

--- a/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/AddSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/AddSubscriptionPopUp.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
         public string UpdateFrequency => _yamlData.UpdateFrequency;
         public List<MergePolicy> MergePolicies => MergePoliciesPopUpHelpers.ConvertMergePolicies(_yamlData.MergePolicies);
         public bool Batchable => bool.Parse(_yamlData.Batchable);
+        public string FailureNotificationTags => _yamlData.FailureNotificationTags;
 
         public AddSubscriptionPopUp(string path,
                                     ILogger logger,
@@ -37,7 +38,8 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
                                     IEnumerable<string> suggestedChannels,
                                     IEnumerable<string> suggestedRepositories,
                                     IEnumerable<string> availableUpdateFrequencies,
-                                    IEnumerable<string> availableMergePolicyHelp)
+                                    IEnumerable<string> availableMergePolicyHelp,
+                                    string failureNotificationTags)
             : base(path)
         {
             _logger = logger;
@@ -49,7 +51,8 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
                 TargetBranch = GetCurrentSettingForDisplay(targetBranch, "<required>", false),
                 UpdateFrequency = GetCurrentSettingForDisplay(updateFrequency, $"<'{string.Join("', '", Constants.AvailableFrequencies)}'>", false),
                 Batchable = GetCurrentSettingForDisplay(batchable.ToString(), batchable.ToString(), false),
-                MergePolicies = MergePoliciesPopUpHelpers.ConvertMergePolicies(mergePolicies)
+                MergePolicies = MergePoliciesPopUpHelpers.ConvertMergePolicies(mergePolicies),
+                FailureNotificationTags = failureNotificationTags
             };
 
             ISerializer serializer = new SerializerBuilder().Build();
@@ -63,7 +66,9 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
                 new Line("A subscription maps a build of a source repository that has been applied to a specific channel", true),
                 new Line("onto a specific branch in a target repository.  The subscription has a trigger (update frequency)", true),
                 new Line("and merge policy. If a subscription is batchable, no merge policy should be provided, and the", true),
-                new Line("set-repository-policies command should be used instead to set policies on the repository + branch level. ", true),
+                new Line("set-repository-policies command should be used instead to set policies at the repository and branch level. ", true),
+                new Line("For non-batched subscriptions, providing a list of semicolon-delineated GitHub tags will tag these", true),
+                new Line("logins when monitoring the pull requests, once one or more policy checks fail.", true),
                 new Line("For additional information about subscriptions, please see", true),
                 new Line("https://github.com/dotnet/arcade/blob/main/Documentation/BranchesChannelsAndSubscriptions.md", true),
                 new Line("", true),
@@ -151,6 +156,8 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
 
             _yamlData.Batchable = outputYamlData.Batchable;
 
+            _yamlData.FailureNotificationTags = outputYamlData.FailureNotificationTags;
+
             _yamlData.UpdateFrequency = ParseSetting(outputYamlData.UpdateFrequency, _yamlData.UpdateFrequency, false);
             if (string.IsNullOrEmpty(_yamlData.UpdateFrequency) ||
                 !Constants.AvailableFrequencies.Contains(_yamlData.UpdateFrequency, StringComparer.OrdinalIgnoreCase))
@@ -176,6 +183,7 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
             public const string updateFrequencyElement = "Update Frequency";
             public const string mergePolicyElement = "Merge Policies";
             public const string batchableElement = "Batchable";
+            public const string failureNotificationTagsElement = "Pull Request Failure Notification Tags";
 
             [YamlMember(Alias = channelElement, ApplyNamingConventions = false)]
             public string Channel { get; set; }
@@ -197,6 +205,9 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
 
             [YamlMember(Alias = mergePolicyElement, ApplyNamingConventions = false)]
             public List<MergePolicyData> MergePolicies { get; set; }
+
+            [YamlMember(Alias = failureNotificationTagsElement, ApplyNamingConventions = false)]
+            public string FailureNotificationTags { get; set; }
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/EditorPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/EditorPopUp.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Darc.Models
         /// </summary>
         /// <param name="currentValue">Current value of the setting</param>
         /// <param name="defaultValue">Default value if the current setting value is empty</param>
-        /// <param name="isSecret">If secret and current value is empty, should display ***</param>
+        /// <param name="isSecret">If secret and current value is not empty, should display ***</param>
         /// <returns>String to display</returns>
         protected static string GetCurrentSettingForDisplay(string currentValue, string defaultValue, bool isSecret)
         {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
@@ -31,6 +31,8 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
 
         public bool Enabled => bool.Parse(_yamlData.Enabled);
 
+        public string FailureNotificationTags => _yamlData.FailureNotificationTags;
+
         public List<MergePolicy> MergePolicies => MergePoliciesPopUpHelpers.ConvertMergePolicies(_yamlData.MergePolicies);
 
         public UpdateSubscriptionPopUp(string path,
@@ -39,7 +41,8 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
                                     IEnumerable<string> suggestedChannels,
                                     IEnumerable<string> suggestedRepositories,
                                     IEnumerable<string> availableUpdateFrequencies,
-                                    IEnumerable<string> availableMergePolicyHelp)
+                                    IEnumerable<string> availableMergePolicyHelp,
+                                    string failureNotificationTags)
             : base(path)
         {
             _logger = logger;
@@ -52,6 +55,7 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
                 Batchable = GetCurrentSettingForDisplay(subscription.Policy.Batchable.ToString(), subscription.Policy.Batchable.ToString(), false),
                 UpdateFrequency = GetCurrentSettingForDisplay(subscription.Policy.UpdateFrequency.ToString(), subscription.Policy.UpdateFrequency.ToString(), false),
                 Enabled = GetCurrentSettingForDisplay(subscription.Enabled.ToString(), subscription.Enabled.ToString(), false),
+                FailureNotificationTags = GetCurrentSettingForDisplay(failureNotificationTags, failureNotificationTags, false)
             };
 
             _yamlData.MergePolicies = MergePoliciesPopUpHelpers.ConvertMergePolicies(subscription.Policy.MergePolicies);
@@ -157,6 +161,8 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
                 return Constants.ErrorCode;
             }
 
+            _yamlData.FailureNotificationTags = ParseSetting(outputYamlData.FailureNotificationTags, _yamlData.FailureNotificationTags, false);
+
             return Constants.SuccessCode;
         }
 
@@ -172,6 +178,7 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
             public const string updateFrequencyElement = "Update Frequency";
             public const string mergePolicyElement = "Merge Policies";
             public const string enabled = "Enabled";
+            public const string failureNotificationTagsElement = "Pull Request Failure Notification Tags";
 
             [YamlMember(ApplyNamingConventions = false)]
             public string Id { get; set; }
@@ -193,6 +200,9 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
 
             [YamlMember(Alias = mergePolicyElement, ApplyNamingConventions = false)]
             public List<MergePolicyData> MergePolicies { get; set; }
+
+            [YamlMember(Alias = failureNotificationTagsElement, ApplyNamingConventions = false)]
+            public string FailureNotificationTags { get; set; }
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateSubscriptionOperation.cs
@@ -49,7 +49,8 @@ namespace Microsoft.DotNet.Darc.Operations
                 (await suggestedChannels).Select(suggestedChannel => suggestedChannel.Name),
                 (await suggestedRepos).SelectMany(subs => new List<string> { subscription.SourceRepository, subscription.TargetRepository }).ToHashSet(),
                 Constants.AvailableFrequencies,
-                Constants.AvailableMergePolicyYamlHelp);
+                Constants.AvailableMergePolicyYamlHelp,
+                subscription.PullRequestFailureNotificationTags);
 
             UxManager uxManager = new UxManager(_options.GitLocation, Logger);
 
@@ -65,6 +66,7 @@ namespace Microsoft.DotNet.Darc.Operations
             string updateFrequency = updateSubscriptionPopUp.UpdateFrequency;
             bool batchable = updateSubscriptionPopUp.Batchable;
             bool enabled = updateSubscriptionPopUp.Enabled;
+            string failureNotificationTags = updateSubscriptionPopUp.FailureNotificationTags;
             List<MergePolicy> mergePolicies = updateSubscriptionPopUp.MergePolicies;
 
             try
@@ -75,6 +77,7 @@ namespace Microsoft.DotNet.Darc.Operations
                     SourceRepository = sourceRepository ?? subscription.SourceRepository,
                     Enabled = enabled,
                     Policy = subscription.Policy,
+                    PullRequestFailureNotificationTags = failureNotificationTags
                 };
                 subscriptionToUpdate.Policy.Batchable = batchable;
                 subscriptionToUpdate.Policy.UpdateFrequency = Enum.Parse<UpdateFrequency>(updateFrequency);

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddSubscriptionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddSubscriptionCommandLineOptions.cs
@@ -29,12 +29,12 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("batchable", HelpText = "Make subscription batchable.")]
         public bool Batchable { get; set; }
 
-        [Option("standard-automerge", HelpText = "Use standard auto-merge policies. GitHub ignores WIP, license/cla and auto-merge.config.enforce checks," +
+        [Option("standard-automerge", HelpText = "Use standard auto-merge policies. GitHub ignores WIP, license/cla and auto-merge.config.enforce checks, " +
             "Azure DevOps ignores comment, reviewer and work item linking. Both will not auto-merge if changes are requested.")]
         public bool StandardAutoMergePolicies { get; set; }
 
-        [Option("all-checks-passed", HelpText = "PR is automatically merged if there is at least one checks and all are passed. " +
-            "Optionally provide a comma separated list of ignored check with --ignore-checks.")]
+        [Option("all-checks-passed", HelpText = "PR is automatically merged if there is at least one check, and all checks have passed. " +
+            "Optionally provide a comma-separated list of ignored check with --ignore-checks.")]
         public bool AllChecksSuccessfulMergePolicy { get; set; }
 
         [Option("ignore-checks", Separator = ',', HelpText = "For use with --all-checks-passed. A set of checks that are ignored.")]
@@ -57,6 +57,9 @@ namespace Microsoft.DotNet.Darc.Options
 
         [Option("no-trigger", SetName = "notrigger", HelpText = "Do not trigger the subscription on creation.")]
         public bool NoTriggerOnCreate { get; set; }
+
+        [Option("failure-notification-tags", HelpText = "Semicolon-delineated list of GitHub tags (GitHub login or GitHub team) to notify in the case of non-batched subscription pull-request policy failure.  Users must be publicly a member of the Microsoft org.", Default = "")]
+        public string PullRequestFailureNotificationTags { get; set; }
 
         public override Operation GetOperation()
         {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -237,7 +237,8 @@ namespace Microsoft.DotNet.DarcLib
             string targetBranch,
             string updateFrequency,
             bool batchable,
-            List<MergePolicy> mergePolicies)
+            List<MergePolicy> mergePolicies,
+            string failureNotificationTags)
         {
             CheckForValidBarClient();
             return _barClient.CreateSubscriptionAsync(
@@ -247,7 +248,8 @@ namespace Microsoft.DotNet.DarcLib
                 targetBranch,
                 updateFrequency,
                 batchable,
-                mergePolicies);
+                mergePolicies,
+                failureNotificationTags);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IBarClient.cs
@@ -47,7 +47,8 @@ namespace Microsoft.DotNet.DarcLib
             string targetBranch,
             string updateFrequency,
             bool batchable,
-            List<MergePolicy> mergePolicies);
+            List<MergePolicy> mergePolicies,
+            string failureNotificationTags);
 
         /// <summary>
         ///     Update an existing subscription

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -149,7 +149,8 @@ namespace Microsoft.DotNet.DarcLib
             string targetBranch,
             string updateFrequency,
             bool batchable,
-            List<MergePolicy> mergePolicies);
+            List<MergePolicy> mergePolicies,
+            string failureNotificationTags);
 
         /// <summary>
         ///     Update an existing subscription

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/MaestroApiBarClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/MaestroApiBarClient.cs
@@ -235,7 +235,7 @@ namespace Microsoft.DotNet.DarcLib
         /// </param>
         /// <returns>Newly created subscription, if successful</returns>
         public Task<Subscription> CreateSubscriptionAsync(string channelName, string sourceRepo, string targetRepo,
-            string targetBranch, string updateFrequency, bool batchable, List<MergePolicy> mergePolicies)
+            string targetBranch, string updateFrequency, bool batchable, List<MergePolicy> mergePolicies, string failureNotificationTags)
         {
             var subscriptionData = new SubscriptionData(
                 channelName: channelName,
@@ -250,7 +250,8 @@ namespace Microsoft.DotNet.DarcLib
                         ignoreCase: true))
                 {
                     MergePolicies = mergePolicies.ToImmutableList(),
-                });
+                }, 
+                failureNotificationTags);
             return _barClient.Subscriptions.CreateAsync(subscriptionData);
         }
 


### PR DESCRIPTION
API changes are in prod and the feature / swagger regeneration is now merged to main (should roll out next Weds) but without these CLI changes users have to update their subscriptions via the swagger client.  

Plumbs a new option through to call the new generated code.

https://github.com/dotnet/core-eng/issues/13008