### PR TITLE
Fix missing branch info when retrieving timelines

### DIFF
--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/AzureDevOpsTimelineTests.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/AzureDevOpsTimelineTests.cs
@@ -144,5 +144,38 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline.Tests
                 .Select(r => r.Raw)
                 .Should().BeEquivalentTo(expectedRecords);
         }
+
+        [Test]
+        public async Task PullRequestWithNoProperties()
+        {
+            DateTimeOffset timeDatum = DateTimeOffset.Parse("2021-01-01T01:00:00Z");
+            string azdoProjectName = "public";
+            string targetBranchName = null;
+
+            BuildAndTimeline build = BuildAndTimelineBuilder.NewPullRequestBuild(1, azdoProjectName, targetBranchName)
+                .AddTimeline(TimelineBuilder.EmptyTimeline("1", timeDatum)
+                    .AddRecord()
+                    .AddRecord()
+                ).Build();
+
+            // Test setup
+            using TestData testData = new TestDataBuilder()
+                .AddTelemetryRepository()
+                .AddStaticClock(timeDatum)
+                .AddBuildsWithTimelines(new List<BuildAndTimeline>() {
+                    build
+                }).Build();
+
+            /// Test execution
+            await testData.Controller.RunProject(azdoProjectName, 1000, CancellationToken.None);
+
+            // Test results
+            testData.Repository.TimelineBuilds.Should().SatisfyRespectively(
+                first =>
+                {
+                    first.Build.Should().BeSameAs(build.Build);
+                    first.TargetBranch.Should().Be(string.Empty);
+                });
+        }
     }
 }

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/AzureDevOpsTimelineTests.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/AzureDevOpsTimelineTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline.Tests
         }
 
         [Test]
-        public async Task PullRequestWithNoProperties()
+        public async Task PullRequestWithNoParameters()
         {
             DateTimeOffset timeDatum = DateTimeOffset.Parse("2021-01-01T01:00:00Z");
             string azdoProjectName = "public";

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/BuildAndTimelineBuilder.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/BuildAndTimelineBuilder.cs
@@ -35,9 +35,17 @@ namespace Microsoft.DotNet.AzureDevOpsTimeline.Tests
                 Id = id,
                 Project = new TeamProjectReference() { Name = projectName },
                 ValidationResults = Array.Empty<BuildRequestValidationResult>(),
-                Reason = "pullRequest",
-                Parameters = $"{{\"system.pullRequest.targetBranch\": \"{branchName}\"}}"
+                Reason = "pullRequest"
             };
+
+            if (branchName == null)
+            {
+                build.Parameters = null;
+            }
+            else
+            {
+                build.Parameters = $"{{\"system.pullRequest.targetBranch\": \"{branchName}\"}}";
+            }
 
             return new BuildAndTimelineBuilder(build);
         }


### PR DESCRIPTION
Fixes dotnet/arcade#7389. 

Build branch information is passed in the `Parameters` field of the AzDO `Build` object. If the pipeline YAML fails to parse, a build is recorded with this field null. 

This PR adds a check for a null Parameter field and, if found, logs it and continues with an empty branch name. 