### PR TITLE
Add monitoring for sdk and installer validation runs

### DIFF
--- a/src/DotNet.Status.Web/appsettings.json
+++ b/src/DotNet.Status.Web/appsettings.json
@@ -48,6 +48,20 @@
           "Branches": [ "main" ],
           "IssuesId": "dotnet-runtime-infra",
           "Tags": [ "runtime" ]
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet-release\\Validate-DotNet",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-sdk-infra",
+          "Tags": [ "sdk" ]
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet-release\\Validate-DotNet",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-installer-infra",
+          "Tags": [ "installer" ]
         }
       ]
     },
@@ -63,6 +77,18 @@
         "Owner": "dotnet",
         "Name": "runtime",
         "Labels": [ "area-Infrastructure" ]
+      },
+      {
+        "Id": "dotnet-sdk-infra",
+        "Owner": "dotnet",
+        "Name": "sdk",
+        "Labels": [ "Area-Infrastructure" ]
+      },
+      {
+        "Id": "dotnet-installer-infra",
+        "Owner": "dotnet",
+        "Name": "installer",
+        "Labels": [ "Area-Infrastructure" ]
       }
     ]
   },


### PR DESCRIPTION
Change adds monitoring of the Validate-DotNet pipeline for dotnet/sdk and dotnet/installer, to open issues in those repos with the Area-Infrastructure label when runs fail.