### PR TITLE
Enable update-subscription to work from Darc CLI directly

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateSubscriptionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateSubscriptionCommandLineOptions.cs
@@ -7,7 +7,7 @@ using Microsoft.DotNet.Darc.Operations;
 
 namespace Microsoft.DotNet.Darc.Options
 {
-    [Verb("update-subscription", HelpText = "Update an existing subscription.")]
+    [Verb("update-subscription", HelpText = "Update an existing subscription. If no arguments beyond '--id' are specified, a text editor is popped up with the current values for the subscription.  (As they are specified via YAML, merge policy settings must use the editor)")]
     class UpdateSubscriptionCommandLineOptions : CommandLineOptions
     {
         [Option("id", Required = true, HelpText = "Subscription's id.")]
@@ -18,6 +18,24 @@ namespace Microsoft.DotNet.Darc.Options
 
         [Option("no-trigger", SetName = "notrigger", HelpText = "Do not trigger the subscription on update.")]
         public bool NoTriggerOnUpdate { get; set; }
+
+        [Option("channel", HelpText = "Target channel of the the subscription to be updated")]
+        public string Channel { get; set; }
+
+        [Option("source-repository-url", HelpText = "Source repository's URL of the subscription to be updated")]
+        public string SourceRepoUrl { get; set; }
+
+        [Option("batchable", HelpText = "Whether this subscription's content can be updated in batches. Not supported when the subscription specifies merge policies")]
+        public bool? Batchable { get; set; }
+
+        [Option("update-frequency", HelpText = "How often subscription updates should occur.")]
+        public string UpdateFrequency { get; set; }
+
+        [Option("enabled", HelpText = "Whether subscription is enabled (active) or not")]
+        public bool? Enabled { get; set; }
+
+        [Option("failure-notification-tags", HelpText = "Semicolon-delineated list of GitHub tags to notify for dependency flow failures from this subscription")]
+        public string FailureNotificationTags { get; set; }
 
         public override Operation GetOperation()
         {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
@@ -245,7 +245,7 @@ namespace Microsoft.DotNet.Darc
                         defaultValueCache.Add(prop.PropertyType, defaultValue = Activator.CreateInstance(prop.PropertyType));
                     }
 
-                    if (defaultValue.Equals(value))
+                    if (defaultValue != null && defaultValue.Equals(value))
                     {
                         continue;
                     }


### PR DESCRIPTION
Addresses https://github.com/dotnet/core-eng/issues/13178 ... sets up the ability to update subscriptions via calling the Darc CLI in a loop