### PR TITLE
Disable dependency tracking telemetry module

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -21,10 +21,10 @@
     <PackageReference Update="Humanizer.Core" Version="2.4.2" />
     <PackageReference Update="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
     <PackageReference Update="LibGit2Sharp" Version="0.27.0-preview-0024" />
-    <PackageReference Update="Microsoft.ApplicationInsights" Version="2.13.1" />
-    <PackageReference Update="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.2" />
-    <PackageReference Update="Microsoft.ApplicationInsights.DependencyCollector" Version="2.11.2" />
-    <PackageReference Update="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.11.2" />
+    <PackageReference Update="Microsoft.ApplicationInsights" Version="2.15.0" />
+    <PackageReference Update="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
+    <PackageReference Update="Microsoft.ApplicationInsights.DependencyCollector" Version="2.15.0" />
+    <PackageReference Update="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Update="Microsoft.ApplicationInsights.ServiceFabric" Version="2.3.1" />
     <PackageReference Update="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
     <PackageReference Update="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
@@ -80,7 +80,7 @@
     <PackageReference Update="Microsoft.Extensions.Identity.Core" Version="$(DotNetAssemblyVersion)" />
     <PackageReference Update="Microsoft.Extensions.Logging" Version="$(DotNetAssemblyVersion)" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="$(DotNetAssemblyVersion)" />
-    <PackageReference Update="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.13.1" />
+    <PackageReference Update="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.15.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="$(DotNetAssemblyVersion)" />
     <PackageReference Update="Microsoft.Extensions.Logging.Debug" Version="$(DotNetAssemblyVersion)" />
     <PackageReference Update="Microsoft.Extensions.Options" Version="$(DotNetAssemblyVersion)" /> 

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.AI.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.AI.cs
@@ -72,7 +72,11 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
 
         private static void ConfigureApplicationInsights(IServiceCollection services)
         {
-            services.AddApplicationInsightsTelemetry();
+            ApplicationInsightsServiceOptions aiOptions = new ApplicationInsightsServiceOptions();
+            // Disable dependency tracking
+            aiOptions.EnableDependencyTrackingTelemetryModule = false;
+            
+            services.AddApplicationInsightsTelemetry(aiOptions);
             services.Configure<LoggerFilterOptions>(o =>
             {
                 // This handler is added by 'AddApplicationInsightsTelemetry' above and hard limits


### PR DESCRIPTION
This change upgrades our AI packages to 2.15.0 so that we can take advantage of the new service options available in that version, namely, being able to set EnableDependencyTrackingTelemetryModule to false to disable it. This will reduce our data usage in app insights, and hopefully stop us from hitting our daily cap.

Fixes https://github.com/dotnet/core-eng/issues/13297.