### PR TITLE
Fix the disabling of dependency tracking

### DIFF
--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.AI.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.AI.cs
@@ -72,11 +72,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
 
         private static void ConfigureApplicationInsights(IServiceCollection services)
         {
-            ApplicationInsightsServiceOptions aiOptions = new ApplicationInsightsServiceOptions();
-            // Disable dependency tracking
-            aiOptions.EnableDependencyTrackingTelemetryModule = false;
-            
-            services.AddApplicationInsightsTelemetry(aiOptions);
+            services.AddApplicationInsightsTelemetry();
             services.Configure<LoggerFilterOptions>(o =>
             {
                 // This handler is added by 'AddApplicationInsightsTelemetry' above and hard limits
@@ -135,6 +131,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
             options.InstrumentationKey = GetApplicationInsightsKey();
             options.EnableQuickPulseMetricStream = false;
             options.EnableAdaptiveSampling = false;
+            options.EnableDependencyTrackingTelemetryModule = false;
         }
     }
 }


### PR DESCRIPTION
Fixes the original change to disable dependency tracking by moving the options setting to the correct function, as the original could have overwritten what we already were setting.