### PR TITLE
Fix bug where updating subscription from CLI stomps existing merge policies with no policy

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateSubscriptionOperation.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Darc.Operations
             bool batchable = subscription.Policy.Batchable;
             bool enabled = subscription.Enabled;
             string failureNotificationTags = subscription.PullRequestFailureNotificationTags;
-            List<MergePolicy> mergePolicies = new List<MergePolicy>();
+            List<MergePolicy> mergePolicies;
 
 
             if (UpdatingViaCommandLine())
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 {
                     failureNotificationTags = _options.FailureNotificationTags;
                 }
-
+                mergePolicies = subscription.Policy.MergePolicies.ToList();
             }
             else
             {


### PR DESCRIPTION
Bug from work done for https://github.com/dotnet/core-eng/issues/13178 . 

 I realized today that not providing merge policy values (even null) ends up overwriting them so plumbs through the existing data when calling from command line.