### PR TITLE
Add build analysis to ignore checks in standard merge policy

### DIFF
--- a/src/Maestro/Maestro.MergePolicies/StandardMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/StandardMergePolicy.cs
@@ -26,7 +26,8 @@ namespace Maestro.MergePolicies
                     new JArray(
                         "WIP",
                         "license/cla",
-                        "auto-merge.config.enforce"
+                        "auto-merge.config.enforce",
+                        "Build Analysis"
                     )
                 },
             });

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -986,12 +986,12 @@ namespace Microsoft.DotNet.DarcLib
                             switch (run.Conclusion?.Value)
                             {
                                 case CheckConclusion.Success:
-                                case CheckConclusion.Neutral:
                                     state = CheckState.Success;
                                     break;
                                 case CheckConclusion.ActionRequired:
                                 case CheckConclusion.Cancelled:
                                 case CheckConclusion.Failure:
+                                case CheckConclusion.Neutral:
                                 case CheckConclusion.TimedOut:
                                     state = CheckState.Failure;
                                     break;


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/13431

Adds the build analysis check to the ignore list for the standard merge policy to mitigate issues where maestro was auto merging PRs where after 5 minutes this was the only check. 