### PR TITLE
enabled secret manager scenario tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -265,6 +265,11 @@ stages:
 
           - publish: $(Build.SourcesDirectory)\artifacts\bin\Maestro.ScenarioTests\$(_BuildConfig)\netcoreapp3.1\publish
             artifact: Maestro.ScenarioTests
+            displayName: Publish Maestro Scenario Tests
+
+          - publish: $(Build.SourcesDirectory)\artifacts\bin\Microsoft.DncEng.SecretManager.ScenarioTests\$(_BuildConfig)\netcoreapp3.1
+            artifact: Microsoft.DncEng.SecretManager.ScenarioTests
+            displayName: Publish Secret Manager Scenario Tests
 
           # Reenable tagging when stable package versions can be generated.
           # https://github.com/dotnet/arcade-services/issues/59

--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -16,6 +16,7 @@ parameters:
   # dn-bot-dnceng-build-rw-code-rw-release-rw
   # maestro-scenario-test-github-token
   # dotnet-build-bot-dotnet-eng-status-token
+  # secret-manager-scenario-tests-auth-connection-string
 
 stages:
 - stage: approval
@@ -104,7 +105,7 @@ stages:
 
   - job: deployMaestro
     displayName: Deploy maestro service fabric application
-    dependsOn: 
+    dependsOn:
     - updateDatabase
     steps:
     - download: current
@@ -188,7 +189,7 @@ stages:
         enableCustomDeployment: true
         DeploymentType: webDeploy
         RemoveAdditionalFilesFlag: true
-  
+
   - job: deployRolloutScorer
     displayName: Deploy rollout scorer azure function
     dependsOn:
@@ -260,10 +261,12 @@ stages:
   displayName: Validate deployment
   pool:
     vmImage: vs2017-win2016
-  dependsOn: 
+  dependsOn:
   - deploy
   variables:
   - group: ${{ parameters.VariableGroup }}
+  # Secret-Manager-Scenario-Tests provides: secret-manager-scenario-tests-client-secret
+  - group: Secret-Manager-Scenario-Tests
   - name: MaestroTestEndpoint
     value: ${{ parameters.MaestroTestEndpoint }}
   jobs:
@@ -273,6 +276,8 @@ stages:
     steps:
     - download: current
       artifact: PackageArtifacts
+    - download: current
+      artifact: Microsoft.DncEng.SecretManager.ScenarioTests
     - download: current
       artifact: Maestro.ScenarioTests
 
@@ -288,6 +293,17 @@ stages:
         version: 3.1.x
 
     - task: VSTest@2
+      displayName: Secret Manager Scenario Tests
+      inputs:
+        testSelector: testAssemblies
+        testAssemblyVer2: |
+          Microsoft.DncEng.SecretManager.ScenarioTests.dll
+        searchFolder: $(Pipeline.Workspace)/Microsoft.DncEng.SecretManager.ScenarioTests
+      env:
+        AzureServicesAuthConnectionString: $(secret-manager-scenario-tests-client-secret)
+
+    - task: VSTest@2
+      displayName: Maestro Scenario Tests
       inputs:
         testSelector: testAssemblies
         testAssemblyVer2: |
@@ -312,4 +328,4 @@ stages:
       displayName: Get DARC version
 
 
-    
+

--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -16,7 +16,7 @@ parameters:
   # dn-bot-dnceng-build-rw-code-rw-release-rw
   # maestro-scenario-test-github-token
   # dotnet-build-bot-dotnet-eng-status-token
-  # secret-manager-scenario-tests-auth-connection-string
+  # secret-manager-scenario-tests-client-secret
 
 stages:
 - stage: approval


### PR DESCRIPTION
I found that scenario tests for secret manager (introduced in https://github.com/dotnet/core-eng/issues/13259) weren't executed automatically.
