### PR TITLE
Trigger after 30 minutes of being down

### DIFF
--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -1596,13 +1596,13 @@
             "query": {
               "params": [
                 "A",
-                "5m",
+                "30m",
                 "now"
               ]
             },
             "reducer": {
               "params": [],
-              "type": "avg"
+              "type": "max"
             },
             "type": "query"
           }
@@ -4086,7 +4086,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 21,
+  "schemaVersion": 22,
   "style": "dark",
   "tags": [],
   "templating": {


### PR DESCRIPTION
[This change was originally merged directly to the azure devops mirror, causing the two versions of the repo to get out of sync. This gets the commit through github so it can then be mirrored: https://dev.azure.com/dnceng/internal/_git/dotnet-arcade-services/pullrequest/16614]

https://github.com/dotnet/core-eng/issues/13556

The current state of the alert was creating noise because it triggers an alert every time a data center reports that it is down so I changed the alert to get triggered if a data center has been down for more than 30 minutes.

Trigger after 30 minutes of being down