### PR TITLE
Remove hack from gather-drop

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -1477,19 +1477,15 @@ namespace Microsoft.DotNet.Darc.Operations
                 replacedName = replacedName.Replace(".symbols", "", StringComparison.OrdinalIgnoreCase);
                 replacedName = replacedName.Replace(".nupkg", "", StringComparison.OrdinalIgnoreCase);
 
-                // blob packages sometimes confuse x86 and x64 as being part of the version
-                string replacedVersion = asset.Version.Replace("64.", "");
-                replacedVersion = replacedVersion.Replace("86.", "");
-
                 // finally, remove the version from the name
-                replacedName = replacedName.Replace($".{replacedVersion}", "", StringComparison.OrdinalIgnoreCase);
+                replacedName = replacedName.Replace($".{asset.Version}", "", StringComparison.OrdinalIgnoreCase);
 
                 // create a temp asset with the mangled name and version
                 Asset mangledAsset = new Asset(asset.Id,
                     asset.BuildId,
                     asset.NonShipping,
                     replacedName,
-                    replacedVersion,
+                    asset.Version,
                     asset.Locations);
 
                 string packageContentUrl = await DownloadAssetFromAzureDevOpsFeedAsync(client,


### PR DESCRIPTION
gather-drop had a hack that removed 64. and 86. from the asset version, which broke versions with legitimate uses. This hack was necessary up until we fixed out version numbers, and is no longer needed. Remove the hack.