### PR TITLE
Allow 7 day grace period for rotation verification and allow extra settings for SQL connections

### DIFF
--- a/src/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
@@ -125,8 +125,13 @@ namespace Microsoft.DncEng.SecretManager.Commands
                             _console.WriteLine($"Secret scheduled for rotation on {nextRotation}, will rotate.");
                             // we have hit the rotation time, rotate
                             regenerate = true;
+                            if (_verifyOnly && nextRotation > now.AddDays(-7))
+                            {
+                                _console.WriteLine("Secret is within verification grace period.");
+                                regenerate = false;
+                            }
                         }
-                        else if (expires <= now)
+                        if (expires <= now)
                         {
                             _console.WriteLine($"Secret expired on {expires}, will rotate.");
                             // the secret has expired, this shouldn't happen in normal operation but we should rotate

--- a/src/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
@@ -125,6 +125,12 @@ namespace Microsoft.DncEng.SecretManager.Commands
                             _console.WriteLine($"Secret scheduled for rotation on {nextRotation}, will rotate.");
                             // we have hit the rotation time, rotate
                             regenerate = true;
+
+                            // since the rotation runs weekly, we need a 1 week grace period
+                            // where verification runs will not fail, but rotation will happen.
+                            // otherwise a secret scheduled for rotation on tuesday, will cause
+                            // a build failure on wednesday, before it gets rotated normally on the following monday
+                            // the verification mode is to catch the "the rotation hasn't happened in months" case
                             if (_verifyOnly && nextRotation > now.AddDays(-7))
                             {
                                 _console.WriteLine("Secret is within verification grace period.");

--- a/src/Microsoft.DncEng.SecretManager/SecretTypes/SqlServerConnectionString.cs
+++ b/src/Microsoft.DncEng.SecretManager/SecretTypes/SqlServerConnectionString.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DncEng.SecretManager.SecretTypes
             public string DataSource { get; set; }
             public string Database { get; set; }
             public string Permissions { get; set; }
+            public string ExtraSettings { get; set; }
         }
 
         public SqlServerConnectionString(ISystemClock clock, IConsole console)
@@ -154,6 +155,10 @@ ALTER ROLE db_datawriter ADD MEMBER [{nextUserId}]
             };
             var result = connectionString.ToString();
             result = OldifyConnectionString(result);
+            if (!string.IsNullOrEmpty(parameters.ExtraSettings))
+            {
+                result += parameters.ExtraSettings;
+            }
             return new SecretData(result, DateTimeOffset.MaxValue, _clock.UtcNow.AddMonths(1));
         }
 


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/13795