### PR TITLE
Fix the auth for the GithubApp

### DIFF
--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubApplicationClientFactory.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubApplicationClientFactory.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.GitHub.Authentication
 
         public IGitHubClient CreateGitHubAppClient()
         {
-            return _clientFactory.CreateGitHubClient(_tokenProvider.GetTokenForApp());
+            return _clientFactory.CreateGitHubClient(_tokenProvider.GetTokenForApp(), AuthenticationType.Bearer);
         }
     }
 }

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubClientFactory.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubClientFactory.cs
@@ -16,11 +16,16 @@ namespace Microsoft.DotNet.GitHub.Authentication
 
         public IGitHubClient CreateGitHubClient(string token)
         {
+            return CreateGitHubClient(token, AuthenticationType.Oauth);
+        }
+
+        public IGitHubClient CreateGitHubClient(string token, AuthenticationType type)
+        {
             var client = new GitHubClient(Options.ProductHeader);
 
             if (!string.IsNullOrEmpty(token))
             {
-                client.Credentials = new Credentials(token);
+                client.Credentials = new Credentials(token, type);
             }
 
             return client;

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubClientFactory.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubClientFactory.cs
@@ -6,5 +6,6 @@ namespace Microsoft.DotNet.GitHub.Authentication
     public interface IGitHubClientFactory
     {
         IGitHubClient CreateGitHubClient(string token);
+        IGitHubClient CreateGitHubClient(string token, AuthenticationType type);
     }
 }


### PR DESCRIPTION
For authing the GitHubApp, we need to make the authentication type Bearer.