### PR TITLE
Don't allocate response buffer when downloading files during gather-drop

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -1626,7 +1626,14 @@ namespace Microsoft.DotNet.Darc.Operations
                                                       _options.Overwrite ? FileMode.Create : FileMode.CreateNew,
                                                       FileAccess.Write))
                 {
-                    HttpRequestManager manager = new HttpRequestManager(client, HttpMethod.Get, sourceUri, Logger, authHeader: authHeader);
+                    HttpRequestManager manager = new HttpRequestManager(
+                        client,
+                        HttpMethod.Get,
+                        sourceUri,
+                        Logger,
+                        authHeader: authHeader,
+                        httpCompletionOption: HttpCompletionOption.ResponseHeadersRead);
+
                     using (var response = await manager.ExecuteAsync())
                     {
                         using (var inStream = await response.Content.ReadAsStreamAsync())

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/HttpRequestManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/HttpRequestManager.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.DarcLib
         private readonly string _requestUri;
         private readonly AuthenticationHeaderValue _authHeader;
         private readonly HttpMethod _method;
+        private readonly HttpCompletionOption _httpCompletionOption;
 
         public HttpRequestManager(
             HttpClient client,
@@ -31,7 +32,8 @@ namespace Microsoft.DotNet.DarcLib
             string body = null,
             string versionOverride = null,
             bool logFailure = true,
-            AuthenticationHeaderValue authHeader = null)
+            AuthenticationHeaderValue authHeader = null,
+            HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
         {
             _client = client;
             _logger = logger;
@@ -40,6 +42,7 @@ namespace Microsoft.DotNet.DarcLib
             _requestUri = requestUri;
             _method = method;
             _authHeader = authHeader;
+            _httpCompletionOption = httpCompletionOption;
         }
 
         public async Task<HttpResponseMessage> ExecuteAsync(int retryCount = 3)
@@ -73,7 +76,7 @@ namespace Microsoft.DotNet.DarcLib
                             message.Headers.Authorization = _authHeader;
                         }
 
-                        response = await _client.SendAsync(message);
+                        response = await _client.SendAsync(message, _httpCompletionOption);
 
                         if (stopRetriesHttpStatusCodes.Contains(response.StatusCode))
                         {


### PR DESCRIPTION
Plumb through an HttpCompletionOption param to the HttpRequestManager so that we can specify when we don't want the response buffer allocated.

I tested this by gathering the drop for build 99274 (I had to pass a longer timeout than the default 180 seconds, because this one asset is just too large)

https://github.com/dotnet/arcade/issues/7668