### PR TITLE
Switch back to -otp naming

### DIFF
--- a/src/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccountInteractiveSecretType.cs
+++ b/src/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccountInteractiveSecretType.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DncEng.SecretManager.SecretTypes
         where TParameters : new()
     {
         protected const string GitHubPasswordSuffix = "-password";
-        protected const string GitHubSecretSuffix = "-secret";
+        protected const string GitHubSecretSuffix = "-otp";
         protected const string GitHubRecoveryCodesSuffix = "-recovery-codes";
 
         protected ISystemClock Clock { get; }


### PR DESCRIPTION
This will cause some benign build breaks as the tool looks for -otp and the vault contains -secret. I will fix those up once this change is all the way through.