### PR TITLE
Fix bug in creating a new comment in BuildMonitor

### DIFF
--- a/src/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
+++ b/src/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
@@ -268,8 +268,9 @@ namespace DotNet.Status.Web.Controllers
 
                         if (matchingIssue != null)
                         {
+                            _logger.LogInformation("Found matching issue {issueNumber} in {owner}/{repo}. Will attempt to add a new comment.", matchingIssue.Number, repo.Owner, repo.Name);
                             // Add a new comment to the issue with the body
-                            IssueComment newComment = await github.Issue.Comment.Create(repo.Owner, repo.Name, matchingIssue.Id, body);
+                            IssueComment newComment = await github.Issue.Comment.Create(repo.Owner, repo.Name, matchingIssue.Number, body);
                             _logger.LogInformation("Logged comment in {owner}/{repo}#{issueNumber} for build failure", repo.Owner, repo.Name, matchingIssue.Number);
 
                             return;


### PR DESCRIPTION
To create a new comment in an issue, we need to use the matching issue number, not its ID.