### PR TITLE
Add Validate-DotNet notifications for installer and sdk

### DIFF
--- a/src/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/.config/settings.json
@@ -46,6 +46,20 @@
           "Project": "internal",
           "DefinitionPath": "\\dotnet-release\\Validate-DotNet",
           "Branches": [ "main" ],
+          "IssuesId": "dotnet-installer-infra",
+          "Tags": [ "installer" ]
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet-release\\Validate-DotNet",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-sdk-infra",
+          "Tags": [ "sdk" ]
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet-release\\Validate-DotNet",
+          "Branches": [ "main" ],
           "IssuesId": "dotnet-runtime-infra",
           "Tags": [ "runtime" ]
         }
@@ -57,6 +71,18 @@
         "Owner": "dotnet",
         "Name": "core-eng",
         "Labels": [ "Build Failed" ]
+      },
+      {
+        "Id": "dotnet-installer-infra",
+        "Owner": "dotnet",
+        "Name": "installer",
+        "Labels": [ "Area-Infrastructure" ]
+      },
+      {
+        "Id": "dotnet-sdk-infra",
+        "Owner": "dotnet",
+        "Name": "sdk",
+        "Labels": [ "Area-Infrastructure" ]
       },
       {
         "Id": "dotnet-runtime-infra",

--- a/src/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/.config/settings.json
@@ -76,13 +76,15 @@
         "Id": "dotnet-installer-infra",
         "Owner": "dotnet",
         "Name": "installer",
-        "Labels": [ "Area-Infrastructure" ]
+        "Labels": [ "Area-Infrastructure" ],
+        "UpdateExisting": true
       },
       {
         "Id": "dotnet-sdk-infra",
         "Owner": "dotnet",
         "Name": "sdk",
-        "Labels": [ "Area-Infrastructure" ]
+        "Labels": [ "Area-Infrastructure" ],
+        "UpdateExisting": true
       },
       {
         "Id": "dotnet-runtime-infra",


### PR DESCRIPTION
This change adds sdk and installer Validate-DotNet runs to the list of repos that we track for notifications.