### PR TITLE
Make Maestro.Contracts packable

### DIFF
--- a/src/Maestro/Maestro.Contracts/Maestro.Contracts.csproj
+++ b/src/Maestro/Maestro.Contracts/Maestro.Contracts.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <Description>Maestro Contracts</Description>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 


### PR DESCRIPTION
DarcLib depends on Maestro.Contracts, and is a packable library. However, because Maestro.Contracts is not packable, when another application that uses DarcLib tries to restore it, Maestro.Contracts cannot be found, as it is not packable. This change makes Maestro.Contracts packabe so that dependencies can be resolved.