### PR TITLE
Add ability to allow list organizations

### DIFF
--- a/src/Maestro/Maestro.Data/BuildAssetRegistryInstallationLookup.cs
+++ b/src/Maestro/Maestro.Data/BuildAssetRegistryInstallationLookup.cs
@@ -21,5 +21,10 @@ namespace Maestro.Data
                 return await ctx.GetInstallationId(repositoryUrl);
             }
         }
+
+        public Task<bool> IsOrganizationSupported(string org)
+        {
+            return Task.FromResult(true);
+        }
     }
 }

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubClientOptions.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubClientOptions.cs
@@ -9,5 +9,6 @@ namespace Microsoft.DotNet.GitHub.Authentication
     public class GitHubClientOptions
     {
         public ProductHeaderValue ProductHeader { get; set; }
+        public string[] AllowOrgs { get; set; }
     }
 }

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/InstallationLookup.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/InstallationLookup.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DotNet.GitHub.Authentication
     public interface IInstallationLookup
     {
         Task<long> GetInstallationId(string repositoryUrl);
+        Task<bool> IsOrganizationSupported(string org);
     }
 
     public static class InstallationLookup


### PR DESCRIPTION
It looks like our applications are getting intalled on organizations outside of our control,
leading to excess burden and unpredictable behavior.

Adding the ability to restrict an app to a subset of organizations.