### PR TITLE
log the name of the dependency that gets updated during coherency upd…

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -596,7 +596,7 @@ namespace Microsoft.DotNet.DarcLib
                         continue;
                     }
 
-                    _logger.LogInformation($"Dependency {dependencyToUpdate} will be updated to " +
+                    _logger.LogInformation($"Dependency {dependencyToUpdate.Name} will be updated to " +
                         $"{cpdDependency.Version} from {cpdDependency.RepoUri}@{cpdDependency.Commit}.");
 
                     Asset coherentAsset = await DisambiguateAssetsAsync(remoteFactory, buildCache, nugetConfigCache,


### PR DESCRIPTION
…ates

Found this while trying to diagnose https://github.com/dotnet/arcade/issues/7720. We always log

```
Dependency Microsoft.DotNet.DarcLib.DependencyDetail will be updated to ...

```