### PR TITLE
Fix TestData generator for nullable/global

### DIFF
--- a/src/Microsoft.DncEng.SecretManager.Tests/SettingsFileValidatorTests.cs
+++ b/src/Microsoft.DncEng.SecretManager.Tests/SettingsFileValidatorTests.cs
@@ -90,7 +90,7 @@ secrets:
                     .Should()
                     .CompleteWithinAsync(new TimeSpan(0, 0, 5)))
                 .Subject.Should().BeFalse();
-            data.Console.Errors.Should().HaveCount(2).And.Subject.First().message.Should().Contain("Secret 'two' does not exist in manifest file.");
+            data.Console.Errors.Should().HaveCountGreaterOrEqualTo(1).And.Subject.First().message.Should().Contain("Secret 'two' does not exist in manifest file.");
         }
 
         [Test]

--- a/src/Shared/Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen.Tests/ParameterTests.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen.Tests/ParameterTests.cs
@@ -123,4 +123,32 @@ namespace Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen.Tests
             testData.Values.Value3.Should().Be("THIRD-VALUE");
         }
     }
+
+    public partial class NullableParameterTests
+    {
+        [TestDependencyInjectionSetup]
+        private static class TestDataConfiguration
+        {
+            public static Func<IServiceProvider, int?> Value(IServiceCollection collection, int? value)
+            {
+                return _ => value;
+            }
+        }
+
+        [Test]
+        public void Defaults()
+        {
+            using TestData testData = TestData.Default.Build();
+            testData.Value.Should().BeNull();
+        }
+
+        [Test]
+        public void SetValue()
+        {
+            using TestData testData = TestData.Default
+                .WithValue(5)
+                .Build();
+            testData.Value.Should().Be(5);
+        }
+    }
 }

--- a/src/Shared/Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen/ConfigMethod.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen/ConfigMethod.cs
@@ -19,7 +19,17 @@ namespace Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen
         {
             Name = name;
             Parameters = parameters;
-            ReturnTypeSymbol = returnTypeSymbol;
+            if (returnTypeSymbol != null)
+            {
+                if (returnTypeSymbol.StartsWith("("))
+                {
+                    ReturnTypeSymbol = returnTypeSymbol;
+                }
+                else
+                {
+                    ReturnTypeSymbol = "global::" + returnTypeSymbol;
+                }
+            }
             ConfigureAllParameters = configureAllParameters;
             IsConfigurationAsync = isConfigurationAsync;
             IsFetchAsync = isFetchAsync;

--- a/src/Shared/Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen/TestDataReceiver.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen/TestDataReceiver.cs
@@ -303,7 +303,7 @@ namespace Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen
                 type is INamedTypeSymbol namedPType &&
                 namedPType.IsGenericType &&
                 !namedPType.IsUnboundGenericType &&
-                namedPType.ConstructedFrom.FullName() == "System.Nullable";
+                namedPType.ConstructedFrom.FullName() == "System.Nullable<T>";
         }
     }
 }


### PR DESCRIPTION
If there is a naming conflict in the namespace
of a test (say because the Test is in the A.B.C namespace,
and it's talking about something in the B.D namespace),
we need to add "global::" to the types to avoid the confusion.

Nullable parameters we not detected correctly either,
and resulted in "Nullable<Nullable<T>>" in the syntax.

Also, the settings file validator test didn't pass locally.