### PR TITLE
Disable implicit namespace

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,11 @@
 
     <EnableCentralPackageVersions>true</EnableCentralPackageVersions>
     <CentralPackagesFile>$(MSBuildThisFileDirectory)eng/Packages.props</CentralPackagesFile>
+	
+	<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+	<DisableImplicitNamespaceImports_DotNet>true</DisableImplicitNamespaceImports_DotNet>
+	<DisableImplicitNamespaceImports_Web>true</DisableImplicitNamespaceImports_Web>
+	<DisableImplicitNamespaceImports_Worker>true</DisableImplicitNamespaceImports_Worker>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
After a chat in the teams channel, everyone that piped up disliked the idea of implicit/global usings affecting a file. So I'm disabling them.