### PR TITLE
Add cross-process Mutex for portable git download in Pull Request actor

### DIFF
--- a/src/Maestro/Maestro.Web/.config/settings.json
+++ b/src/Maestro/Maestro.Web/.config/settings.json
@@ -46,6 +46,6 @@
     "uri": "https://maestro-prod.westus2.cloudapp.azure.com",
     "token": "[vault(prod-maestro-token)]"
   },
-  "GitDownloadLocation": "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/git/Git-2.22.0-64-bit.zip",
+  "GitDownloadLocation": "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/git/Git-2.32.0-64-bit.zip",
   "EnableAutoBuildPromotion": "[config(FeatureManagement:AutoBuildPromotion)]"
 }

--- a/src/Maestro/SubscriptionActorService/.config/settings.json
+++ b/src/Maestro/SubscriptionActorService/.config/settings.json
@@ -7,7 +7,7 @@
     "GitHubAppId": "[vault(github-app-id)]",
     "PrivateKey": "[vault(github-app-private-key)]"
   },
-  "GitDownloadLocation": "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/git/Git-2.22.0-64-bit.zip",
+  "GitDownloadLocation": "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/git/Git-2.32.0-64-bit.zip",
   "AzureDevOps": {
     "Tokens": [
       {

--- a/src/Maestro/SubscriptionActorService/LocalGit.cs
+++ b/src/Maestro/SubscriptionActorService/LocalGit.cs
@@ -61,20 +61,21 @@ namespace SubscriptionActorService
             // a deterministic modification of that for the name of the semaphore (using a raw path as the name throws)
             string semaphoreName = _tempFiles.GetFilePath("git-download-semaphore").Replace('/', '-').Replace('\\', '-').Replace(':', '-');
             Semaphore crossProcessSemaphore = new Semaphore(1, 1, semaphoreName);
-            crossProcessSemaphore.WaitOne(TimeSpan.FromMinutes(5));
-
-            string gitLocation = _configuration.GetValue<string>("GitDownloadLocation", null);
-            string[] pathSegments = new Uri(gitLocation, UriKind.Absolute).Segments;
-            string remoteFileName = pathSegments[pathSegments.Length - 1];
-
-            // There are multiple checks whether Git Works, so if it's already there, we'll just rely on 
-            // falling through into CheckGitInstallation()
-            string gitRoot = _tempFiles.GetFilePath("git-portable");
-            string targetPath = Path.Combine(gitRoot, Path.GetFileNameWithoutExtension(remoteFileName));
-            _gitExecutable = Path.Combine(targetPath, "bin", "git.exe");
 
             try
             {
+                crossProcessSemaphore.WaitOne(TimeSpan.FromMinutes(5));
+
+                string gitLocation = _configuration.GetValue<string>("GitDownloadLocation", null);
+                string[] pathSegments = new Uri(gitLocation, UriKind.Absolute).Segments;
+                string remoteFileName = pathSegments[pathSegments.Length - 1];
+
+                // There are multiple checks whether Git Works, so if it's already there, we'll just rely on 
+                // falling through into CheckGitInstallation()
+                string gitRoot = _tempFiles.GetFilePath("git-portable");
+                string targetPath = Path.Combine(gitRoot, Path.GetFileNameWithoutExtension(remoteFileName));
+                _gitExecutable = Path.Combine(targetPath, "bin", "git.exe");
+
                 // Determine whether another process/ thread ended up getting the lock and downloaded git in the meantime.
                 if (!File.Exists(_gitExecutable))
                 {

--- a/src/Maestro/SubscriptionActorService/LocalGit.cs
+++ b/src/Maestro/SubscriptionActorService/LocalGit.cs
@@ -59,7 +59,7 @@ namespace SubscriptionActorService
 
             // Since the collisions are already using paths from _tempFiles.GetFilePath (instance-specific) we'll try
             // a deterministic modification of that for the name of the semaphore (using a raw path as the name throws)
-            string semaphoreName = _tempFiles.GetFilePath("git-download-mutex").Replace('/', '-').Replace('\\', '-').Replace(':', '-');
+            string semaphoreName = _tempFiles.GetFilePath("git-download-semaphore").Replace('/', '-').Replace('\\', '-').Replace(':', '-');
             Semaphore crossProcessSemaphore = new Semaphore(1, 1, semaphoreName);
             crossProcessSemaphore.WaitOne(TimeSpan.FromMinutes(5));
 
@@ -89,8 +89,8 @@ namespace SubscriptionActorService
                             _logger.LogInformation($"Target directory {targetPath} already exists. Deleting it.");
 
                             // https://github.com/dotnet/arcade/issues/7343
-                            // If this continues to fail despite having both process/thread semaphores wrapping it, we should consider
-                            // killing any git.exe whose image path resides under this folder or simply using another folder and wasting disk space.
+                            // If this continues to fail despite having a named semaphore, we should consider 
+                            // killing any git.exe whose image path resides under this folder, or simply using another folder and wasting disk space.
                             Directory.Delete(targetPath, true);
                         }
 

--- a/src/Maestro/SubscriptionActorService/LocalGit.cs
+++ b/src/Maestro/SubscriptionActorService/LocalGit.cs
@@ -118,9 +118,6 @@ namespace SubscriptionActorService
                                 // https://github.com/dotnet/arcade/issues/7343
                                 // If this continues to fail despite having both process/thread semaphores wrapping it, we should consider
                                 // killing any git.exe whose image path resides under this folder or simply using another folder and wasting disk space.
-
-                                // However, since we now only check for the executable's presence, if we somehow do just hang a git.exe or two,
-                                // since we already know _gitExecutable we'll be able to just test if it runs.
                                 Directory.Delete(targetPath, true);
                             }
 

--- a/src/Maestro/SubscriptionActorService/LocalGit.cs
+++ b/src/Maestro/SubscriptionActorService/LocalGit.cs
@@ -34,7 +34,7 @@ namespace SubscriptionActorService
             _operations = operations;
         }
         /// <summary>
-        ///     Download and install git to the a temporary location.
+        ///     Download and install git to a temporary location.
         ///     Git is used by DarcLib, and the Service Fabric nodes do not have it installed natively.
         ///     
         ///     The file is assumed to be on a public endpoint.
@@ -46,7 +46,7 @@ namespace SubscriptionActorService
             if (!string.IsNullOrEmpty(_gitExecutable) && File.Exists(_gitExecutable))
             {
                 _logger.LogInformation($"Git executable found at {_gitExecutable}. Checking the installation.");
-                // We should also mke sure that the git executable that exists runs properly
+                // We should also make sure that the git executable that exists runs properly
                 try
                 {
                     LocalHelpers.CheckGitInstallation(_gitExecutable, _logger);
@@ -58,51 +58,92 @@ namespace SubscriptionActorService
                 }
             }
 
+            // First, make sure we're the only actor in the process doing this
             await _semaphoreSlim.WaitAsync();
-            try
+
+            // Since the collisions are already using paths from _tempFiles.GetFilePath (instance-specific) we'll try
+            // a deterministic modification of that for the name of the mutex (using a raw path as the name throws)
+            string mutexName = _tempFiles.GetFilePath("git-download-mutex").Replace('/', '-').Replace('\\', '-').Replace(':', '-');
+
+            using (var mutex = new Mutex(false, mutexName))
             {
-                // Determine whether another thread ended up getting the lock and downloaded git
-                // in the meantime.
-                if (string.IsNullOrEmpty(_gitExecutable) || !File.Exists(_gitExecutable))
+                bool mutexAcquired = false;
+
+                // The Portable Git is around ~120 MB so 5 minutes should be plenty of time for the other Actor to
+                // download and unzip, otherwise we'll just throw/retry when the TimeoutException is thrown, allowing
+                // even more time for the instance that is downloading.
+                try
                 {
-                    using (_operations.BeginOperation($"Installing a local copy of git"))
+                    // acquire the mutex (or timeout after 5 minutes)
+                    // will return false if it timed out
+                    mutexAcquired = mutex.WaitOne((int)TimeSpan.FromMinutes(5).TotalMilliseconds);
+                }
+                catch (AbandonedMutexException)
+                {
+                    // "abandoned" means still acquired
+                    mutexAcquired = true;
+                }
+
+                // if it wasn't acquired, it timed out, throw so it goes to retry.
+                if (!mutexAcquired)
+                {
+                    throw new TimeoutException("Timed out acquiring a Mutex for git download, will retry.");
+                }
+
+                string gitLocation = _configuration.GetValue<string>("GitDownloadLocation", null);
+                string[] pathSegments = new Uri(gitLocation, UriKind.Absolute).Segments;
+                string remoteFileName = pathSegments[pathSegments.Length - 1];
+
+                // There are multiple checks whether Git Works, so if it's already there, we'll just rely on 
+                // falling through into CheckGitInstallation()
+                string gitRoot = _tempFiles.GetFilePath("git-portable");
+                string targetPath = Path.Combine(gitRoot, Path.GetFileNameWithoutExtension(remoteFileName));
+                _gitExecutable = Path.Combine(targetPath, "bin", "git.exe");
+
+                try
+                {
+                    // Determine whether another process/ thread ended up getting the lock and downloaded git in the meantime.
+                    if (!File.Exists(_gitExecutable))
                     {
-                        string gitLocation = _configuration.GetValue<string>("GitDownloadLocation", null);
-                        string[] pathSegments = new Uri(gitLocation, UriKind.Absolute).Segments;
-                        string remoteFileName = pathSegments[pathSegments.Length - 1];
-
-                        string gitRoot = _tempFiles.GetFilePath("git-portable");
-                        string targetPath = Path.Combine(gitRoot, Path.GetFileNameWithoutExtension(remoteFileName));
-                        string gitZipFile = Path.Combine(gitRoot, remoteFileName);
-
-                        _logger.LogInformation($"Downloading git from '{gitLocation}' to '{gitZipFile}'");
-
-                        if (Directory.Exists(targetPath))
+                        using (_operations.BeginOperation($"Installing a local copy of git"))
                         {
-                            _logger.LogInformation($"Target directory {targetPath} already exists. Deleting it.");
-                            Directory.Delete(targetPath, true);
+                            string gitZipFile = Path.Combine(gitRoot, remoteFileName);
+
+                            _logger.LogInformation($"Downloading git from '{gitLocation}' to '{gitZipFile}'");
+
+                            if (Directory.Exists(targetPath))
+                            {
+                                _logger.LogInformation($"Target directory {targetPath} already exists. Deleting it.");
+
+                                // https://github.com/dotnet/arcade/issues/7343
+                                // If this continues to fail despite having both process/thread semaphores wrapping it, we should consider
+                                // killing any git.exe whose image path resides under this folder or simply using another folder and wasting disk space.
+
+                                // However, since we now only check for the executable's presence, if we somehow do just hang a git.exe or two,
+                                // since we already know _gitExecutable we'll be able to just test if it runs.
+                                Directory.Delete(targetPath, true);
+                            }
+
+                            Directory.CreateDirectory(targetPath);
+
+                            using (HttpClient client = new HttpClient())
+                            using (FileStream outStream = new FileStream(gitZipFile, FileMode.Create, FileAccess.Write))
+                            using (var inStream = await client.GetStreamAsync(gitLocation))
+                            {
+                                await inStream.CopyToAsync(outStream);
+                            }
+
+                            _logger.LogInformation($"Extracting '{gitZipFile}' to '{targetPath}'");
+
+                            ZipFile.ExtractToDirectory(gitZipFile, targetPath, overwriteFiles: true);
                         }
-
-                        Directory.CreateDirectory(targetPath);
-
-                        using (HttpClient client = new HttpClient())
-                        using (FileStream outStream = new FileStream(gitZipFile, FileMode.Create, FileAccess.Write))
-                        using (var inStream = await client.GetStreamAsync(gitLocation))
-                        {
-                            await inStream.CopyToAsync(outStream);
-                        }
-
-                        _logger.LogInformation($"Extracting '{gitZipFile}' to '{targetPath}'");
-
-                        ZipFile.ExtractToDirectory(gitZipFile, targetPath, overwriteFiles: true);
-
-                        _gitExecutable = Path.Combine(targetPath, "bin", "git.exe");
                     }
                 }
-            }
-            finally
-            {
-                _semaphoreSlim.Release();
+                finally
+                {
+                    mutex.ReleaseMutex();
+                    _semaphoreSlim.Release();
+                }
             }
 
             // Will throw if something is wrong with the git executable, forcing a retry

--- a/src/Maestro/SubscriptionActorService/LocalGit.cs
+++ b/src/Maestro/SubscriptionActorService/LocalGit.cs
@@ -21,7 +21,6 @@ namespace SubscriptionActorService
     {
         private string _gitExecutable;
         private readonly TemporaryFiles _tempFiles;
-        private readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
         private readonly IConfiguration _configuration;
         private readonly ILogger<LocalGit> _logger;
         private readonly OperationManager _operations;
@@ -53,94 +52,66 @@ namespace SubscriptionActorService
                     return _gitExecutable;
                 }
                 catch
-                { 
+                {
                     _logger.LogWarning($"Something went wrong with validating git executable at {_gitExecutable}. Downloading new version.");
                 }
             }
 
-            // First, make sure we're the only actor in the process doing this
-            await _semaphoreSlim.WaitAsync();
-
             // Since the collisions are already using paths from _tempFiles.GetFilePath (instance-specific) we'll try
-            // a deterministic modification of that for the name of the mutex (using a raw path as the name throws)
-            string mutexName = _tempFiles.GetFilePath("git-download-mutex").Replace('/', '-').Replace('\\', '-').Replace(':', '-');
+            // a deterministic modification of that for the name of the semaphore (using a raw path as the name throws)
+            string semaphoreName = _tempFiles.GetFilePath("git-download-mutex").Replace('/', '-').Replace('\\', '-').Replace(':', '-');
+            Semaphore crossProcessSemaphore = new Semaphore(1, 1, semaphoreName);
+            crossProcessSemaphore.WaitOne(TimeSpan.FromMinutes(5));
 
-            using (var mutex = new Mutex(false, mutexName))
+            string gitLocation = _configuration.GetValue<string>("GitDownloadLocation", null);
+            string[] pathSegments = new Uri(gitLocation, UriKind.Absolute).Segments;
+            string remoteFileName = pathSegments[pathSegments.Length - 1];
+
+            // There are multiple checks whether Git Works, so if it's already there, we'll just rely on 
+            // falling through into CheckGitInstallation()
+            string gitRoot = _tempFiles.GetFilePath("git-portable");
+            string targetPath = Path.Combine(gitRoot, Path.GetFileNameWithoutExtension(remoteFileName));
+            _gitExecutable = Path.Combine(targetPath, "bin", "git.exe");
+
+            try
             {
-                bool mutexAcquired = false;
-
-                // The Portable Git is around ~120 MB so 5 minutes should be plenty of time for the other Actor to
-                // download and unzip, otherwise we'll just throw/retry when the TimeoutException is thrown, allowing
-                // even more time for the instance that is downloading.
-                try
+                // Determine whether another process/ thread ended up getting the lock and downloaded git in the meantime.
+                if (!File.Exists(_gitExecutable))
                 {
-                    // acquire the mutex (or timeout after 5 minutes)
-                    // will return false if it timed out
-                    mutexAcquired = mutex.WaitOne((int)TimeSpan.FromMinutes(5).TotalMilliseconds);
-                }
-                catch (AbandonedMutexException)
-                {
-                    // "abandoned" means still acquired
-                    mutexAcquired = true;
-                }
-
-                // if it wasn't acquired, it timed out, throw so it goes to retry.
-                if (!mutexAcquired)
-                {
-                    throw new TimeoutException("Timed out acquiring a Mutex for git download, will retry.");
-                }
-
-                string gitLocation = _configuration.GetValue<string>("GitDownloadLocation", null);
-                string[] pathSegments = new Uri(gitLocation, UriKind.Absolute).Segments;
-                string remoteFileName = pathSegments[pathSegments.Length - 1];
-
-                // There are multiple checks whether Git Works, so if it's already there, we'll just rely on 
-                // falling through into CheckGitInstallation()
-                string gitRoot = _tempFiles.GetFilePath("git-portable");
-                string targetPath = Path.Combine(gitRoot, Path.GetFileNameWithoutExtension(remoteFileName));
-                _gitExecutable = Path.Combine(targetPath, "bin", "git.exe");
-
-                try
-                {
-                    // Determine whether another process/ thread ended up getting the lock and downloaded git in the meantime.
-                    if (!File.Exists(_gitExecutable))
+                    using (_operations.BeginOperation($"Installing a local copy of git"))
                     {
-                        using (_operations.BeginOperation($"Installing a local copy of git"))
+                        string gitZipFile = Path.Combine(gitRoot, remoteFileName);
+
+                        _logger.LogInformation($"Downloading git from '{gitLocation}' to '{gitZipFile}'");
+
+                        if (Directory.Exists(targetPath))
                         {
-                            string gitZipFile = Path.Combine(gitRoot, remoteFileName);
+                            _logger.LogInformation($"Target directory {targetPath} already exists. Deleting it.");
 
-                            _logger.LogInformation($"Downloading git from '{gitLocation}' to '{gitZipFile}'");
-
-                            if (Directory.Exists(targetPath))
-                            {
-                                _logger.LogInformation($"Target directory {targetPath} already exists. Deleting it.");
-
-                                // https://github.com/dotnet/arcade/issues/7343
-                                // If this continues to fail despite having both process/thread semaphores wrapping it, we should consider
-                                // killing any git.exe whose image path resides under this folder or simply using another folder and wasting disk space.
-                                Directory.Delete(targetPath, true);
-                            }
-
-                            Directory.CreateDirectory(targetPath);
-
-                            using (HttpClient client = new HttpClient())
-                            using (FileStream outStream = new FileStream(gitZipFile, FileMode.Create, FileAccess.Write))
-                            using (var inStream = await client.GetStreamAsync(gitLocation))
-                            {
-                                await inStream.CopyToAsync(outStream);
-                            }
-
-                            _logger.LogInformation($"Extracting '{gitZipFile}' to '{targetPath}'");
-
-                            ZipFile.ExtractToDirectory(gitZipFile, targetPath, overwriteFiles: true);
+                            // https://github.com/dotnet/arcade/issues/7343
+                            // If this continues to fail despite having both process/thread semaphores wrapping it, we should consider
+                            // killing any git.exe whose image path resides under this folder or simply using another folder and wasting disk space.
+                            Directory.Delete(targetPath, true);
                         }
+
+                        Directory.CreateDirectory(targetPath);
+
+                        using (HttpClient client = new HttpClient())
+                        using (FileStream outStream = new FileStream(gitZipFile, FileMode.Create, FileAccess.Write))
+                        using (var inStream = await client.GetStreamAsync(gitLocation))
+                        {
+                            await inStream.CopyToAsync(outStream);
+                        }
+
+                        _logger.LogInformation($"Extracting '{gitZipFile}' to '{targetPath}'");
+
+                        ZipFile.ExtractToDirectory(gitZipFile, targetPath, overwriteFiles: true);
                     }
                 }
-                finally
-                {
-                    mutex.ReleaseMutex();
-                    _semaphoreSlim.Release();
-                }
+            }
+            finally
+            {
+                crossProcessSemaphore.Release();
             }
 
             // Will throw if something is wrong with the git executable, forcing a retry


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/7343

- Use Mutex to wait 5 minutes for a (this instance's temp path-derived) turn, acquire this lock before any downloading
- Simplify check by always calculating the path to git.exe and checking for its existence, since the final path of _gitExecutable doesn't change per actor/instance