### PR TITLE
Improves error messages of downgrade detection to include check(s) which failed

### DIFF
--- a/src/Maestro/Maestro.MergePolicies/DontAutomergeDowngradesMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/DontAutomergeDowngradesMergePolicy.cs
@@ -19,15 +19,22 @@ namespace Maestro.MergePolicies
         {
             try
             {
-                if (HasAnyDowngrade(pr))
+                List<string> versionCheckMessages = GetDowngradeOrInvalidVersionMessages(pr);
+
+                if (versionCheckMessages.Count > 0)
                 {
-                    return Task.FromResult(
-                        Fail("Some dependency updates are downgrades. Aborting auto-merge."));
+                    // It'd be great if this could be markdown, but checks as implemented today are just a big run-on sentence with no special formatting characters.
+                    string errorMessage = @$"
+The following dependency updates appear to be downgrades or invalid versions: {string.Join(',', versionCheckMessages)}. Aborting auto-merge.
+ Note that this may be caused by manual commits pushed to fix up the pull request (does not re-evaluate if you manually correct the pull request, though this is still acceptable to do).
+ If you think this PR should merge but lack permission to override this check, considering finding an admin or recreating the pull request manually.
+ If you feel you are seeing this message in error, please contact the dnceng team.";
+                    return Task.FromResult(Fail(errorMessage));
                 }
                 else
                 {
                     return Task.FromResult(
-                        Succeed("No version downgrade detected."));
+                        Succeed("No version downgrade detected and all specified versions semantically valid."));
                 }
             }
             catch (Exception e)
@@ -37,27 +44,32 @@ namespace Maestro.MergePolicies
             }
         }
 
-        private static bool HasAnyDowngrade(IPullRequest pr)
+        private static List<string> GetDowngradeOrInvalidVersionMessages(IPullRequest pr)
         {
+            List<string> messages = new List<string>();
+
             foreach (var dependency in pr.RequiredUpdates)
             {
+                bool gotValidVersions = true;
                 if (!SemanticVersion.TryParse(dependency.FromVersion, out var fromVersion))
                 {
-                    throw new ArgumentException($"Could not parse '{dependency.FromVersion}' as a Semantic Version string.");
+                    messages.Add($" Could not parse the 'from' version '{dependency.FromVersion}' of {dependency.DependencyName} as a Semantic Version string");
+                    gotValidVersions = false;
                 }
 
                 if (!SemanticVersion.TryParse(dependency.ToVersion, out var toVersion))
                 {
-                    throw new ArgumentException($"Could not parse '{dependency.ToVersion}' as a Semantic Version string.");
+                    messages.Add($" Could not parse the 'to' version '{dependency.ToVersion}' of {dependency.DependencyName} as a Semantic Version string");
+                    gotValidVersions = false;
                 }
 
-                if (fromVersion.CompareTo(toVersion) > 0)
+                if (gotValidVersions && fromVersion.CompareTo(toVersion) > 0)
                 {
-                    return true;
+                    messages.Add($" Dependency {dependency.DependencyName} was downgraded from {fromVersion} to {toVersion}");
                 }
             }
 
-            return false;
+            return messages;
         }
     }
 

--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -413,7 +413,7 @@ namespace SubscriptionActorService
                     $"Not Applicable: Pull Request '{prUrl}' is not tracked by maestro anymore.");
             }
 
-            (string targetRepository, string targetBranch) = await GetTargetAsync();
+            (string targetRepository, _) = await GetTargetAsync();
             IRemote darc = await DarcRemoteFactory.GetRemoteAsync(targetRepository, Logger);
 
             InProgressPullRequest pr = maybePr.Value;


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/13967 - manual pushing to the PR branch doesn't update the RequiredUpdates value, and after some discussion I am not currently pursuing doing that.  

As a mitigation for the confusion, this PR adds details about the downgrade(s) detected if found, and includes them in the text of the check.  
