### PR TITLE
Enable .NET analyzers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,10 +22,12 @@
     <EnableCentralPackageVersions>true</EnableCentralPackageVersions>
     <CentralPackagesFile>$(MSBuildThisFileDirectory)eng/Packages.props</CentralPackagesFile>
 	
-	<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-	<DisableImplicitNamespaceImports_DotNet>true</DisableImplicitNamespaceImports_DotNet>
-	<DisableImplicitNamespaceImports_Web>true</DisableImplicitNamespaceImports_Web>
-	<DisableImplicitNamespaceImports_Worker>true</DisableImplicitNamespaceImports_Worker>
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    <DisableImplicitNamespaceImports_DotNet>true</DisableImplicitNamespaceImports_DotNet>
+    <DisableImplicitNamespaceImports_Web>true</DisableImplicitNamespaceImports_Web>
+    <DisableImplicitNamespaceImports_Worker>true</DisableImplicitNamespaceImports_Worker>
+
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Enable default .NET analyzers for all projects (and fix a tab/spacing inconsistency).