### PR TITLE
Make v3 publishing the default

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddBuildToChannelCommandLineOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Darc.Options
         [RedactFromLogging]
         public int Id { get; set; }
 
-        [Option("publishing-infra-version", Default = 2, Required = false, HelpText = "Which version of the publishing infrastructure should be used.")]
+        [Option("publishing-infra-version", Default = 3, Required = false, HelpText = "Which version of the publishing infrastructure should be used.")]
         public int PublishingInfraVersion { get; set; }
 
         [Option("channel", HelpText = "Channel to assign build to. Required if --default-channels is not specified.")]
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("default-channels", HelpText = "Assign build to all default channels. Required if --channel is not specified.")]
         public bool AddToDefaultChannels { get; set; }
 
-        [Option("source-branch", HelpText = "Branch that should be used as base for the promotion build. Required if source-sha is specified.")]
+        [Option("source-branch", Default = "main", HelpText = "Branch that should be used as base for the promotion build. Required if source-sha is specified.")]
         public string SourceBranch { get; set; }
 
         [Option("source-sha", HelpText = "SHA that should be used as base for the promotion build.")]
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Darc.Options
         [RedactFromLogging]
         public string ArtifactPublishingAdditionalParameters { get; set; }
 
-        [Option("publish-installers-and-checksums", HelpText = "Whether installers and checksums should be published.")]
+        [Option("publish-installers-and-checksums", HelpText = "Whether installers and checksums should be published. This option is ignored")]
         public bool PublishInstallersAndChecksums { get; set; }
 
         [Option("skip-assets-publishing", HelpText = "Add the build to the channel without publishing assets to the channel's feeds.")]


### PR DESCRIPTION
Avoid some confusion and set v3 to be the default, as well as using arcade @ main for the source branch. These are the normal defaults everyone typically passes anyway.