### PR TITLE
Increase the timeout for gather-drop

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -876,7 +876,7 @@ namespace Microsoft.DotNet.Darc.Operations
             bool success = true;
             var downloaded = new ConcurrentBag<DownloadedAsset>();
             bool anyShipping = false;
-            using (HttpClient client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }))
+            using (HttpClient client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }) { Timeout = TimeSpan.FromMinutes(5) })
             {
                 using (var clientThrottle = new SemaphoreSlim(_options.MaxConcurrentDownloads, _options.MaxConcurrentDownloads))
                 {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GatherDropCommandLineOptions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("max-downloads", Default = 4, HelpText = "Maximum concurrent downloads.")]
         public int MaxConcurrentDownloads { get; set; }
 
-        [Option("download-timeout", Default = 180, HelpText = "Timeout in seconds for downloading each asset.")]
+        [Option("download-timeout", Default = 400, HelpText = "Timeout in seconds for downloading each asset.")]
         public int AssetDownloadTimeoutInSeconds { get; set; }
 
         [Option('f', "full", HelpText = "Gather the full drop (build and all input builds).")]


### PR DESCRIPTION
There are a few files now that are exceptionally large, for which the default timeouts are too low. This change increases the cancellation timeout from 180s to 400s, and the HttpClient timeout to 5 minutes.

Fixes https://github.com/dotnet/arcade/issues/7827.

Note: I attempted lower timeouts, but locally this would still fail. This was the combination I could guarantee would download the dotnet-sdk-source.*.tar.gz file, which is what has been failing.