### PR TITLE
Update the version tools to take in version identification fix

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -23,9 +23,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f73f462f75b5fa21805f0b3c477b11277c5da556</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.VersionTools" Version="6.0.0-beta.21062.10">
+    <Dependency Name="Microsoft.DotNet.VersionTools" Version="6.0.0-beta.21460.7">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ff8fec9066eca51a26abf723dd7d92e20926a90e</Sha>
+      <Sha>7324320f814152b72295946847ca72413507705a</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.21063.3</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>5.0.0-beta.21063.3</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <MicrosoftDotNetGitIssueManagerVersion>5.0.0-beta.21063.3</MicrosoftDotNetGitIssueManagerVersion>
-    <MicrosoftDotNetVersionToolsVersion>6.0.0-beta.21062.10</MicrosoftDotNetVersionToolsVersion>
+    <MicrosoftDotNetVersionToolsVersion>6.0.0-beta.21460.7</MicrosoftDotNetVersionToolsVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>


### PR DESCRIPTION
This pulls in the fix made here https://github.com/dotnet/arcade/pull/7769, which is necessary for an internal build, which pushes symbol packages to a nuget feed. The version identification is critical there because the version is a separate element of the azdo download path. This contrasts with public builds, where symbol packages end up in blob storage and no version identification is necessary.