### PR TITLE
Ignore released builds by default

### DIFF
--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.html
@@ -74,7 +74,7 @@
   </thead>
   <tbody @noop>
     <ng-container *ngFor="let node of sortedBuilds; trackBy getBuildId">
-    <tr *ngIf="(includeToolsets || !node.isToolset) && (showAllDependencies || node.isRootOrImmediateDependency)"
+    <tr *ngIf="(includeToolsets || !node.isToolset) && (showAllDependencies || node.isRootOrImmediateDependency) && (showReleasedDependencies || !node.build.released)"
       @insertRemove
       [ngClass]="{'table-danger': !isCoherent(node), 'table-warning': hasIncoherencies(node)}"
       (mouseenter)="hover(node.build.id)"

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/build-graph-table.component.ts
@@ -234,6 +234,7 @@ export class BuildGraphTableComponent implements OnChanges {
   @Input() public graph?: BuildGraph;
   @Input() public includeToolsets?: boolean;
   @Input() public showAllDependencies?: boolean;
+  @Input() public showReleasedDependencies?: boolean;
   public sortedBuilds?: BuildData[];
   public locked: boolean = false;
   public focusedBuildId?: number;
@@ -329,6 +330,15 @@ export class BuildGraphTableComponent implements OnChanges {
         {
           featureName: "includeToolsets",
           featureState: changes.includeToolsets.currentValue
+        });
+    }
+    
+    if(changes.showReleasedDependencies && (changes.showReleasedDependencies.previousValue != changes.showReleasedDependencies.currentValue))
+    {
+      this.ai.trackEvent({name: "featureEnabled"}, 
+        {
+          featureName: "showReleasedDependencies",
+          featureState: changes.showReleasedDependencies.currentValue
         });
     }
   }

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.html
@@ -124,6 +124,12 @@
               Show Sub-Dependencies
             </label>
           </span>
+          <span class="form-check float-right">
+            <mc-switch [style]="" [(value)]="showReleasedDependencies" title="Include Released Builds"></mc-switch>
+            <label class="form-check-label">
+              Include Released Builds
+            </label>
+          </span>
         </div>
         <ng-container *stateful="let graph from graph$; loadingTemplate: loadingData">
           <ul class="nav nav-tabs">
@@ -136,7 +142,7 @@
           </ul>
           <ng-container *ngIf="view$ | async as view">
             <ng-container *ngIf="view == 'graph'">
-              <mc-build-graph-table [graph]="graph" [includeToolsets]="includeToolsets" [showAllDependencies]="showAllDependencies"></mc-build-graph-table>
+              <mc-build-graph-table [graph]="graph" [includeToolsets]="includeToolsets" [showAllDependencies]="showAllDependencies" [showReleasedDependencies]="showReleasedDependencies"></mc-build-graph-table>
             </ng-container>
             <ng-container *ngIf="view == 'tree'">
               <mc-build-graph-tree [graph]="graph" [includeToolsets]="includeToolsets" [rootId]="build.id"></mc-build-graph-tree>

--- a/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
+++ b/src/Maestro/maestro-angular/src/app/page/build/build.component.ts
@@ -54,6 +54,7 @@ export class BuildComponent implements OnInit, OnChanges {
   public azDevOnGoingBuildUrl$!: Observable<StatefulResult<string | null>>;
   public includeToolsets: boolean = false;
   public showAllDependencies: boolean = false;
+  public showReleasedDependencies: boolean = false;
 
   public neverToastNewBuilds: boolean = false;
 


### PR DESCRIPTION
By default, this changes dependencies of a build over to not showing if they are released. There is a new toggle to reenable. This is particularly useful in determining coherency in servicing, where there are many different builds of the same repo that are dependencies.

Example. This is aspnetcore before the change (with box checked):

![image](https://user-images.githubusercontent.com/8725170/134735751-ffc81f0f-5339-4966-98ed-eaa9ce2588af.png)

And after

![image](https://user-images.githubusercontent.com/8725170/134735798-c79cfc3e-a7c1-4f89-bfc9-7d790c0a5827.png)
