### PR TITLE
Stream CSV instead of buffering in memory

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -115,6 +115,7 @@
     <PackageReference Update="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
     <PackageReference Update="System.IO.FileSystem.AccessControl" Version="4.3.0" />
+    <PackageReference Update="System.IO.Pipelines" Version="5.0.1" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Text.Encodings.Web" Version="4.5.1" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" /> 

--- a/src/Shared/Microsoft.DotNet.Kusto/KustoHelpers.cs
+++ b/src/Shared/Microsoft.DotNet.Kusto/KustoHelpers.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Pipelines;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -76,72 +77,111 @@ namespace Microsoft.DotNet.Kusto
             IAsyncEnumerable<T> data,
             Func<T, IList<KustoValue>> mapFunc)
         {
-            CsvColumnMapping[] mappings = null;
+            TaskCompletionSource<CsvColumnMapping[]> mappingTaskSource = new TaskCompletionSource<CsvColumnMapping[]>();
             int size = 5;
-            await using var stream = new MemoryStream();
-            await using (var writer = new StreamWriter(stream, new UTF8Encoding(false), 1024, leaveOpen: true))
+
+            async Task RecordToStream(Stream s)
             {
-                await foreach (T d in data)
+                CsvColumnMapping[] mappingArray = null;
+                await using (var writer = new StreamWriter(s, new UTF8Encoding(false), 1024, leaveOpen: true))
                 {
-                    IList<KustoValue> kustoValues = mapFunc(d);
-                    if (kustoValues == null)
+                    await foreach (T d in data)
                     {
-                        continue;
-                    }
-
-                    var dataList = new List<string>(size);
-                    if (mappings == null)
-                    {
-                        var mapList = new List<CsvColumnMapping>();
-                        foreach (KustoValue p in kustoValues)
+                        IList<KustoValue> kustoValues = mapFunc(d);
+                        if (kustoValues == null)
                         {
-                            mapList.Add(new CsvColumnMapping {ColumnName = p.Column, CslDataType = p.DataType.CslDataType});
-                            dataList.Add(p.StringValue);
+                            continue;
                         }
 
-                        mappings = mapList.ToArray();
-                        size = mappings.Length;
-                    }
-                    else
-                    {
-                        if (!kustoValues.Select(v => v.Column).SequenceEqual(mappings.Select(m => m.ColumnName)))
+                        var dataList = new List<string>(size);
+                        if (mappingArray == null)
                         {
-                            throw new ArgumentException("Fields must be supplied in the same order for each record");
+                            var mapList = new List<CsvColumnMapping>();
+                            foreach (KustoValue p in kustoValues)
+                            {
+                                mapList.Add(
+                                    new CsvColumnMapping {ColumnName = p.Column, CslDataType = p.DataType.CslDataType}
+                                );
+                                dataList.Add(p.StringValue);
+                            }
+
+                            mappingArray = mapList.ToArray();
+                            mappingTaskSource.SetResult(mappingArray);
+                            size = mappingArray.Length;
+                        }
+                        else
+                        {
+                            if (!kustoValues.Select(v => v.Column).SequenceEqual(mappingArray.Select(m => m.ColumnName)))
+                            {
+                                throw new ArgumentException(
+                                    "Fields must be supplied in the same order for each record"
+                                );
+                            }
+
+                            dataList.AddRange(kustoValues.Select(p => p.StringValue));
                         }
 
-                        dataList.AddRange(kustoValues.Select(p => p.StringValue));
+                        await writer.WriteCsvLineAsync(dataList);
                     }
+                }
 
-                    await writer.WriteCsvLineAsync(dataList);
+                if (mappingArray == null)
+                {
+                    mappingTaskSource.SetResult(null);
                 }
             }
 
-            if (mappings == null)
+            async Task SendFromStream(Stream s)
             {
-                logger.LogInformation("No rows to upload.");
-                return;
-            }
-
-            for (int i = 0; i < mappings.Length; i++)
-            {
-                mappings[i].Ordinal = i;
-            }
-
-            stream.Seek(0, SeekOrigin.Begin);
-
-            logger.LogInformation($"Ingesting {mappings.Length} columns at {stream.Length} bytes...");
-
-            await client.IngestFromStreamAsync(
-                stream,
-                new KustoQueuedIngestionProperties(databaseName, tableName)
+                var mappings = await mappingTaskSource.Task;
+                if (mappings == null)
                 {
-                    Format = DataSourceFormat.csv,
-                    ReportLevel = IngestionReportLevel.FailuresOnly,
-                    ReportMethod = IngestionReportMethod.Queue,
-                    CSVMapping = mappings
-                });
+                    logger.LogInformation("No rows to upload.");
+                    return;
+                }
+
+                for (int i = 0; i < mappings.Length; i++)
+                {
+                    mappings[i].Ordinal = i;
+                }
+
+                logger.LogInformation($"Ingesting {mappings.Length} columns ...");
+
+                var result = await client.IngestFromStreamAsync(
+                    s,
+                    new KustoQueuedIngestionProperties(databaseName, tableName)
+                    {
+                        Format = DataSourceFormat.csv,
+                        ReportLevel = IngestionReportLevel.FailuresOnly,
+                        ReportMethod = IngestionReportMethod.Queue,
+                        CSVMapping = mappings
+                    }
+                );
+
+            }
+
+            await StreamDataAsync(RecordToStream, SendFromStream);
 
             logger.LogTrace("Ingest complete");
+        }
+
+        private static async Task StreamDataAsync(Func<Stream, Task> useWritableStream, Func<Stream, Task> useReadableSteam)
+        {
+            var pipe = new Pipe();
+
+            async Task Write()
+            {
+                await using Stream writableStream = pipe.Writer.AsStream();
+                await useWritableStream(writableStream);
+            }
+            
+            async Task Read()
+            {
+                await using Stream readableStream = pipe.Reader.AsStream();
+                await useReadableSteam(readableStream);
+            }
+
+            await Task.WhenAll(Write(), Read());
         }
     }
 

--- a/src/Shared/Microsoft.DotNet.Kusto/Microsoft.DotNet.Kusto.csproj
+++ b/src/Shared/Microsoft.DotNet.Kusto/Microsoft.DotNet.Kusto.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="System.IO.Pipelines" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Let's save a lot of memory here and stream the CSV.

With System.IO.Pipelines, this is pretty straightforward,
and can save us a lot of buffering space/time in the services.