### PR TITLE
Add controller to serve deployment information to Grafana

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageReference Update="Azure.Core" Version="1.0.2" /> 
     <PackageReference Update="Azure.Data.AppConfiguration" Version="1.0.0" />
+    <PackageReference Update="Azure.Data.Tables" Version="12.2.0" />
     <PackageReference Update="Azure.Identity" Version="1.1.1" /> 
     <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.0.1" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.0.1" />

--- a/src/DotNet.Status.Web/.config/settings.Development.json
+++ b/src/DotNet.Status.Web/.config/settings.Development.json
@@ -43,6 +43,9 @@
   "Grafana": {
     "TableUri": ""
   },
+  "Annotations": {
+    "DeploymentsTableConnectionString": ""
+  },
   "Kusto": {
     "QueryConnectionString": ""
   },

--- a/src/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/.config/settings.json
@@ -136,6 +136,9 @@
     "ApiToken": "[vault(grafana-api-token)]",
     "TableUri": "[vault(deployment-table-sas-uri)]"
   },
+  "Annotations": {
+    "DeploymentsTableConnectionString": "[vault(deployment-table-sas-uri)]"
+  },
   "WebHooks": {
     "github": {
       "SecretKey": {

--- a/src/DotNet.Status.Web/Controllers/AnnotationsController.cs
+++ b/src/DotNet.Status.Web/Controllers/AnnotationsController.cs
@@ -1,0 +1,110 @@
+using Azure.Data.Tables;
+using DotNet.Status.Web.Models;
+using DotNet.Status.Web.Options;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.DotNet.Services.Utility;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DotNet.Status.Web.Controllers
+{
+    /// <summary>
+    /// This Annotations controller serves queries in a format compatible with the Grafana
+    /// "Simple JSON Datasource". It is used to expose the "Deployments" table data to 
+    /// Grafana, which may then render the information in dashboards.
+    /// </summary>
+    [Route("api/[controller]")]
+    [ApiController]
+    public class AnnotationsController : ControllerBase
+    {
+        // Limit query complexity
+        private const int _maximumServerCount = 10;
+        private readonly ILogger<AnnotationsController> _logger;
+        private readonly IOptionsMonitor<AnnotationsOptions> _options;
+
+        public AnnotationsController(ILogger<AnnotationsController> logger, IOptionsMonitor<AnnotationsOptions> options)
+        {
+            _logger = logger;
+            _options = options;
+        }
+
+        [HttpGet]
+        public ActionResult Get()
+        {
+            return Ok();
+        }
+
+        [HttpPost]
+        [Route("query")]
+        public ActionResult Query()
+        {   // Not supported
+            return NoContent();
+        }
+
+        [HttpPost]
+        [Route("search")]
+        public ActionResult Search()
+        {   // Not supported
+            return NoContent();
+        }
+
+        [HttpPost]
+        [Route("annotations")]
+        public async IAsyncEnumerable<AnnotationEntry> Post(AnnotationQueryBody annotationQuery, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            TableClient tableClient = new TableClient(new Uri(_options.CurrentValue.DeploymentsTableConnectionString));
+
+            IEnumerable<string> services = (annotationQuery.Annotation.Query?.Split(',') ?? Array.Empty<string>())
+               .Take(_maximumServerCount)
+               .Where(s => !string.IsNullOrWhiteSpace(s))
+               .Select(s => s.Trim());
+
+            StringBuilder filterBuilder = new StringBuilder();
+            filterBuilder.Append($"Started gt datetime'{annotationQuery.Range.From:O}' and Ended lt datetime'{annotationQuery.Range.To:O}'");
+            if (services.Any())
+            {
+                filterBuilder.Append(" and (");
+                filterBuilder.Append(string.Join(" or ", services.Select(s => $"PartitionKey eq '{s}'")));
+                filterBuilder.Append(')');
+            }
+
+            string filter = filterBuilder.ToString();
+            _logger.LogTrace("Compiled filter query: {Query}", filter);
+
+            IAsyncEnumerable<DeploymentEntity> entityQuery = tableClient.QueryAsync<DeploymentEntity>(
+                filter: filter,
+                cancellationToken: cancellationToken);
+
+            await foreach (DeploymentEntity entity in entityQuery)
+            {
+                if (entity.Started == null)
+                {
+                    // Invalid entity, skip it.
+                    continue;
+                }
+
+                AnnotationEntry entry = new AnnotationEntry(
+                    annotationQuery.Annotation,
+                    entity.Started.Value.ToUnixTimeMilliseconds(),
+                    $"Deployment of {entity.Service}");
+
+                entry.Tags = new[] { "deploy", $"deploy-{entity.Service}", entity.Service };
+
+                if (entity.Ended != null)
+                {
+                    entry.IsRange = true;
+                    entry.TimeEnd = entity.Ended.Value.ToUnixTimeMilliseconds();
+                }
+
+                yield return entry;
+            }
+        }
+    }
+}

--- a/src/DotNet.Status.Web/Controllers/AnnotationsController.cs
+++ b/src/DotNet.Status.Web/Controllers/AnnotationsController.cs
@@ -24,8 +24,7 @@ namespace DotNet.Status.Web.Controllers
     [ApiController]
     public class AnnotationsController : ControllerBase
     {
-        // Limit query complexity
-        private const int _maximumServerCount = 10;
+        private const int _maximumServerCount = 10; // Safety limit on query complexity
         private readonly ILogger<AnnotationsController> _logger;
         private readonly IOptionsMonitor<AnnotationsOptions> _options;
 
@@ -44,14 +43,14 @@ namespace DotNet.Status.Web.Controllers
         [HttpPost]
         [Route("query")]
         public ActionResult Query()
-        {   // Not supported
+        {   // Required endpoint, but not used
             return NoContent();
         }
 
         [HttpPost]
         [Route("search")]
         public ActionResult Search()
-        {   // Not supported
+        {   // Required endpoint, but not used
             return NoContent();
         }
 

--- a/src/DotNet.Status.Web/DotNet.Status.Web.csproj
+++ b/src/DotNet.Status.Web/DotNet.Status.Web.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubJwt" />
+    <PackageReference Include="Azure.Data.Tables" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.Storage.Queues" />
     <PackageReference Include="JetBrains.Annotations" />
@@ -27,7 +28,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Octokit" />
-    <PackageReference Include="System.Text.Encodings.Web" />
     <PackageReference Include="WindowsAzure.Storage" /> 
   </ItemGroup>
 

--- a/src/DotNet.Status.Web/Models/AnnotationEntry.cs
+++ b/src/DotNet.Status.Web/Models/AnnotationEntry.cs
@@ -1,0 +1,35 @@
+namespace DotNet.Status.Web.Models
+{
+    public class AnnotationEntry
+    {
+        /// <summary>
+        /// The original annotation sent from Grafana.
+        /// </summary>
+        public Annotation Annotation { get; set; }
+        /// <summary>
+        /// Time since UNIX Epoch in milliseconds. (required)
+        /// </summary>
+        public long Time { get; set; }
+        public long? TimeEnd { get; set; }
+        public bool? IsRange { get; set; } = false;
+        /// <summary>
+        /// The title for the annotation tooltip. (required)
+        /// </summary>
+        public string Title { get; set; }
+        /// <summary>
+        /// Tags for the annotation. (optional)
+        /// </summary>
+        public string[]? Tags { get; set; }
+        /// <summary>
+        /// Text for the annotation. (optional)
+        /// </summary>
+        public string? Text { get; set; }
+
+        public AnnotationEntry(Annotation annotation, long time, string title)
+        {
+            Annotation = annotation;
+            Time = time;
+            Title = title;
+        }
+    }
+}

--- a/src/DotNet.Status.Web/Models/AnnotationQueryBody.cs
+++ b/src/DotNet.Status.Web/Models/AnnotationQueryBody.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace DotNet.Status.Web.Models
+{
+    /// <summary>
+    /// Query body used by the Grafana SimpleJsonDataSource when requesting annotations
+    /// </summary>
+    public class AnnotationQueryBody
+    {
+        public Range Range { get; set; }
+        public RangeRaw RangeRaw { get; set; }
+        public Annotation Annotation { get; set; }
+    }
+
+    public class Range
+    {
+        public DateTimeOffset From { get; set; }
+        public DateTimeOffset To { get; set; }
+    }
+
+    public class RangeRaw
+    {
+        public string From { get; set; }
+        public string To { get; set; }
+    }
+
+    public class Annotation
+    {
+        public string Name { get; set; }
+        public string Datasource { get; set; }
+        public string IconColor { get; set; }
+        public bool Enable { get; set; }
+        public string Query { get; set; }
+    }
+}

--- a/src/DotNet.Status.Web/Models/DeploymentEntity.cs
+++ b/src/DotNet.Status.Web/Models/DeploymentEntity.cs
@@ -1,0 +1,19 @@
+using Azure;
+using Azure.Data.Tables;
+using System;
+
+namespace DotNet.Status.Web.Models
+{
+    public class DeploymentEntity : ITableEntity
+    {
+        public string PartitionKey { get; set; }
+        public string RowKey { get; set; }
+        public DateTimeOffset? Timestamp { get; set; }
+        public ETag ETag { get; set; }
+
+        public string Service => PartitionKey;
+        public string BuildNumber => RowKey;
+        public DateTimeOffset? Started { get; set; }
+        public DateTimeOffset? Ended { get; set; }
+    }
+}

--- a/src/DotNet.Status.Web/Options/AnnotationsOptions.cs
+++ b/src/DotNet.Status.Web/Options/AnnotationsOptions.cs
@@ -1,0 +1,7 @@
+namespace DotNet.Status.Web.Options
+{
+    public class AnnotationsOptions
+    {
+        public string DeploymentsTableConnectionString { get; set; }
+    }
+}

--- a/src/DotNet.Status.Web/Program.cs
+++ b/src/DotNet.Status.Web/Program.cs
@@ -27,10 +27,10 @@ namespace DotNet.Status.Web
                 .ConfigureAppConfiguration((host, config) =>
                 {
                     config
-                        .AddCommandLine(args)
+                        .AddDefaultJsonConfiguration(host.HostingEnvironment)
                         .AddUserSecrets(Assembly.GetEntryAssembly())
                         .AddEnvironmentVariables()
-                        .AddDefaultJsonConfiguration(host.HostingEnvironment);
+                        .AddCommandLine(args);
                 })
                 .ConfigureLogging(
                     builder =>

--- a/src/DotNet.Status.Web/Startup.cs
+++ b/src/DotNet.Status.Web/Startup.cs
@@ -88,6 +88,7 @@ namespace DotNet.Status.Web
             services.Configure<TeamMentionForwardingOptions>(Configuration.GetSection("IssueMentionForwarding"));
             services.Configure<GitHubConnectionOptions>(Configuration.GetSection("GitHub"));
             services.Configure<GrafanaOptions>(Configuration.GetSection("Grafana"));
+            services.Configure<AnnotationsOptions>(Configuration.GetSection("Annotations"));
             services.Configure<GitHubTokenProviderOptions>(Configuration.GetSection("GitHubAppAuth"));
             services.Configure<ZenHubOptions>(Configuration.GetSection("ZenHub"));
             services.Configure<BuildMonitorOptions>(Configuration.GetSection("BuildMonitor"));


### PR DESCRIPTION
This adds a controller to dotnet status web that is compatible with Grafana's "[Simple JSON Datasource](https://grafana.com/grafana/plugins/grafana-simple-json-datasource/)", which we can use to bridge the service deployment Azure table and show deployment information within the dashboards. 

This will replace the portion of the DeploymentController that POSTs to Grafana directly. 