### PR TITLE
Add an option to the repositories list to only include builds in last N days

### DIFF
--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/ChannelsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/ChannelsController.cs
@@ -76,10 +76,9 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;
 
-            var buildChannelList = await _context.BuildChannels
+            var buildChannelList = _context.BuildChannels
                     .Include(b => b.Build)
-                    .Where(bc => bc.ChannelId == id)
-                    .ToListAsync();
+                    .Where(bc => bc.ChannelId == id);
 
             if (withBuildsInDays != null)
             {
@@ -90,15 +89,14 @@ namespace Maestro.Web.Api.v2018_07_16.Controllers
                 }
 
                 buildChannelList = buildChannelList
-                    .Where(bc => now.Subtract(bc.Build.DateProduced).TotalDays < withBuildsInDays)
-                    .ToList();
+                    .Where(bc => now.Subtract(bc.Build.DateProduced).TotalDays < withBuildsInDays);
             }
 
-            List<string> repositoryList = buildChannelList
+            List<string> repositoryList = await buildChannelList
                     .Select(bc => bc.Build.GitHubRepository ?? bc.Build.AzureDevOpsRepository)
                     .Where(b => !String.IsNullOrEmpty(b))
                     .Distinct()
-                    .ToList();
+                    .ToListAsync();
 
             return Ok(repositoryList);
         }

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/ChannelsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/ChannelsController.cs
@@ -76,10 +76,9 @@ namespace Maestro.Web.Api.v2020_02_20.Controllers
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;
 
-            var buildChannelList = await _context.BuildChannels
+            var buildChannelList = _context.BuildChannels
                     .Include(b => b.Build)
-                    .Where(bc => bc.ChannelId == id)
-                    .ToListAsync();
+                    .Where(bc => bc.ChannelId == id);
 
             if (withBuildsInDays != null)
             {
@@ -90,15 +89,14 @@ namespace Maestro.Web.Api.v2020_02_20.Controllers
                 }
 
                 buildChannelList = buildChannelList
-                    .Where(bc => now.Subtract(bc.Build.DateProduced).TotalDays < withBuildsInDays)
-                    .ToList();
+                    .Where(bc => now.Subtract(bc.Build.DateProduced).TotalDays < withBuildsInDays);
             }
 
-            List<string> repositoryList = buildChannelList
+            List<string> repositoryList = await buildChannelList
                     .Select(bc => bc.Build.GitHubRepository ?? bc.Build.AzureDevOpsRepository)
                     .Where(b => !String.IsNullOrEmpty(b))
                     .Distinct()
-                    .ToList();
+                    .ToListAsync();
 
             return Ok(repositoryList);
         }


### PR DESCRIPTION
In support of future ability to filter out builds in channels that are old, add an optional parameter to ListRepositories that restricts the repositories returned to those with builds in the last N days.

Also:
- Add some comments as to why there are identical implementations in the derived class for the 2020 controller