### PR TITLE
[Hotfix] Fix feed patterns

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/FeedConstants.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/FeedConstants.cs
@@ -18,10 +18,10 @@ namespace Microsoft.DotNet.DarcLib.Helpers
         {
             // Matches package feeds like
             // https://dnceng.pkgs.visualstudio.com/public/_packaging/darc-pub-arcade-fd8184c3fcde81eb27ca4c061c6e171f418d753f-1/nuget/v3/index.json
-            @"https://(?<organization>\w+).pkgs.visualstudio.com/(public/){0,1}_packaging/" + MaestroManagedFeedNamePattern + @"/nuget/v\d+/index.json",
+            @"https://(?<organization>\w+).pkgs.visualstudio.com/((public|internal)/){0,1}_packaging/" + MaestroManagedFeedNamePattern + @"/nuget/v\d+/index.json",
             // Matches package feeds like
             // https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-wpf-8182abc8/nuget/v3/index.json
-            @"https://pkgs.dev.azure.com/(?<organization>\w+)/(public/){0,1}_packaging/"+ MaestroManagedFeedNamePattern + @"/nuget/v\d+/index.json"
+            @"https://pkgs.dev.azure.com/(?<organization>\w+)/((public|internal)/){0,1}_packaging/"+ MaestroManagedFeedNamePattern + @"/nuget/v\d+/index.json"
         };
 
         // Matches package feeds like

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
@@ -27,6 +27,12 @@ namespace Microsoft.DotNet.Darc.Tests
         [TestCase("AddFeedsToNuGetConfigWithoutManagedFeeds", new string[] {
             "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-standard-a5b5f2e1/nuget/v3/index.json",
             "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-4ac4c036/nuget/v3/index.json" })]
+        [TestCase("MatchMoreFeedPatterns", new string[] {
+            "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-standard-a5b5f2e1/nuget/v3/index.json",
+            "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-4ac4c036/nuget/v3/index.json",
+            // Both forms of the internal feeds (org and internal project)
+            "https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-runtime-5a18de8a/nuget/v3/index.json",
+            "https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-aspnetcore-10cdf3ba/nuget/v3/index.json" })]
         [TestCase("ReplaceExistingFeedsWithNewOnes", new string[] {
             "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-standard-a5b5f2e1/nuget/v3/index.json" })]
         [TestCase("PreserveCommentsInRightLocationsWhenReplacing", new string[] {

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/MatchMoreFeedPatterns/NuGet.input.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/MatchMoreFeedPatterns/NuGet.input.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This test case exercises being called with a nuget config with no managed packageSources comment blocks and no feeds
+     Expected behaviors:
+       - <clear> tag honored at beginning of packageSources
+       - 'Begin: Package sources' and 'End: Package sources' comments created outside of added feeds
+       - 'Begin: Package sources from ...' and 'End: Package sources from ...' comments created around each repo's feeds
+       - Feeds are added in alphabetic order
+       - Disabled Sources node is created, but is empty because the feeds added are darc-pub feeds and don't need to be disabled.
+ -->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
+    <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/MatchMoreFeedPatterns/NuGet.output.config
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/NugetConfigFiles/MatchMoreFeedPatterns/NuGet.output.config
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This test case exercises being called with a nuget config with no managed packageSources comment blocks and no feeds
+     Expected behaviors:
+       - <clear> tag honored at beginning of packageSources
+       - 'Begin: Package sources' and 'End: Package sources' comments created outside of added feeds
+       - 'Begin: Package sources from ...' and 'End: Package sources from ...' comments created around each repo's feeds
+       - Feeds are added in alphabetic order
+       - Disabled Sources node is created, but is empty because the feeds added are darc-pub feeds and don't need to be disabled.
+ -->
+<configuration>
+  <packageSources>
+    <clear />
+    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--  Begin: Package sources from dotnet-aspnetcore -->
+    <add key="darc-int-dotnet-aspnetcore-10cdf3b" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-aspnetcore-10cdf3ba/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-aspnetcore -->
+    <!--  Begin: Package sources from dotnet-corefx -->
+    <add key="darc-pub-dotnet-corefx-4ac4c03" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-4ac4c036/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-corefx -->
+    <!--  Begin: Package sources from dotnet-runtime -->
+    <add key="darc-int-dotnet-runtime-5a18de8" value="https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-runtime-5a18de8a/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-runtime -->
+    <!--  Begin: Package sources from dotnet-standard -->
+    <add key="darc-pub-dotnet-standard-a5b5f2e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-standard-a5b5f2e1/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-standard -->
+    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
+    <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--  Begin: Package sources from dotnet-aspnetcore -->
+    <add key="darc-int-dotnet-aspnetcore-10cdf3b" value="true" />
+    <!--  End: Package sources from dotnet-aspnetcore -->
+    <!--  Begin: Package sources from dotnet-runtime -->
+    <add key="darc-int-dotnet-runtime-5a18de8" value="true" />
+    <!--  End: Package sources from dotnet-runtime -->
+    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+  </disabledPackageSources>
+</configuration>


### PR DESCRIPTION
When the publishing change was made to move newly created feeds into the internal project vs. the organization, the regex's needed to be updated in Maestro to correctly identify this new feed pattern. The original feed pattern was based on the incorrect understanding that public feeds always had 'public' in their name, but non-public feeds never did. It was mainly confusion around project vs. org feeds.

Right now this is causing some major annoyance with the 5.0 and 3.1 internal builds. Does not affect 6.0.