### PR TITLE
Update two package dependencies

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -4,7 +4,10 @@
     <DotNetAssemblyVersion>3.1.3</DotNetAssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Update="Azure.Core" Version="1.0.2" /> 
+    <!-- Note: These libraries can be loaded by Arcade SDK clients, which may already have a
+         newer copy of this package loaded. When updating one, be aware of the other to prevent runtime issues
+         See: https://github.com/dotnet/arcade/blob/main/eng/Versions.props -->
+    <PackageReference Update="Azure.Core" Version="1.19.0" />
     <PackageReference Update="Azure.Data.AppConfiguration" Version="1.0.0" />
     <PackageReference Update="Azure.Data.Tables" Version="12.2.0" />
     <PackageReference Update="Azure.Identity" Version="1.1.1" /> 
@@ -121,7 +124,7 @@
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
     <PackageReference Update="System.IO.FileSystem.AccessControl" Version="4.3.0" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
-    <PackageReference Update="System.Text.Encodings.Web" Version="4.5.1" />
+    <PackageReference Update="System.Text.Encodings.Web" Version="4.7.2" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" /> 
     <PackageReference Update="WindowsAzure.Storage" Version="9.3.3" />
     <PackageReference Update="YamlDotNet" Version="9.1.4" />


### PR DESCRIPTION
Updates Azure.Core to latest and one incidental update needed to clean build.
Fallout from updating and unifying Azure.Storage.Blob versions for https://github.com/dotnet/core-eng/issues/14789