### PR TITLE
Update System.Text.Encodings.Web version

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -124,7 +124,7 @@
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
     <PackageReference Update="System.IO.FileSystem.AccessControl" Version="4.3.0" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
-    <PackageReference Update="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Update="System.Text.Encodings.Web" Version="4.7.1" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" /> 
     <PackageReference Update="WindowsAzure.Storage" Version="9.3.3" />
     <PackageReference Update="YamlDotNet" Version="9.1.4" />


### PR DESCRIPTION
Component governance is failing in helix-machines in this file -> https://dev.azure.com/dnceng/internal/_git/569090e3-cc96-4250-a2d3-cd9b0039aa14?path=/src/ServiceFabric/QuotaManagerActorService/QuotaManagerActorService.csproj&version=GBmain&line=18&lineEnd=19&lineStartColumn=1&lineEndColumn=84&lineStyle=plain&_a=contents,
 this change is being reverted. But the package Microsoft.DotNet.ServiceFabric.ServiceHost is generated in arcade services and uses System.Text.Encodings.Web and that version is not secure. 
So upgrading it

Issue -> https://github.com/dotnet/core-eng/issues/14879
Secure versions -> https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-arcade/alert/6087962?typeId=6283540