### PR TITLE
Preserve category in merged manifest

### DIFF
--- a/src/Maestro/Client/src/BuildData.cs
+++ b/src/Maestro/Client/src/BuildData.cs
@@ -45,7 +45,8 @@ namespace Microsoft.DotNet.Maestro.Client.Models
                     {
                         Name = asset.Name,
                         Version = asset.Version,
-                        Locations = locationsList.ToImmutableList<AssetLocationData>()
+                        Locations = locationsList.ToImmutableList<AssetLocationData>(),
+                        Category = asset.Category
                     });
                 }
 

--- a/src/Maestro/Client/src/BuildData.cs
+++ b/src/Maestro/Client/src/BuildData.cs
@@ -46,7 +46,6 @@ namespace Microsoft.DotNet.Maestro.Client.Models
                         Name = asset.Name,
                         Version = asset.Version,
                         Locations = locationsList.ToImmutableList<AssetLocationData>(),
-                        Category = asset.Category
                     });
                 }
 

--- a/src/Maestro/Client/src/Generated/Models/AssetData.cs
+++ b/src/Maestro/Client/src/Generated/Models/AssetData.cs
@@ -22,8 +22,5 @@ namespace Microsoft.DotNet.Maestro.Client.Models
 
         [JsonProperty("locations")]
         public IImmutableList<Models.AssetLocationData> Locations { get; set; }
-
-        [JsonProperty("category")]
-        public string Category { get; set; }
     }
 }

--- a/src/Maestro/Client/src/Generated/Models/AssetData.cs
+++ b/src/Maestro/Client/src/Generated/Models/AssetData.cs
@@ -22,5 +22,8 @@ namespace Microsoft.DotNet.Maestro.Client.Models
 
         [JsonProperty("locations")]
         public IImmutableList<Models.AssetLocationData> Locations { get; set; }
+
+        [JsonProperty("category")]
+        public string Category { get; set; }
     }
 }

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/AddAssetTests.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/AddAssetTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
             List<AssetData> assetData = new List<AssetData>();
             AssetData expectedAssetData = new AssetData(true) { Name = "testName", Version = "12345", Locations = ImmutableList<AssetLocationData>.Empty.Add(new AssetLocationData(LocationType.None) { Location = "testLocation" }) };
 
-            pushMetadata.AddAsset(assetData, expectedAssetData.Name, expectedAssetData.Version, "testLocation", LocationType.None, true);
+            pushMetadata.AddAsset(assetData, expectedAssetData.Name, expectedAssetData.Version, "testLocation", LocationType.None, true, null);
             assetData.Count.Should().Be(1);
             assetData.Should().BeEquivalentTo(expectedAssetData);
         }
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
 
             AssetData newAssetData = new AssetData(true) { Name = "testName", Version = "12345", Locations = ImmutableList<AssetLocationData>.Empty.Add(new AssetLocationData(LocationType.None) { Location = "testLocation" }) };
 
-            pushMetadata.AddAsset(assetData, newAssetData.Name, newAssetData.Version, "testLocation", LocationType.None, true);
+            pushMetadata.AddAsset(assetData, newAssetData.Name, newAssetData.Version, "testLocation", LocationType.None, true, null);
             assetData.Count.Should().Be(2);
             assetData[0].Should().BeEquivalentTo(existingAssetData);
             assetData[1].Should().BeEquivalentTo(newAssetData);
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
             PushMetadataToBuildAssetRegistry pushMetadata = new PushMetadataToBuildAssetRegistry();
 
             Action act = () =>
-                pushMetadata.AddAsset(null, "testName", "12345", "testLocation", LocationType.None, true);
+                pushMetadata.AddAsset(null, "testName", "12345", "testLocation", LocationType.None, true, null);
             act.Should().Throw<NullReferenceException>();
         }
     }

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/CreateMergedManifestBuildModelTests.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/CreateMergedManifestBuildModelTests.cs
@@ -40,12 +40,6 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
         private readonly AssetData assetDataWithoutVersion = new AssetData(true)
         { Name = "noVersionData" };
 
-        private readonly AssetData nonShippingAssetDataForBlob = new AssetData(true)
-        {
-            Name = "NonShippingAssetData",
-            Version = "nonShippingAsssetVersion"
-        };
-
         private readonly AssetData nonShippingAssetData = new AssetData(true)
         {
             Name = "NonShippingAssetData",
@@ -171,7 +165,7 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
             PushMetadataToBuildAssetRegistry pushMetadata = GetPushMetadata();
             ConditionalWeakTable<AssetData, string> assetWithCategory = new ConditionalWeakTable<AssetData, string>();
 
-            AssetData dataInBlobSet = pushMetadata.GetManifestAsAsset(ImmutableList.Create(nonShippingAssetDataForBlob), "thisIsALocation", "thisIsTheManifestFileName");
+            AssetData dataInBlobSet = pushMetadata.GetManifestAsAsset(ImmutableList.Create(nonShippingAssetData), "thisIsALocation", "thisIsTheManifestFileName");
             BlobArtifactModel blobArtifactModel = new BlobArtifactModel
             {
                 Attributes = new Dictionary<string, string>

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/CreateMergedManifestBuildModelTests.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/CreateMergedManifestBuildModelTests.cs
@@ -39,6 +39,13 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
         private readonly AssetData assetDataWithoutVersion = new AssetData(true)
         { Name = "noVersionData" };
 
+        private readonly AssetData nonShippingAssetDataForBlob = new AssetData(true)
+        {
+            Name = "NonShippingAssetData",
+            Version = "nonShippingAsssetVersion",
+            Category = "OTHER"
+        };
+
         private readonly AssetData nonShippingAssetData = new AssetData(true)
         {
             Name = "NonShippingAssetData",
@@ -163,12 +170,13 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
             BuildModel expectedBuildModel = GetBuildModel();
             PushMetadataToBuildAssetRegistry pushMetadata = GetPushMetadata();
 
-            AssetData dataInBlobSet = pushMetadata.GetManifestAsAsset(ImmutableList.Create(nonShippingAssetData), "thisIsALocation", "thisIsTheManifestFileName");
+            AssetData dataInBlobSet = pushMetadata.GetManifestAsAsset(ImmutableList.Create(nonShippingAssetDataForBlob), "thisIsALocation", "thisIsTheManifestFileName");
             BlobArtifactModel blobArtifactModel = new BlobArtifactModel
             {
                 Attributes = new Dictionary<string, string>
                 {
-                    { "NonShipping", "true" }
+                    { "NonShipping", "true" },
+                    { "Category", "OTHER" }
                 },
                 Id = dataInBlobSet.Name
             };
@@ -196,7 +204,7 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
             {
                 Attributes = new Dictionary<string, string>
                     {
-                        { "NonShipping", "false" },
+                        { "NonShipping", "false" }
                     },
                 Id = shippingAssetData.Name,
                 Version = shippingAssetData.Version
@@ -206,7 +214,8 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
             {
                 Attributes = new Dictionary<string, string>
                 {
-                    { "NonShipping", "true" }
+                    { "NonShipping", "true" },
+                    { "Category", "" }
                 },
                 Id = dataInBlobSet.Name
             };

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/CreateMergedManifestBuildModelTests.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/CreateMergedManifestBuildModelTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using FluentAssertions;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.DotNet.Maestro.Tasks.Proxies;
@@ -42,8 +43,7 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
         private readonly AssetData nonShippingAssetDataForBlob = new AssetData(true)
         {
             Name = "NonShippingAssetData",
-            Version = "nonShippingAsssetVersion",
-            Category = "OTHER"
+            Version = "nonShippingAsssetVersion"
         };
 
         private readonly AssetData nonShippingAssetData = new AssetData(true)
@@ -169,6 +169,7 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
         {
             BuildModel expectedBuildModel = GetBuildModel();
             PushMetadataToBuildAssetRegistry pushMetadata = GetPushMetadata();
+            ConditionalWeakTable<AssetData, string> assetWithCategory = new ConditionalWeakTable<AssetData, string>();
 
             AssetData dataInBlobSet = pushMetadata.GetManifestAsAsset(ImmutableList.Create(nonShippingAssetDataForBlob), "thisIsALocation", "thisIsTheManifestFileName");
             BlobArtifactModel blobArtifactModel = new BlobArtifactModel
@@ -176,10 +177,11 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
                 Attributes = new Dictionary<string, string>
                 {
                     { "NonShipping", "true" },
-                    { "Category", "OTHER" }
+                    { "Category", "" }
                 },
                 Id = dataInBlobSet.Name
             };
+
 
             expectedBuildModel.Artifacts =
                 new ArtifactSet

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/CreateMergedManifestBuildModelTests.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks.Tests/CreateMergedManifestBuildModelTests.cs
@@ -177,7 +177,7 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
                 Attributes = new Dictionary<string, string>
                 {
                     { "NonShipping", "true" },
-                    { "Category", "" }
+                    { "Category", "NONE" }
                 },
                 Id = dataInBlobSet.Name
             };
@@ -217,7 +217,7 @@ namespace Microsoft.DotNet.Maestro.Tasks.Tests
                 Attributes = new Dictionary<string, string>
                 {
                     { "NonShipping", "true" },
-                    { "Category", "" }
+                    { "Category", "NONE" }
                 },
                 Id = dataInBlobSet.Name
             };

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
@@ -111,6 +111,9 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
         [XmlAttribute(AttributeName = "NonShipping")]
         public bool NonShipping { get; set; }
+
+        [XmlAttribute(AttributeName = "Category")]
+        public string Category { get; set; }
     }
 
     [XmlRoot(ElementName = "SigningInformation")]

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -654,7 +654,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 {
                     AssetVersion = asset.Version;
                 }
-                if(asset.Category != null)
+                if (asset != null && !String.IsNullOrEmpty(asset.Category))
                 {
                     AssetCategory = asset.Category;
                 }
@@ -668,7 +668,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 }),
                 Name = $"assets/manifests/{repoName}/{AssetVersion}/{manifestFileName}",
                 Version = AssetVersion,
-                Category = AssetCategory
+                Category = !String.IsNullOrEmpty(AssetCategory) ? AssetCategory : null
             };
 
             blobSet.Add(assetData.Name);

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -42,6 +42,8 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
         public string AssetVersion { get; set; }
 
+        public string AssetCategory { get; set; }
+
         [Output]
         public int BuildId { get; set; }
 
@@ -359,7 +361,8 @@ namespace Microsoft.DotNet.Maestro.Tasks
                         version,
                         manifest.InitialAssetsLocation ?? manifest.Location,
                         LocationType.Container,
-                        blob.NonShipping);
+                        blob.NonShipping,
+                        blob.Category);
 
                     blobSet.Add(blob.Id);
                 }
@@ -461,7 +464,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
         /// <param name="location">Location of asset</param>
         /// <param name="locationType">Type of location</param>
         /// <param name="nonShipping">If true, the asset is not intended for end customers</param>
-        internal void AddAsset(List<AssetData> assets, string assetName, string version, string location, LocationType locationType, bool nonShipping)
+        internal void AddAsset(List<AssetData> assets, string assetName, string version, string location, LocationType locationType, bool nonShipping, string category=null)
         {
             assets.Add(new AssetData(nonShipping)
             {
@@ -471,6 +474,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 }),
                 Name = assetName,
                 Version = version,
+                Category = category
             });
         }
 
@@ -650,6 +654,10 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 {
                     AssetVersion = asset.Version;
                 }
+                if(asset.Category != null)
+                {
+                    AssetCategory = asset.Category;
+                }
             }
 
             AssetData assetData = new AssetData(true)
@@ -660,6 +668,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 }),
                 Name = $"assets/manifests/{repoName}/{AssetVersion}/{manifestFileName}",
                 Version = AssetVersion,
+                Category = AssetCategory
             };
 
             blobSet.Add(assetData.Name);
@@ -692,7 +701,8 @@ namespace Microsoft.DotNet.Maestro.Tasks
                     {
                         Attributes = new Dictionary<string, string>
                                 {
-                                    { "NonShipping", data.NonShipping.ToString().ToLower() }
+                                    { "NonShipping", data.NonShipping.ToString().ToLower() },
+                                    { "Category", !string.IsNullOrEmpty(data.Category)? data.Category.ToString().ToUpper(): ""}
                                 },
                         Id = data.Name
                     };

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -654,7 +654,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 {
                     AssetVersion = asset.Version;
                 }
-                if (asset != null && !String.IsNullOrEmpty(asset.Category))
+                if (asset != null && !string.IsNullOrEmpty(asset.Category))
                 {
                     AssetCategory = asset.Category;
                 }
@@ -668,7 +668,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 }),
                 Name = $"assets/manifests/{repoName}/{AssetVersion}/{manifestFileName}",
                 Version = AssetVersion,
-                Category = !String.IsNullOrEmpty(AssetCategory) ? AssetCategory : null
+                Category = !string.IsNullOrEmpty(AssetCategory) ? AssetCategory : null
             };
 
             blobSet.Add(assetData.Name);

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -711,7 +711,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                         Attributes = new Dictionary<string, string>
                                 {
                                     { "NonShipping", data.NonShipping.ToString().ToLower() },
-                                    { "Category", !string.IsNullOrEmpty(AssetCategory)? AssetCategory.ToString().ToUpper(): ""}},
+                                    { "Category", !string.IsNullOrEmpty(AssetCategory)? AssetCategory.ToString().ToUpper(): "NONE"}},
                         Id = data.Name
                     };
                     buildModel.Artifacts.Blobs.Add(blobArtifactModel);


### PR DESCRIPTION
Issue -> https://github.com/dotnet/arcade/issues/6517

This is part -1 pr for preserving the category of blobs in merged manifest in arcade-services 

So if no category is present then I added empty string. I think this is not a good idea. Its better to add a new category like 'NONE' or something here. 

So when we infer category here in arcade, I can check if its 'NONE' then go determine the category like we used to before https://github.com/dotnet/arcade/blob/6818f9bff65fb7277174876bdf207f5ac8933286/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs#L1106

else if its other then do something else. 

This is how the merged manifest looks like now
![Capture](https://user-images.githubusercontent.com/47157394/141875423-647853d4-77a8-4d9c-b689-3bc7269266a8.PNG)

Arcade test -> https://dev.azure.com/dnceng/internal/_build/results?buildId=1470781&view=results

 