### PR TITLE
Remove publishing.props file

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,5 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <PublishingVersion>3</PublishingVersion>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
This breaks the official build of arcade-services, probably because it's far out of date on templates.