### PR TITLE
Fix service principal secret name

### DIFF
--- a/src/Monitoring/Monitoring.ArcadeServices/datasource/Production/Azure Data Explorer.datasource.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/datasource/Production/Azure Data Explorer.datasource.json
@@ -22,6 +22,6 @@
   },
   "readOnly": false,
   "secureJsonData": {
-    "clientSecret": "[vault(helix-grafana-ad-client-secret)]"
+    "clientSecret": "[vault(helix-grafana-app-secret)]"
   }
 }

--- a/src/Monitoring/Monitoring.ArcadeServices/datasource/Production/Azure Monitor.datasource.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/datasource/Production/Azure Monitor.datasource.json
@@ -13,7 +13,7 @@
   "withCredentials": false,
   "isDefault": false,
   "jsonData": {
-    "azureAuthType": "clientsecret",
+    "azureAuthType": "msi",
     "clientId": "a2541735-8225-40af-9c8a-2ae233203739",
     "cloudName": "azuremonitor",
     "logAnalyticsClientId": "a2541735-8225-40af-9c8a-2ae233203739",
@@ -23,7 +23,7 @@
   },
   "readOnly": false,
   "secureJsonData": {
-    "clientSecret": "[vault(helix-grafana-app-secret)]",
-    "logAnalyticsClientSecret": "[vault(helix-grafana-app-secret)]"
+    "clientSecret": "",
+    "logAnalyticsClientSecret": ""
   }
 }

--- a/src/Monitoring/Monitoring.ArcadeServices/datasource/Production/Azure Monitor.datasource.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/datasource/Production/Azure Monitor.datasource.json
@@ -23,7 +23,7 @@
   },
   "readOnly": false,
   "secureJsonData": {
-    "clientSecret": "[vault(helix-grafana-ad-client-secret)]",
-    "logAnalyticsClientSecret": "[vault(helix-grafana-ad-client-secret)]"
+    "clientSecret": "[vault(helix-grafana-app-secret)]",
+    "logAnalyticsClientSecret": "[vault(helix-grafana-app-secret)]"
   }
 }

--- a/src/Monitoring/Monitoring.ArcadeServices/datasource/Staging/Azure Data Explorer.datasource.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/datasource/Staging/Azure Data Explorer.datasource.json
@@ -22,6 +22,6 @@
   },
   "readOnly": false,
   "secureJsonData": {
-    "clientSecret": "[vault(helix-grafana-ad-client-secret)]"
+    "clientSecret": "[vault(helix-grafana-app-secret)]"
   }
 }

--- a/src/Monitoring/Monitoring.ArcadeServices/datasource/Staging/Azure Monitor.datasource.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/datasource/Staging/Azure Monitor.datasource.json
@@ -13,7 +13,7 @@
   "withCredentials": false,
   "isDefault": false,
   "jsonData": {
-    "azureAuthType": "clientsecret",
+    "azureAuthType": "msi",
     "clientId": "a2541735-8225-40af-9c8a-2ae233203739",
     "cloudName": "azuremonitor",
     "logAnalyticsClientId": "a2541735-8225-40af-9c8a-2ae233203739",
@@ -23,7 +23,7 @@
   },
   "readOnly": false,
   "secureJsonData": {
-    "clientSecret": "[vault(helix-grafana-app-secret)]",
-    "logAnalyticsClientSecret": "[vault(helix-grafana-app-secret)]"
+    "clientSecret": "",
+    "logAnalyticsClientSecret": ""
   }
 }

--- a/src/Monitoring/Monitoring.ArcadeServices/datasource/Staging/Azure Monitor.datasource.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/datasource/Staging/Azure Monitor.datasource.json
@@ -23,7 +23,7 @@
   },
   "readOnly": false,
   "secureJsonData": {
-    "clientSecret": "[vault(helix-grafana-ad-client-secret)]",
-    "logAnalyticsClientSecret": "[vault(helix-grafana-ad-client-secret)]"
+    "clientSecret": "[vault(helix-grafana-app-secret)]",
+    "logAnalyticsClientSecret": "[vault(helix-grafana-app-secret)]"
   }
 }

--- a/src/Monitoring/Monitoring.ArcadeServices/datasource/Staging/Azure Monitor.datasource.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/datasource/Staging/Azure Monitor.datasource.json
@@ -18,7 +18,7 @@
     "cloudName": "azuremonitor",
     "logAnalyticsClientId": "a2541735-8225-40af-9c8a-2ae233203739",
     "logAnalyticsTenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-    "subscriptionId": "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f",
+    "subscriptionId": "cab65fc3-d077-467d-931f-3932eabf36d3",
     "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
   },
   "readOnly": false,

--- a/src/Monitoring/grafana-init/grafana.ini
+++ b/src/Monitoring/grafana-init/grafana.ini
@@ -71,6 +71,9 @@ provider = azure_blob
 ;account_key = <managed by environment>
 container_name = grafana
 
+[azure]
+managed_identity_enabled = true
+
 [snapshots]
 external_enabled = false
 


### PR DESCRIPTION
Secrets for the service principals were renamed as part of adopting Secret Manager. I missed updating the references in the data source definitions, which then broke. This renames them to be correct. 

While I was here, I also enabled Grafana's feature to use Azure's managed identities feature. The Azure Monitor plugin is the only piece that takes advantage of it, but I expect the other data sources to follow. And any removal of secrets is a good thing. 