### PR TITLE
Fix gather-drop's IsBlobFeedUrl for dotnetbuilds locations

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -1208,17 +1208,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 // Construct the source uri.
                 string name = asset.Name.ToLowerInvariant();
                 string version = asset.Version.ToLowerInvariant();
-                string finalUri = assetLocation.Location;
-                
-                if (finalUri.EndsWith("index.json"))
-                {
-                    finalUri = finalUri.Substring(0, finalUri.Length - "index.json".Length);
-                }
-
-                if (!finalUri.EndsWith("/"))
-                {
-                    finalUri += "/";
-                }
+                string finalUri = GetBlobBaseUri(assetLocation.Location);
 
                 finalUri += $"flatcontainer/{name}/{version}/{name}.{version}.nupkg";
 
@@ -1386,6 +1376,31 @@ namespace Microsoft.DotNet.Darc.Operations
             return locationUri.Host.Equals("dev.azure.com") && location.EndsWith("/artifacts");
         }
 
+        /// <summary>
+        ///     Gets the base uri of a blob uri
+        /// </summary>
+        /// <param name="blobUri">Uri of the blob</param>
+        /// <returns>The blob uri with index.json removed, ending in a trailing slash</returns>
+        /// <remarks>
+        ///     Blob feed uris look like: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+        /// </remarks>
+        private static string GetBlobBaseUri(string blobUri)
+        {
+            string baseUri = blobUri;
+
+            if (baseUri.EndsWith("index.json"))
+            {
+                baseUri = baseUri.Substring(0, baseUri.Length - "index.json".Length);
+            }
+
+            if (!baseUri.EndsWith("/"))
+            {
+                baseUri += "/";
+            }
+
+            return baseUri;
+        }
+
         private async Task<DownloadedAsset> DownloadBlobAsync(HttpClient client,
                                                             Asset asset,
                                                             AssetLocation assetLocation,
@@ -1437,17 +1452,7 @@ namespace Microsoft.DotNet.Darc.Operations
             if (IsBlobFeedUrl(assetLocation.Location))
             {
 
-                string finalBaseUri = assetLocation.Location;
-
-                if (finalBaseUri.EndsWith("index.json"))
-                {
-                    finalBaseUri = finalBaseUri.Substring(0, finalBaseUri.Length - "index.json".Length);
-                }
-
-                if (!finalBaseUri.EndsWith("/"))
-                {
-                    finalBaseUri += "/";
-                }
+                string finalBaseUri = GetBlobBaseUri(assetLocation.Location);
 
                 string finalUri1 = $"{finalBaseUri}{asset.Name}";
                 string finalUri2 = $"{finalBaseUri}assets/{asset.Name}";

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -1208,7 +1208,18 @@ namespace Microsoft.DotNet.Darc.Operations
                 // Construct the source uri.
                 string name = asset.Name.ToLowerInvariant();
                 string version = asset.Version.ToLowerInvariant();
-                string finalUri = assetLocation.Location.Substring(0, assetLocation.Location.Length - "index.json".Length);
+                string finalUri = assetLocation.Location;
+                
+                if (finalUri.EndsWith("index.json"))
+                {
+                    finalUri = finalUri.Substring(0, finalUri.Length - "index.json".Length);
+                }
+
+                if (!finalUri.EndsWith("/"))
+                {
+                    finalUri += "/";
+                }
+
                 finalUri += $"flatcontainer/{name}/{version}/{name}.{version}.nupkg";
 
                 using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(_options.AssetDownloadTimeoutInSeconds));
@@ -1326,7 +1337,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 return false;
             }
 
-            return locationUri.Host.EndsWith("blob.core.windows.net") && location.EndsWith("/index.json");
+            return locationUri.Host.EndsWith("blob.core.windows.net");
         }
 
         /// <summary>
@@ -1425,7 +1436,19 @@ namespace Microsoft.DotNet.Darc.Operations
 
             if (IsBlobFeedUrl(assetLocation.Location))
             {
-                string finalBaseUri = assetLocation.Location.Substring(0, assetLocation.Location.Length - "index.json".Length);
+
+                string finalBaseUri = assetLocation.Location;
+
+                if (finalBaseUri.EndsWith("index.json"))
+                {
+                    finalBaseUri = finalBaseUri.Substring(0, finalBaseUri.Length - "index.json".Length);
+                }
+
+                if (!finalBaseUri.EndsWith("/"))
+                {
+                    finalBaseUri += "/";
+                }
+
                 string finalUri1 = $"{finalBaseUri}{asset.Name}";
                 string finalUri2 = $"{finalBaseUri}assets/{asset.Name}";
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -1451,9 +1451,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
             if (IsBlobFeedUrl(assetLocation.Location))
             {
-
                 string finalBaseUri = GetBlobBaseUri(assetLocation.Location);
-
                 string finalUri1 = $"{finalBaseUri}{asset.Name}";
                 string finalUri2 = $"{finalBaseUri}assets/{asset.Name}";
 


### PR DESCRIPTION
IsBlobFeedUrl was used as a check to see if a location is a sleet feed, but was also repurposed to check if it was simply a blob storage location. We don't actually care if index.json is at the end of the uri in the later case, and, in fact, the dotnetbuilds locations no longer include index.json in the asset locations.

This change removes the index.json check, and adds some additional logic around removing the index.json part of the asset location uri, so that gather-drop works with dotnetbuilds locations.

Will fix https://github.com/dotnet/arcade/issues/8225.