### PR TITLE
Teach MockHttpClientFactory to support multiple requests

### DIFF
--- a/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/MockHttpClientFactory.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/MockHttpClientFactory.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Internal.Testing.Utility
             {
                 foreach (CannedResponse response in _responses)
                 {
-                    if (request.RequestUri.AbsoluteUri == response.Uri && request.Method == response.Method)
+                    if (request.RequestUri.AbsoluteUri == response.Uri && request.Method == response.Method && response.Used == false)
                     {
                         response.Used = true;
                         return Task.FromResult(CreateResponse(response));


### PR DESCRIPTION
This makes a small modification to MockHttpClientFactory to support returning multiple different requests to the same URI by using the "This Has Been Sent" flag when matching requested URLs with their response. 

I think this is technically a behavior change, as previously it was perfectly legal to accept the same URL over and over and get the same response back, but you'd have to be careful about not over-disposing all the IDisposables involved. I've also confirmed all unit tests in arcade-services and dotnet-helix-services using this build.