### PR TITLE
Remove legacy coherency in Maestro subscription updates

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -1136,7 +1136,6 @@ namespace SubscriptionActorService
             // Once we have applied all of non coherent updates, then we need to run a coherency check on the dependencies.
             // First, we'll try it with strict mode; failing that an attempt with legacy mode.
             List<DependencyUpdate> coherencyUpdates = new List<DependencyUpdate>();
-            bool strictCheckFailed = false;
             try
             {
                 Logger.LogInformation($"Running a coherency check on the existing dependencies for branch {branch} of repo {targetRepository}");
@@ -1144,16 +1143,7 @@ namespace SubscriptionActorService
             }
             catch (DarcCoherencyException)
             {
-                Logger.LogInformation("Failed attempting strict coherency update on branch '{strictCoherencyFailedBranch}' of repo '{strictCoherencyFailedRepo}'.  Will now retry in Legacy mode.",
-                     branch, targetRepository);
-                strictCheckFailed = true;
-            }
-            if (strictCheckFailed)
-            {
-                coherencyUpdates = await darc.GetRequiredCoherencyUpdatesAsync(existingDependencies, remoteFactory, CoherencyMode.Legacy);
-                // If the above call didn't throw, that means legacy worked while strict did not.
-                // Send a special trace that can be easily queried later from App Insights, to gauge when everything can handle Strict mode.
-                Logger.LogInformation("Strict coherency update failed, but Legacy update worked for branch '{strictCoherencyFailedBranch}' of repo '{strictCoherencyFailedRepo}'.",
+                Logger.LogInformation("Failed attempting strict coherency update on branch '{strictCoherencyFailedBranch}' of repo '{strictCoherencyFailedRepo}'.",
                      branch, targetRepository);
             }
 


### PR DESCRIPTION
Removes legacy coherency support. We are down to the last few repos that use this, and it's time for it to go. Temporarily leaving this in for the command line, so we can work around issues if needed.