### PR TITLE
Fix exceptions in TeamMentionForwarder

### DIFF
--- a/src/DotNet.Status.Web/Models/TeamMentionForwarder.cs
+++ b/src/DotNet.Status.Web/Models/TeamMentionForwarder.cs
@@ -48,7 +48,7 @@ namespace DotNet.Status.Web.Models
                 shouldSend = false;
             }
 
-            if (!newBody.Contains(team))
+            if (string.IsNullOrEmpty(newBody) || !newBody.Contains(team))
             {
                 shouldSend = false;
             }


### PR DESCRIPTION
Github will send comment bodies as null if there is no comment body (as opposed to empty string). TeamMentionForwarder's HandleMentions assumes that the comment body will, at a minimum, be an empty string before checking to see if it contains the team name, which it uses to inform the team if there are any mentions we need to be aware of. When the comment body is null, this will throw an exception. This change adds a null check, and if the new body is null, or it doesn't contain the team name, we will not send a notification.