### PR TITLE
Fix symbol release generation

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -473,8 +473,28 @@ namespace Microsoft.DotNet.Darc.Operations
                 // This goes into the release layout. Walk the downloaded assets
                 foreach (DownloadedAsset asset in downloadedBuild.DownloadedAssets)
                 {
+                    // Otherwise, if the asset is a symbol package (ends in .symbols.nupkg), then copy it to symbols
+                    if (asset.Asset.Name.EndsWith(".symbols.nupkg"))
+                    {
+                        if (doNotListSymbolPackageFilenamePrefixes.Any(doNotListPrefix =>
+                            Path.GetFileName(asset.UnifiedLayoutTargetLocation).StartsWith(doNotListPrefix)))
+                        {
+                            continue;
+                        }
+
+                        // Create the target directory
+                        string targetFile = Path.Combine(sympkgsDirectory, shortName,
+                            symPackagesSubDir, Path.GetFileName(asset.UnifiedLayoutTargetLocation));
+                        Directory.CreateDirectory(Path.GetDirectoryName(targetFile));
+
+                        File.Copy(asset.UnifiedLayoutTargetLocation, targetFile, true);
+
+                        // Add the relative path to the sympkg list. Choose paths are relative to the root output dir
+                        string relativeSymPackagePath = Path.GetRelativePath(outputDirectory, targetFile);
+                        sympkgsFileContent.AppendLine(relativeSymPackagePath);
+                    }
                     // If the asset is a shipping package, it goes into nupkgDirectory\<short name>\packages    
-                    if (!asset.Asset.NonShipping && asset.LocationType == LocationType.NugetFeed)
+                    else if (!asset.Asset.NonShipping && asset.LocationType == LocationType.NugetFeed)
                     {
                         // Create the target directory
                         string targetFile = Path.Combine(nupkgDirectory, shortName,
@@ -496,26 +516,6 @@ namespace Microsoft.DotNet.Darc.Operations
                         StringBuilder identityStringBuilder = identitiesFileContents.GetOrAddValue(shortName,
                             () => new StringBuilder());
                         identityStringBuilder.AppendLine($"{asset.Asset.Name},{asset.Asset.Version}");
-                    }
-                    // Otherwise, if the asset is a symbol package (ends in .symbols.nupkg), then copy it to symbols
-                    else if (asset.Asset.Name.EndsWith(".symbols.nupkg"))
-                    {
-                        if (doNotListSymbolPackageFilenamePrefixes.Any(doNotListPrefix =>
-                            Path.GetFileName(asset.UnifiedLayoutTargetLocation).StartsWith(doNotListPrefix)))
-                        {
-                            continue;
-                        }
-
-                        // Create the target directory
-                        string targetFile = Path.Combine(sympkgsDirectory, shortName,
-                            symPackagesSubDir, Path.GetFileName(asset.UnifiedLayoutTargetLocation));
-                        Directory.CreateDirectory(Path.GetDirectoryName(targetFile));
-
-                        File.Copy(asset.UnifiedLayoutTargetLocation, targetFile, true);
-
-                        // Add the relative path to the sympkg list. Choose paths are relative to the root output dir
-                        string relativeSymPackagePath = Path.GetRelativePath(outputDirectory, targetFile);
-                        sympkgsFileContent.AppendLine(relativeSymPackagePath);
                     }
                 }
             }


### PR DESCRIPTION
Gather drop was incorrectly skipping some symbol nupkg files when they were shipping and on nuget feeds. This is a common internal servicing and stable package scenario. While originally reported for 6.0, this bug does appear for 5.0 servicing scenarios too.

To fix, reorder the conditionals because some .symbols.nupkg files would incorrectly match into of the original first conditional.