### PR TITLE
Fix issue with github token storage

### DIFF
--- a/src/DotNet.Status.Web/.config/settings.Development.json
+++ b/src/DotNet.Status.Web/.config/settings.Development.json
@@ -37,7 +37,7 @@
     "ApiToken": null
   },
   "DataProtection": {
-    "KeyFileUri": "",
+    "StorageAccountConnectionString": "",
     "KeyIdentifier": ""
   },
   "Grafana": {

--- a/src/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/.config/settings.json
@@ -128,7 +128,7 @@
     "TableUri": "[vault(token-table-sas-uri)]"
   },
   "DataProtection": {
-    "KeyFileUri": "[vault(data-protection-key-file-uri)]",
+    "StorageAccountConnectionString": "[vault(dotnet-status-storage-account)]",
     "KeyIdentifier": "dotnet-status-data-protection"
   },
   "Grafana": {

--- a/src/DotNet.Status.Web/Startup.cs
+++ b/src/DotNet.Status.Web/Startup.cs
@@ -38,6 +38,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.DotNet.Internal.AzureDevOps;
 using Microsoft.DotNet.Kusto;
 using Octokit;
+using AzureStorage = Microsoft.Azure.Storage;
 
 namespace DotNet.Status.Web
 {
@@ -72,8 +73,10 @@ namespace DotNet.Status.Web
                 string vaultUri = Configuration[ConfigurationConstants.KeyVaultUriConfigurationKey];
                 string keyVaultKeyIdentifierName = dpConfig["KeyIdentifier"];
                 KeyBundle key = kvClient.GetKeyAsync(vaultUri, keyVaultKeyIdentifierName).GetAwaiter().GetResult();
+                AzureStorage.CloudStorageAccount cloudStorageAccount = AzureStorage.CloudStorageAccount.Parse(dpConfig["StorageAccountConnectionString"]);
+
                 services.AddDataProtection()
-                    .PersistKeysToAzureBlobStorage(new Uri(dpConfig["KeyFileUri"]))
+                    .PersistKeysToAzureBlobStorage(cloudStorageAccount, "/site/keys.xml")
                     .ProtectKeysWithAzureKeyVault(kvClient, key.KeyIdentifier.ToString())
                     .SetDefaultKeyLifetime(TimeSpan.FromDays(14))
                     .SetApplicationName(typeof(Startup).FullName);


### PR DESCRIPTION
Detected in https://github.com/dotnet/core-eng/issues/15239.  Basically, we had a secret that was a SAS URL of a blob in the same storage account used for other stuff in dotneteng-status* sites, but this wasn't automatically kept up.  By simply using the existing, secret-manager-managed secret in a different overload to the `PersistKeysToAzureBlobStorage()` call, we prevent having to manually regenerate the blob SAS URI every year or so.