### PR TITLE
Change Maestro availability to keep state if no data

### DIFF
--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -2047,7 +2047,7 @@
         "frequency": "1m",
         "handler": 1,
         "name": "Maestro / BarViz alert",
-        "noDataState": "no_data",
+        "noDataState": "keep_state",
         "notifications": [
           {
             "uid": "statusHook"


### PR DESCRIPTION
This sets the maestro availability alert in Grafana to ignore the "no_data" state. It doesn't add anything for our configuration and has only caused false positives. 