### PR TITLE
Grafana export/import tool updated so it can process grafana schemaVersion 33

### DIFF
--- a/src/Monitoring/Microsoft.DotNet.Monitoring.Sdk.Tests/MakePackTests.cs
+++ b/src/Monitoring/Microsoft.DotNet.Monitoring.Sdk.Tests/MakePackTests.cs
@@ -14,7 +14,7 @@ namespace DotNet.Grafana.Tests
     {
 
         [Test]
-        public void ExtractDataSourceNamesTest()
+        public void ExtractDataSourceUidsTest()
         {
             //$.dashboard.panels[*]..datasource
             var dashboard = new JObject
@@ -28,12 +28,26 @@ namespace DotNet.Grafana.Tests
                             {
                                 new JObject
                                 {
-                                    {"datasource", "Test Datasource 1"},
+                                    {
+                                        "datasource",
+                                        new JObject
+                                        {
+                                            {"type", "Test Datasource 1"},
+                                            {"uid", "1234"}
+                                        }
+                                    },
                                     {"other-property", "IGNORED"},
                                 },
                                 new JObject
                                 {
-                                    {"datasource", "Test Datasource 2"},
+                                    {
+                                        "datasource",
+                                        new JObject
+                                        {
+                                            {"type", "Test Datasource 2"},
+                                            {"uid", "4321"}
+                                        }
+                                    }
                                 },
                             }
                         },
@@ -43,11 +57,11 @@ namespace DotNet.Grafana.Tests
             };
 
             var expected = new List<string> {
-                "Test Datasource 1",
-                "Test Datasource 2",
+                "1234",
+                "4321",
             };
 
-            IEnumerable<string> actual = GrafanaSerialization.ExtractDataSourceNames(dashboard);
+            IEnumerable<string> actual = GrafanaSerialization.ExtractDataSourceUids(dashboard);
 
             actual.Should().Equal(expected);
         }

--- a/src/Monitoring/Microsoft.DotNet.Monitoring.Sdk.Tests/MakePackTests.cs
+++ b/src/Monitoring/Microsoft.DotNet.Monitoring.Sdk.Tests/MakePackTests.cs
@@ -12,56 +12,59 @@ namespace DotNet.Grafana.Tests
     [TestFixture]
     public class MakePackTests
     {
-
         [Test]
-        public void ExtractDataSourceUidsTest()
+        public void ExtractDataSourceIdentifiersTest()
         {
-            //$.dashboard.panels[*]..datasource
+            //$.dashboard.[*].datasource
             var dashboard = new JObject
             {
                 {
-                    "dashboard", new JObject
+                    "dashboard", 
+                    new JObject
                     {
-                        {
-                            "panels",
-                            new JArray
+                        {  "annotations",
+                            new JObject
                             {
-                                new JObject
                                 {
+                                    "list", new JArray
                                     {
-                                        "datasource",
                                         new JObject
                                         {
-                                            {"type", "Test Datasource 1"},
-                                            {"uid", "1234"}
-                                        }
-                                    },
-                                    {"other-property", "IGNORED"},
-                                },
-                                new JObject
-                                {
-                                    {
-                                        "datasource",
-                                        new JObject
-                                        {
-                                            {"type", "Test Datasource 2"},
-                                            {"uid", "4321"}
+                                            {"datasource", "Test Datasource Name 1"},
                                         }
                                     }
-                                },
-                            }
-                        },
-                        {"other-property", "IGNORED"},
+                                }
+                            } 
+                        }
                     }
                 },
+                {
+                    "panels",
+                    new JArray
+                    {
+                        new JObject
+                        {
+                            {
+                                "datasource",
+                                new JObject
+                                {
+                                    {"type", "Test Datasource Type"},
+                                    {"uid", "1234"}
+                                }
+                            },
+                            {"other-property", "IGNORED"},
+                        }
+                    }
+                },
+                {"other-property", "IGNORED"}
             };
 
             var expected = new List<string> {
-                "1234",
-                "4321",
+                "Test Datasource Name 1",
+                "1234"
             };
 
-            IEnumerable<string> actual = GrafanaSerialization.ExtractDataSourceUids(dashboard);
+            IEnumerable<string> actual = GrafanaSerialization.ExtractDataSourceIdentifiers(dashboard);
 
             actual.Should().Equal(expected);
         }

--- a/src/Monitoring/Sdk/DeployImporter.cs
+++ b/src/Monitoring/Sdk/DeployImporter.cs
@@ -118,7 +118,6 @@ namespace Microsoft.DotNet.Monitoring.Sdk
                 {
                     JObject datasource = await GrafanaClient.GetDataSourceByUidAsync(dataSourceIdentifier).ConfigureAwait(false) ??
                                          await GrafanaClient.GetDataSourceByNameAsync(dataSourceIdentifier).ConfigureAwait(false);
-
                     string datasourceName = datasource.Value<string>("name");
 
                     datasource = GrafanaSerialization.SanitizeDataSource(datasource);

--- a/src/Monitoring/Sdk/DeployImporter.cs
+++ b/src/Monitoring/Sdk/DeployImporter.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
@@ -113,13 +112,14 @@ namespace Microsoft.DotNet.Monitoring.Sdk
                 FolderData folderData = GrafanaSerialization.SanitizeFolder(folder);
                 
                 // Get datasources used in the dashboard
-                IEnumerable<string> dataSourceNames = GrafanaSerialization.ExtractDataSourceNames(dashboard);
-
-                foreach (string datasourceName in dataSourceNames)
+                IEnumerable<string> dataSourceUids = GrafanaSerialization.ExtractDataSourceUids(dashboard);
+               
+                foreach (string datasourceUid in dataSourceUids)
                 {
-                    JObject datasource = await GrafanaClient.GetDataSourceAsync(datasourceName).ConfigureAwait(false);
-                    datasource = GrafanaSerialization.SanitizeDataSource(datasource);
+                    JObject datasource = await GrafanaClient.GetDataSourceAsync(datasourceUid).ConfigureAwait(false);
+                    string datasourceName = datasource.Value<string>("name") ?? datasourceUid;
 
+                    datasource = GrafanaSerialization.SanitizeDataSource(datasource);
                     // Create the data source for each environment
                     foreach (string env in _environments)
                     {

--- a/src/Monitoring/Sdk/DeployImporter.cs
+++ b/src/Monitoring/Sdk/DeployImporter.cs
@@ -112,12 +112,14 @@ namespace Microsoft.DotNet.Monitoring.Sdk
                 FolderData folderData = GrafanaSerialization.SanitizeFolder(folder);
                 
                 // Get datasources used in the dashboard
-                IEnumerable<string> dataSourceUids = GrafanaSerialization.ExtractDataSourceUids(dashboard);
-               
-                foreach (string datasourceUid in dataSourceUids)
+                IEnumerable<string> dataSourceIdentifiers = GrafanaSerialization.ExtractDataSourceIdentifiers(dashboard);
+
+                foreach (string dataSourceIdentifier in dataSourceIdentifiers)
                 {
-                    JObject datasource = await GrafanaClient.GetDataSourceAsync(datasourceUid).ConfigureAwait(false);
-                    string datasourceName = datasource.Value<string>("name") ?? datasourceUid;
+                    JObject datasource = await GrafanaClient.GetDataSourceByUidAsync(dataSourceIdentifier).ConfigureAwait(false) ??
+                                         await GrafanaClient.GetDataSourceByNameAsync(dataSourceIdentifier).ConfigureAwait(false);
+
+                    string datasourceName = datasource.Value<string>("name");
 
                     datasource = GrafanaSerialization.SanitizeDataSource(datasource);
                     // Create the data source for each environment

--- a/src/Monitoring/Sdk/GrafanaClient.cs
+++ b/src/Monitoring/Sdk/GrafanaClient.cs
@@ -87,10 +87,9 @@ namespace Microsoft.DotNet.Monitoring.Sdk
         /// </summary>
         /// <param name="name">The data source name</param>
         /// <returns>The Data Source JSON object as defined by the Grafana Data Source API</returns>
-        public async Task<JObject> GetDataSourceAsync(string name)
+        public async Task<JObject> GetDataSourceAsync(string uid)
         {
-            var uri = new Uri(new Uri(_baseUrl), $"/api/datasources/name/{name}");
-
+            var uri = new Uri(new Uri(_baseUrl), $"/api/datasources/uid/{uid}");
             using (HttpResponseMessage response = await _client.GetAsync(uri).ConfigureAwait(false))
             {
                 if (response.StatusCode == HttpStatusCode.NotFound)

--- a/src/Monitoring/Sdk/GrafanaClient.cs
+++ b/src/Monitoring/Sdk/GrafanaClient.cs
@@ -87,7 +87,31 @@ namespace Microsoft.DotNet.Monitoring.Sdk
         /// </summary>
         /// <param name="name">The data source name</param>
         /// <returns>The Data Source JSON object as defined by the Grafana Data Source API</returns>
-        public async Task<JObject> GetDataSourceAsync(string uid)
+        public async Task<JObject> GetDataSourceByNameAsync(string name)
+        {
+            var uri = new Uri(new Uri(_baseUrl), $"/api/datasources/name/{name}");
+            using (HttpResponseMessage response = await _client.GetAsync(uri).ConfigureAwait(false))
+            {
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                    return null;
+
+                await response.EnsureSuccessWithContentAsync();
+
+                using (Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                using (var streamReader = new StreamReader(stream))
+                using (var jsonReader = new JsonTextReader(streamReader))
+                {
+                    return await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get a Data Source by its uid
+        /// </summary>
+        /// <param uid="uid">The data source udi</param>
+        /// <returns>The Data Source JSON object as defined by the Grafana Data Source API</returns>
+        public async Task<JObject> GetDataSourceByUidAsync(string uid)
         {
             var uri = new Uri(new Uri(_baseUrl), $"/api/datasources/uid/{uid}");
             using (HttpResponseMessage response = await _client.GetAsync(uri).ConfigureAwait(false))

--- a/src/Monitoring/Sdk/GrafanaSerialization.cs
+++ b/src/Monitoring/Sdk/GrafanaSerialization.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Monitoring.Sdk
         /// </summary>
         /// <param name="dashboard">A JSON definition of a dashboard as delivered by the Grafana API</param>
         /// <returns></returns>
-        public static IEnumerable<string> ExtractDataSourceNames(JObject dashboard)
+        public static IEnumerable<string> ExtractDataSourceUids(JObject dashboard)
         {
             // Panel data sources live in panel[*].datasource, unless the "Mixed Data source" 
             // feature is used. Then, get names from panel[*].target.datasource. 
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Monitoring.Sdk
             // datasource. This is an unsupported configuration.
 
             return dashboard
-                .SelectTokens("$..datasource")
+                .SelectTokens("$..datasource.uid")
                 .Values<string>()
                 .Where(x => !String.IsNullOrEmpty(x))
                 .Where(x => x != "-- Mixed --" && x != "-- Grafana --")

--- a/src/Monitoring/Sdk/GrafanaSerialization.cs
+++ b/src/Monitoring/Sdk/GrafanaSerialization.cs
@@ -253,9 +253,4 @@ namespace Microsoft.DotNet.Monitoring.Sdk
         public string Name { get; set; }
         public IDictionary<string, string> Values { get; set; }
     }
-
-    public class DataSource
-    {
-        public IDictionary<string, string> Values { get; set; }
-    }
 }

--- a/src/Monitoring/Sdk/README.md
+++ b/src/Monitoring/Sdk/README.md
@@ -1,4 +1,4 @@
-﻿## How to create a montioring project
+## How to create a montioring project
 Use `<Project Sdk="Helix.DotNet.Monitoring.Sdk">` in a project file.
 
 This will, by default, scan for dashboards in json files named ./dashboard/\*.dashboard.json,
@@ -22,8 +22,9 @@ e.g.
     -p:GrafanaAccessToken=GRAFANA_ADMIN_API_KEY \
     -p:GrafanaKeyVaultName=dotnet-grafana \
     -p:GrafanaKeyVaultAppId=2bdfceef-194a-4775-99d9-b5575c77bc6b \
+    -p:ParametersFile=parameters.json \
     -p:GrafanaKeyVaultAppSecret=KEY_VAULT_APP_SECRET \
-    -p:GrafanaEnvironment=DEPLOYMENT_ENVIRONMENT
+    -p:GrafanaEnvironments=DEPLOYMENT_ENVIRONMENT
 ```
 
 `GrafanaAccessToken`: An API token with Admin access level
@@ -43,7 +44,7 @@ To run the publish, run:
 To import a dashboard, run:
 
 ```bash
-  dotnet build MyMonitoring.proj -t:ImportGrafana -p:GrafanaHost=https://dotnet-eng-grafana-staging.westus2.cloudapp.azure.com/ -p:GrafanaAccessToken=MY_ACCESS_TOKEN -p:DashBoardId=MyDashboardUid
+  dotnet build MyMonitoring.proj -t:ImportGrafana -p:GrafanaHost=https://dotnet-eng-grafana-staging.westus2.cloudapp.azure.com/ -p:GrafanaAccessToken=MY_ACCESS_TOKEN -p:ParametersFile=parameters.json -p:Environment=Staging -p:DashBoardId=MyDashboardUid
 ```
 
 where 999 is the ID from grafana of the dashboard you wish to import.

--- a/src/Monitoring/Sdk/README.md
+++ b/src/Monitoring/Sdk/README.md
@@ -24,7 +24,7 @@ e.g.
     -p:GrafanaKeyVaultAppId=2bdfceef-194a-4775-99d9-b5575c77bc6b \
     -p:ParametersFile=parameters.json \
     -p:GrafanaKeyVaultAppSecret=KEY_VAULT_APP_SECRET \
-    -p:GrafanaEnvironments=DEPLOYMENT_ENVIRONMENT
+    -p:GrafanaEnvironment=DEPLOYMENT_ENVIRONMENT
 ```
 
 `GrafanaAccessToken`: An API token with Admin access level


### PR DESCRIPTION
These Grafana APIs include a field schemaVersion that describes the shape of the JSON. The current tool was implicitly designed to work with version 31. Grafana version 8.3.1, used by dnceng, is sending schemaVersion 33.