### PR TITLE
Do not include graph image in issue when Grafana alert doesn't have it

### DIFF
--- a/src/DotNet.Status.Web/Controllers/AlertHookController.cs
+++ b/src/DotNet.Status.Web/Controllers/AlertHookController.cs
@@ -148,6 +148,7 @@ namespace DotNet.Status.Web.Controllers
             }
             
             string icon = GetIcon(notification);
+            string image = !string.IsNullOrEmpty(notification.ImageUrl) ? "![Metric Graph]({notification.ImageUrl})" : string.Empty;
 
             return $@":{icon}: Metric state changed to *{notification.State}*
 
@@ -155,7 +156,7 @@ namespace DotNet.Status.Web.Controllers
 
 {metricText}
 
-![Metric Graph]({notification.ImageUrl})
+{image}
 
 [Go to rule]({notification.RuleUrl})".Replace("\r\n","\n");
         }
@@ -169,6 +170,7 @@ namespace DotNet.Status.Web.Controllers
             }
 
             string icon = GetIcon(notification);
+            string image = !string.IsNullOrEmpty(notification.ImageUrl) ? "![Metric Graph]({notification.ImageUrl})" : string.Empty;
 
             string issueTitle = notification.Title;
 
@@ -187,7 +189,7 @@ namespace DotNet.Status.Web.Controllers
 
 {metricText}
 
-![Metric Graph]({notification.ImageUrl})
+{image}
 
 [Go to rule]({notification.RuleUrl})
 


### PR DESCRIPTION
Some alerts have charts that don't really bring much value and it might be confusing for FR ICs to see a graph with a single point in the middle because they might be wondering whether Grafana is working fine.

Example:
![image](https://user-images.githubusercontent.com/7013027/150359815-77ce6a5f-cf86-4c8b-adf4-54999782d5fc.png)

I have added a new Grafana notification channel which doesn't send the image with the alert but we need to ignore it in markdown too