### PR TITLE
Revert "Add F# to nuget gather process"

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -353,7 +353,6 @@ namespace Microsoft.DotNet.Darc.Operations
             { $"{githubRepoPrefix}dotnet/emsdk", (coreRepoCategory, "emsdk") },
             { $"{githubRepoPrefix}dotnet/sdk", (coreRepoCategory, "sdk") },
             { $"{githubRepoPrefix}dotnet/roslyn-analyzers", (coreRepoCategory, "roslyn-analyzers") },
-            { $"{githubRepoPrefix}dotnet/fsharp", (coreRepoCategory, "dotnet-fsharp") },
             // Internal
             { $"{azdoRepoPrefix}dotnet-corefx", (coreRepoCategory, "corefx") },
             { $"{azdoRepoPrefix}dotnet-coreclr", (coreRepoCategory, "coreclr") },
@@ -364,7 +363,6 @@ namespace Microsoft.DotNet.Darc.Operations
             { $"{azdoRepoPrefix}dotnet-emsdk", (coreRepoCategory, "emsdk") },
             { $"{azdoRepoPrefix}dotnet-sdk", (coreRepoCategory, "sdk") },
             { $"{azdoRepoPrefix}dotnet-roslyn-analyzers", (coreRepoCategory, "roslyn-analyzers") },
-            { $"{azdoRepoPrefix}dotnet-fsharp", (coreRepoCategory, "dotnet-fsharp") },
 
             // ASPNET
 


### PR DESCRIPTION
Reverts dotnet/arcade-services#1758

FSharp has decided on a different approach, so this is not needed.