### PR TITLE
Use IOptionsMonitor for updating values

### DIFF
--- a/src/Maestro/Maestro.AzureDevOps/AzureDevOpsTokenProvider.cs
+++ b/src/Maestro/Maestro.AzureDevOps/AzureDevOpsTokenProvider.cs
@@ -10,18 +10,17 @@ namespace Maestro.AzureDevOps
 {
     public class AzureDevOpsTokenProvider : IAzureDevOpsTokenProvider
     {
-        private readonly IOptions<AzureDevOpsTokenProviderOptions> _options;
+        private readonly IOptionsMonitor<AzureDevOpsTokenProviderOptions> _options;
 
-        public AzureDevOpsTokenProvider(IOptions<AzureDevOpsTokenProviderOptions> options)
+        public AzureDevOpsTokenProvider(IOptionsMonitor<AzureDevOpsTokenProviderOptions> options)
         {
             _options = options;
         }
 
-        public AzureDevOpsTokenProviderOptions Options => _options.Value;
-
         public Task<string> GetTokenForAccount(string account)
         {
-            if (!Options.Tokens.TryGetValue(account, out string pat) || string.IsNullOrEmpty(pat))
+            var options = _options.CurrentValue;
+            if (!options.Tokens.TryGetValue(account, out string pat) || string.IsNullOrEmpty(pat))
             {
                 throw new ArgumentOutOfRangeException($"Azure DevOps account {account} does not have a configured PAT. " +
                     $"Please ensure the 'Tokens' array in the 'AzureDevOps' section of settings.json contains a PAT for {account}");

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubAppTokenProvider.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubAppTokenProvider.cs
@@ -11,16 +11,17 @@ namespace Microsoft.DotNet.GitHub.Authentication
 {
     public class GitHubAppTokenProvider : IGitHubAppTokenProvider
     {
-        private readonly IOptions<GitHubTokenProviderOptions> _options;
+        private readonly IOptionsMonitor<GitHubTokenProviderOptions> _options;
 
-        public GitHubAppTokenProvider(IOptions<GitHubTokenProviderOptions> options = null)
+        public GitHubAppTokenProvider(IOptionsMonitor<GitHubTokenProviderOptions> options = null)
         {
             _options = options;
         }
 
         public string GetAppToken()
         {
-            return GetAppToken(_options.Value.GitHubAppId, new StringPrivateKeySource(_options.Value.PrivateKey));
+            var options = _options.CurrentValue;
+            return GetAppToken(options.GitHubAppId, new StringPrivateKeySource(options.PrivateKey));
         }
 
         public string GetAppTokenFromEnvironmentVariableBase64(int gitHubAppId, string environmentVariableName)

--- a/src/Shared/Microsoft.DotNet.Kusto.Tests/KustoClientProviderTests.cs
+++ b/src/Shared/Microsoft.DotNet.Kusto.Tests/KustoClientProviderTests.cs
@@ -11,7 +11,6 @@ using FluentAssertions;
 using Kusto.Data.Common;
 using Kusto.Data.Exceptions;
 using Microsoft.DotNet.Internal.Testing.Utility;
-using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 
@@ -33,10 +32,10 @@ namespace Microsoft.DotNet.Kusto.Tests
             queryProvider.Setup(q =>
                     q.ExecuteQueryAsync(Capture.In(dbNames), Capture.In(queries), Capture.In(properties)))
                 .Returns(Task.FromResult(reader));
-
-            using (var client = new KustoClientProvider(Options.Create(new KustoClientProviderOptions
-                    {QueryConnectionString = "IGNORED-CONNECTION-STRING", Database = "TEST-DATABASE",}),
-                queryProvider.Object))
+            
+            using (var client = new KustoClientProvider(MockOptionMonitor.Create(new KustoClientProviderOptions
+                           {QueryConnectionString = "IGNORED-CONNECTION-STRING", Database = "TEST-DATABASE",}),
+                       queryProvider.Object))
             {
                 IDataReader result = await client.ExecuteKustoQueryAsync(new KustoQuery("basicQuery"));
                 reader.Should().BeSameAs(result);
@@ -59,7 +58,7 @@ namespace Microsoft.DotNet.Kusto.Tests
                     q.ExecuteQueryAsync(Capture.In(dbNames), Capture.In(queries), Capture.In(properties)))
                 .Returns(Task.FromResult(reader));
 
-            using (var client = new KustoClientProvider(Options.Create(new KustoClientProviderOptions
+            using (var client = new KustoClientProvider(MockOptionMonitor.Create(new KustoClientProviderOptions
                     {QueryConnectionString = "IGNORED-CONNECTION-STRING", Database = "TEST-DATABASE",}),
                 queryProvider.Object))
             {
@@ -86,7 +85,7 @@ namespace Microsoft.DotNet.Kusto.Tests
                     q.ExecuteQueryAsync(Capture.In(dbNames), Capture.In(queries), Capture.In(properties)))
                 .Returns(Task.FromResult(reader));
 
-            using (var client = new KustoClientProvider(Options.Create(new KustoClientProviderOptions
+            using (var client = new KustoClientProvider(MockOptionMonitor.Create(new KustoClientProviderOptions
                     {QueryConnectionString = "IGNORED-CONNECTION-STRING", Database = "TEST-DATABASE",}),
                 queryProvider.Object))
             {
@@ -128,7 +127,7 @@ namespace Microsoft.DotNet.Kusto.Tests
                     q.ExecuteQueryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ClientRequestProperties>()))
                 .Throws(new SemanticException());
 
-            using (var client = new KustoClientProvider(Options.Create(new KustoClientProviderOptions
+            using (var client = new KustoClientProvider(MockOptionMonitor.Create(new KustoClientProviderOptions
                     {QueryConnectionString = "IGNORED-CONNECTION-STRING", Database = "TEST-DATABASE",}),
                 queryProvider.Object))
             {

--- a/src/Shared/Microsoft.DotNet.Kusto.Tests/MockOptionMonitor.cs
+++ b/src/Shared/Microsoft.DotNet.Kusto.Tests/MockOptionMonitor.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Microsoft.DotNet.Kusto.Tests
+{
+    public static class MockOptionMonitor
+    {
+        public static MockOptionMonitor<TOptions> Create<TOptions>(TOptions opts) where TOptions : class, new() => new MockOptionMonitor<TOptions>(opts);
+    }
+
+    public class MockOptionMonitor<TOptions> : IOptionsMonitor<TOptions>, IOptionsSnapshot<TOptions>, IOptions<TOptions>
+        where TOptions : class, new()
+    {
+        public MockOptionMonitor(TOptions value)
+        {
+            Value = value;
+        }
+
+        TOptions IOptionsMonitor<TOptions>.Get(string name) => Value;
+
+        public IDisposable OnChange(Action<TOptions, string> listener)
+        {
+            return Mock.Of<IDisposable>();
+        }
+
+        public TOptions CurrentValue => Value;
+        public TOptions Value { get; }
+        TOptions IOptionsSnapshot<TOptions>.Get(string name) => Value;
+    }
+}


### PR DESCRIPTION
IOptions is a non-dynamic value, so when secrets rotate in long lived
services, these values remain stuck at their old values

This replaces any usage of IOptions with IOptionsMonitor
if any of the values in those options are dynamic (based in secrets).