### PR TITLE
Inherit Framework/NUnit from Directory.Build.props

### DIFF
--- a/src/Microsoft.DncEng.PatGenerator.Tests/Microsoft.DncEng.PatGenerator.Tests.csproj
+++ b/src/Microsoft.DncEng.PatGenerator.Tests/Microsoft.DncEng.PatGenerator.Tests.csproj
@@ -2,13 +2,10 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="NUnit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DncEng.PatGenerator/Microsoft.DncEng.PatGenerator.csproj
+++ b/src/Microsoft.DncEng.PatGenerator/Microsoft.DncEng.PatGenerator.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DncEng.PatGeneratorTool/Microsoft.DncEng.PatGeneratorTool.csproj
+++ b/src/Microsoft.DncEng.PatGeneratorTool/Microsoft.DncEng.PatGeneratorTool.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <SignAssembly>false</SignAssembly>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackAstool>true</PackAstool>
     <Description>Command line tool for generating Azure DevOps PATs.</Description>


### PR DESCRIPTION
The framework and test references are managed by Directory.Build.props,
let's just let them get inherited here, since they aren't being overridden
for any particular reason.