### PR TITLE
Return the AzDO build id from get-build

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxHelpers.cs
@@ -111,6 +111,7 @@ namespace Microsoft.DotNet.Darc
                 buildNumber = build.AzureDevOpsBuildNumber,
                 dateProduced = build.DateProduced.ToLocalTime().ToString("g"),
                 buildLink = GetBuildLink(build),
+                azdoBuildId = build.AzureDevOpsBuildId,
                 released = build.Released,
                 channels = build.Channels.Select(channel => channel.Name)
             });
@@ -130,6 +131,7 @@ namespace Microsoft.DotNet.Darc
             builder.AppendLine($"Build Number:  {build.AzureDevOpsBuildNumber}");
             builder.AppendLine($"Date Produced: {build.DateProduced.ToLocalTime().ToString("g")}");
             builder.AppendLine($"Build Link:    {GetBuildLink(build) ?? "N/A"}");
+            builder.AppendLine($"AzDO Build Id: {build.AzureDevOpsBuildId}");
             builder.AppendLine($"BAR Build Id:  {build.Id}");
             builder.AppendLine($"Released:      {build.Released}");
             if (build.Channels != null)


### PR DESCRIPTION
As part of anything that gets the build information from BAR, we may also want the AzDO build id, rather than having to parse it from the AzDO build link. This change updates the UxHelpers to also return the AzDO build id, in addition to everything else.

This will help push the work of https://github.com/dotnet/core-eng/issues/12374 forward, since today we would need to parse the build link to get the id, which could potentially break. Instead, we will be able to just grab the AzDO build id (all this so that our webhook won't have to directly talk to BAR itself).