### PR TITLE
Add CodeQL pipeline and make repo compliant

### DIFF
--- a/azure-pipeline-codeql.yml
+++ b/azure-pipeline-codeql.yml
@@ -92,7 +92,7 @@ stages:
 
       - pwsh: |
           . $(Build.SourcesDirectory)\eng\codeql.ps1
-          New-GdnSemmelConfig -GuardianCliLocation $(GuardianCliLocation) `
+          New-GdnSemmleConfig -GuardianCliLocation $(GuardianCliLocation) `
             -LoggerLevel 'Standard' `
             -Language 'csharp' `
             -WorkingDirectory $(Build.SourcesDirectory) `
@@ -103,7 +103,7 @@ stages:
 
       - pwsh: |
           . $(Build.SourcesDirectory)\eng\codeql.ps1
-          New-GdnSemmelConfig -GuardianCliLocation $(GuardianCliLocation) `
+          New-GdnSemmleConfig -GuardianCliLocation $(GuardianCliLocation) `
             -LoggerLevel 'Standard' `
             -Language 'javascript' `
             -WorkingDirectory $(Build.SourcesDirectory) `

--- a/azure-pipeline-codeql.yml
+++ b/azure-pipeline-codeql.yml
@@ -137,15 +137,15 @@ stages:
           Publish-GdnTsa -GuardianCliLocation $(GuardianCliLocation) `
             -WorkingDirectory $(Build.SourcesDirectory) `
             -LoggerLevel 'Standard' `
-            -TsaRepositoryName "arcade-services" `
-            -TsaCodebaseName "arcade-services" `
+            -TsaRepositoryName "Arcade-Services" `
+            -TsaCodebaseName "Arcade-Services" `
             -TsaCodebaseAdmin $(_TsaCodebaseAdmin) `
             -TsaNotificationEmail $(_TsaNotificationEmail) `
             -TsaInstanceUrl $(_TsaInstanceURL) `
             -TsaProjectName $(_TsaProjectName) `
             -TsaBugAreaPath $(_TsaBugAreaPath) `
             -TsaIterationPath $(_TsaIterationPath) `
-            -TsaPublish $false
+            -TsaPublish $true
         displayName: Publish results to TSA
 
       - pwsh: |

--- a/azure-pipeline-codeql.yml
+++ b/azure-pipeline-codeql.yml
@@ -97,7 +97,7 @@ stages:
             -Language 'csharp' `
             -WorkingDirectory $(Build.SourcesDirectory) `
             -SourceCodeDirectory $(Build.SourcesDirectory)\src `
-            -BuildCommand "$(Build.SourcesDirectory)\build.cmd -configuration Release -prepareMachine /p:Test=false /P:Sign=false" `
+            -BuildCommand "$(Build.SourcesDirectory)\build.cmd -configuration Release -prepareMachine /p:Test=false /P:Sign=false # Remove-Item -Recurse $(Build.SourcesDirectory)\src\Maestro\maestro-angular\dist" `
             -OutputPath $(Build.SourcesDirectory)\.gdn\r\semmle-csharp-configure.gdnconfig
         displayName: 'CodeQL: Create C# configuration'
 

--- a/azure-pipeline-codeql.yml
+++ b/azure-pipeline-codeql.yml
@@ -97,7 +97,7 @@ stages:
             -Language 'csharp' `
             -WorkingDirectory $(Build.SourcesDirectory) `
             -SourceCodeDirectory $(Build.SourcesDirectory)\src `
-            -BuildCommand "$(Build.SourcesDirectory)\build.cmd -configuration Release -prepareMachine /p:Test=false /P:Sign=false # Remove-Item -Recurse $(Build.SourcesDirectory)\src\Maestro\maestro-angular\dist" `
+            -BuildCommand "$(Build.SourcesDirectory)\build.cmd -configuration Release -prepareMachine /p:Test=false /P:Sign=false # rmdir /s /q $(Build.SourcesDirectory)\src\Maestro\maestro-angular\dist" `
             -OutputPath $(Build.SourcesDirectory)\.gdn\r\semmle-csharp-configure.gdnconfig
         displayName: 'CodeQL: Create C# configuration'
 

--- a/azure-pipeline-codeql.yml
+++ b/azure-pipeline-codeql.yml
@@ -1,0 +1,155 @@
+variables:
+  - name: _TeamName
+    value: DotNetCore
+  - group: SDL_Settings
+
+trigger: none
+
+schedules:
+  - cron: 0 12 * * 1
+    displayName: Weekly Monday CodeQL/Semmle run
+    branches:
+      include:
+      - main
+    always: true
+
+stages:
+- stage: CodeQL
+  displayName: CodeQL
+
+  jobs:
+    - job: CSharp
+      timeoutInMinutes: 90
+      pool: 
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+      displayName: "CodeQL Scan"
+      steps:
+
+      # Guardian requirements
+      - task: NuGetToolInstaller@1
+        displayName: 'Install NuGet.exe'
+
+      - task: NuGetAuthenticate@0
+        displayName: 'Authenticate NuGet'
+        inputs:
+          nuGetServiceConnections: GuardianConnect
+  
+      - pwsh: |
+          . $(Build.SourcesDirectory)\eng\CodeQL.ps1
+          $guardianCliLocation = Install-Gdn -Path $(Build.SourcesDirectory)\.artifacts
+          Write-Host "##vso[task.setvariable variable=GuardianCliLocation]$guardianCliLocation"
+        displayName: Install Guardian
+
+      # Project requirements
+      - task: UseDotNet@2
+        displayName: Install Correct .NET Version
+        inputs:
+          useGlobalJson: true
+
+      - task: UseDotNet@2
+        displayName: Install .NET Version 3.1
+        inputs:
+          version: 3.1.x
+
+      - task: NodeTool@0
+        displayName: 'Install Node'
+        inputs:
+          versionSpec: '12.x'
+
+      - task: NuGetCommand@2
+        displayName: Restore Packages
+        inputs:
+          command: restore
+          solution: "**/*.sln"
+          feedstoUse: config
+
+      - pwsh: eng\set-version-parameters.ps1
+        displayName: Calculate release version variables
+        
+      - pwsh: |
+          [xml]$manifest = Get-Content src\Maestro\MaestroApplication\ApplicationPackageRoot\ApplicationManifest.xml
+          $manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Policies']").RemoveAll()
+          $manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Principals']").RemoveAll()
+          $manifest.Save("src\Maestro\MaestroApplication\ApplicationPackageRoot\ApplicationManifest.xml")
+          git diff
+        displayName: Remove Service Fabric RunAsPolicy from MaestroApplication
+
+      - pwsh: |
+          [xml]$manifest = Get-Content src\Telemetry\TelemetryApplication\ApplicationPackageRoot\ApplicationManifest.xml
+          $manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Policies']").RemoveAll()
+          $manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Principals']").RemoveAll()
+          $manifest.Save("src\Telemetry\TelemetryApplication\ApplicationPackageRoot\ApplicationManifest.xml")
+          git diff
+        displayName: Remove Service Fabric RunAsPolicy from TelemetryApplication
+      
+      - pwsh: |
+          . $(Build.SourcesDirectory)\eng\codeql.ps1
+          Initialize-Gdn -GuardianCliLocation $(GuardianCliLocation) `
+            -WorkingDirectory $(Build.SourcesDirectory) `
+            -LoggerLevel 'Standard'
+        displayName: 'CodeQL: Initialize'
+
+      - pwsh: |
+          . $(Build.SourcesDirectory)\eng\codeql.ps1
+          New-GdnSemmelConfig -GuardianCliLocation $(GuardianCliLocation) `
+            -LoggerLevel 'Standard' `
+            -Language 'csharp' `
+            -WorkingDirectory $(Build.SourcesDirectory) `
+            -SourceCodeDirectory $(Build.SourcesDirectory)\src `
+            -BuildCommand "$(Build.SourcesDirectory)\build.cmd -configuration Release -prepareMachine /p:Test=false /P:Sign=false" `
+            -OutputPath $(Build.SourcesDirectory)\.gdn\r\semmle-csharp-configure.gdnconfig
+        displayName: 'CodeQL: Create C# configuration'
+
+      - pwsh: |
+          . $(Build.SourcesDirectory)\eng\codeql.ps1
+          New-GdnSemmelConfig -GuardianCliLocation $(GuardianCliLocation) `
+            -LoggerLevel 'Standard' `
+            -Language 'javascript' `
+            -WorkingDirectory $(Build.SourcesDirectory) `
+            -SourceCodeDirectory $(Build.SourcesDirectory)\src\Maestro\maestro-angular `
+            -OutputPath $(Build.SourcesDirectory)\.gdn\r\semmle-javascript-configure.gdnconfig `
+            -AdditionalSemmleParameters @("Typescript < $true")
+        displayName: 'CodeQL: Create Typescript configuration'
+
+      - pwsh: |
+          . $(Build.SourcesDirectory)\eng\codeql.ps1
+          Invoke-GdnSemmle -GuardianCliLocation $(GuardianCliLocation) `
+            -WorkingDirectory $(Build.SourcesDirectory) `
+            -ConfigurationPath $(Build.SourcesDirectory)\.gdn\r\semmle-csharp-configure.gdnconfig
+        displayName: 'CodeQL: C#'
+
+      - pwsh: |
+          . $(Build.SourcesDirectory)\eng\codeql.ps1
+          Invoke-GdnSemmle -GuardianCliLocation $(GuardianCliLocation) `
+            -WorkingDirectory $(Build.SourcesDirectory) `
+            -ConfigurationPath $(Build.SourcesDirectory)\.gdn\r\semmle-javascript-configure.gdnconfig
+        displayName: 'CodeQL: Typescript'
+
+      - pwsh: |
+          . $(Build.SourcesDirectory)\eng\codeql.ps1
+          Publish-GdnArtifacts -GuardianCliLocation $(GuardianCliLocation) `
+            -WorkingDirectory $(Build.SourcesDirectory)
+        displayName: Publish results artifact
+
+      - pwsh: |
+          . $(Build.SourcesDirectory)\eng\CodeQL.ps1
+          Publish-GdnTsa -GuardianCliLocation $(GuardianCliLocation) `
+            -WorkingDirectory $(Build.SourcesDirectory) `
+            -LoggerLevel 'Standard' `
+            -TsaRepositoryName "arcade-services" `
+            -TsaCodebaseName "arcade-services" `
+            -TsaCodebaseAdmin $(_TsaCodebaseAdmin) `
+            -TsaNotificationEmail $(_TsaNotificationEmail) `
+            -TsaInstanceUrl $(_TsaInstanceURL) `
+            -TsaProjectName $(_TsaProjectName) `
+            -TsaBugAreaPath $(_TsaBugAreaPath) `
+            -TsaIterationPath $(_TsaIterationPath) `
+            -TsaPublish $false
+        displayName: Publish results to TSA
+
+      - pwsh: |
+          . $(Build.SourcesDirectory)\eng\codeql.ps1
+          Invoke-GdnBuildBreak -GuardianCliLocation $(GuardianCliLocation) `
+            -WorkingDirectory $(Build.SourcesDirectory)
+        displayName: Break On Failures

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ stages:
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
           # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat, symweb-symbol-server-pat
-          # Publish-Build-Ass['=-ets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
+          # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
           - group: DotNet-Blob-Feed
           - group: DotNet-Symbol-Server-Pats
           - group: Publish-Build-Assets

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ stages:
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
           # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat, symweb-symbol-server-pat
-          # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
+          # Publish-Build-Ass['=-ets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
           - group: DotNet-Blob-Feed
           - group: DotNet-Symbol-Server-Pats
           - group: Publish-Build-Assets

--- a/eng/codeql.ps1
+++ b/eng/codeql.ps1
@@ -1,0 +1,195 @@
+function Install-Gdn {
+    param(
+        [string]$Path
+    )
+
+    Start-Process nuget -Verbose -ArgumentList "install", "Microsoft.Guardian.Cli", "-Source https://securitytools.pkgs.visualstudio.com/_packaging/Guardian/nuget/v3/index.json", "-OutputDirectory $Path", "-NonInteractive", "-NoCache" -NoNewWindow -Wait
+    $gdnCliPath = Get-ChildItem -Filter guardian.cmd -Recurse -Path $Path
+    return $gdnCliPath.FullName
+}
+
+function Initialize-Gdn {
+    param(
+        [Parameter(Mandatory)]
+        [string]$GuardianCliLocation,
+        [Parameter(Mandatory)]
+        [string]$WorkingDirectory,
+        [ValidateSet("Trace", "Verbose", "Standard", "Warning", "Error")]
+        [string]$LoggerLevel = "Standard"
+    )
+
+    if (!(Test-Path $GuardianCliLocation)) {
+        throw "GuardianCliLocation not found"
+    }
+
+    & $GuardianCliLocation init --working-directory $WorkingDirectory --logger-level $LoggerLevel
+}
+
+function New-GdnSemmelConfig {
+    param(
+        [Parameter(Mandatory)]
+        [string]$GuardianCliLocation,
+        
+        [Parameter(Mandatory)]
+        [string]$Language,
+
+        [Parameter(Mandatory)]
+        [string]$WorkingDirectory,
+        
+        [ValidateSet("Trace", "Verbose", "Standard", "Warning", "Error")]
+        [string]$LoggerLevel = "Standard",
+        
+        [ValidateSet("SuiteSDLRequired", "SuiteSDLRecommended")]
+        [string]$Suite = "SuiteSDLRequired",
+        
+        [string]$BuildCommand,
+        
+        [Parameter(Mandatory)]
+        [string]$SourceCodeDirectory,
+
+        [Parameter(Mandatory)]
+        [string]$OutputPath,
+
+        # Additional semmle configuration in splat form, "ParameterName < ParameterValue"
+        [string[]]$AdditionalSemmleParameters,
+
+        [switch]$Force
+    )
+    
+    if (!(Test-Path $GuardianCliLocation)) {
+        throw "GuardianCliLocation not found"
+    }
+
+    [string[]]$splatParameters = "SourceCodeDirectory < $SourceCodeDirectory", "Language < $Language"
+
+    if ($BuildCommand) {
+        $splatParameters = $splatParameters + "BuildCommands < $BuildCommand"
+    }
+
+    if ($Suite) {
+        $splatParameters = $splatParameters + "Suite < `$($Suite)"
+    }
+
+    if ($AdditionalSemmleParameters) {
+        $splatParameters = $splatParameters + $AdditionalSemmleParameters
+    }
+
+    # Surround each parameter name-value pair with quotes and separate with a comma
+    $splatParametersString = '"' + $($splatParameters -Join '" "') + '"'
+
+    if ($Force) {
+        Start-Process -Verbose -NoNewWindow -Wait $GuardianCliLocation -ArgumentList "configure", "--noninteractive", "--working-directory $WorkingDirectory", "--tool semmle", "--output-path $OutputPath", "--logger-level $LoggerLevel", "--args $splatParametersString", "-Force"
+    } else { 
+        Start-Process -Verbose -NoNewWindow -Wait $GuardianCliLocation -ArgumentList "configure", "--noninteractive", "--working-directory $WorkingDirectory", "--tool semmle", "--output-path $OutputPath", "--logger-level $LoggerLevel", "--args $splatParametersString"
+    }
+
+    Get-Content $OutputPath
+}
+
+function Invoke-GdnSemmle {
+    param(
+        [Parameter(Mandatory)]
+        [string]$GuardianCliLocation,
+        [Parameter(Mandatory)]
+        [string]$ConfigurationPath,
+        [Parameter(Mandatory)]
+        [string]$WorkingDirectory,
+        [ValidateSet("Trace", "Verbose", "Standard", "Warning", "Error")]
+        [string]$LoggerLevel = "Standard"
+    )
+
+    if (!(Test-Path $GuardianCliLocation)) {
+        throw "GuardianCliLocation not found"
+    }
+
+    & $GuardianCliLocation run --not-break-on-detections --working-directory $WorkingDirectory --logger-level $LoggerLevel --config $ConfigurationPath
+}
+
+function Publish-GdnArtifacts {
+    param(
+        [Parameter(Mandatory)]
+        [string]$GuardianCliLocation,
+        [Parameter(Mandatory)]
+        [string]$WorkingDirectory,
+        [ValidateSet("Trace", "Verbose", "Standard", "Warning", "Error")]
+        [string]$LoggerLevel = "Standard"
+    )
+
+    if (!(Test-Path $GuardianCliLocation)) {
+        throw "GuardianCliLocation not found"
+    }
+    
+    & $GuardianCliLocation publish-artifacts --working-directory $WorkingDirectory --logger-level $LoggerLevel
+}
+
+function Invoke-GdnBuildBreak {
+    param (
+        [Parameter(Mandatory)]
+        [string]$GuardianCliLocation,
+        [Parameter(Mandatory)]
+        [string]$WorkingDirectory,
+        [ValidateSet("Trace", "Verbose", "Standard", "Warning", "Error")]
+        [string]$LoggerLevel = "Standard"
+    )
+
+    if (!(Test-Path $GuardianCliLocation)) {
+        throw "GuardianCliLocation not found"
+    }
+
+    & $GuardianCliLocation break --working-directory $WorkingDirectory --logger-level $LoggerLevel
+}
+
+function Publish-GdnTsa {
+    param (
+        [Parameter(Mandatory)]
+        [string]$GuardianCliLocation,
+        [Parameter(Mandatory)]
+        [string]$WorkingDirectory,
+        [ValidateSet("Trace", "Verbose", "Standard", "Warning", "Error")]
+        [string]$LoggerLevel = 'Standard',
+        
+        [Parameter(Mandatory)]
+        [string]$TsaRepositoryName,
+        [Parameter(Mandatory)]
+        [string]$TsaCodebaseName,
+        [Parameter(Mandatory)]
+        [string]$TsaNotificationEmail,
+        [Parameter(Mandatory)]
+        [string]$TsaCodebaseAdmin,
+        [Parameter(Mandatory)]
+        # Must be known to TSA
+        [string]$TsaInstanceUrl,
+        [Parameter(Mandatory)]
+        # Must be known to TSA
+        [string]$TsaProjectName,
+        [Parameter(Mandatory)]
+        [string]$TsaBugAreaPath,
+        [Parameter(Mandatory)]
+        [string]$TsaIterationPath,
+        [bool]$OnBoard = $true,
+        [bool]$TsaPublish = $true
+    )
+
+    if (!$TsaPublish)
+    {
+        Write-Host "TsaPublish is 'false', skipping publish"
+        return
+    }
+
+    if (!(Test-Path $GuardianCliLocation)) {
+        throw "GuardianCliLocation not found"
+    }
+
+    & $guardianCliLocation tsa-publish --all-tools `
+        --working-directory $workingDirectory `
+        --logger-level $LoggerLevel `
+        --repository-name "$TsaRepositoryName" `
+        --codebase-name "$TsaCodebaseName" `
+        --notification-alias "$TsaNotificationEmail" `
+        --codebase-admin "$TsaCodebaseAdmin" `
+        --instance-url "$TsaInstanceUrl" `
+        --project-name "$TsaProjectName" `
+        --area-path "$TsaBugAreaPath" `
+        --iteration-path "$TsaIterationPath" `
+        --onboard $OnBoard
+}

--- a/eng/codeql.ps1
+++ b/eng/codeql.ps1
@@ -25,7 +25,7 @@ function Initialize-Gdn {
     & $GuardianCliLocation init --working-directory $WorkingDirectory --logger-level $LoggerLevel
 }
 
-function New-GdnSemmelConfig {
+function New-GdnSemmleConfig {
     param(
         [Parameter(Mandatory)]
         [string]$GuardianCliLocation,

--- a/eng/local-codeql.ps1
+++ b/eng/local-codeql.ps1
@@ -1,0 +1,46 @@
+$loggerLevel = 'Standard'
+
+Set-Location $(Join-Path $PSScriptRoot "..")
+
+Write-Host $pwd
+
+. $(Join-Path $pwd "eng\codeql.ps1")
+
+$GdnCliPath = Install-Gdn -Path $(Join-Path $pwd "artifacts")
+
+if (!$(Test-Path $GdnCliPath)) {
+    throw "Unable to find Guardian CLI"
+}
+
+Write-Host "Guardian CLI is at $($GdnCliPath)"
+
+Initialize-Gdn `
+    -GuardianCliLocation $GdnCliPath `
+    -WorkingDirectory $pwd `
+    -LoggerLevel $loggerLevel
+
+New-GdnSemmelConfig -GuardianCliLocation $GdnCliPath `
+    -LoggerLevel 'Standard' `
+    -Language 'csharp' `
+    -WorkingDirectory $pwd `
+    -SourceCodeDirectory $pwd\src `
+    -OutputPath $(Join-Path $pwd ".gdn\r\semmle-csharp-configure.gdnconfig") `
+    -Suite "SuiteSDLRecommended" `
+    -BuildCommand "..\build.cmd -configuration Release"
+
+.\eng\set-version-parameters.ps1
+
+[xml]$manifest = Get-Content src\Maestro\MaestroApplication\ApplicationPackageRoot\ApplicationManifest.xml
+$manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Policies']").RemoveAll()
+$manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Principals']").RemoveAll()
+$manifest.Save("src\Maestro\MaestroApplication\ApplicationPackageRoot\ApplicationManifest.xml")
+
+[xml]$manifest = Get-Content src\Telemetry\TelemetryApplication\ApplicationPackageRoot\ApplicationManifest.xml
+$manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Policies']").RemoveAll()
+$manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Principals']").RemoveAll()
+$manifest.Save("src\Telemetry\TelemetryApplication\ApplicationPackageRoot\ApplicationManifest.xml")
+
+
+Invoke-GdnSemmle -GuardianCliLocation $GdnCliPath `
+    -WorkingDirectory $pwd `
+    -ConfigurationPath $(Join-Path $pwd ".gdn\r\semmle-csharp-configure.gdnconfig")

--- a/eng/local-codeql.ps1
+++ b/eng/local-codeql.ps1
@@ -19,7 +19,7 @@ Initialize-Gdn `
     -WorkingDirectory $pwd `
     -LoggerLevel $loggerLevel
 
-New-GdnSemmelConfig -GuardianCliLocation $GdnCliPath `
+New-GdnSemmleConfig -GuardianCliLocation $GdnCliPath `
     -LoggerLevel 'Standard' `
     -Language 'csharp' `
     -WorkingDirectory $pwd `

--- a/src/DotNet.Status.Web/Controllers/DeploymentController.cs
+++ b/src/DotNet.Status.Web/Controllers/DeploymentController.cs
@@ -58,7 +58,7 @@ namespace DotNet.Status.Web.Controllers
             };
             
             NewGrafanaAnnotationResponse annotation;
-            using (var client = new HttpClient())
+            using (var client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true }))
             {
                 annotation = await _retry.RetryAsync(async () =>
                     {
@@ -121,7 +121,7 @@ namespace DotNet.Status.Web.Controllers
                 TimeEnd = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             };
 
-            using (var client = new HttpClient())
+            using (var client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true }))
             {
                 await _retry.RetryAsync(async () =>
                     {

--- a/src/DotNet.Status.Web/ZenHubClient.cs
+++ b/src/DotNet.Status.Web/ZenHubClient.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -32,7 +32,7 @@ namespace DotNet.Status.Web
                 _logger.LogWarning("No ZenHub API token configured, skipping");
             }
 
-            using (var client = new HttpClient())
+            using (var client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true }))
             {
                 client.DefaultRequestHeaders.Add("X-Authentication-Token", apiToken);
                 string epicUpdateUri = $"https://api.zenhub.com/p1/repositories/{epic.RepositoryId}/epics/{epic.IssueId}/update_issues";

--- a/src/Maestro/FeedCleanerService/FeedCleanerService.cs
+++ b/src/Maestro/FeedCleanerService/FeedCleanerService.cs
@@ -38,7 +38,7 @@ namespace FeedCleanerService
         {
             Logger = logger;
             Context = context;
-            _httpClient = new HttpClient();
+            _httpClient = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true });
             _options = options;
             AzureDevOpsClients = new Dictionary<string, IAzureDevOpsClient>();
             foreach (string account in _options.Value.AzdoAccounts)

--- a/src/Maestro/Maestro.Web/Pages/Account/AccountController.cs
+++ b/src/Maestro/Maestro.Web/Pages/Account/AccountController.cs
@@ -67,7 +67,7 @@ namespace Maestro.Web.Pages.Account
             }
 
             SignInResult signInResult =
-                await SignInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, true);
+                await SignInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, true); // lgtm [cs/user-controlled-bypass] Safe in this context, failure will block user from sign-in
             if (signInResult.Succeeded)
             {
                 return RedirectToLocal(returnUrl);

--- a/src/Maestro/Maestro.Web/Pages/Index.cshtml
+++ b/src/Maestro/Maestro.Web/Pages/Index.cshtml
@@ -83,7 +83,7 @@
     <script type="text/javascript">
         window.applicationData = {
           brand: '@Html.Raw(ViewBag.Brand)',
-          userName: '@Html.Raw(HttpUtility.JavaScriptStringEncode(await GetUserNameAsync()))',
+          userName: '@Html.Raw(HttpUtility.JavaScriptStringEncode(await GetUserNameAsync()))', // lgtm [cs/inappropriate-encoding]
           authorized: @Html.Raw((await Authorization.AuthorizeAsync(HttpContext.User, Startup.MsftAuthorizationPolicyName)).Succeeded.ToString().ToLower()),
           themes: [
             @foreach (var theme in Model.Themes)

--- a/src/Maestro/Maestro.Web/Pages/Index.cshtml
+++ b/src/Maestro/Maestro.Web/Pages/Index.cshtml
@@ -83,7 +83,7 @@
     <script type="text/javascript">
         window.applicationData = {
           brand: '@Html.Raw(ViewBag.Brand)',
-          userName: '@Html.Raw(HttpUtility.JavaScriptStringEncode(await GetUserNameAsync()))', // lgtm [cs/inappropriate-encoding]
+          userName: '@Html.Raw(HttpUtility.JavaScriptStringEncode(await GetUserNameAsync()))', // lgtm [cs/inappropriate-encoding] Generating javascript object
           authorized: @Html.Raw((await Authorization.AuthorizeAsync(HttpContext.User, Startup.MsftAuthorizationPolicyName)).Succeeded.ToString().ToLower()),
           themes: [
             @foreach (var theme in Model.Themes)

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/popIncoherencies.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/popIncoherencies.component.html
@@ -3,7 +3,7 @@
     <li>{{summary.dependencyName}}
       <ul>
         <ng-container *ngFor="let detail of summary.incoherencies">
-          <li><a target="_blank" href="{{ detail.repository }}/commit/{{ detail.commit }}">{{ detail.version }} <fa-icon icon="external-link-alt"></fa-icon></a></li>
+          <li><a target="_blank" rel="noopener" href="{{ detail.repository }}/commit/{{ detail.commit }}">{{ detail.version }} <fa-icon icon="external-link-alt"></fa-icon></a></li>
         </ng-container>
       </ul>
     </li>

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/popIncoherencies.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/popIncoherencies.component.html
@@ -3,7 +3,7 @@
     <li>{{summary.dependencyName}}
       <ul>
         <ng-container *ngFor="let detail of summary.incoherencies">
-          <li><a target="_blank" href="{{ detail.repository }}/commit/{{ detail.commit }}">{{ detail.version }} <fa-icon icon="external-link-alt"></fa-icon></a></li>
+          <li><a target="_blank" href="{{ detail.repository }}/commit/{{ detail.commit }}">{{ detail.version }} <fa-icon icon="external-link-alt"></fa-icon></a></li> <!-- lgtm[js/unsafe-external-link] Temporarily add this to test inline code exclusion -->
         </ng-container>
       </ul>
     </li>

--- a/src/Maestro/maestro-angular/src/app/page/build-graph-table/popIncoherencies.component.html
+++ b/src/Maestro/maestro-angular/src/app/page/build-graph-table/popIncoherencies.component.html
@@ -3,7 +3,7 @@
     <li>{{summary.dependencyName}}
       <ul>
         <ng-container *ngFor="let detail of summary.incoherencies">
-          <li><a target="_blank" href="{{ detail.repository }}/commit/{{ detail.commit }}">{{ detail.version }} <fa-icon icon="external-link-alt"></fa-icon></a></li> <!-- lgtm[js/unsafe-external-link] Temporarily add this to test inline code exclusion -->
+          <li><a target="_blank" href="{{ detail.repository }}/commit/{{ detail.commit }}">{{ detail.version }} <fa-icon icon="external-link-alt"></fa-icon></a></li>
         </ng-container>
       </ul>
     </li>

--- a/src/Microsoft.DncEng.PatGenerator/AzureDevOpsPATGenerator.cs
+++ b/src/Microsoft.DncEng.PatGenerator/AzureDevOpsPATGenerator.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DncEng.PatGenerator
             try
             {
                 using var connection = new VssConnection(new Uri(OAuth2Endpoint), credentials);
-                using var client = new HttpClient(connection.InnerHandler);
+                using var client = new HttpClient(connection.InnerHandler); // lgtm [cs/httpclient-checkcertrevlist-disabled] dependant on client library behavior
                 using var response = await client.GetAsync($"{OAuth2Endpoint}/_apis/accounts");
                 availableOrganizations = await JsonSerializer.DeserializeAsync<List<AzureDevOpsOrganizationModel>>(await response.Content.ReadAsStreamAsync());
             }

--- a/src/Microsoft.DncEng.SecretManager/OneTimePasswordGenerator.cs
+++ b/src/Microsoft.DncEng.SecretManager/OneTimePasswordGenerator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DncEng.SecretManager
             byte[] timestampBy30sBytes = BitConverter.GetBytes(timestamp.ToUnixTimeSeconds() / 30);
             Array.Reverse((Array)timestampBy30sBytes);
             byte[] hash;
-            using (HMACSHA1 hmacsha1 = new HMACSHA1(_seed))
+            using (HMACSHA1 hmacsha1 = new HMACSHA1(_seed)) // lgtm [cs/weak-hmacs] Algorithm specified by OTP standard
                 hash = hmacsha1.ComputeHash(timestampBy30sBytes);
             Array.Reverse((Array)hash);
             int num = (int)hash[0] & 15;

--- a/src/Microsoft.DncEng.SecretManager/SecretTypes/SqlServerConnectionString.cs
+++ b/src/Microsoft.DncEng.SecretManager/SecretTypes/SqlServerConnectionString.cs
@@ -69,11 +69,11 @@ namespace Microsoft.DncEng.SecretManager.SecretTypes
             switch (currentUserIndex)
             {
                 case "1":
-                    nextUserId = context.SecretName + "-2";
+                    nextUserId = context.SecretName + "-2"; // lgtm [cs/hardcoded-credentials] Value decorates name intentionally and checked elsewhere
                     nextUserIndex = 2;
                     break;
                 case "2":
-                    nextUserId = context.SecretName + "-1";
+                    nextUserId = context.SecretName + "-1"; // lgtm [cs/hardcoded-credentials] Value decorates name intentionally and checked elsewhere
                     nextUserIndex = 1;
                     break;
                 default:

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/RemoteRepoBase.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns></returns>
         protected void Clone(string repoUri, string commit, string targetDirectory, ILogger logger, string pat, string gitDirectory)
         {
-            string dotnetMaestro = "dotnet-maestro";
+            string dotnetMaestro = "dotnet-maestro"; // lgtm [cs/hardcoded-credentials] Value is correct for this service
             LibGit2Sharp.CloneOptions cloneOptions = new LibGit2Sharp.CloneOptions
             {
                 Checkout = false,

--- a/src/Monitoring/Sdk/GrafanaClient.cs
+++ b/src/Monitoring/Sdk/GrafanaClient.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Monitoring.Sdk
         public GrafanaClient(string baseUrl, string apiToken)
         {
             _baseUrl = baseUrl;
-            _client = new HttpClient();
+            _client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true });
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiToken);
         }
 

--- a/src/RolloutScorer/RolloutScorer/RolloutScorer.cs
+++ b/src/RolloutScorer/RolloutScorer/RolloutScorer.cs
@@ -38,7 +38,7 @@ namespace RolloutScorer
         public List<ScorecardBuildBreakdown> BuildBreakdowns { get; set; } = new List<ScorecardBuildBreakdown>();
 
         // The AzDO API has some 302s in it that break auth so we have to handle those ourselves
-        private readonly HttpClient _httpClient = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+        private readonly HttpClient _httpClient = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false, CheckCertificateRevocationList = true });
         private GitHubClient _githubClient;
 
         public ILogger Log { get; set; }

--- a/src/Shared/Microsoft.DotNet.Internal.Health.Tests/MockHandler.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.Health.Tests/MockHandler.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Internal.Health.Tests
 
         public HttpClient CreateClient(string name)
         {
-            return new HttpClient(CreateHandler(name));
+            return new HttpClient(CreateHandler(name)); // lgtm [cs/httpclient-checkcertrevlist-disabled] Used only for unit testing
         }
 
         public HttpMessageHandler CreateHandler(string name)

--- a/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/MockHttpClientFactory.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/MockHttpClientFactory.cs
@@ -145,7 +145,7 @@ namespace Microsoft.DotNet.Internal.Testing.Utility
 
         public HttpClient CreateClient(string name)
         {
-            return new HttpClient(new Handler(_cannedResponses, _unexpectedRequests));
+            return new HttpClient(new Handler(_cannedResponses, _unexpectedRequests)); // lgtm [cs/httpclient-checkcertrevlist-disabled] Used in unit testing
         }
 
         public void VerifyAll()

--- a/src/Shared/Microsoft.DotNet.Web.Authentication.Tests/PersonalAccessTokenAuthenticationTests.cs
+++ b/src/Shared/Microsoft.DotNet.Web.Authentication.Tests/PersonalAccessTokenAuthenticationTests.cs
@@ -390,7 +390,7 @@ namespace Microsoft.DotNet.Web.Authentication.Tests
 
         public static string CalculateHash(TestUser user, string password)
         {
-            return $":HASH:{user.Name}:{password}";
+            return $":HASH:{user.Name}:{password}"; // lgtm [cs/hardcoded-credentials] Part of unit tests
         }
 
         public PasswordVerificationResult VerifyHashedPassword(

--- a/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
+++ b/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Internal.AzureDevOps
         {
             _baseUrl = baseUrl;
             _organization = organization;
-            _httpClient = new HttpClient();
+            _httpClient = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true });
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _parallelism = new SemaphoreSlim(maxParallelRequests, maxParallelRequests);
 


### PR DESCRIPTION
This adds a CodeQL pipeline scheduled for a weekly analysis. This also makes changes to resolve existing errors.

New pipeline is [arcade-services-codeql](https://dev.azure.com/dnceng/internal/_build?definitionId=1084). Latest green build (from the head of this PR) is build [1627220](https://dev.azure.com/dnceng/internal/_build/results?buildId=1627220&view=results).

Resolves dotnet/core-eng#15329.