### PR TITLE
Correct resilience problems with our ServiceHost core

### DIFF
--- a/src/Maestro/CoreHealthMonitor/CoreHealthMonitor.cs
+++ b/src/Maestro/CoreHealthMonitor/CoreHealthMonitor.cs
@@ -90,7 +90,7 @@ namespace CoreHealthMonitor
         private async Task UploadMemoryDumpsAsync(CancellationToken cancellationToken)
         {
             string folder = Registry.GetValue(
-                @"HKKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps",
+                @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps",
                 "DumpFolder",
                 null
             ) as string;

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Actors/DelegatedActor.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Actors/DelegatedActor.cs
@@ -296,6 +296,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost.Actors
 
         protected override async Task RunAsync(CancellationToken cancellationToken)
         {
+            await Lifecycle.OnStartingAsync(Container);
             var logger = Container.GetRequiredService<ILogger<DelegatedActor>>();
             try
             {
@@ -313,6 +314,10 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost.Actors
             {
                 logger.LogCritical(e, "Unhandled exception crashing actor execution");
                 throw;
+            }
+            finally
+            {
+                await Lifecycle.OnStoppingAsync(Container);
             }
         }
 

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/AppInsightsFlushLifecycle.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/AppInsightsFlushLifecycle.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ApplicationInsights.Channel;
+
+namespace Microsoft.DotNet.ServiceFabric.ServiceHost
+{
+    public class AppInsightsFlushLifecycle : Lifecycle
+    {
+        private readonly ITelemetryChannel _channel;
+
+        public AppInsightsFlushLifecycle(ITelemetryChannel channel)
+        {
+            _channel = channel;
+        }
+
+        public override void OnStopping()
+        {
+            _channel.Flush();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedService.cs
@@ -60,7 +60,10 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                             );
                             break;
                         }
+                        // The first await was just to get the task that was no longer running
+                        // now we need to await it to get it's exception/result
                         await completed;
+                        logger.LogWarning("During cancellation, abnormal service exit without cancellation");
                     }
                     catch (OperationCanceledException e2) when (e2.CancellationToken == linkedToken.Token)
                     {
@@ -96,6 +99,9 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                             break;
                         }
                         await completed;
+                        // The first await was just to get the task that was no longer running
+                        // now we need to await it to get it's exception/result
+                        logger.LogWarning("During unhandled exception, abnormal service exit without cancellation");
                     }
                     catch (OperationCanceledException e2) when (e2.CancellationToken == linkedToken.Token)
                     {

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedService.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.ServiceFabric.ServiceHost
+{
+    public static class DelegatedService
+    {
+        public static async Task RunServiceLoops<T>(IServiceProvider services, CancellationToken cancellationToken, params Func<CancellationToken, Task>[] loops)
+        {
+            using var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            await Lifecycle.OnStartingAsync(services);
+            var logger = services.GetRequiredService<ILogger<T>>();
+            List<Task> pendingTasks = new List<Task>();
+            try
+            {
+                await using var _ =
+                    cancellationToken.Register(() => logger.LogInformation("Service abort cancellation requested"));
+                logger.LogInformation("Entering service 'RunAsync'");
+                pendingTasks = loops.Select(l => l(linkedToken.Token)).ToList();
+                var finished = await Task.WhenAny(pendingTasks);
+                pendingTasks.Remove(finished);
+                await finished;
+                logger.LogWarning("Abnormal service exit without cancellation");
+            }
+            catch (OperationCanceledException e) when (e.CancellationToken == linkedToken.Token)
+            {
+                // ONE of the tasks cancelled, but we need to wait for the others
+                var killTimer = Task.Delay(TimeSpan.FromSeconds(15));
+                pendingTasks.Add(killTimer);
+                // While there is more than the kill timer waiting to be completed
+                while (pendingTasks.Count > 1)
+                {
+                    try
+                    {
+                        var completed = await Task.WhenAny(pendingTasks);
+                        if (completed == killTimer)
+                        {
+                            // Times up...
+                            logger.LogCritical(
+                                "When cancelling, other loops did not exit in 15 seconds, abandoning"
+                            );
+                            break;
+                        }
+                    }
+                    catch (OperationCanceledException e2) when (e2.CancellationToken == linkedToken.Token)
+                    {
+                        // Other guy cancelled normally, goodness, move on
+                    }
+                    catch (Exception e2)
+                    {
+                        logger.LogCritical(e2, "During cancellation exit, a loop threw an unhandled exception");
+                    }
+                }
+
+                logger.LogInformation("Normal service shutdown complete");
+            }
+            catch (Exception e)
+            {
+                // ONE of the tasks crashed, we need to stop the other, if we can
+                linkedToken.Cancel();
+                var killTimer = Task.Delay(TimeSpan.FromSeconds(15));
+                pendingTasks.Add(killTimer);
+                // While there is more than the kill timer waiting to be completed
+                while (pendingTasks.Count > 1)
+                {
+                    try
+                    {
+                        var completed = await Task.WhenAny(pendingTasks);
+                        if (completed == killTimer)
+                        {
+                            // Times up...
+                            logger.LogCritical(
+                                "When exiting because of unhandled exception, other loops did not exit in 15 seconds, abandoning"
+                            );
+                            break;
+                        }
+                    }
+                    catch (OperationCanceledException e2) when (e2.CancellationToken == linkedToken.Token)
+                    {
+                        // Other guy cancelled normally, goodness, move on
+                    }
+                    catch (Exception e2)
+                    {
+                        logger.LogCritical(e2, "During crash exit, another loop threw an unhandled exception");
+                    }
+                }
+
+                logger.LogCritical(e, "Unhandled exception crashing service execution");
+                throw;
+            }
+            finally
+            {
+                await Lifecycle.OnStoppingAsync(services);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedService.cs
@@ -98,9 +98,9 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                             );
                             break;
                         }
-                        await completed;
                         // The first await was just to get the task that was no longer running
                         // now we need to await it to get it's exception/result
+                        await completed;
                         logger.LogWarning("During unhandled exception, abnormal service exit without cancellation");
                     }
                     catch (OperationCanceledException e2) when (e2.CancellationToken == linkedToken.Token)

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedService.cs
@@ -51,6 +51,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                     try
                     {
                         var completed = await Task.WhenAny(pendingTasks);
+                        pendingTasks.Remove(completed);
                         if (completed == killTimer)
                         {
                             // Times up...
@@ -59,6 +60,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                             );
                             break;
                         }
+                        await completed;
                     }
                     catch (OperationCanceledException e2) when (e2.CancellationToken == linkedToken.Token)
                     {
@@ -84,6 +86,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                     try
                     {
                         var completed = await Task.WhenAny(pendingTasks);
+                        pendingTasks.Remove(completed);
                         if (completed == killTimer)
                         {
                             // Times up...
@@ -92,6 +95,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                             );
                             break;
                         }
+                        await completed;
                     }
                     catch (OperationCanceledException e2) when (e2.CancellationToken == linkedToken.Token)
                     {

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatelessService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatelessService.cs
@@ -72,25 +72,12 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
 
         protected override async Task RunAsync(CancellationToken cancellationToken)
         {
-            var logger = _container.GetRequiredService<ILogger<DelegatedStatefulService<TServiceImplementation>>>();
-            try
-            {
-                await using var _ =
-                    cancellationToken.Register(() => logger.LogInformation("Service abort cancellation requested"));
-                logger.LogInformation("Entering service 'RunAsync'");
-                await Task.WhenAll(RunSchedule(cancellationToken),
-                    RunAsyncLoop(cancellationToken));
-                logger.LogWarning("Abnormal service exit without cancellation");
-            }
-            catch (OperationCanceledException e) when (e.CancellationToken == cancellationToken)
-            {
-                logger.LogInformation("Service shutdown complete");
-            }
-            catch (Exception e)
-            {
-                logger.LogCritical(e, "Unhandled exception crashing service execution");
-                throw;
-            }
+            await DelegatedService.RunServiceLoops<DelegatedStatelessService<TServiceImplementation>>(
+                _container,
+                cancellationToken,
+                RunAsyncLoop,
+                RunSchedule
+            );
         }
 
         private async Task RunAsyncLoop(CancellationToken cancellationToken)

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Lifecycle.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Lifecycle.cs
@@ -45,8 +45,8 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
             var lifecycles = services.GetServices<Lifecycle>();
             if (lifecycles != null)
             {
-                IEnumerable<Lifecycle> lifecycleLIst = lifecycles.ToList();
-                foreach (var lifecycle in lifecycleLIst)
+                IEnumerable<Lifecycle> lifecycleList = lifecycles.ToList();
+                foreach (var lifecycle in lifecycleList)
                 {
                     try
                     {
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                 }
                 try
                 {
-                    await Task.WhenAll(lifecycleLIst.Select(l => l.OnStoppingAsync()));
+                    await Task.WhenAll(lifecycleList.Select(l => l.OnStoppingAsync()));
                 }
                 catch (Exception e)
                 {

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Lifecycle.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/Lifecycle.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.ServiceFabric.ServiceHost
+{
+    public abstract class Lifecycle
+    {
+        public virtual void OnStarting()
+        {
+        }
+
+        public virtual Task OnStartingAsync() => Task.CompletedTask;
+
+        public virtual void OnStopping()
+        {
+        }
+
+        public virtual Task OnStoppingAsync() => Task.CompletedTask;
+
+        public static async Task OnStartingAsync(IServiceProvider services)
+        {
+            var lifecycles = services.GetServices<Lifecycle>();
+            if (lifecycles != null)
+            {
+                IEnumerable<Lifecycle> lifecyleArray = lifecycles.ToList();
+                await Task.WhenAll(lifecyleArray.Select(l => l.OnStartingAsync()));
+                foreach (var lifecycle in lifecyleArray)
+                {
+                    lifecycle.OnStarting();
+                }
+            }
+        }
+
+        public static async Task OnStoppingAsync(IServiceProvider services)
+        {
+            var lifecycles = services.GetServices<Lifecycle>();
+            if (lifecycles != null)
+            {
+                IEnumerable<Lifecycle> lifecycleLIst = lifecycles.ToList();
+                foreach (var lifecycle in lifecycleLIst)
+                {
+                    try
+                    {
+                        lifecycle.OnStopping();
+                    }
+                    catch (Exception e)
+                    {
+                        // It's important that if we are stopping that we not crash other cleanup operations
+                        // However, it's a bit too late to log, so Console and hope
+                        Console.WriteLine($"EXCEPTION IN LIFECYCLE.ONSTOPPING: {e}");
+                    }
+                }
+                try
+                {
+                    await Task.WhenAll(lifecycleLIst.Select(l => l.OnStoppingAsync()));
+                }
+                catch (Exception e)
+                {
+                    // It's important that if we are stopping that we not crash other cleanup operations
+                    // However, it's a bit too late to log, so Console and hope
+                    Console.WriteLine($"EXCEPTION IN LIFECYCLE.ONSTOPPINGASYNC: {e}");
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ScheduledService/ScheduledService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ScheduledService/ScheduledService.cs
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Exception processing scheduled method {scheduledMethod}", method.ToString());
+                    _logger.LogCritical(ex, "Exception processing scheduled method {scheduledMethod}", method.ToString());
                 }
             }
         }

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
@@ -262,6 +262,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                     b.AddAzureTable((o, p) => o.WriteSasUri = p.GetRequiredService<IConfiguration>()["HealthTableUri"]);
                 });
             services.AddSingleton<ISystemClock, SystemClock>();
+            services.AddSingleton<Lifecycle, AppInsightsFlushLifecycle>();
         }
 
         private static void EnableCertificateRevocationCheck(HttpMessageHandlerBuilder builder)


### PR DESCRIPTION
* Unhandled exceptions in RunAsync zombie the process
  (because RunScheduleAsync never exits, so WhenAll never returns)
* Unhandled exception in RunAsync are never logged, for the same reason
* Exceptions close to process exist are never logged anyway
  (because ServerTelemetryChannel doesn't flush on Dispose)