### PR TITLE
Fix the formatting for the year value

### DIFF
--- a/src/Maestro/CoreHealthMonitor/CoreHealthMonitor.cs
+++ b/src/Maestro/CoreHealthMonitor/CoreHealthMonitor.cs
@@ -131,7 +131,7 @@ namespace CoreHealthMonitor
                 foreach (string file in Directory.GetFiles(folder))
                 {
                     string blobName =
-                        $"{_context.NodeContext.NodeName}/{_clock.UtcNow:YYYY-MM-ddTHH-mm-ss}-{Path.GetFileName(file)}";
+                        $"{_context.NodeContext.NodeName}/{_clock.UtcNow:yyyy-MM-ddTHH-mm-ss}-{Path.GetFileName(file)}";
                     _logger.LogError(
                         "Found crash dump at '{crashDumpPath}', uploading to '{blobName}'",
                         file,


### PR DESCRIPTION
Files are being uploaded being named like this: 
<img width="156" alt="image" src="https://user-images.githubusercontent.com/47990216/158417971-e4f79f1c-bc91-4855-bcf6-094fe547b4a0.png">

This PR fixes the year value to be the year instead of YYYY. 