### PR TITLE
Organize and filter dumps

### DIFF
--- a/src/Maestro/CoreHealthMonitor/.config/settings.json
+++ b/src/Maestro/CoreHealthMonitor/.config/settings.json
@@ -4,6 +4,9 @@
     "MinimumFreeSpaceBytes": 10000000000
   },
   "MemoryDump": {
-    "ContainerUri": "[vault(maestro-memory-dumps-container-sas-uri)]"
+    "ContainerUri": "[vault(maestro-memory-dumps-container-sas-uri)]",
+    "IgnoreDumpPatterns": [
+      "MsSense\\.exe"
+    ]
   }
 }

--- a/src/Maestro/CoreHealthMonitor/CoreHealthMonitor.cs
+++ b/src/Maestro/CoreHealthMonitor/CoreHealthMonitor.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Fabric;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
@@ -130,9 +132,15 @@ namespace CoreHealthMonitor
             {
                 foreach (string file in Directory.GetFiles(folder))
                 {
+                    string fileName = Path.GetFileName(file);
+                    if (IsIgnoredFile(fileName))
+                    {
+                        continue;
+                    }
+
                     DateTimeOffset now = _clock.UtcNow;
                     string blobName =
-                        $"{_context.NodeContext.NodeName}/{now:yyyy-MM}/{now:dd}/{now:yyyy-MM-ddTHH-mm-ss}-{Path.GetFileName(file)}";
+                        $"{_context.NodeContext.NodeName}/{now:yyyy-MM}/{now:dd}/{now:yyyy-MM-ddTHH-mm-ss}-{fileName}";
                     _logger.LogError(
                         "Found crash dump at '{crashDumpPath}', uploading to '{blobName}'",
                         file,
@@ -158,6 +166,17 @@ namespace CoreHealthMonitor
                     }
                 }
             }
+        }
+
+        private bool IsIgnoredFile(string fileName)
+        {
+            string[] patterns = _memoryDumpOptions.CurrentValue.IgnoreDumpPatterns;
+            if (patterns == null)
+            {
+                return false;
+            }
+
+            return patterns.Any(pattern => Regex.IsMatch(fileName, pattern, RegexOptions.IgnoreCase));
         }
     }
 }

--- a/src/Maestro/CoreHealthMonitor/CoreHealthMonitor.cs
+++ b/src/Maestro/CoreHealthMonitor/CoreHealthMonitor.cs
@@ -130,8 +130,9 @@ namespace CoreHealthMonitor
             {
                 foreach (string file in Directory.GetFiles(folder))
                 {
+                    DateTimeOffset now = _clock.UtcNow;
                     string blobName =
-                        $"{_context.NodeContext.NodeName}/{_clock.UtcNow:yyyy-MM-ddTHH-mm-ss}-{Path.GetFileName(file)}";
+                        $"{_context.NodeContext.NodeName}/{now:yyyy-MM}/{now:dd}/{now:yyyy-MM-ddTHH-mm-ss}-{Path.GetFileName(file)}";
                     _logger.LogError(
                         "Found crash dump at '{crashDumpPath}', uploading to '{blobName}'",
                         file,

--- a/src/Maestro/CoreHealthMonitor/MemoryDumpOptions.cs
+++ b/src/Maestro/CoreHealthMonitor/MemoryDumpOptions.cs
@@ -4,8 +4,9 @@
 
 namespace CoreHealthMonitor
 {
-    public class DriveMonitorOptions
+    public class MemoryDumpOptions
     {
-        public long MinimumFreeSpaceBytes { get; set; }
+        public string ContainerUri { get; set; }
+        public string[] IgnoreDumpPatterns { get; set; }
     }
 }


### PR DESCRIPTION
Put dumps in Month/Day folders for easy delete/browsing

Also allow filtering of the dumps (to ignore, for example, the hundreds of MsSense crashes)