### PR TITLE
Make sure the MappedConfig thing logs

### DIFF
--- a/src/DotNet.Status.Web/Program.cs
+++ b/src/DotNet.Status.Web/Program.cs
@@ -27,7 +27,7 @@ namespace DotNet.Status.Web
                 .ConfigureAppConfiguration((host, config) =>
                 {
                     config
-                        .AddDefaultJsonConfiguration(host.HostingEnvironment)
+                        .AddDefaultJsonConfiguration(host.HostingEnvironment, serviceProvider: null)
                         .AddUserSecrets(Assembly.GetEntryAssembly())
                         .AddEnvironmentVariables()
                         .AddCommandLine(args);

--- a/src/Microsoft.DncEng.Configuration.Extensions/MappedJsonConfigurationProvider.cs
+++ b/src/Microsoft.DncEng.Configuration.Extensions/MappedJsonConfigurationProvider.cs
@@ -3,7 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Configuration.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DncEng.Configuration.Extensions
 {
@@ -11,12 +14,18 @@ namespace Microsoft.DncEng.Configuration.Extensions
     {
         private readonly Func<string, string> _mapFunc;
         private readonly Timer _timer;
+        private readonly TelemetryClient _telemetry;
         private IDictionary<string, string> _rawData = new Dictionary<string, string>();
 
-        public MappedJsonConfigurationProvider(MappedJsonConfigurationSource source, TimeSpan reloadTime, Func<string, string> mapFunc) : base(source)
+        public MappedJsonConfigurationProvider(
+            MappedJsonConfigurationSource source,
+            TimeSpan reloadTime,
+            Func<string, string> mapFunc,
+            IServiceProvider serviceProvider) : base(source)
         {
             _mapFunc = mapFunc;
             _timer = new Timer(Reload, null, reloadTime, reloadTime);
+            _telemetry = serviceProvider.GetService<TelemetryClient>();
         }
 
         public override void Load(Stream stream)
@@ -33,8 +42,21 @@ namespace Microsoft.DncEng.Configuration.Extensions
 
         private void Reload(object? state)
         {
-            MapData();
-            OnReload();
+            try
+            {
+                MapData();
+                OnReload();
+            }
+            catch (Exception e)
+            {
+                // This exception, because it's in a System.Threading.Timer
+                // is going to crash the process, if we are reporting to AppInsights, let's send it to the channel
+                // and flush it, so that it gets recorded somewhere
+                _telemetry?.TrackException(e);
+                _telemetry?.Flush();
+                // Then rethrow it... resume destroying the process
+                throw;
+            }
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Microsoft.DncEng.Configuration.Extensions/MappedJsonConfigurationProvider.cs
+++ b/src/Microsoft.DncEng.Configuration.Extensions/MappedJsonConfigurationProvider.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DncEng.Configuration.Extensions
 {
@@ -52,7 +51,7 @@ namespace Microsoft.DncEng.Configuration.Extensions
                 // This exception, because it's in a System.Threading.Timer
                 // is going to crash the process, if we are reporting to AppInsights, let's send it to the channel
                 // and flush it, so that it gets recorded somewhere
-                var telemetry = _serviceProvider.GetService<TelemetryClient>();
+                var telemetry = _serviceProvider?.GetService<TelemetryClient>();
                 if (telemetry != null)
                 {
                     telemetry.TrackException(e);

--- a/src/Microsoft.DncEng.Configuration.Extensions/MappedJsonConfigurationSource.cs
+++ b/src/Microsoft.DncEng.Configuration.Extensions/MappedJsonConfigurationSource.cs
@@ -8,17 +8,22 @@ namespace Microsoft.DncEng.Configuration.Extensions
     {
         private readonly TimeSpan _reloadTime;
         private readonly Func<string, string> _mapFunc;
+        private readonly IServiceProvider _serviceProvider;
 
-        public MappedJsonConfigurationSource(TimeSpan reloadTime, Func<string, string> mapFunc)
+        public MappedJsonConfigurationSource(
+            TimeSpan reloadTime,
+            Func<string, string> mapFunc,
+            IServiceProvider serviceProvider)
         {
             _reloadTime = reloadTime;
             _mapFunc = mapFunc;
+            _serviceProvider = serviceProvider;
         }
 
         public override IConfigurationProvider Build(IConfigurationBuilder builder)
         {
             EnsureDefaults(builder);
-            return new MappedJsonConfigurationProvider(this, _reloadTime, _mapFunc);
+            return new MappedJsonConfigurationProvider(this, _reloadTime, _mapFunc, _serviceProvider);
         }
     }
 }

--- a/src/Microsoft.DncEng.DeployServiceFabricCluster/ClusterDeployer.cs
+++ b/src/Microsoft.DncEng.DeployServiceFabricCluster/ClusterDeployer.cs
@@ -165,7 +165,7 @@ namespace Microsoft.DncEng.DeployServiceFabricCluster
             ICollection<IGenericResource> unexpectedResources,
             IResourceManager resourceManager,
             ServiceFabricNodeType nodeType,
-            ILoadBalancer? lb,
+            ILoadBalancer lb,
             string backendAddressPool,
             ISubnet subnet,
             string clusterEndpoint,

--- a/src/Microsoft.DncEng.DeployServiceFabricCluster/GatewaySettings.cs
+++ b/src/Microsoft.DncEng.DeployServiceFabricCluster/GatewaySettings.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DncEng.DeployServiceFabricCluster
 {
     public class GatewaySettings : ResourceGroupDeployerSettings
     {
-        public Dictionary<string, string>? NeededSecurityGroupRules
+        public Dictionary<string, string> NeededSecurityGroupRules
         {
             get
             {

--- a/src/Microsoft.DncEng.DeployServiceFabricCluster/Microsoft.DncEng.DeployServiceFabricCluster.csproj
+++ b/src/Microsoft.DncEng.DeployServiceFabricCluster/Microsoft.DncEng.DeployServiceFabricCluster.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <SignAssembly>false</SignAssembly>
-    <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>deploy-sf</ToolCommandName>

--- a/src/Microsoft.DncEng.DeployServiceFabricCluster/Program.cs
+++ b/src/Microsoft.DncEng.DeployServiceFabricCluster/Program.cs
@@ -52,6 +52,7 @@ namespace Microsoft.DncEng.DeployServiceFabricCluster
                 IConfigurationRoot configuration = new ConfigurationBuilder()
                     .SetBasePath(Path.GetDirectoryName(configFile))
                     .AddDefaultJsonConfiguration(new HostEnvironment(environment, configDir!),
+                        serviceProvider: null,
                         configFileName + "{0}" + configExtension)
                     .Build();
 

--- a/src/Microsoft.DncEng.DeployServiceFabricCluster/Program.cs
+++ b/src/Microsoft.DncEng.DeployServiceFabricCluster/Program.cs
@@ -20,9 +20,9 @@ namespace Microsoft.DncEng.DeployServiceFabricCluster
         {
             try
             {
-                string? configFile = null;
-                string? environment = null;
-                string? deploy = null;
+                string configFile = null;
+                string environment = null;
+                string deploy = null;
                 var options = new OptionSet
                 {
                     {"c|config=", c => configFile = c},
@@ -45,9 +45,9 @@ namespace Microsoft.DncEng.DeployServiceFabricCluster
                     Fatal(3, $"config file '{configFile}' does not exist.");
                 }
 
-                string? configFileName = Path.GetFileNameWithoutExtension(configFile);
-                string? configExtension = Path.GetExtension(configFile);
-                string? configDir = Path.GetDirectoryName(configFile);
+                string configFileName = Path.GetFileNameWithoutExtension(configFile);
+                string configExtension = Path.GetExtension(configFile);
+                string configDir = Path.GetDirectoryName(configFile);
 
                 IConfigurationRoot configuration = new ConfigurationBuilder()
                     .SetBasePath(Path.GetDirectoryName(configFile))
@@ -104,7 +104,7 @@ namespace Microsoft.DncEng.DeployServiceFabricCluster
             Console.WriteLine(result);
         }
 
-        private static void RequireParameter([NotNull] string? parameter, string name)
+        private static void RequireParameter([NotNull] string parameter, string name)
         {
             if (string.IsNullOrEmpty(parameter))
             {

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHostWebSite.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHostWebSite.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                 .UseContentRoot(AppContext.BaseDirectory)
                 .ConfigureAppConfiguration((context, builder) =>
                 {
-                    builder.AddDefaultJsonConfiguration(context.HostingEnvironment);
+                    builder.AddDefaultJsonConfiguration(context.HostingEnvironment, serviceProvider: null);
                 })
                 .ConfigureServices(ServiceHost.ConfigureDefaultServices)
                 .ConfigureServices(services =>
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                 {
                     hostBuilder.ConfigureAppConfiguration((context, builder) =>
                     {
-                        builder.AddDefaultJsonConfiguration(context.HostingEnvironment);
+                        builder.AddDefaultJsonConfiguration(context.HostingEnvironment, serviceProvider: null);
                     });
                 }));
         }


### PR DESCRIPTION
Since it's using System.Threading.Timer, any exception
in the callback terminates the process from a background thread,
avoiding ALL other logging.

As such, we need to log this as well.  If we need this sort of thing in more places,
we might need some sort of "ITerminalExceptionReporter" or something.