### PR TITLE
Fix darc on mac M1 (arm64) architecture

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -24,7 +24,7 @@
     <PackageReference Update="GitHubJwt" Version="0.0.2" />
     <PackageReference Update="Humanizer.Core" Version="2.4.2" />
     <PackageReference Update="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
-    <PackageReference Update="LibGit2Sharp" Version="0.27.0-preview-0024" />
+    <PackageReference Update="LibGit2Sharp" Version="0.27.0-preview-0175" />
     <PackageReference Update="Microsoft.ApplicationInsights" Version="2.18.0" />
     <PackageReference Update="Microsoft.ApplicationInsights.AspNetCore" Version="2.18.0" />
     <PackageReference Update="Microsoft.ApplicationInsights.DependencyCollector" Version="2.18.0" />

--- a/src/Maestro/Maestro.Contracts/Maestro.Contracts.csproj
+++ b/src/Maestro/Maestro.Contracts/Maestro.Contracts.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <Description>Maestro Contracts</Description>
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change fixes the errors we were seeing on M1 hardware by removing the runtimeIdentifier and updating the version of LibGit2Sharp to the latest preview.

Fixes https://github.com/dotnet/core-eng/issues/15536