### PR TITLE
Move all pipelines for arcade-services to NetCore1ES hosted pools

### DIFF
--- a/azure-pipeline-codeql.yml
+++ b/azure-pipeline-codeql.yml
@@ -22,7 +22,7 @@ stages:
       timeoutInMinutes: 90
       pool: 
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals 1es-windows-2019
       displayName: "CodeQL Scan"
       steps:
 

--- a/azure-pipeline-weekly.yml
+++ b/azure-pipeline-weekly.yml
@@ -19,8 +19,9 @@ stages:
   - stage: SynchronizeSecrets
     jobs:
     - job: Synchronize
-      pool:
-        vmImage: windows-2019
+      pool: 
+        name: NetCore1ESPool-Internal-NoMSI
+        demands: ImageOverride -equals 1es-windows-2019
       steps:
       - task: UseDotNet@2
         displayName: Install Correct .NET Version
@@ -48,8 +49,9 @@ stages:
     dependsOn:
     jobs:
     - job: Build
-      pool:
-        vmImage: windows-2019
+      pool: 
+        name: NetCore1ESPool-Internal-NoMSI
+        demands: ImageOverride -equals 1es-windows-2019
       steps:
       - download: arcadeServicesInternalCI
         artifact: MaestroApplication

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,12 @@ stages:
       - job: Windows_NT
         timeoutInMinutes: 90
         pool:
-          vmImage: windows-2019
+          ${{ if eq(variables['System.TeamProject'], 'internal')}}:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals 1es-windows-2019
+          ${{ if eq(variables['System.TeamProject'], 'public')}}:
+            name: NetCore1ESPool-Public          
+            demands: ImageOverride -equals 1es-windows-2019-open
 
         variables:
         - _InternalBuildArgs: ''

--- a/grafana-setup.yml
+++ b/grafana-setup.yml
@@ -22,8 +22,9 @@ stages:
 - stage: SynchronizeSecrets
   jobs:
   - job: Synchronize
-    pool:
-      vmImage: windows-2019
+    pool: 
+      name: NetCore1ESPool-Internal-NoMSI
+      demands: ImageOverride -equals 1es-windows-2019
     steps:
     - task: UseDotNet@2
       displayName: Install Correct .NET Version
@@ -64,8 +65,9 @@ stages:
       jobs:
       - job: Windows_NT
         timeoutInMinutes: 90
-        pool:
-          vmImage: windows-2019
+        pool: 
+          name: NetCore1ESPool-Internal-NoMSI
+          demands: ImageOverride -equals 1es-windows-2019
 
         steps:
         - checkout: self


### PR DESCRIPTION
Somehow we thought we'd done this, I noticed it in today's rollouts.