### PR TITLE
Move more pipelines to 1ES Hosted Pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,14 +36,6 @@ stages:
       enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
       enableTelemetry: true
       helixRepo: dotnet/arcade-services
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'internal')}}:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals 1es-windows-2019
-        ${{ if eq(variables['System.TeamProject'], 'public')}}:
-          name: NetCore1ESPool-Public          
-          demands: ImageOverride -equals 1es-windows-2019-open
-      
       jobs:
       - job: Windows_NT
         timeoutInMinutes: 90

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,14 @@ stages:
       enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
       enableTelemetry: true
       helixRepo: dotnet/arcade-services
+      pool:
+        ${{ if eq(variables['System.TeamProject'], 'internal')}}:
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals 1es-windows-2019
+        ${{ if eq(variables['System.TeamProject'], 'public')}}:
+          name: NetCore1ESPool-Public          
+          demands: ImageOverride -equals 1es-windows-2019-open
+      
       jobs:
       - job: Windows_NT
         timeoutInMinutes: 90

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -27,8 +27,9 @@ jobs:
       value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOPipelineId'] ]
     - name: AzDOBuildId
       value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
-  pool:
-    vmImage: windows-2019
+  pool: 
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals 1es-windows-2019
   steps:
   - checkout: self
     clean: true

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -71,8 +71,9 @@ jobs:
             - ${{ job.job }}
         - ${{ if eq(parameters.runSourceBuild, true) }}:
           - Source_Build_Complete
-        pool:
-          vmImage: windows-2019
+        pool: 
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals 1es-windows-2019
         runAsPublic: ${{ parameters.runAsPublic }}
         publishUsingPipelines: ${{ parameters.enablePublishUsingPipelines }}
         enablePublishBuildArtifacts: ${{ parameters.enablePublishBuildArtifacts }}
@@ -84,5 +85,6 @@ jobs:
         includeToolset: ${{ parameters.graphFileGeneration.includeToolset }}
         dependsOn:
           - Asset_Registry_Publish
-        pool:
-          vmImage: windows-2019
+        pool: 
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals 1es-windows-2019

--- a/eng/common/templates/post-build/channels/generic-internal-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-internal-channel.yml
@@ -38,7 +38,8 @@ stages:
       - name: AzDOBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
     pool:
-      vmImage: 'windows-2019'
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals 1es-windows-2019
     steps:
       # This is necessary whenever we want to publish/restore to an AzDO private feed
       - task: NuGetAuthenticate@0
@@ -107,7 +108,8 @@ stages:
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
     condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.TargetChannels'], format('[{0}]', ${{ parameters.channelId }} ))
     pool:
-      vmImage: 'windows-2019'
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals 1es-windows-2019
     steps:
       - task: DownloadBuildArtifacts@0
         displayName: Download Build Assets

--- a/eng/common/templates/post-build/channels/generic-public-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-public-channel.yml
@@ -40,7 +40,8 @@ stages:
       - name: AzDOBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
     pool:
-      vmImage: 'windows-2019'
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals 1es-windows-2019
     steps:
       - task: DownloadBuildArtifacts@0
         displayName: Download Build Assets
@@ -106,7 +107,8 @@ stages:
         value: ${{ coalesce(variables._DotNetArtifactsCategory, '.NETCore') }}
     condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.TargetChannels'], format('[{0}]', ${{ parameters.channelId }} ))
     pool:
-      vmImage: 'windows-2019'
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals 1es-windows-2019
     steps:
       - task: DownloadBuildArtifacts@0
         displayName: Download Build Assets

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -59,7 +59,8 @@ stages:
       - name: TargetChannels
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.TargetChannels'] ]
     pool:
-      vmImage: 'windows-2019'
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals 1es-windows-2019
     steps:
       - task: PowerShell@2
         displayName: Maestro Channels Consistency
@@ -73,7 +74,8 @@ stages:
     dependsOn: setupMaestroVars
     condition: eq( ${{ parameters.enableNugetValidation }}, 'true')
     pool:
-      vmImage: 'windows-2019'
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals 1es-windows-2019
     variables:
       - name: AzDOProjectName
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOProjectName'] ]
@@ -112,7 +114,8 @@ stages:
       - name: AzDOBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
     pool:
-      vmImage: 'windows-2019'
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals 1es-windows-2019
     steps:
       - ${{ if eq(parameters.useBuildManifest, true) }}:
         - task: DownloadBuildArtifacts@0
@@ -175,7 +178,8 @@ stages:
       - name: AzDOBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
     pool:
-      vmImage: 'windows-2019'
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals 1es-windows-2019
     steps:
       - task: DownloadBuildArtifacts@0
         displayName: Download Blob Artifacts

--- a/eng/common/templates/post-build/setup-maestro-vars.yml
+++ b/eng/common/templates/post-build/setup-maestro-vars.yml
@@ -8,7 +8,8 @@ jobs:
   variables:
     - template: common-variables.yml
   pool:
-    vmImage: 'windows-2019'
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals 1es-windows-2019
   steps:
     - checkout: none
 

--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -24,8 +24,9 @@ stages:
   - build
   jobs:
   - job: ValidateSecrets
-    pool:
-      vmImage: windows-2019
+    pool: 
+      name: NetCore1ESPool-Internal-NoMSI
+      demands: ImageOverride -equals 1es-windows-2019
     steps:
     - task: UseDotNet@2
       displayName: Install Correct .NET Version
@@ -50,8 +51,7 @@ stages:
           Get-ChildItem .vault-config/*.yaml |% { dotnet run -p src/Microsoft.DncEng.SecretManager -- synchronize --verify-only $_}
 
 - stage: approval
-  pool:
-    vmImage: windows-latest
+  pool: server
   dependsOn:
   - build
   - Validate
@@ -60,16 +60,10 @@ stages:
   - deployment: approval
     displayName: deployment approval (conditional)
     environment: ${{ parameters.DeploymentEnvironment }}
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-          - download: none
 
 - stage: predeploy
   displayName: Pre-Deployment
-  pool:
-    vmImage: windows-2019
+  pool: server
   dependsOn:
   - build
   - Validate
@@ -90,7 +84,8 @@ stages:
 - stage: deploy
   displayName: Deploy
   pool:
-    vmImage: windows-2019
+    name: NetCore1ESPool-Internal-NoMSI
+    demands: ImageOverride -equals 1es-windows-2019
   dependsOn:
   - predeploy
   - approval
@@ -140,6 +135,9 @@ stages:
     displayName: Deploy maestro service fabric application
     dependsOn:
     - updateDatabase
+    pool:
+      name: NetCore1ESPool-Internal-NoMSI
+      demands: ImageOverride -equals 1es-windows-2019
     steps:
     - download: current
       artifact: MaestroApplication
@@ -172,6 +170,9 @@ stages:
 
   - job: deployTelemetry
     displayName: Deploy telemetry service fabric application
+    pool:
+      name: NetCore1ESPool-Internal-NoMSI
+      demands: ImageOverride -equals 1es-windows-2019    
     dependsOn:
     steps:
     - download: current
@@ -205,6 +206,9 @@ stages:
 
   - job: deployStatus
     displayName: Deploy dotnet-status web app
+    pool:
+      name: NetCore1ESPool-Internal-NoMSI
+      demands: ImageOverride -equals 1es-windows-2019
     dependsOn:
     steps:
     - download: current
@@ -225,6 +229,9 @@ stages:
 
   - job: deployRolloutScorer
     displayName: Deploy rollout scorer azure function
+    pool:
+      name: NetCore1ESPool-Internal-NoMSI
+      demands: ImageOverride -equals 1es-windows-2019
     dependsOn:
     steps:
     - download: current
@@ -253,7 +260,8 @@ stages:
 - stage: postdeploy
   displayName: Post-Deployment
   pool:
-    vmImage: windows-2019
+    name: NetCore1ESPool-Internal-NoMSI
+    demands: ImageOverride -equals 1es-windows-2019
   dependsOn:
   - deploy
   condition: always()
@@ -293,7 +301,8 @@ stages:
 - stage: validateDeployment
   displayName: Validate deployment
   pool:
-    vmImage: windows-2019
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals 1es-windows-2019
   dependsOn:
   - deploy
   variables:

--- a/eng/pre-deploy-tests.yaml
+++ b/eng/pre-deploy-tests.yaml
@@ -7,13 +7,15 @@ stages:
 - stage: ${{ parameters.stageName }}
   displayName: Pre-Deployment Validation
   pool:
-    vmImage: windows-2019
+    name: NetCore1ESPool-Internal-NoMSI
+    demands: ImageOverride -equals 1es-windows-2019
   dependsOn:
   - Build
   jobs:
   - job: Validate_Existing_Services
     pool:
-      vmImage: windows-2019
+      name: NetCore1ESPool-Internal-NoMSI
+      demands: ImageOverride -equals 1es-windows-2019
     steps:
     - download: current
       artifact: ValidationScripts


### PR DESCRIPTION
Continuation of previous PR; eng/common was littered with hosted pool info, but since updating arcade/3.x is much riskier, just update the eng/common folder of this repo to pick up proper images.