### PR TITLE
Don't swallow the cancellation exception

### DIFF
--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost.Tests/DelegatedServiceTest.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost.Tests/DelegatedServiceTest.cs
@@ -1,0 +1,243 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Specialized;
+using Microsoft.DotNet.Internal.Testing.DependencyInjection.Abstractions;
+using Microsoft.DotNet.Internal.Testing.Utility;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+
+namespace Microsoft.DotNet.ServiceFabric.ServiceHost.Tests
+{
+    [Serializable]
+    public class TestThrowableException : Exception
+    {
+        public TestThrowableException()
+        {
+        }
+
+        public TestThrowableException(string message)
+            : base(message)
+        {
+        }
+
+        public TestThrowableException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        protected TestThrowableException(
+            SerializationInfo info,
+            StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+
+    public partial class DelegatedServiceTest
+    {
+        [TestDependencyInjectionSetup]
+        private static class TestDataConfig
+        {
+            public static Func<IServiceProvider, CancellationTokenSource> CancellationToken(IServiceCollection collection)
+            {
+                CancellationTokenSource source = new CancellationTokenSource();
+                return _ => source;
+            }
+
+            public static Func<IServiceProvider, IServiceProvider> ServiceProvider(IServiceCollection collection) =>
+                s => s;
+
+            public static Func<IServiceProvider, CountingLogger> Logger(IServiceCollection collection)
+            {
+                CountingLogger logger = new CountingLogger();
+                collection.AddLogging(
+                    l => l.AddProvider(logger));
+                return _ => logger;
+            }
+
+            public static Func<IServiceProvider, Dictionary<string, int>> Counter(IServiceCollection collection)
+            {
+                Dictionary<string, int> counter = new Dictionary<string, int>();
+                return _ => counter;
+            }
+        }
+
+        [Test]
+        public async Task SingleCancellationExitsAsExpected()
+        {
+            TestData testData = await TestData.Default.BuildAsync();
+            Task task = Run(testData, WaitLoop);
+            testData.CancellationToken.Cancel();
+            Func<Task> callback = () => task;
+            (await callback.Should().ThrowAsync<OperationCanceledException>())
+                .Where(e => e.CancellationToken == testData.CancellationToken.Token, "cancellation token should match");
+        }
+
+        [Test]
+        public async Task AbnormalExitIsWarned()
+        {
+            TestData testData = await TestData.Default.BuildAsync();
+            Task task = Run(testData, ExitsWithoutWaitingLoop);
+            Func<Task> callback = () => task;
+            await callback.Should().CompleteWithinAsync(TimeSpan.FromSeconds(1));
+            testData.Logger.Warning.Should().Be(1);
+        }
+
+        [Test]
+        public async Task ExceptionExitIsLogged()
+        {
+            TestData testData = await TestData.Default.BuildAsync();
+            Task task = Run(testData, ThrowsTestException);
+            Func<Task> callback = () => task;
+            await callback.Should().ThrowAsync<TestThrowableException>();
+            testData.Logger.Exception.Should().Be(1);
+        }
+
+        [Test]
+        public async Task MultipleCancellationExitsAsExpected()
+        {
+            TestData testData = await TestData.Default.BuildAsync();
+            Task task = Run(testData, WaitLoop, WaitLoop);
+            testData.CancellationToken.Cancel();
+            Func<Task> callback = () => task;
+            (await callback.Should().ThrowAsync<OperationCanceledException>())
+                .Where(e => e.CancellationToken == testData.CancellationToken.Token, "cancellation token should match");
+            AssertionExtensions.Should(testData.Counter).ContainKey(nameof(WaitLoop))
+                .WhichValue.Should().Be(2, "both loops should have executed");
+            testData.Logger.Error.Should().Be(0);
+            testData.Logger.Warning.Should().Be(0);
+        }
+
+        [Test]
+        public async Task WaitDelaysUntilCancellation()
+        {
+            TestData testData = await TestData.Default.BuildAsync();
+            Task task = Run(testData, WaitLoop);
+            Func<Task> callback = () => task;
+            await callback.Should().NotCompleteWithinAsync(TimeSpan.FromSeconds(1));
+            testData.CancellationToken.Cancel();
+            (await callback.Should().ThrowAsync<OperationCanceledException>())
+                .Where(e => e.CancellationToken == testData.CancellationToken.Token, "cancellation token should match");
+            testData.Logger.Error.Should().Be(0);
+            testData.Logger.Warning.Should().Be(0);
+        }
+        
+        [Test]
+        public async Task AbnormalExitCausesCancellation()
+        {
+            TestData testData = await TestData.Default.BuildAsync();
+            Task task = Run(testData, ExitsWithoutWaitingLoop, WaitLoop);
+            Func<Task> callback = () => task;
+            await callback.Should().CompleteWithinAsync(TimeSpan.FromSeconds(1), because: "First task exiting should cancel the others");
+            testData.Logger.Warning.Should().Be(1);
+        }
+        
+        [Test]
+        public async Task ThrowExceptionCausesCancellation()
+        {
+            TestData testData = await TestData.Default.BuildAsync();
+            Task task = Run(testData, ThrowsTestException, WaitLoop);
+            Func<Task> callback = () => task;
+            await callback.Should().ThrowAsync<TestThrowableException>();
+            testData.Logger.Exception.Should().Be(1);
+        }
+        
+        [Test]
+        public async Task DoubleThrowLogsBoth()
+        {
+            TestData testData = await TestData.Default.BuildAsync();
+            Task task = Run(testData, ThrowsTestException, ThrowsTestException);
+            Func<Task> callback = () => task;
+            await callback.Should().ThrowAsync<TestThrowableException>();
+            testData.Logger.Exception.Should().Be(2);
+        }
+
+        private static Task Run(TestData testData, params Func<TestData, CancellationToken, Task>[] loops)
+        {
+            return DelegatedService.RunServiceLoops<DelegatedServiceTest>(
+                testData.ServiceProvider,
+                testData.CancellationToken.Token,
+                loops.Select(loop => (Func<CancellationToken, Task>)(t => loop(testData, t))).ToArray()
+            );
+        }
+
+        private static Task ExitsWithoutWaitingLoop(TestData testData, CancellationToken ignored)
+        {
+            CountCall(testData);
+            return Task.CompletedTask;
+        }
+
+        private static Task ThrowsTestException(TestData testData, CancellationToken ignored)
+        {
+            CountCall(testData);
+            return Task.FromException(new TestThrowableException("TEST-EXCEPTION"));
+        }
+
+        private static Task WaitLoop(TestData testData, CancellationToken token)
+        {
+            CountCall(testData);
+            return token.AsTask();
+        }
+
+        private static void CountCall(TestData data, [CallerMemberName] string key = "Unknown")
+        {
+            var count = data.Counter;
+            lock (count)
+            {
+                if (count.TryGetValue(key, out var value))
+                {
+                    count[key] = value + 1;
+                }
+                else
+                {
+                    count.Add(key, 1);
+                }
+            }
+        }
+    }
+    
+    public static class NotCompleteGenericAsyncTaskAssertion
+    {
+        public static async Task<AndConstraint<AsyncFunctionAssertions>> NotCompleteWithinAsync(
+            this NonGenericAsyncFunctionAssertions parentConstraint,
+            TimeSpan timeSpan,
+            string because = "",
+            params object[] becauseArgs)
+        {
+            Execute.Assertion.ForCondition(parentConstraint.Subject != null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected {context:task} to complete within {0}{reason}, but found <null>.",
+                    new object[1]
+                        { timeSpan }
+                );
+            using var timeoutCancellationTokenSource = new CancellationTokenSource();
+            Task task = parentConstraint.Subject();
+            Task completedTask = await Task.WhenAny(task, Task.Delay(timeSpan, timeoutCancellationTokenSource.Token)).ConfigureAwait(false);
+            if (completedTask == task)
+            {
+                timeoutCancellationTokenSource.Cancel();
+                await completedTask.ConfigureAwait(false);
+            }
+            Execute.Assertion.ForCondition(completedTask != task).BecauseOf(because, becauseArgs).FailWith("Expected {context:task} not to complete within {0}{reason}.", new object[1]
+            {
+                timeSpan
+            });
+            var andConstraint = new AndConstraint<AsyncFunctionAssertions>(parentConstraint);
+            return andConstraint;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost.Tests/Microsoft.DotNet.ServiceFabric.ServiceHost.Tests.csproj
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost.Tests/Microsoft.DotNet.ServiceFabric.ServiceHost.Tests.csproj
@@ -10,5 +10,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Maestro\ServiceFabricMocks\ServiceFabricMocks.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.ServiceFabric.ServiceHost\Microsoft.DotNet.ServiceFabric.ServiceHost.csproj" />
+    <ProjectReference Include="..\Shared\Microsoft.DotNet.Internal.Testing.DependencyInjection.Abstractions\Microsoft.DotNet.Internal.Testing.DependencyInjection.Abstractions.csproj" />
+    <ProjectReference Include="..\Shared\Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen\Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Shared\Microsoft.DotNet.Internal.Testing.Utility\Microsoft.DotNet.Internal.Testing.Utility.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedService.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                 await finished;
                 logger.LogWarning("Abnormal service exit without cancellation");
             }
-            catch (OperationCanceledException e) when (e.CancellationToken == linkedToken.Token)
+            catch (OperationCanceledException) when (serviceFabricShutdownToken.IsCancellationRequested)
             {
                 // ONE of the tasks cancelled, but we need to wait for the others
                 var killTimer = Task.Delay(TimeSpan.FromSeconds(15));
@@ -76,6 +76,8 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                 }
 
                 logger.LogInformation("Normal service shutdown complete");
+                // This should rethrow and exit back to SF
+                serviceFabricShutdownToken.ThrowIfCancellationRequested();
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ScheduledService/ScheduledService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ScheduledService/ScheduledService.cs
@@ -147,14 +147,12 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                 await scheduler.Start(cancellationToken);
                 await cancellationToken.AsTask();
             }
-            catch (OperationCanceledException)
+            finally
             {
-                //ignore
-            }
-
-            if (scheduler != null)
-            {
-                await scheduler.Shutdown(true, CancellationToken.None);
+                if (scheduler != null)
+                {
+                    await scheduler.Shutdown(true, CancellationToken.None);
+                }
             }
         }
     }

--- a/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/CountingLogger.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/CountingLogger.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Internal.Testing.Utility
+{
+    public class CountingLogger : ILoggerProvider, ILoggerFactory, ILogger
+    {
+        public int Verbose = 0;
+        public int Information = 0;
+        public int Warning = 0;
+        public int Error = 0;
+        public int Exception = 0;
+        public string CurrentOperation = null;
+        public int OperationChanges = 0;
+
+        private sealed class SetCurrent : IDisposable
+        {
+            private readonly CountingLogger _logger;
+            private string _opName;
+
+            public SetCurrent(CountingLogger logger)
+            {
+                _opName = logger.CurrentOperation;
+                _logger = logger;
+            }
+
+            public void Dispose()
+            {
+                _logger.CurrentOperation = _opName;
+            }
+        }
+
+        public void Dispose()
+        {
+        }
+
+        ILogger ILoggerProvider.CreateLogger(string categoryName)
+        {
+            return this;
+        }
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+            if (provider != this)
+                throw new ArgumentException();
+        }
+
+        ILogger ILoggerFactory.CreateLogger(string categoryName)
+        {
+            return this;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (exception != null)
+            {
+                Exception++;
+                return;
+            }
+
+            switch (logLevel)
+            {
+                case LogLevel.Trace:
+                case LogLevel.Debug:
+                case LogLevel.None:
+                    break;
+                case LogLevel.Information:
+                    Information++;
+                    break;
+                case LogLevel.Warning:
+                    Warning++;
+                    break;
+                case LogLevel.Error:
+                case LogLevel.Critical:
+                    Error++;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, null);
+            }
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            var startOperation = new SetCurrent(this);
+            CurrentOperation = state.ToString();
+            OperationChanges++;
+            return startOperation;
+        }
+    }
+
+    public class CountingLogger<T> : ILogger<T>
+    {
+        private readonly CountingLogger _generic;
+
+        public CountingLogger(
+            CountingLogger generic)
+        {
+            _generic = generic;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception exception,
+            Func<TState, Exception, string> formatter)
+        {
+            _generic.Log(logLevel, eventId, state, exception, formatter);
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return _generic.IsEnabled(logLevel);
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return _generic.BeginScope(state);
+        }
+    }
+}


### PR DESCRIPTION
Also, test these behaviors

NOTE: This will be a breaking change to helix, because I pulled "CountingLogger" down into arcade-services, so there will be a conflict, and we'll want to delete the type from Helix and use the shared one.