### PR TITLE
Add extra logging around GitHub API calls

### DIFF
--- a/src/Maestro/DependencyUpdateErrorProcessor/DependencyUpdateErrorProcessor.cs
+++ b/src/Maestro/DependencyUpdateErrorProcessor/DependencyUpdateErrorProcessor.cs
@@ -123,7 +123,7 @@ namespace DependencyUpdateErrorProcessor
 
             if (!unprocessedHistoryEntries.Any())
             {
-                _logger.LogInformation($"No errors found in the 'RepositoryBranchUpdates' or 'SubscriptionUpdates' tables. The last checkpoint time was : '{checkPoint}'");
+                _logger.LogInformation("No errors found in the 'RepositoryBranchUpdates' or 'SubscriptionUpdates' tables. The last checkpoint time was : '{CheckPoint}'", checkPoint);
                 return;
             }
             foreach (var error in unprocessedHistoryEntries)
@@ -143,11 +143,11 @@ namespace DependencyUpdateErrorProcessor
                 }
                 catch (TimeoutException exe)
                 {
-                    _logger.LogError(exe, $"Unable to update the last processed error timestamp : '{error.Timestamp}");
+                    _logger.LogError(exe, "Unable to update the last processed error timestamp : '{Timestamp}", error.Timestamp);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, $"Unable to create a github issue for error message : '{error.ErrorMessage}' for {GetPrintableDescription(error)}");
+                    _logger.LogError(ex, "Unable to create a github issue for error message : '{ErrorMessage}' for {PrintableDescription}", error.ErrorMessage, GetPrintableDescription(error));
                 }
             }
         }
@@ -178,7 +178,7 @@ namespace DependencyUpdateErrorProcessor
             {
                 case RepositoryBranchUpdateHistoryEntry repoBranchUpdateHistoryError:
                     {
-                        _logger.LogInformation($"Error Message : '{repoBranchUpdateHistoryError.ErrorMessage}' in repository :  '{repoBranchUpdateHistoryError.Repository}'");
+                        _logger.LogInformation("Error Message : '{ErrorMessage}' in repository :  '{Repository}'", repoBranchUpdateHistoryError.ErrorMessage, repoBranchUpdateHistoryError.Repository);
 
                         IReliableDictionary<(string repository, string branch), int> gitHubIssueEvaluator =
                             await _stateManager.GetOrAddAsync<IReliableDictionary<(string repository, string branch), int>>("gitHubIssueEvaluator");
@@ -194,7 +194,7 @@ namespace DependencyUpdateErrorProcessor
 
                         if (issueNumber.HasValue)
                         {
-                            _logger.LogInformation($"Found a matching issue for {repoBranchUpdateHistoryError.Repository}:{repoBranchUpdateHistoryError.Branch}. Issue number: {issueNumber.Value}");
+                            _logger.LogInformation("Found a matching issue for {Repository}:{Branch}. Issue number: {Value}", repoBranchUpdateHistoryError.Repository, repoBranchUpdateHistoryError.Branch, issueNumber.Value);
                             issue = await client.Issue.Get(repo.Id, issueNumber.Value);
                             // check if the issue is open only then update it else create a new issue and update the dictionary.
                             if (issue.State.Equals("Open"))
@@ -203,10 +203,10 @@ namespace DependencyUpdateErrorProcessor
                                 break;
                             }
 
-                            _logger.LogInformation($"Matching issue {issueNumber.Value} for {repoBranchUpdateHistoryError.Repository}:{repoBranchUpdateHistoryError.Branch} was closed. Creating a new issue.");
+                            _logger.LogInformation("Matching issue {IssueNumber} for {Repository}:{Branch} was closed. Creating a new issue.", issueNumber.Value, repoBranchUpdateHistoryError.Repository, repoBranchUpdateHistoryError.Branch);
                         }
                         // Create a new issue for the error if the issue is already closed or the issue does not exist.
-                        _logger.LogInformation($@"Creating a new gitHub issue for dependency Update Error, for the error message : '{repoBranchUpdateHistoryError.ErrorMessage} for the repository : '{repoBranchUpdateHistoryError.Repository}'");
+                        _logger.LogInformation("Creating a new gitHub issue for dependency Update Error, for the error message : '{ErrorMessage} for the repository : '{Repository}'", repoBranchUpdateHistoryError.ErrorMessage, repoBranchUpdateHistoryError.Repository);
                         await CreateDependencyUpdateErrorIssueAsync(
                             client,
                             repoBranchUpdateHistoryError,
@@ -219,7 +219,7 @@ namespace DependencyUpdateErrorProcessor
 
                 case SubscriptionUpdateHistoryEntry subscriptionUpdateHistoryError:
                     {
-                        _logger.LogInformation($"Error Message : '{subscriptionUpdateHistoryError.ErrorMessage}' in subscription :  '{subscriptionUpdateHistoryError.SubscriptionId}'");
+                        _logger.LogInformation("Error Message : '{ErrorMessage}' in subscription :  '{SubscriptionId}'", subscriptionUpdateHistoryError.ErrorMessage, subscriptionUpdateHistoryError.SubscriptionId);
 
                         IReliableDictionary<Guid, int> gitHubIssueEvaluator =
                             await _stateManager.GetOrAddAsync<IReliableDictionary<Guid, int>>("gitHubSubscriptionIssueEvaluator");
@@ -233,7 +233,7 @@ namespace DependencyUpdateErrorProcessor
                         }
                         if (issueNumber.HasValue)
                         {
-                            _logger.LogInformation($"Found a matching issue for subscription {subscriptionUpdateHistoryError.SubscriptionId}. Issue number: {issueNumber}");
+                            _logger.LogInformation("Found a matching issue for subscription {SubscriptionId}. Issue number: {IssueNumber}", subscriptionUpdateHistoryError.SubscriptionId, issueNumber.Value);
                             issue = await client.Issue.Get(repo.Id, issueNumber.Value);
                             // check if the issue is open only then update it else create a new issue and update the dictionary.
                             if (issue.State.Equals("Open"))
@@ -242,10 +242,10 @@ namespace DependencyUpdateErrorProcessor
                                 break;
                             }
 
-                            _logger.LogInformation($"Matching issue {issueNumber.Value} for subscription {subscriptionUpdateHistoryError.SubscriptionId} was closed. Creating a new issue.");
+                            _logger.LogInformation("Matching issue {IssueNumber} for subscription {SubscriptionId} was closed. Creating a new issue.", issueNumber.Value, subscriptionUpdateHistoryError.SubscriptionId);
                         }
                         // Create a new issue for the error if the issue is already closed or the issue does not exist.
-                        _logger.LogInformation($@"Creating a new gitHub issue for Subscription Update Error, for the error message : '{subscriptionUpdateHistoryError.ErrorMessage} for subscription : '{subscriptionUpdateHistoryError.SubscriptionId}'");
+                        _logger.LogInformation("Creating a new gitHub issue for Subscription Update Error, for the error message : '{ErrorMessage} for subscription : '{SubscriptionId}'", subscriptionUpdateHistoryError.ErrorMessage, subscriptionUpdateHistoryError.SubscriptionId);
                         await CreateSubscriptionUpdateErrorIssueAsync(
                             client,
                             subscriptionUpdateHistoryError,
@@ -266,7 +266,7 @@ namespace DependencyUpdateErrorProcessor
                 // check if the issue is open only then update it. Otherwise, we already created the new issue, so do nothing.
                 if (issue.State.Equals("Open"))
                 {
-                    _logger.LogInformation($@"Updating a gitHub issue number : '{issueNumber.Value}' for the error : '{updateHistoryError.ErrorMessage}' for {GetPrintableDescription(updateHistoryError)}");
+                    _logger.LogInformation("Updating a gitHub issue number : '{IssueNumber}' for the error : '{ErrorMessage}' for {PrintableDescription}", issueNumber.Value, updateHistoryError.ErrorMessage, GetPrintableDescription(updateHistoryError));
                     await UpdateIssueAsync(client, updateHistoryError, shouldReplaceDescription, description, issue, repo.Id);
                     return;
                 }
@@ -330,7 +330,7 @@ namespace DependencyUpdateErrorProcessor
 **/FyiHandle :** {_options.FyiHandle}";
             newIssue.Labels.Add(labelName);
             Issue issue = await client.Issue.Create(repoId, newIssue);
-            _logger.LogInformation($"Issue Number '{issue.Number}' was created in '{issueRepo}'");
+            _logger.LogInformation("Issue Number '{IssueNumber}' was created in '{IssueRepo}'", issue.Number, issueRepo);
             // add or update the newly generated issue number in the reliable dictionary.
             using (ITransaction tx = _stateManager.CreateTransaction())
             {
@@ -372,7 +372,7 @@ namespace DependencyUpdateErrorProcessor
 **/FyiHandle :** {_options.FyiHandle}";
             newIssue.Labels.Add(labelName);
             Issue issue = await client.Issue.Create(repoId, newIssue);
-            _logger.LogInformation($"Issue Number '{issue.Number}' was created in '{issueRepo}'");
+            _logger.LogInformation("Issue Number '{IssueNumber}' was created in '{IssueRepo}'", issue.Number, issueRepo);
             // add or update the newly generated issue number in the reliable dictionary.
             using (ITransaction tx = _stateManager.CreateTransaction())
             {
@@ -412,7 +412,7 @@ namespace DependencyUpdateErrorProcessor
 
                 issueUpdate.Body = $@"{bodyTitle}  {description}
 **/FyiHandle :** {_options.FyiHandle}";
-                _logger.LogInformation($"Updating issue body for the issue :  '{issue.Number}'");
+                _logger.LogInformation("Updating issue body for the issue :  '{IssueNumber}'", issue.Number);
                 await client.Issue.Update(
                     repoId,
                     issue.Number,
@@ -426,7 +426,7 @@ namespace DependencyUpdateErrorProcessor
                 if (shouldReplaceDescription(updateHistoryError.Arguments, comment.Body))
                 {
                     // Issue's comment body will be updated
-                    _logger.LogInformation($"Updating comment body for the issue : '{issue.Number}'");
+                    _logger.LogInformation("Updating comment body for the issue : '{IssueNumber}'", issue.Number);
                     await client.Issue.Comment.Update(
                         repoId,
                         comment.Id,
@@ -437,7 +437,7 @@ namespace DependencyUpdateErrorProcessor
             // New error for the same repo-branch combination, so adding a new comment to it. 
             if (!string.IsNullOrEmpty(description))
             {
-                _logger.LogInformation($"Creating a new comment for the issue : '{issue.Number}'");
+                _logger.LogInformation("Creating a new comment for the issue : '{IssueNumber}'", issue.Number);
                 await client.Issue.Comment.Create(
                     repoId,
                     issue.Number,
@@ -585,7 +585,7 @@ $@"{GetGitHubIssueMarkerString(string.Empty, updateHistoryError.Method, updateHi
             // Subscription might be removed, so if the subscription does not exist then the error is no longer valid. So we can skip this error.
             if (subscription == null)
             {
-                _logger.LogInformation($@"SubscriptionId '{subscriptionId}' has been deleted for the repository : ");
+                _logger.LogInformation("SubscriptionId '{SubscriptionId}' has been deleted for the repository : ", subscriptionId);
                 return string.Empty;
             }
             description =

--- a/src/Maestro/DependencyUpdateErrorProcessor/DependencyUpdateErrorProcessor.cs
+++ b/src/Maestro/DependencyUpdateErrorProcessor/DependencyUpdateErrorProcessor.cs
@@ -194,7 +194,7 @@ namespace DependencyUpdateErrorProcessor
 
                         if (issueNumber.HasValue)
                         {
-                            _logger.LogInformation($"Found a matching issue for {repoBranchUpdateHistoryError.Repository}:{repoBranchUpdateHistoryError.Branch}. Issue number: {issueNumber}");
+                            _logger.LogInformation($"Found a matching issue for {repoBranchUpdateHistoryError.Repository}:{repoBranchUpdateHistoryError.Branch}. Issue number: {issueNumber.Value}");
                             issue = await client.Issue.Get(repo.Id, issueNumber.Value);
                             // check if the issue is open only then update it else create a new issue and update the dictionary.
                             if (issue.State.Equals("Open"))
@@ -203,7 +203,7 @@ namespace DependencyUpdateErrorProcessor
                                 break;
                             }
 
-                            _logger.LogInformation($"Matching issue {issueNumber} for {repoBranchUpdateHistoryError.Repository}:{repoBranchUpdateHistoryError.Branch} was closed. Creating a new issue.");
+                            _logger.LogInformation($"Matching issue {issueNumber.Value} for {repoBranchUpdateHistoryError.Repository}:{repoBranchUpdateHistoryError.Branch} was closed. Creating a new issue.");
                         }
                         // Create a new issue for the error if the issue is already closed or the issue does not exist.
                         _logger.LogInformation($@"Creating a new gitHub issue for dependency Update Error, for the error message : '{repoBranchUpdateHistoryError.ErrorMessage} for the repository : '{repoBranchUpdateHistoryError.Repository}'");
@@ -242,7 +242,7 @@ namespace DependencyUpdateErrorProcessor
                                 break;
                             }
 
-                            _logger.LogInformation($"Matching issue {issueNumber} for subscription {subscriptionUpdateHistoryError.SubscriptionId} was closed. Creating a new issue.");
+                            _logger.LogInformation($"Matching issue {issueNumber.Value} for subscription {subscriptionUpdateHistoryError.SubscriptionId} was closed. Creating a new issue.");
                         }
                         // Create a new issue for the error if the issue is already closed or the issue does not exist.
                         _logger.LogInformation($@"Creating a new gitHub issue for Subscription Update Error, for the error message : '{subscriptionUpdateHistoryError.ErrorMessage} for subscription : '{subscriptionUpdateHistoryError.SubscriptionId}'");
@@ -266,7 +266,7 @@ namespace DependencyUpdateErrorProcessor
                 // check if the issue is open only then update it. Otherwise, we already created the new issue, so do nothing.
                 if (issue.State.Equals("Open"))
                 {
-                    _logger.LogInformation($@"Updating a gitHub issue number : '{issueNumber}' for the error : '{updateHistoryError.ErrorMessage}' for {GetPrintableDescription(updateHistoryError)}");
+                    _logger.LogInformation($@"Updating a gitHub issue number : '{issueNumber.Value}' for the error : '{updateHistoryError.ErrorMessage}' for {GetPrintableDescription(updateHistoryError)}");
                     await UpdateIssueAsync(client, updateHistoryError, shouldReplaceDescription, description, issue, repo.Id);
                     return;
                 }

--- a/src/Maestro/DependencyUpdateErrorProcessor/DependencyUpdateErrorProcessor.cs
+++ b/src/Maestro/DependencyUpdateErrorProcessor/DependencyUpdateErrorProcessor.cs
@@ -86,6 +86,19 @@ namespace DependencyUpdateErrorProcessor
                 {
                     _logger.LogError(exe, "Unable to connect to reliable services.");
                 }
+                catch (ApiException ex)
+                {
+                    if (ex.ApiError == null)
+                    {
+                        _logger.LogError(ex, "Unable to create GitHub issue. Caught GitHub API-related exception. No ApiError included.");
+                    }
+                    else
+                    {
+                        string logMessage = Newtonsoft.Json.JsonConvert.SerializeObject(ex.ApiError);
+
+                        _logger.LogError(ex, "Unable to create GitHub issue. Caught GitHub API-related exception. ApiError: {ApiError}", logMessage);
+                    }
+                }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Unable to create a github issue.");

--- a/src/Maestro/DependencyUpdateErrorProcessor/DependencyUpdateErrorProcessor.cs
+++ b/src/Maestro/DependencyUpdateErrorProcessor/DependencyUpdateErrorProcessor.cs
@@ -94,9 +94,10 @@ namespace DependencyUpdateErrorProcessor
                     }
                     else
                     {
-                        string logMessage = Newtonsoft.Json.JsonConvert.SerializeObject(ex.ApiError);
+                        string errorDetailsSerialized = Newtonsoft.Json.JsonConvert.SerializeObject(ex.ApiError.Errors);
 
-                        _logger.LogError(ex, "Unable to create GitHub issue. Caught GitHub API-related exception. ApiError: {ApiError}", logMessage);
+                        _logger.LogError(ex, "Unable to create GitHub issue. Caught GitHub API-related exception. Message: {Message}, DocumentationUrl: {DocumentationUrl},  ApiError: {ApiErrorDetails}", 
+                            ex.ApiError.Message, ex.ApiError.DocumentationUrl, errorDetailsSerialized);
                     }
                 }
                 catch (Exception ex)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -1300,18 +1300,15 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         private void LogApiErrorDetails(ApiException apiException)
         {
-            _logger.LogError(apiException, "Caught ApiException, will rethrow -- StatusCode: {StatusCode}", apiException.StatusCode);
-
-            if (!string.IsNullOrEmpty(apiException.ApiError.DocumentationUrl))
+            if (apiException.ApiError != null)
             {
-                _logger.LogError("Documentation URL: {DocumentationUrl}", apiException.ApiError.DocumentationUrl);
+                string logMessage = JsonConvert.SerializeObject(apiException.ApiError);
+
+                _logger.LogError(apiException, "Caught ApiException, will rethrow. ApiError: {ApiError}", logMessage);
             }
-
-            IEnumerable<ApiErrorDetail> errorDetails = apiException.ApiError?.Errors ?? Enumerable.Empty<ApiErrorDetail>();
-            foreach (ApiErrorDetail errorDetail in errorDetails)
+            else
             {
-                _logger.LogError("ApiErrorDetail -- Code: {Code}, Field: {Field}, Resource: {Resource}, Message: {Message}",
-                    errorDetail.Code, errorDetail.Field, errorDetail.Resource, errorDetail.Message);
+                _logger.LogError(apiException, "Caught ApiException, will rethrow. No ApiError included.");
             }
         }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.DarcLib
         public async Task AddIssueComment(string repoUri, int issueNumber, string message)
         {
             (string owner, string repo) = ParseRepoUri(repoUri);
-            await Client.Issue.Comment.Create(owner, repo, issueNumber, message);
+            await ExecuteAndLogApiErrors(() => Client.Issue.Comment.Create(owner, repo, issueNumber, message));
         }
 
 
@@ -218,7 +218,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns></returns>
         private async Task DeleteBranchAsync(string owner, string repo, string branch)
         {
-            await Client.Git.Reference.Delete(owner, repo, $"heads/{branch}");
+            await ExecuteAndLogApiErrors(() => Client.Git.Reference.Delete(owner, repo, $"heads/{branch}"));
         }
 
         /// <summary>
@@ -317,7 +317,7 @@ namespace Microsoft.DotNet.DarcLib
         public async Task<PullRequest> GetPullRequestAsync(string pullRequestUrl)
         {
             (string owner, string repo, int id) = ParsePullRequestUri(pullRequestUrl);
-            Octokit.PullRequest pr = await Client.PullRequest.Get(owner, repo, id);
+            Octokit.PullRequest pr = await ExecuteAndLogApiErrors(() => Client.PullRequest.Get(owner, repo, id));
             return new PullRequest
             {
                 Title = pr.Title,
@@ -341,7 +341,7 @@ namespace Microsoft.DotNet.DarcLib
             {
                 Body = pullRequest.Description
             };
-            Octokit.PullRequest createdPullRequest = await Client.PullRequest.Create(owner, repo, pr);
+            Octokit.PullRequest createdPullRequest = await ExecuteAndLogApiErrors(() => Client.PullRequest.Create(owner, repo, pr));
 
             return createdPullRequest.Url;
         }
@@ -356,7 +356,7 @@ namespace Microsoft.DotNet.DarcLib
         {
             (string owner, string repo, int id) = ParsePullRequestUri(pullRequestUri);
 
-            await Client.PullRequest.Update(
+            await ExecuteAndLogApiErrors(() => Client.PullRequest.Update(
                 owner,
                 repo,
                 id,
@@ -364,7 +364,7 @@ namespace Microsoft.DotNet.DarcLib
                 {
                     Title = pullRequest.Title,
                     Body = pullRequest.Description
-                });
+                }));
         }
 
         /// <summary>
@@ -375,7 +375,9 @@ namespace Microsoft.DotNet.DarcLib
         public async Task<IList<Commit>> GetPullRequestCommitsAsync(string pullRequestUrl)
         {
             (string owner, string repo, int id) = ParsePullRequestUri(pullRequestUrl);
-            var pullRequestCommits = await Client.PullRequest.Commits(owner, repo, id);
+
+            IReadOnlyList<PullRequestCommit> pullRequestCommits = await ExecuteAndLogApiErrors(() => Client.PullRequest.Commits(owner, repo, id));
+
             IList<Commit> commits = new List<Commit>(pullRequestCommits.Count);
             foreach (var commit in pullRequestCommits)
             {
@@ -405,11 +407,11 @@ namespace Microsoft.DotNet.DarcLib
                 MergeMethod = parameters.SquashMerge ? PullRequestMergeMethod.Squash : PullRequestMergeMethod.Merge
             };
 
-            await Client.PullRequest.Merge(owner, repo, id, mergePullRequest);
+            await ExecuteAndLogApiErrors(() => Client.PullRequest.Merge(owner, repo, id, mergePullRequest));
 
             if (parameters.DeleteSourceBranch)
             {
-                await Client.Git.Reference.Delete(owner, repo, $"heads/{pr.Head.Ref}");
+                await ExecuteAndLogApiErrors(() => Client.Git.Reference.Delete(owner, repo, $"heads/{pr.Head.Ref}"));
             }
         }
 
@@ -422,14 +424,14 @@ namespace Microsoft.DotNet.DarcLib
         public async Task CreateOrUpdatePullRequestCommentAsync(string pullRequestUrl, string message)
         {
             (string owner, string repo, int id) = ParsePullRequestUri(pullRequestUrl);
-            IssueComment lastComment = (await Client.Issue.Comment.GetAllForIssue(owner, repo, id)).LastOrDefault();
+            IssueComment lastComment = (await ExecuteAndLogApiErrors(() => Client.Issue.Comment.GetAllForIssue(owner, repo, id))).LastOrDefault();
             if (lastComment != null && lastComment.Body.EndsWith(CommentMarker))
             {
-                await Client.Issue.Comment.Update(owner, repo, lastComment.Id, message + CommentMarker);
+                await ExecuteAndLogApiErrors(() => Client.Issue.Comment.Update(owner, repo, lastComment.Id, message + CommentMarker));
             }
             else
             {
-                await Client.Issue.Comment.Create(owner, repo, id, message + CommentMarker);
+                await ExecuteAndLogApiErrors(() => Client.Issue.Comment.Create(owner, repo, id, message + CommentMarker));
             }
         }
 
@@ -455,7 +457,7 @@ namespace Microsoft.DotNet.DarcLib
 
             // Get a list of all the merge policies checks runs for the current PR
             List <CheckRun> existingChecksRuns = 
-                (await Client.Check.Run.GetAllForReference(owner, repo, prSha))
+                (await ExecuteAndLogApiErrors(() => Client.Check.Run.GetAllForReference(owner, repo, prSha)))
                 .CheckRuns.Where(e => e.ExternalId.StartsWith(MergePolicyConstants.MaestroMergePolicyCheckRunPrefix)).ToList();
 
             var toBeAdded = evaluations.Where(e => existingChecksRuns.All(c => c.ExternalId != CheckRunId(e, prSha)));
@@ -464,17 +466,17 @@ namespace Microsoft.DotNet.DarcLib
 
             foreach (var newCheckRunValidation in toBeAdded)
             {
-                await Client.Check.Run.Create(owner, repo, CheckRunForAdd(newCheckRunValidation, prSha));
+                await ExecuteAndLogApiErrors(() => Client.Check.Run.Create(owner, repo, CheckRunForAdd(newCheckRunValidation, prSha)));
             }
             foreach (var updatedCheckRun in toBeUpdated)
             {                
                 MergePolicyEvaluationResult eval = evaluations.Single(e => updatedCheckRun.ExternalId == CheckRunId(e, prSha));
                 CheckRunUpdate newCheckRunUpdateValidation = CheckRunForUpdate(eval);
-                await Client.Check.Run.Update(owner, repo, updatedCheckRun.Id, newCheckRunUpdateValidation);
+                await ExecuteAndLogApiErrors(() => Client.Check.Run.Update(owner, repo, updatedCheckRun.Id, newCheckRunUpdateValidation));
             }
             foreach (var deletedCheckRun in toBeDeleted)
             {
-                await Client.Check.Run.Update(owner, repo, deletedCheckRun.Id, CheckRunForDelete(deletedCheckRun));
+                await ExecuteAndLogApiErrors(() => Client.Check.Run.Update(owner, repo, deletedCheckRun.Id, CheckRunForDelete(deletedCheckRun)));
             }
         }
 
@@ -691,6 +693,11 @@ namespace Microsoft.DotNet.DarcLib
                                             await Task.Delay(retryAfterSeconds * 1000);
                                             attempts++;
                                         }
+                                        catch(ApiValidationException ex)
+                                        {
+                                            LogApiErrorDetails(ex);
+                                            throw;
+                                        }
                                     }
 
                                     return blob;
@@ -830,8 +837,8 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns>Return the commit matching the specified sha. Null if no commit were found.</returns>
         private async Task<Commit> GetCommitAsync(string owner, string repo, string sha)
         {
-            Repository repository = await Client.Repository.Get(owner, repo);
-            Octokit.GitHubCommit commit = await Client.Repository.Commit.Get(repository.Id, sha);
+            Repository repository = await ExecuteAndLogApiErrors(() => Client.Repository.Get(owner, repo));
+            Octokit.GitHubCommit commit = await ExecuteAndLogApiErrors(() => Client.Repository.Commit.Get(repository.Id, sha));
             if (commit == null)
             {
                 return null;
@@ -877,7 +884,7 @@ namespace Microsoft.DotNet.DarcLib
         {
             (string owner, string repo, int id) = ParsePullRequestUri(pullRequestUrl);
 
-            var commits = await Client.Repository.PullRequest.Commits(owner, repo, id);
+            var commits = await ExecuteAndLogApiErrors(() => Client.Repository.PullRequest.Commits(owner, repo, id));
             var lastCommitSha = commits.Last().Sha;
 
             return (await GetChecksFromStatusApiAsync(owner, repo, lastCommitSha))
@@ -897,7 +904,7 @@ namespace Microsoft.DotNet.DarcLib
         {
             (string owner, string repo, int id) = ParsePullRequestUri(pullRequestUrl);
 
-            var reviews = await Client.Repository.PullRequest.Review.GetAll(owner, repo, id);
+            var reviews = await ExecuteAndLogApiErrors(() => Client.Repository.PullRequest.Review.GetAll(owner, repo, id));
 
             // Filter out comments because they could come after Approved/ChangedRequested, and they don't change the decision.
             reviews = reviews.Where(r => r.State != PullRequestReviewState.Commented).ToImmutableList();
@@ -1282,6 +1289,66 @@ namespace Microsoft.DotNet.DarcLib
             PullRequest pr = await GetPullRequestAsync(pullRequestUri);
             (string owner, string repo, int id) prInfo = ParsePullRequestUri(pullRequestUri);
             await DeleteBranchAsync(prInfo.owner, prInfo.repo, pr.HeadBranch);
+        }
+
+        /// <summary>
+        /// Log extra details from ApiException.
+        /// 
+        /// GitHub returns a GitHub-custom JSON payload on most errors that contains more information than
+        /// the standard exception message. See <see href="https://docs.github.com/en/rest/overview/resources-in-the-rest-api#client-errors">Client Errors</see> 
+        /// for details on the structure.
+        /// </summary>
+        private void LogApiErrorDetails(ApiException apiException)
+        {
+            _logger.LogError(apiException, "Caught ApiException, will rethrow -- StatusCode: {StatusCode}", apiException.StatusCode);
+
+            if (!string.IsNullOrEmpty(apiException.ApiError.DocumentationUrl))
+            {
+                _logger.LogError("Documentation URL: {DocumentationUrl}", apiException.ApiError.DocumentationUrl);
+            }
+
+            IEnumerable<ApiErrorDetail> errorDetails = apiException.ApiError?.Errors ?? Enumerable.Empty<ApiErrorDetail>();
+            foreach (ApiErrorDetail errorDetail in errorDetails)
+            {
+                _logger.LogError("ApiErrorDetail -- Code: {Code}, Field: {Field}, Resource: {Resource}, Message: {Message}",
+                    errorDetail.Code, errorDetail.Field, errorDetail.Resource, errorDetail.Message);
+            }
+        }
+
+        /// <summary>
+        /// Execute the provided function. If the function throws <see cref="ApiException"/>, log those details
+        /// and rethrow the exception.
+        /// </summary>
+        private async Task<T> ExecuteAndLogApiErrors<T>(Func<Task<T>> function)
+        {
+            try
+            {
+                return await function();
+            }
+            catch (ApiException apiException)
+            {
+                LogApiErrorDetails(apiException);
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Execute the provided function. If the function throws <see cref="ApiException"/>, log those details
+        /// and rethrow the exception.
+        /// </summary>
+        private async Task ExecuteAndLogApiErrors(Func<Task> function)
+        {
+            try
+            {
+                await function();
+            }
+            catch (ApiException apiException)
+            {
+                LogApiErrorDetails(apiException);
+
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves dotnet/arcade#8579.

Maestro occasionally errors because of responses from GitHub. The current logging situation isn't giving quite enough info to determine if this is a Maestro problem or a GitHub problem. Application Insights telemetry shows that Octokit is throwing `ApiValidationException`s, but the default message and stack is missing context.

This PR adds extra logging around calls to capture the information GitHub sends in its response JSON. This should give much more detailed information on what exactly went wrong. Hopefully then that will be enough to know how to guard against them.

Info on the error payload format may be found at [Resources in the REST API - Client errors](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#client-errors).