### PR TITLE
Monitor GitHub app hook health

### DIFF
--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubAppTokenProvider.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubAppTokenProvider.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using GitHubJwt;
-using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.Extensions.Options;
 using System.Text;
 
@@ -29,7 +28,7 @@ namespace Microsoft.DotNet.GitHub.Authentication
             return GetAppToken(options.GitHubAppId, new StringPrivateKeySource(options.PrivateKey));
         }
 
-        public string GetAppTokenFromEnvironmentVariableBase64(int gitHubAppId, string environmentVariableName)
+        public static string GetAppTokenFromEnvironmentVariableBase64(int gitHubAppId, string environmentVariableName)
         {
             string encodedKey = System.Environment.GetEnvironmentVariable(environmentVariableName);
             byte[] keydata = System.Convert.FromBase64String(encodedKey);
@@ -38,7 +37,7 @@ namespace Microsoft.DotNet.GitHub.Authentication
             return GetAppToken(gitHubAppId, new StringPrivateKeySource(privateKey));
         }
 
-        private string GetAppToken(int gitHubAppId, IPrivateKeySource privateKeySource)
+        private static string GetAppToken(int gitHubAppId, IPrivateKeySource privateKeySource)
         {
             var generator = new GitHubJwtFactory(
                 privateKeySource,

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubAppTokenProvider.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubAppTokenProvider.cs
@@ -22,6 +22,9 @@ namespace Microsoft.DotNet.GitHub.Authentication
             return GetAppToken(Options.DefaultName);
         }
 
+        /// <summary>
+        /// Get an app token using the <see cref="GitHubTokenProviderOptions"/> corresponding to the specified <see href="https://docs.microsoft.com/en-us/dotnet/core/extensions/options#named-options-support-using-iconfigurenamedoptions">named option</see>.
+        /// </summary>
         public string GetAppToken(string name)
         {
             var options = _options.Get(name);

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubAppTokenProvider.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubAppTokenProvider.cs
@@ -20,7 +20,12 @@ namespace Microsoft.DotNet.GitHub.Authentication
 
         public string GetAppToken()
         {
-            var options = _options.CurrentValue;
+            return GetAppToken(Options.DefaultName);
+        }
+
+        public string GetAppToken(string name)
+        {
+            var options = _options.Get(name);
             return GetAppToken(options.GitHubAppId, new StringPrivateKeySource(options.PrivateKey));
         }
 

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubApplicationClientFactory.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubApplicationClientFactory.cs
@@ -27,5 +27,10 @@ namespace Microsoft.DotNet.GitHub.Authentication
         {
             return _clientFactory.CreateGitHubClient(_tokenProvider.GetTokenForApp(), AuthenticationType.Bearer);
         }
+
+        public IGitHubClient CreateGitHubAppClient(string name)
+        {
+            return _clientFactory.CreateGitHubClient(_tokenProvider.GetTokenForApp(name), AuthenticationType.Bearer);
+        }
     }
 }

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubClientFactory.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubClientFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Options;
 using Octokit;
+using System;
 
 namespace Microsoft.DotNet.GitHub.Authentication
 {
@@ -21,6 +22,11 @@ namespace Microsoft.DotNet.GitHub.Authentication
 
         public IGitHubClient CreateGitHubClient(string token, AuthenticationType type)
         {
+            if (Options?.ProductHeader == null)
+            {
+                throw new InvalidOperationException($"A {nameof(GitHubClientOptions.ProductHeader)} is required for a GitHub client, but the value in {nameof(GitHubClientOptions)} is null.");
+            }
+
             var client = new GitHubClient(Options.ProductHeader);
 
             if (!string.IsNullOrEmpty(token))

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
@@ -56,6 +56,7 @@ namespace Microsoft.DotNet.GitHub.Authentication
                     return token.Token;
                 },
                 ex => _logger.LogError(ex, "Failed to get a github token for installation id {installationId}, retrying", installationId),
+                ex => ex is ApiException exception && exception.StatusCode == HttpStatusCode.InternalServerError);
         }
 
         public string GetTokenForApp()

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
@@ -64,6 +64,11 @@ namespace Microsoft.DotNet.GitHub.Authentication
             return _tokens.GetAppToken();
         }
 
+        public string GetTokenForApp(string name)
+        {
+            return _tokens.GetAppToken(name);
+        }
+
         public async Task<string> GetTokenForRepository(string repositoryUrl)
         {
             return await GetTokenForInstallationAsync(await _installationLookup.GetInstallationId(repositoryUrl));

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.GitHub.Authentication
         {
             if (TryGetCachedToken(installationId, out AccessToken cachedToken))
             {
-                _logger.LogInformation($"Cached token obtained for GitHub installation {installationId}. Expires at {cachedToken.ExpiresAt}.");
+                _logger.LogInformation("Cached token obtained for GitHub installation {installationId}. Expires at {tokenExpiresAt}.", installationId, cachedToken.ExpiresAt);
                 return cachedToken.Token;
             }
 
@@ -51,12 +51,11 @@ namespace Microsoft.DotNet.GitHub.Authentication
                     string jwt = _tokens.GetAppToken();
                     var appClient = new Octokit.GitHubClient(_gitHubClientOptions.Value.ProductHeader) { Credentials = new Credentials(jwt, AuthenticationType.Bearer) };
                     AccessToken token = await appClient.GitHubApps.CreateInstallationToken(installationId);
-                    _logger.LogInformation($"New token obtained for GitHub installation {installationId}. Expires at {token.ExpiresAt}.");
+                    _logger.LogInformation("New token obtained for GitHub installation {installationId}. Expires at {tokenExpiresAt}.", installationId, token.ExpiresAt);
                     UpdateTokenCache(installationId, token);
                     return token.Token;
                 },
-                ex => _logger.LogError(ex, $"Failed to get a github token for installation id {installationId}, retrying"),
-                ex => ex is ApiException && ((ApiException)ex).StatusCode == HttpStatusCode.InternalServerError);
+                ex => _logger.LogError(ex, "Failed to get a github token for installation id {installationId}, retrying", installationId),
         }
 
         public string GetTokenForApp()

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubAppTokenProvider.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubAppTokenProvider.cs
@@ -7,5 +7,6 @@ namespace Microsoft.DotNet.GitHub.Authentication
     public interface IGitHubAppTokenProvider 
     {
         string GetAppToken();
+        string GetAppToken(string name);
     }
 }

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubAppTokenProvider.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubAppTokenProvider.cs
@@ -7,6 +7,10 @@ namespace Microsoft.DotNet.GitHub.Authentication
     public interface IGitHubAppTokenProvider 
     {
         string GetAppToken();
+
+        /// <summary>
+        /// Get an app token using the configuration that corresponds to the logical name specified by <paramref name="name"/>.
+        /// </summary>
         string GetAppToken(string name);
     }
 }

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubApplicationClientFactory.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubApplicationClientFactory.cs
@@ -12,8 +12,9 @@ namespace Microsoft.DotNet.GitHub.Authentication
         Task<IGitHubClient> CreateGitHubClientAsync(string owner, string repo);
         IGitHubClient CreateGitHubAppClient();
 
-        /// <param name="name">When using <see href="https://docs.microsoft.com/en-us/dotnet/core/extensions/options#named-options-support-using-iconfigurenamedoptions">named options</see>, 
-        /// the name of the <see cref="GitHubTokenProviderOptions"/> to use when creating the client.</param>
+        /// <summary>
+        /// Creates a GitHub App client configured the configuration that corresponds to the logical name specified by <paramref name="name"/>.
+        /// </summary>
         IGitHubClient CreateGitHubAppClient(string name);
     }
 }

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubApplicationClientFactory.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubApplicationClientFactory.cs
@@ -11,5 +11,9 @@ namespace Microsoft.DotNet.GitHub.Authentication
     { 
         Task<IGitHubClient> CreateGitHubClientAsync(string owner, string repo);
         IGitHubClient CreateGitHubAppClient();
+
+        /// <param name="name">When using <see href="https://docs.microsoft.com/en-us/dotnet/core/extensions/options#named-options-support-using-iconfigurenamedoptions">named options</see>, 
+        /// the name of the <see cref="GitHubTokenProviderOptions"/> to use when creating the client.</param>
+        IGitHubClient CreateGitHubAppClient(string name);
     }
 }

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubTokenProvider.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubTokenProvider.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DotNet.GitHub.Authentication
         Task<string> GetTokenForInstallationAsync(long installationId);
         Task<string> GetTokenForRepository(string repositoryUrl);
         string GetTokenForApp();
+        string GetTokenForApp(string name);
     }
 
     public static class GitHubTokenProviderExtensions

--- a/src/Shared/Microsoft.DotNet.Internal.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.DependencyInjection/ServiceCollectionExtensions.cs
@@ -40,5 +40,26 @@ namespace Microsoft.Extensions.DependencyInjection
                 )
             );
         }
+
+        public static IServiceCollection Configure<TOptions>(
+            this IServiceCollection services,
+            string optionName,
+            string sectionName,
+            Action<TOptions, IConfiguration> configure) where TOptions : class
+        {
+            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(provider =>
+            {
+                var config = provider.GetRequiredService<IConfiguration>().GetSection(sectionName);
+                return new ConfigurationChangeTokenSource<TOptions>(optionName, config);
+            });
+            return services.AddSingleton<IConfigureOptions<TOptions>>(
+                provider => new ConfigureNamedOptions<TOptions>(
+                    optionName,
+                    options => configure(options,
+                        provider.GetRequiredService<IConfiguration>().GetSection(sectionName)
+                    )
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
This is the arcade-services part of resolving dotnet/arcade#8952. The dotnet-helix-service companion is [22274](https://dev.azure.com/dnceng/internal/_git/dotnet-helix-service/pullrequest/22274).

To allow MetricsObserver to monitor GitHub Apps, these changes are needed:

- Add overloads to classes that use GitHubAppTokenProvider to support [named options](https://docs.microsoft.com/en-us/dotnet/core/extensions/options#named-options-support-using-iconfigurenamedoptions).
- Add overload Dependency Injection Configuration method to support named options (and also expose configuration to builder)
- Minor quality-of-life log message improvements
- Minor changes to make the linter happy