### PR TITLE
Add a null check to ProcessNotifications for edited events

### DIFF
--- a/src/DotNet.Status.Web/Controllers/GitHubHookController.cs
+++ b/src/DotNet.Status.Web/Controllers/GitHubHookController.cs
@@ -198,8 +198,7 @@ namespace DotNet.Status.Web.Controllers
                         date);
                     break;
                 case "edited":
-                    string fromBody = issueEvent.Changes.Body == null ? null : issueEvent.Changes.Body.From;
-                    await _teamMentionForwarder.HandleMentions(repo, fromBody, issueEvent.Issue.Body, title, uri, username, date);
+                    await _teamMentionForwarder.HandleMentions(repo, issueEvent.Changes.Body?.From, issueEvent.Issue.Body, title, uri, username, date);
                     break;
             }
         }

--- a/src/DotNet.Status.Web/Controllers/GitHubHookController.cs
+++ b/src/DotNet.Status.Web/Controllers/GitHubHookController.cs
@@ -198,8 +198,8 @@ namespace DotNet.Status.Web.Controllers
                         date);
                     break;
                 case "edited":
-                    await _teamMentionForwarder.HandleMentions(repo, issueEvent.Changes.Body.From,
-                        issueEvent.Issue.Body, title, uri, username, date);
+                    string fromBody = issueEvent.Changes.Body == null ? null : issueEvent.Changes.Body.From;
+                    await _teamMentionForwarder.HandleMentions(repo, fromBody, issueEvent.Issue.Body, title, uri, username, date);
                     break;
             }
         }


### PR DESCRIPTION
When an issue is edited, it may have been edited from a null issue body (ie issueEvent.Changes.Body is null), but we assume that it is never null and blindly grab issueEvent.Changes.Body.From. This causes a lot of errors in DotNetStatus-Eng. This change adds a null check so that we don't fail in this instance.

Fixes https://github.com/dotnet/arcade/issues/8791