### PR TITLE
Update the message for DotNetEng Status Failed Requests/Hour alert

### DIFF
--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -2753,7 +2753,7 @@
         "for": "5m",
         "frequency": "1m",
         "handler": 1,
-        "message": "The number of failed DotNetEng Status requests per hour is above 20. This may indicate a systemic problem that needs to be investigated.\nTo intially investigate prod, run the following query in DotNetEng-Status-Prod, and to investigate staging, run the query in DotNetEng-Status-Staging:\n\n```\nunion exceptions, traces\n| project timestamp, customDimensions, message, problemId, details\n| order by timestamp asc\n```",
+        "message": "The number of failed DotNetEng Status requests per hour is above 20. This may indicate a systemic problem that needs to be investigated.\nTo intially investigate prod, run the following query in DotNetEng-Status-Prod, and to investigate staging, run the query in DotNetEng-Status-Staging:\n\n```\nunion exceptions, traces\n| project timestamp, operation_Name, customDimensions, message, problemId, details\n| order by timestamp asc\n```",
         "name": "DotNetEng Status Failed Requests/Hour alert",
         "noDataState": "ok",
         "notifications": [

--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -2753,7 +2753,7 @@
         "for": "5m",
         "frequency": "1m",
         "handler": 1,
-        "message": "The number of failed DotNetEng Status requests per hour is above 20. This may indicate a systemic problem that needs to be investigated.\nTo intially investigate prod, run the following query in DotNetEng-Status-Prod, and to investigate staging, run the query in DotNetEng-Status-Staging:\n\n```\nexceptions\n| union traces\n| project timestamp, customDimensions, message, problemId, details\n| order by timestamp asc\n```",
+        "message": "The number of failed DotNetEng Status requests per hour is above 20. This may indicate a systemic problem that needs to be investigated.\nTo intially investigate prod, run the following query in DotNetEng-Status-Prod, and to investigate staging, run the query in DotNetEng-Status-Staging:\n\n```\nunion exceptions, traces\n| project timestamp, customDimensions, message, problemId, details\n| order by timestamp asc\n```",
         "name": "DotNetEng Status Failed Requests/Hour alert",
         "noDataState": "ok",
         "notifications": [

--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -2753,7 +2753,7 @@
         "for": "5m",
         "frequency": "1m",
         "handler": 1,
-        "message": "The number of failed DotNetEng Status requests per hour is above 20. This may indicate a systemic problem that needs to be investigated.",
+        "message": "The number of failed DotNetEng Status requests per hour is above 20. This may indicate a systemic problem that needs to be investigated.\nTo intially investigate prod, run the following query in DotNetEng-Status-Prod, and to investigate staging, run the query in DotNetEng-Status-Staging:\n\n```\nexceptions\n| union traces\n| project timestamp, customDimensions, message, problemId, details\n| order by timestamp asc\n```",
         "name": "DotNetEng Status Failed Requests/Hour alert",
         "noDataState": "ok",
         "notifications": [


### PR DESCRIPTION
This will give the investigator an easier starting point for investigating what the exceptions were and what was going on at the time of the exception.