### PR TITLE
Reduce noise from source.dot.net in staging

### DIFF
--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -645,7 +645,7 @@
           {
             "evaluator": {
               "params": [
-                99
+                60
               ],
               "type": "lt"
             },
@@ -667,7 +667,7 @@
           }
         ],
         "executionErrorState": "keep_state",
-        "for": "5m",
+        "for": "15m",
         "frequency": "1m",
         "handler": 1,
         "message": "source.dot.net availability is low!",
@@ -709,7 +709,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": false,
+            "spanNulls": true,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -757,7 +757,7 @@
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "list",
+          "displayMode": "hidden",
           "placement": "bottom"
         },
         "tooltip": {
@@ -779,7 +779,7 @@
           "azureMonitor": {
             "aggOptions": [],
             "aggregation": "Average",
-            "alias": "{{ availabilityresult/location }}",
+            "alias": "",
             "allowedTimeGrainsMs": [
               60000,
               300000,
@@ -795,11 +795,6 @@
               {
                 "dimension": "availabilityResult/name",
                 "filter": "source-dot-net",
-                "operator": "eq"
-              },
-              {
-                "dimension": "availabilityResult/location",
-                "filter": "",
                 "operator": "eq"
               }
             ],


### PR DESCRIPTION
This should tamp down on dotnet/arcade#9234

Basically we stop splitting out the regions (North Central US is being incredibly flaky here), and dropped the threshold from "99%" (which basically means any failure at all), to 60% in 15 minutes. Each thing only pings once every 5 minutes, so the alert needs to be longer than that to avoid one spike causing an alert and then self resolving.

15 minutes = 3 intervals of 5 regions, so 60% means either every region failed 2 pings in a row (that's weird and bad), or 2 regions failed all 3 pings (also bad).