### PR TITLE
Some settings are null, don't map those

### DIFF
--- a/src/Microsoft.DncEng.Configuration.Extensions/RegexConfigMapper.cs
+++ b/src/Microsoft.DncEng.Configuration.Extensions/RegexConfigMapper.cs
@@ -9,6 +9,9 @@ namespace Microsoft.DncEng.Configuration.Extensions
         {
             return value =>
             {
+                if (value == null)
+                    return null;
+
                 return regex.Replace(value, match =>
                 {
                     string key = match.Groups["key"].Value;


### PR DESCRIPTION
This looks to be a breaking change from Microsoft.Extensions.Configuration.Json.  In the 5.0.0 -> 6.0.0 update, `{}` is interpreted, for some incomprehensible reason, as the null string.

This behavior is pretty nonsensical, but the 6.0.0 ship has sailed, so lets just deal with it.