### PR TITLE
Add weekly build pipelines to build monitor

### DIFF
--- a/.vault-config/dotneteng-status-prod.yaml
+++ b/.vault-config/dotneteng-status-prod.yaml
@@ -39,3 +39,8 @@ secrets:
         name: nethelix-prod-kusto-ad-application
       dataSource: https://ingest-engsrvprod.kusto.windows.net:443
       additionalParameters: Streaming=true;Authority Id=72f988bf-86f1-41af-91ab-2d7cd011db47
+
+build-monitor-hook-dotnet-eng-status-token:
+  type: text
+  parameters:
+    description: Generate API token from https://dotneteng-status.azurewebsites.net/ and save it to the service hook with ID 439d5934-8e89-4407-8e31-5b04d58b7854

--- a/.vault-config/dotneteng-status-prod.yaml
+++ b/.vault-config/dotneteng-status-prod.yaml
@@ -40,7 +40,7 @@ secrets:
       dataSource: https://ingest-engsrvprod.kusto.windows.net:443
       additionalParameters: Streaming=true;Authority Id=72f988bf-86f1-41af-91ab-2d7cd011db47
 
-build-monitor-hook-dotnet-eng-status-token:
-  type: text
-  parameters:
-    description: Generate API token from https://dotneteng-status.azurewebsites.net/ and save it to the service hook with ID 439d5934-8e89-4407-8e31-5b04d58b7854
+  build-monitor-hook-dotnet-eng-status-token:
+    type: text
+    parameters:
+      description: Generate API token from https://dotneteng-status.azurewebsites.net/ and save it to the service hook with ID 439d5934-8e89-4407-8e31-5b04d58b7854

--- a/src/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/.config/settings.json
@@ -51,6 +51,36 @@
         },
         {
           "Project": "internal",
+          "DefinitionPath": "\\dotnet\\arcade-services\\dotnet-arcade-services-weekly",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-arcade"
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet\\helix-machines\\dotnet-helix-machines-weekly",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-arcade"
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet\\helix-service\\dotnet-helix-service-weekly",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-arcade"
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet\\arcade\\dotnet-arcade-weekly",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-arcade"
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet\\release\\dotnet-release-weekly",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-arcade"
+        },
+        {
+          "Project": "internal",
           "DefinitionPath": "\\dotnet-release\\Validate-DotNet",
           "Branches": [ "main" ],
           "IssuesId": "dotnet-aspnetcore-infra",


### PR DESCRIPTION
Resolves dotnet/core-eng#15172.

This adds the pipelines run weekly against the Big Five dnceng repos. These pipelines have become a place to do periodic analysis and scans, where failures are harder to see but just as important.