### PR TITLE
Add empty Directory.* files

### DIFF
--- a/.packages/Directory.Build.props
+++ b/.packages/Directory.Build.props
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+</Project>

--- a/.packages/Directory.Build.targets
+++ b/.packages/Directory.Build.targets
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+</Project>

--- a/.packages/Directory.Packages.props
+++ b/.packages/Directory.Packages.props
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+</Project>

--- a/artifacts/Directory.Build.props
+++ b/artifacts/Directory.Build.props
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+</Project>

--- a/artifacts/Directory.Build.targets
+++ b/artifacts/Directory.Build.targets
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+</Project>

--- a/artifacts/Directory.Packages.props
+++ b/artifacts/Directory.Packages.props
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+</Project>


### PR DESCRIPTION
The "artifacts" and "packages" directories are inside our repository, meaning they implicitly grab settings here, which means we can't really touch stuff in our repo without artifacts breaking (like BAR publish).

This should break the connection in the cheapest way possible.

If this doesn't work, we either need to move artfacts/packages into a sub folder where we can put these files,
OR we need to move EVERYTHING in the repo "down a level" so we have a safe place to party.