### PR TITLE
Suppress this warning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <NoWarn>$(NoWarn);NU5125;CA1416</NoWarn>
+    <NoWarn>$(NoWarn);NU5125;CA1416;NU1507</NoWarn>
     <!--
       We sort of half sort of support macOS in this repo, this warning is telling us that we are on the precipice of 
       failure (because we are depending on win-x64 only assemblies). But darc is basically standing in the middle

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,25 +7,4 @@
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
-  <packageSourceMapping>
-    <packageSource key="dotnet-public">
-      <package pattern="*"/>
-    </packageSource>
-    <packageSource key="dotnet-eng">
-      <package pattern="Microsoft.DotNet.Arcade.*"/>
-      <package pattern="Microsoft.DotNet.SwaggerGenerator.*"/>
-      <package pattern="Microsoft.DncEng.*"/>
-      <package pattern="sn"/>
-      <package pattern="MicroBuild.Core.Sentinel"/>
-      <package pattern="Microsoft.DotNet.Build.Tasks.Feed"/>
-      <package pattern="Microsoft.DotNet.SignTool"/>
-      <package pattern="Microsoft.SymbolUploader.Build.Task"/>
-      <package pattern="Microsoft.DotNet.VersionTools"/>
-      <package pattern="Microsoft.DiaSymReader.Pdb2Pdb"/>
-      <package pattern="Microsoft.Arcade.Common"/>
-    </packageSource>
-    <packageSource key="dotnet-tools">
-      <package pattern="Microsoft.DiaSymReader.Pdb2Pdb"/>
-    </packageSource>
-  </packageSourceMapping>
 </configuration>

--- a/src/Monitoring/Sdk/Microsoft.DotNet.Monitoring.Sdk.csproj
+++ b/src/Monitoring/Sdk/Microsoft.DotNet.Monitoring.Sdk.csproj
@@ -4,7 +4,7 @@
     <PackageType>MSBuildSdk</PackageType>
     <LangVersion>latest</LangVersion>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-    <NoWarn>NU5110,NU5111</NoWarn>
+    <NoWarn>$(NoWarn);NU5110,NU5111</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Package mapping really doesn't play well with arcade/maestro,
since they dynamically add/remove feeds and packages,
which can't be mapped in advance.