### PR TITLE
Fix path for arcade-services build in build monitor

### DIFF
--- a/src/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/.config/settings.json
@@ -44,7 +44,7 @@
         },
         {
           "Project": "internal",
-          "DefinitionPath": "\\dotnet\\dotnet-arcade-services\\arcade-services-internal-ci",
+          "DefinitionPath": "\\dotnet\\arcade-services\\arcade-services-internal-ci",
           "Branches": [ "main" ],
           "Assignee": "riarenas",
           "IssuesId": "dotnet-arcade"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23242101/168624950-177444bc-92a2-496f-9091-97d966151dea.png) 

shows that this is the correct path.

https://github.com/dotnet/arcade/issues/9374
