### PR TITLE
Set ASPNETCORE_ENVIRONMENT instead of ENVIRONMENT

### DIFF
--- a/src/Maestro/CoreHealthMonitor.Tests/DependencyRegistrationTests.cs
+++ b/src/Maestro/CoreHealthMonitor.Tests/DependencyRegistrationTests.cs
@@ -15,7 +15,7 @@ namespace CoreHealthMonitor.Tests
             DependencyInjectionValidation.IsDependencyResolutionCoherent(
                     s =>
                     {
-                        Environment.SetEnvironmentVariable("ENVIRONMENT", "XUNIT");
+                        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "XUNIT");
                         ServiceHost.ConfigureDefaultServices(s);
                         Program.Configure(s);
                     },

--- a/src/Maestro/Maestro.Web.Tests/DependencyRegistrationTests.cs
+++ b/src/Maestro/Maestro.Web.Tests/DependencyRegistrationTests.cs
@@ -19,7 +19,7 @@ namespace Maestro.Web.Tests
         [Test]
         public void AreDependenciesRegistered()
         {
-            Environment.SetEnvironmentVariable("ENVIRONMENT", Environments.Development);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", Environments.Development);
 
             var config = new ConfigurationBuilder();
             var collection = new ServiceCollection();

--- a/src/Maestro/Maestro.Web.Tests/LoggingConfigurationTests.cs
+++ b/src/Maestro/Maestro.Web.Tests/LoggingConfigurationTests.cs
@@ -66,7 +66,7 @@ namespace Maestro.Web.Tests
 
         private static TestData Setup()
         {
-            Environment.SetEnvironmentVariable("ENVIRONMENT", Environments.Development);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", Environments.Development);
             var channel = new Mock<ITelemetryChannel>();
             var telemetry = new List<ITelemetry>();
             channel.Setup(s => s.Send(Capture.In(telemetry)));

--- a/src/Maestro/tests/DependencyUpdater.Tests/DependencyRegistrationTests.cs
+++ b/src/Maestro/tests/DependencyUpdater.Tests/DependencyRegistrationTests.cs
@@ -17,7 +17,7 @@ namespace DependencyUpdater.Tests
         {
             DependencyInjectionValidation.IsDependencyResolutionCoherent(s =>
                     {
-                        Environment.SetEnvironmentVariable("ENVIRONMENT", "XUNIT");
+                        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "XUNIT");
                         ServiceHost.ConfigureDefaultServices(s);
                         Program.Configure(s);
 

--- a/src/Maestro/tests/FeedCleaner.Tests/DependencyRegistrationTests.cs
+++ b/src/Maestro/tests/FeedCleaner.Tests/DependencyRegistrationTests.cs
@@ -15,7 +15,7 @@ namespace FeedCleanerService.Tests
         {
             DependencyInjectionValidation.IsDependencyResolutionCoherent(s =>
                     {
-                        Environment.SetEnvironmentVariable("ENVIRONMENT", "XUNIT");
+                        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "XUNIT");
                         ServiceHost.ConfigureDefaultServices(s);
                         Program.Configure(s);
                         s.AddScoped<FeedCleanerService>();

--- a/src/Maestro/tests/SubscriptionActorService.Tests/DependencyRegistrationTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/DependencyRegistrationTests.cs
@@ -15,7 +15,7 @@ namespace SubscriptionActorService.Tests
         {
             DependencyInjectionValidation.IsDependencyResolutionCoherent(s =>
                     {
-                        Environment.SetEnvironmentVariable("ENVIRONMENT", "XUNIT");
+                        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "XUNIT");
                         ServiceHost.ConfigureDefaultServices(s);
                         Program.Configure(s);
                         s.AddScoped<SubscriptionActor>();

--- a/src/Maestro/tests/SubscriptionActorService.Tests/TestsWithServices.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/TestsWithServices.cs
@@ -26,7 +26,7 @@ namespace SubscriptionActorService.Tests
         protected async Task Execute(Func<IServiceProvider, Task> run)
         {
             var services = new ServiceCollection();
-            Environment.SetEnvironmentVariable("ENVIRONMENT", "XUNIT");
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "XUNIT");
             services.TryAddSingleton(typeof(IActorProxyFactory<>), typeof(ActorProxyFactory<>));
             services.AddLogging(l => l.AddProvider(new NUnitLogger()));
             RegisterServices(services);

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost.Tests/ServiceHostTests.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost.Tests/ServiceHostTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost.Tests
         [Test]
         public void HttpExceptionsAreAugmentedByRichTelemetry()
         {
-            Environment.SetEnvironmentVariable("ENVIRONMENT", "XUnit");
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "XUnit");
             ServiceCollection services = new ServiceCollection();
             var channel = new FakeChannel();
             services.AddSingleton<ITelemetryChannel>(channel);
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost.Tests
         [Test]
         public void HttpExceptionsContentIsTruncatedByRichTelemetry()
         {
-            Environment.SetEnvironmentVariable("ENVIRONMENT", "XUnit");
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "XUnit");
             ServiceCollection services = new ServiceCollection();
             var channel = new FakeChannel();
             services.AddSingleton<ITelemetryChannel>(channel);


### PR DESCRIPTION
Set Environment variable `ASPNETCORE_ENVIRONMENT` instead of `ENVIRONMENT` when configuring tests.

Resolves dotnet/arcade#9395 for this repo.