### PR TITLE
Change rollout scorer to have a max allowed time rather than dinging per minute over an "average" time

### DIFF
--- a/src/RolloutScorer/RolloutScorer/Commands.cs
+++ b/src/RolloutScorer/RolloutScorer/Commands.cs
@@ -114,7 +114,7 @@ namespace RolloutScorer
             }
 
             Scorecard scorecard = await Scorecard.CreateScorecardAsync(_rolloutScorer);
-            string expectedTimeToRollout = TimeSpan.FromMinutes(_rolloutScorer.RepoConfig.ExpectedTime).ToString();
+            string expectedTimeToRollout = TimeSpan.FromMinutes(_rolloutScorer.RepoConfig.MaxAllowedTimeInMinutes).ToString();
 
             Console.WriteLine($"The {_rolloutScorer.Repo} {_rolloutScorer.RolloutStartDate.Date.ToShortDateString()} rollout score is {scorecard.TotalScore}.\n");
             Console.WriteLine($"|              Metric              |   Value  |  Target  |   Score   |");

--- a/src/RolloutScorer/RolloutScorer/Config.cs
+++ b/src/RolloutScorer/RolloutScorer/Config.cs
@@ -24,13 +24,13 @@ namespace RolloutScorer
         public List<string> BuildDefinitionIds { get; set; }
         public string AzdoInstance { get; set; }
         public string GithubIssueLabel { get; set; }
-        public int ExpectedTime { get; set; }
+        public int MaxAllowedTimeInMinutes { get; set; }
         public List<string> ExcludeStages { get; set; }
     }
 
     public class RolloutWeightConfig
     {
-        public int RolloutMinutesPerPoint { get; set; }
+        public int RolloutOverTimePoints { get; set; }
         public int PointsPerIssue { get; set; }
         public int PointsPerHotfix { get; set; }
         public int PointsPerRollback { get; set; }

--- a/src/RolloutScorer/RolloutScorer/RolloutUploader.cs
+++ b/src/RolloutScorer/RolloutScorer/RolloutUploader.cs
@@ -189,7 +189,7 @@ namespace RolloutScorer
             string summary = $"## {scorecard.Repo.Repo}\n\n" +
                 $"|              Metric              |   Value  |  Target  |   Score   |\n" +
                 $"|:--------------------------------:|:--------:|:--------:|:---------:|\n" +
-                $"| Time to Rollout                  | {scorecard.TimeToRollout} | {TimeSpan.FromMinutes(scorecard.Repo.ExpectedTime)} |     {scorecard.TimeToRolloutScore}     |\n" +
+                $"| Time to Rollout                  | {scorecard.TimeToRollout} | {TimeSpan.FromMinutes(scorecard.Repo.MaxAllowedTimeInMinutes)} |     {scorecard.TimeToRolloutScore}     |\n" +
                 $"| Critical/blocking issues created |     {scorecard.CriticalIssues}    |    0     |     {scorecard.CriticalIssueScore}     |\n" +
                 $"| Hotfixes                         |     {scorecard.Hotfixes}    |    0     |     {scorecard.HotfixScore}     |\n" +
                 $"| Rollbacks                        |     {scorecard.Rollbacks}    |    0     |     {scorecard.RollbackScore}     |\n" +

--- a/src/RolloutScorer/RolloutScorer/Scorecard.cs
+++ b/src/RolloutScorer/RolloutScorer/Scorecard.cs
@@ -23,7 +23,7 @@ namespace RolloutScorer
         private List<string> _githubIssuesUris = new List<string>();
         public List<string> GithubIssueUris => _githubIssuesUris.Count == 0 ? GithubIssues.Select(issue => issue.HtmlUrl.ToString()).ToList() : _githubIssuesUris;
 
-        public int TimeToRolloutScore => Math.Max((int)Math.Ceiling((TimeToRollout.TotalMinutes - Repo.ExpectedTime) / RolloutWeightConfig.RolloutMinutesPerPoint), 0);
+        public int TimeToRolloutScore => TimeToRollout.TotalMinutes > Repo.MaxAllowedTimeInMinutes ? RolloutWeightConfig.RolloutOverTimePoints : 0;
         public int CriticalIssueScore => CriticalIssues * RolloutWeightConfig.PointsPerIssue;
         public int HotfixScore => Hotfixes * RolloutWeightConfig.PointsPerHotfix;
         public int RollbackScore => Rollbacks * RolloutWeightConfig.PointsPerRollback;

--- a/src/RolloutScorer/RolloutScorer/StandardConfig.cs
+++ b/src/RolloutScorer/RolloutScorer/StandardConfig.cs
@@ -14,7 +14,7 @@ namespace RolloutScorer
                     BuildDefinitionIds = new List<string> { "620", "697" },
                     AzdoInstance = "dnceng",
                     GithubIssueLabel = "Rollout Helix",
-                    ExpectedTime = 90,
+                    MaxAllowedTimeInMinutes = 360,
                     ExcludeStages = new List<string>() { "Post_Deployment_Tests" },
                 },
                 new RepoConfig
@@ -23,7 +23,7 @@ namespace RolloutScorer
                     BuildDefinitionIds = new List<string> { "596" },
                     AzdoInstance = "dnceng",
                     GithubIssueLabel = "Rollout OSOB",
-                    ExpectedTime = 150,
+                    MaxAllowedTimeInMinutes = 360,
                     ExcludeStages = new List<string> { "Validate", "Cleanup", "Validate_OnPrem" },
                 },
                 new RepoConfig
@@ -32,7 +32,7 @@ namespace RolloutScorer
                     BuildDefinitionIds = new List<string> { "252", "728" },
                     AzdoInstance = "dnceng",
                     GithubIssueLabel = "Rollout Arcade-Services",
-                    ExpectedTime = 90,
+                    MaxAllowedTimeInMinutes = 360,
                     ExcludeStages = new List<string> { "Post-Deployment", "Validate deployment" },
                 },
             },
@@ -48,7 +48,7 @@ namespace RolloutScorer
             },
             RolloutWeightConfig = new RolloutWeightConfig
             {
-                RolloutMinutesPerPoint = 15,
+                RolloutOverTimePoints = 50,
                 PointsPerIssue = 1,
                 PointsPerHotfix = 5,
                 PointsPerRollback = 10,


### PR DESCRIPTION
It's all in the title folkssss

Closes https://github.com/dotnet/arcade/issues/9329.