### PR TITLE
Tweak "--force-secret" behavior and expand docs

### DIFF
--- a/src/Microsoft.DncEng.SecretManager.Tests/SynchronizeCommandTests.cs
+++ b/src/Microsoft.DncEng.SecretManager.Tests/SynchronizeCommandTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Microsoft.DncEng.CommandLineLib;
 using Microsoft.DncEng.SecretManager.Commands;
 using Microsoft.Extensions.DependencyInjection;
+using Mono.Options;
 using Moq;
 using Moq.Protected;
 using NUnit.Framework;
@@ -17,7 +18,7 @@ namespace Microsoft.DncEng.SecretManager.Tests
     public class SynchronizeCommandTests
     {
         private async Task TestCommand(DateTimeOffset now, string manifestText, string locationTypeName, List<SecretProperties> existingSecrets, string secretTypeName, List<string> suffixes,
-            Func<IDictionary<string, object>, List<string>> referencesGenerator, List<List<SecretData>> rotationResults, List<(string name, SecretValue value)> expectedSets)
+            Func<IDictionary<string, object>, List<string>> referencesGenerator, List<List<SecretData>> rotationResults, List<(string name, SecretValue value)> expectedSets, string[] nonPositionalArguments = null)
         {
             var cts = new CancellationTokenSource();
             var cancellationToken = cts.Token;
@@ -73,6 +74,8 @@ namespace Microsoft.DncEng.SecretManager.Tests
                     .Returns(secretType.Object);
 
                 var command = provider.GetRequiredService<SynchronizeCommand>();
+                OptionSet optionSet = command.GetOptions();
+                optionSet.Parse(nonPositionalArguments ?? Array.Empty<string>());
                 command.HandlePositionalArguments(new List<string> {manifestFile});
 
                 await command.RunAsync(cancellationToken);
@@ -350,6 +353,146 @@ secrets:
                     }, new List<(string name, SecretValue value)>
                     {
                     }));
+        }
+
+        /// <summary>
+        /// Use of --force should rotate all secrets even if valid
+        /// </summary>
+        [Test]
+        public async Task ForcedSecretsAreRotated()
+        {
+            var now = DateTimeOffset.Parse("3/25/2021 1:30");
+            await TestCommand(
+                now: now, 
+                manifestText: @"
+storageLocation:
+  type: test
+secrets:
+  valid-secret:
+    type: test-secret
+  to-be-rotated-secret:
+    type: test-secret
+", 
+                locationTypeName: "test",
+                existingSecrets: new List<SecretProperties>
+                {
+                    new SecretProperties("valid-secret", now.AddDays(10), now.AddDays(4), ImmutableDictionary.Create<string, string>()),
+                    new SecretProperties("to-be-rotated-secret", now.AddDays(10), now.AddDays(-1), ImmutableDictionary.Create<string, string>()),
+                },
+                secretTypeName: "test-secret",
+                suffixes: new List<string>{""},
+                referencesGenerator: parameters => new List<string>(),
+                rotationResults: new List<List<SecretData>>
+                {
+                    new List<SecretData>
+                    {
+                        new SecretData("valid-secret-test-value", now.AddDays(20), now.AddDays(5)),
+                    },
+                    new List<SecretData>
+                    {
+                        new SecretData("to-be-rotated-secret-test-value", now.AddDays(20), now.AddDays(5))
+                    },
+                }, 
+                expectedSets: new List<(string name, SecretValue value)> 
+                {
+                    ("valid-secret", new SecretValue("valid-secret-test-value", ImmutableDictionary.Create<string, string>(), now.AddDays(5), now.AddDays(20))),
+                    ("to-be-rotated-secret", new SecretValue("to-be-rotated-secret-test-value", ImmutableDictionary.Create<string, string>(), now.AddDays(5), now.AddDays(20))),
+                }, 
+                nonPositionalArguments: new[] {"--force"}
+            );
+        }
+
+        /// <summary>
+        /// Use of --force-secret should reset a secret even if it is valid
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task ForceSecretSecretsAreRotated()
+        {
+            var now = DateTimeOffset.Parse("3/25/2021 1:30");
+            await TestCommand(
+                now: now,
+                manifestText: @"
+storageLocation:
+  type: test
+secrets:
+  valid-secret-alpha:
+    type: test-secret
+  valid-secret-beta:
+    type: test-secret
+",
+                locationTypeName: "test",
+                existingSecrets: new List<SecretProperties>
+                {
+                    new SecretProperties("valid-secret-beta", now.AddDays(10), now.AddDays(4), ImmutableDictionary.Create<string, string>()),
+                    new SecretProperties("valid-secret-alpha", now.AddDays(10), now.AddDays(4), ImmutableDictionary.Create<string, string>())
+                },
+                secretTypeName: "test-secret",
+                suffixes: new List<string> { "" },
+                referencesGenerator: parameters => new List<string>(),
+                rotationResults: new List<List<SecretData>>
+                {
+                    new List<SecretData>
+                    {
+                        new SecretData("beta-test-value", now.AddDays(20), now.AddDays(5))
+                    },
+                    new List<SecretData>
+                    {
+                        new SecretData("alpha-test-value", now.AddDays(20), now.AddDays(5)),
+                    }
+                },
+                expectedSets: new List<(string name, SecretValue value)>
+                {
+                    ("valid-secret-beta", new SecretValue("beta-test-value", ImmutableDictionary.Create<string, string>(), now.AddDays(5), now.AddDays(20)))
+                },
+                nonPositionalArguments: new[] { "--force-secret=valid-secret-beta" }
+            );
+        }
+
+        /// <summary>
+        /// Use of --force-secret should reset a valid secret while ignoring other secrets even when invalid.
+        /// </summary>
+        [Test]
+        public async Task OnlyForceSecretSecretsAreRotated()
+        {
+            var now = DateTimeOffset.Parse("3/25/2021 1:30");
+            await TestCommand(
+                now: now,
+                manifestText: @"
+storageLocation:
+  type: test
+secrets:
+  invalid-secret-alpha:
+    type: test-secret
+  valid-secret-beta:
+    type: test-secret
+",
+                locationTypeName: "test",
+                existingSecrets: new List<SecretProperties>
+                {
+                    new SecretProperties("valid-secret-beta", now.AddDays(10), now.AddDays(4), ImmutableDictionary.Create<string, string>()),
+                    new SecretProperties("invalid-secret-alpha", now.AddDays(10), now.AddDays(-1), ImmutableDictionary.Create<string, string>())
+                },
+                secretTypeName: "test-secret",
+                suffixes: new List<string> { "" },
+                referencesGenerator: parameters => new List<string>(),
+                rotationResults: new List<List<SecretData>>
+                {
+                    new List<SecretData>
+                    {
+                        new SecretData("beta-test-value", now.AddDays(20), now.AddDays(5))
+                    },
+                    new List<SecretData>
+                    {
+                        new SecretData("alpha-test-value", now.AddDays(20), now.AddDays(5)),
+                    }
+                },
+                expectedSets: new List<(string name, SecretValue value)>
+                {
+                    ("valid-secret-beta", new SecretValue("beta-test-value", ImmutableDictionary.Create<string, string>(), now.AddDays(5), now.AddDays(20)))
+                },
+                nonPositionalArguments: new[] { "--force-secret=valid-secret-beta" }
+            );
         }
     }
 }

--- a/src/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
@@ -10,7 +10,7 @@ using Command = Microsoft.DncEng.CommandLineLib.Command;
 
 namespace Microsoft.DncEng.SecretManager.Commands
 {
-    [Command("synchronize")]
+    [Command("synchronize", Description = "Compare every secret specified in the manifest with the corresponding vault, and performs the appropriate rotation for each secret that requires it.")]
     public class SynchronizeCommand : Command
     {
         private readonly StorageLocationTypeRegistry _storageLocationTypeRegistry;
@@ -41,8 +41,8 @@ namespace Microsoft.DncEng.SecretManager.Commands
         {
             return new OptionSet
             {
-                {"f|force", "Force rotate all secrets", f => _force = !string.IsNullOrEmpty(f)},
-                {"force-secret=", "Force rotate the specified secret", f => _forcedSecrets.Add(f)},
+                {"f|force", "Rotate all secrets specified in the manifest regardless of expiration", f => _force = !string.IsNullOrEmpty(f)},
+                {"force-secret=", "Rotate the specified secret regardless of its expiration. May be specified multiple times.", f => _forcedSecrets.Add(f)},
                 {"verify-only", "Does not rotate any secrets, instead, produces an error for every secret that needs to be rotated.", v => _verifyOnly = !string.IsNullOrEmpty(v)},
             };
         }
@@ -55,7 +55,7 @@ namespace Microsoft.DncEng.SecretManager.Commands
                 if (_force || _forcedSecrets.Any())
                 {
                     bool confirmed = await _console.ConfirmAsync(
-                        "--force or --force-secret is set, this will rotate one or more secrets ahead of schedule, possibly causing service disruption. Continue? ");
+                        "--force or --force-secret is set, this will rotate one or more secrets ahead of schedule, possibly causing service disruption. Type 'yes' to continue. ");
                     if (!confirmed)
                     {
                         return;
@@ -115,7 +115,7 @@ namespace Microsoft.DncEng.SecretManager.Commands
                         _console.WriteLine("Referenced secret was rotated, will rotate.");
                         regenerate = true;
                     }
-                    else
+                    else if (!_forcedSecrets.Any())
                     {
                         // If these fields aren't the same for every part of a composite secrets, assume the soonest value is right
                         DateTimeOffset nextRotation = existing.Select(e => e.NextRotationOn).Min();

--- a/src/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DncEng.SecretManager.Commands
             try
             {
                 _console.WriteLine($"Synchronizing secrets contained in {_manifestFile}");
-                if (_force || _forcedSecrets.Any())
+                if ((_force || _forcedSecrets.Any()) && _console.IsInteractive)
                 {
                     bool confirmed = await _console.ConfirmAsync(
                         "--force or --force-secret is set, this will rotate one or more secrets ahead of schedule, possibly causing service disruption. Type 'yes' to continue. ");

--- a/src/Microsoft.DncEng.SecretManager/Commands/ValidateAllCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/Commands/ValidateAllCommand.cs
@@ -13,7 +13,7 @@ using Command = Microsoft.DncEng.CommandLineLib.Command;
 
 namespace Microsoft.DncEng.SecretManager.Commands
 {
-    [Command("validate-all")]
+    [Command("validate-all", Description = "Validate all `settings.json` and `settings.<environment>.json` files against the specified manifest(s).")]
     public class ValidateAllCommand : Command
     {
         private readonly IConsole _console;

--- a/src/Microsoft.DncEng.SecretManager/Commands/ValidateCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/Commands/ValidateCommand.cs
@@ -6,7 +6,7 @@ using Command = Microsoft.DncEng.CommandLineLib.Command;
 
 namespace Microsoft.DncEng.SecretManager.Commands
 {
-    [Command("validate")]
+    [Command("validate", Description = "Validate a given `settings.json` and `settings.<environment>.json` against a secret manifest.")]
     public class ValidateCommand : Command
     {
         private readonly SettingsFileValidator _settingsFileValidator;

--- a/src/Microsoft.DncEng.SecretManager/InfoCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/InfoCommand.cs
@@ -6,7 +6,7 @@ using Microsoft.DncEng.CommandLineLib;
 
 namespace Microsoft.DncEng.SecretManager
 {
-    [Command("info")]
+    [Command("info", Description = "Get tool version details")]
     class InfoCommand : Command
     {
         private readonly IConsole _console;

--- a/src/Microsoft.DncEng.SecretManager/TestCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/TestCommand.cs
@@ -7,7 +7,7 @@ using Microsoft.DncEng.CommandLineLib.Authentication;
 
 namespace Microsoft.DncEng.SecretManager
 {
-    [Command("test")]
+    [Command("test", Description = "Attempt authentication")]
     class TestCommand : Command
     {
         private readonly IConsole _console;


### PR DESCRIPTION
Change `synchronize --force-secret=<secret-name>` to ignore all secrets except those specified. Previously, it would force-rotate specified secrets _and_ any other expired secret in the manifest. 

Also add tests around these arguments. 

To support testing the "force" arguments, no longer require confirmation when used in a noninteractive terminal (such as a test harness). Previously, the confirmation would fail on a noninteractive terminal. 