### PR TITLE
Revert "Tweak "--force-secret" behavior and expand docs"

### DIFF
--- a/src/Microsoft.DncEng.SecretManager/Commands/ValidateAllCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/Commands/ValidateAllCommand.cs
@@ -13,7 +13,7 @@ using Command = Microsoft.DncEng.CommandLineLib.Command;
 
 namespace Microsoft.DncEng.SecretManager.Commands
 {
-    [Command("validate-all", Description = "Validate all `settings.json` and `settings.<environment>.json` files against the specified manifest(s).")]
+    [Command("validate-all")]
     public class ValidateAllCommand : Command
     {
         private readonly IConsole _console;

--- a/src/Microsoft.DncEng.SecretManager/Commands/ValidateCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/Commands/ValidateCommand.cs
@@ -6,7 +6,7 @@ using Command = Microsoft.DncEng.CommandLineLib.Command;
 
 namespace Microsoft.DncEng.SecretManager.Commands
 {
-    [Command("validate", Description = "Validate a given `settings.json` and `settings.<environment>.json` against a secret manifest.")]
+    [Command("validate")]
     public class ValidateCommand : Command
     {
         private readonly SettingsFileValidator _settingsFileValidator;

--- a/src/Microsoft.DncEng.SecretManager/InfoCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/InfoCommand.cs
@@ -6,7 +6,7 @@ using Microsoft.DncEng.CommandLineLib;
 
 namespace Microsoft.DncEng.SecretManager
 {
-    [Command("info", Description = "Get tool version details")]
+    [Command("info")]
     class InfoCommand : Command
     {
         private readonly IConsole _console;

--- a/src/Microsoft.DncEng.SecretManager/TestCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/TestCommand.cs
@@ -7,7 +7,7 @@ using Microsoft.DncEng.CommandLineLib.Authentication;
 
 namespace Microsoft.DncEng.SecretManager
 {
-    [Command("test", Description = "Attempt authentication")]
+    [Command("test")]
     class TestCommand : Command
     {
         private readonly IConsole _console;


### PR DESCRIPTION
Reverts dotnet/arcade-services#1902

The `ForcedSecretsAreRotated()` test fails occasionally. I don't yet know why, but I do not want to get in the way.