### PR TITLE
Update build moniter secret usage

### DIFF
--- a/.vault-config/shared/dotneteng-status-secrets.yaml
+++ b/.vault-config/shared/dotneteng-status-secrets.yaml
@@ -46,3 +46,12 @@ dn-bot-dnceng-workitems-rw:
     domainAccountSecret:
       name: dn-bot-account-redmond
       location: helixkv
+
+dn-bot-dnceng-build-r-code-r-project-r-profile-r:
+  type: azure-devops-access-token
+  parameters:
+    organization: dnceng
+    requiredScopes: Build (Read) Code (Read) Project (Read) Profile (Read)
+    domainAccountSecret:
+      name: dn-bot-account-redmond
+      location: helixkv

--- a/src/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/.config/settings.json
@@ -101,31 +101,31 @@
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\arcade-services\\dotnet-arcade-services-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade"
+          "IssuesId": "dotnet-arcade-first-responder"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\helix-machines\\dotnet-helix-machines-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade"
+          "IssuesId": "dotnet-arcade-first-responder"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\helix-service\\dotnet-helix-service-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade"
+          "IssuesId": "dotnet-arcade-first-responder"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\arcade\\dotnet-arcade-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade"
+          "IssuesId": "dotnet-arcade-first-responder"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\release\\dotnet-release-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade"
+          "IssuesId": "dotnet-arcade-first-responder"
         },
         {
           "Project": "internal",
@@ -163,6 +163,12 @@
         "Owner": "dotnet",
         "Name": "arcade",
         "Labels": [ "Build Failed" ]
+      },
+      {
+        "Id": "dotnet-arcade-first-responder",
+        "Owner": "dotnet",
+        "Name": "arcade",
+        "Labels": [ "Build Failed", "First Responder" ]
       },
       {
         "Id": "dotnet-aspnetcore-infra",

--- a/src/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/.config/settings.json
@@ -51,79 +51,13 @@
         },
         {
           "Project": "internal",
-          "DefinitionPath": "\\dotnet\\arcade\\arcade-codeql",
-          "Branches": [ "main", "release/6.0" ],
-          "IssuesId": "dotnet-arcade"
-        },
-        {
-          "Project": "internal",
-          "DefinitionPath": "\\dotnet\\arcade-services\\arcade-services-codeql",
-          "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade"
-        },
-        {
-          "Project": "internal",
-          "DefinitionPath": "\\dotnet\\arcade-extensions\\dotnet-arcade-extensions-codeql",
-          "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade"
-        },
-        {
-          "Project": "internal",
-          "DefinitionPath": "\\dotnet\\dotnet-helix-machines\\dotnet-helix-machines-codeql",
-          "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade"
-        },
-        {
-          "Project": "internal",
-          "DefinitionPath": "\\dotnet\\helix-service\\dotnet-helix-service-codeql",
-          "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade"
-        },
-        {
-          "Project": "internal",
-          "DefinitionPath": "\\dotnet\\migrate-package\\dotnet-migrate-package-codeql",
-          "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade"
-        },
-        {
-          "Project": "internal",
-          "DefinitionPath": "\\dotnet\\source-indexer\\dotnet-source-indexer-codeql",
-          "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade"
-        },
-        {
-          "Project": "internal",
-          "DefinitionPath": "\\dotnet\\xliff-tasks\\xliff-tasks-codeql",
-          "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade"
-        },
-        {
-          "Project": "internal",
           "DefinitionPath": "\\dotnet\\arcade-services\\dotnet-arcade-services-weekly",
           "Branches": [ "main" ],
           "IssuesId": "dotnet-arcade-first-responder"
         },
         {
           "Project": "internal",
-          "DefinitionPath": "\\dotnet\\helix-machines\\dotnet-helix-machines-weekly",
-          "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade-first-responder"
-        },
-        {
-          "Project": "internal",
-          "DefinitionPath": "\\dotnet\\helix-service\\dotnet-helix-service-weekly",
-          "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade-first-responder"
-        },
-        {
-          "Project": "internal",
           "DefinitionPath": "\\dotnet\\arcade\\dotnet-arcade-weekly",
-          "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade-first-responder"
-        },
-        {
-          "Project": "internal",
-          "DefinitionPath": "\\dotnet\\release\\dotnet-release-weekly",
           "Branches": [ "main" ],
           "IssuesId": "dotnet-arcade-first-responder"
         },

--- a/src/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/.config/settings.json
@@ -26,7 +26,7 @@
       "BaseUrl": "https://dev.azure.com",
       "Organization": "dnceng",
       "MaxParallelRequests": 10,
-      "AccessToken": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
+      "AccessToken": "[vault(dn-bot-dnceng-build-r-code-r-project-r-profile-r)]",
       "Builds": [
         {
           "Project": "internal",

--- a/src/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
+++ b/src/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
@@ -26,7 +26,7 @@ namespace DotNet.Status.Web.Controllers
     {
         private readonly IGitHubApplicationClientFactory _gitHubApplicationClientFactory;
         private readonly IAzureDevOpsClientFactory _azureDevOpsClientFactory;
-        private readonly IOptions<BuildMonitorOptions> _options;
+        private readonly IOptionsSnapshot<BuildMonitorOptions> _options;
         private readonly ILogger<AzurePipelinesController> _logger;
         private readonly Lazy<IAzureDevOpsClient> _clientLazy;
         private readonly Lazy<Task<Dictionary<string, string>>> _projectMapping;
@@ -34,7 +34,7 @@ namespace DotNet.Status.Web.Controllers
         public AzurePipelinesController(
             IGitHubApplicationClientFactory gitHubApplicationClientFactory,
             IAzureDevOpsClientFactory azureDevOpsClientFactory,
-            IOptions<BuildMonitorOptions> options,
+            IOptionsSnapshot<BuildMonitorOptions> options,
             ILogger<AzurePipelinesController> logger)
         {
             _gitHubApplicationClientFactory = gitHubApplicationClientFactory;


### PR DESCRIPTION
Updates:

* The secret used by Build Monitor to be explicit as to what it is using
* Changes the usage of IOptions to IOptionsSnapshot
* Updates the Build Monitor alerts for the weekly builds to include the First Responder label (as this generally means a secret expired)

Addresses https://github.com/dotnet/arcade/issues/9516