### PR TITLE
Change secret type from text to azure-devops-access-token

### DIFF
--- a/.vault-config/maestrolocal.yaml
+++ b/.vault-config/maestrolocal.yaml
@@ -41,13 +41,33 @@ secrets:
     type: maestro-access-token
     parameters:
       environment: https://maestro-prod.westus2.cloudapp.azure.com/
-
+   
   dn-bot-dnceng-build-rw-code-rw-release-rw:
-    type: text
-
+    type: azure-devops-access-token
+    parameters:
+      domainAccountName: dn-bot
+      domainAccountSecret:
+          location: helixkv
+          name: dn-bot-account-redmond
+      name: dn-bot-dnceng-build
+      organization: dnceng
+   
   dn-bot-devdiv-build-rw-code-rw-release-rw:
-    type: text
-
+    type: azure-devops-access-token
+    parameters:
+      domainAccountName: dn-bot
+      domainAccountSecret:
+          location: helixkv
+          name: dn-bot-account-redmond
+      name: dn-bot-devdiv-build
+      organization: devdiv
+   
   dn-bot-dnceng-packaging-rwm:
-    type: text
-
+    type: azure-devops-access-token
+    parameters:
+      domainAccountName: dn-bot
+      domainAccountSecret:
+          location: helixkv
+          name: dn-bot-account-redmond
+      name: dn-bot-dnceng-build
+      organization: dnceng

--- a/.vault-config/shared/maestro-secrets.yaml
+++ b/.vault-config/shared/maestro-secrets.yaml
@@ -33,10 +33,31 @@ prod-maestro-token:
     environment: https://maestro-prod.westus2.cloudapp.azure.com/
 
 dn-bot-dnceng-build-rw-code-rw-release-rw:
-  type: text
+  type: azure-devops-access-token
+  parameters:
+    domainAccountName: dn-bot
+    domainAccountSecret:
+        location: helixkv
+        name: dn-bot-account-redmond
+    name: dn-bot-dnceng-build
+    organization: dnceng
 
 dn-bot-devdiv-build-rw-code-rw-release-rw:
-  type: text
+  type: azure-devops-access-token
+  parameters:
+    domainAccountName: dn-bot
+    domainAccountSecret:
+        location: helixkv
+        name: dn-bot-account-redmond
+    name: dn-bot-devdiv-build
+    organization: devdiv
 
 dn-bot-dnceng-packaging-rwm:
-  type: text
+  type: azure-devops-access-token
+  parameters:
+    domainAccountName: dn-bot
+    domainAccountSecret:
+        location: helixkv
+        name: dn-bot-account-redmond
+    name: dn-bot-dnceng-build
+    organization: dnceng


### PR DESCRIPTION
Manually cycling these secrets, they caused a null-ref since "text" kind needs " description".  So, fix them from text -> what they are.

@alexperovich please review... 