### PR TITLE
Only add build to distinct channels

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -113,7 +113,8 @@ namespace Microsoft.DotNet.Darc.Operations
                     targetChannels.AddRange(
                         defaultChannels.
                             Where(dc => dc.Enabled).
-                            Select(dc => dc.Channel));
+                            Select(dc => dc.Channel).
+                            Distinct());
                 }
 
                 IEnumerable<Channel> currentChannels = build.Channels.Where(ch => targetChannels.Any(tc => tc.Id == ch.Id));

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Darc.Operations
                         defaultChannels.
                             Where(dc => dc.Enabled).
                             Select(dc => dc.Channel).
-                            Distinct());
+                            DistinctBy(c => c.Id));
                 }
 
                 IEnumerable<Channel> currentChannels = build.Channels.Where(ch => targetChannels.Any(tc => tc.Id == ch.Id));


### PR DESCRIPTION
In AddBuildToChannel, we would get all the channels that a build is supposed to be published to by default. However, as in the case of https://github.com/dotnet/arcade/issues/9508, where a default channel is set up for a specific branch and for a regex matching that branch, we'd add the same channel to the list multiple times. This caused arcade's publishing infrastructure to also get confused. We don't need to publish to the same channel twice, so we should distinct the list of channels that we will be publishing to, distinguished by their channel id.