### PR TITLE
GitHub application client factory working for multiple applications

### DIFF
--- a/src/Maestro/Maestro.Data/BuildAssetRegistryInstallationLookup.cs
+++ b/src/Maestro/Maestro.Data/BuildAssetRegistryInstallationLookup.cs
@@ -26,5 +26,19 @@ namespace Maestro.Data
         {
             return Task.FromResult(true);
         }
+
+        public async Task<long> GetInstallationIdForApp(string appName, string repositoryUrl)
+        {
+            using (var scope = _scopeFactory.CreateScope())
+            {
+                var ctx = scope.ServiceProvider.GetRequiredService<BuildAssetRegistryContext>();
+                return await ctx.GetInstallationId(repositoryUrl);
+            }
+        }
+
+        public Task<bool> IsOrganizationSupportedForApp(string appName, string org)
+        {
+            return Task.FromResult(true);
+        }
     }
 }

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubApplicationClientFactory.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/GitHubApplicationClientFactory.cs
@@ -23,6 +23,11 @@ namespace Microsoft.DotNet.GitHub.Authentication
             return _clientFactory.CreateGitHubClient(await _tokenProvider.GetTokenForRepository(owner, repo));
         }
 
+        public async Task<IGitHubClient> CreateGitHubClientForAppAsync(string appName, string owner, string repo)
+        {
+            return _clientFactory.CreateGitHubClient(await _tokenProvider.GetTokenForRepositoryForApp(appName, owner, repo));
+        }
+
         public IGitHubClient CreateGitHubAppClient()
         {
             return _clientFactory.CreateGitHubClient(_tokenProvider.GetTokenForApp(), AuthenticationType.Bearer);

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubApplicationClientFactory.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubApplicationClientFactory.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DotNet.GitHub.Authentication
     public interface IGitHubApplicationClientFactory
     { 
         Task<IGitHubClient> CreateGitHubClientAsync(string owner, string repo);
+        Task<IGitHubClient> CreateGitHubClientForAppAsync(string appName, string owner, string repo);
         IGitHubClient CreateGitHubAppClient();
 
         /// <summary>

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubTokenProvider.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/IGitHubTokenProvider.cs
@@ -9,7 +9,11 @@ namespace Microsoft.DotNet.GitHub.Authentication
     public interface IGitHubTokenProvider
     {
         Task<string> GetTokenForInstallationAsync(long installationId);
+        Task<string> GetTokenForInstallationForAppAsync(string appName, long installationId);
+
         Task<string> GetTokenForRepository(string repositoryUrl);
+        Task<string> GetTokenForRepositoryForApp(string appName, string repositoryUrl);
+
         string GetTokenForApp();
         string GetTokenForApp(string name);
     }
@@ -20,5 +24,11 @@ namespace Microsoft.DotNet.GitHub.Authentication
         {
             return provider.GetTokenForRepository(GitHubHelper.GetRepositoryUrl(organization, repository));
         }
+
+        public static Task<string> GetTokenForRepositoryForApp(this IGitHubTokenProvider provider, string appName, string organization, string repository)
+        {
+            return provider.GetTokenForRepositoryForApp(appName, GitHubHelper.GetRepositoryUrl(organization, repository));
+        }
+
     }
 }

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/InMemoryCacheInstallationLookup.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/InMemoryCacheInstallationLookup.cs
@@ -22,7 +22,10 @@ namespace Microsoft.DotNet.GitHub.Authentication
         private readonly SemaphoreSlim _sem = new SemaphoreSlim(1, 1);
 
         private ImmutableDictionary<string, long> _cache = ImmutableDictionary<string, long>.Empty;
+        private Dictionary<string, ImmutableDictionary<string, long>> _cacheForApp = new Dictionary<string, ImmutableDictionary<string, long>>();
+
         private DateTimeOffset _lastCached = DateTimeOffset.MinValue;
+        private Dictionary<string, DateTimeOffset> _lastCachedForApp = new Dictionary<string, DateTimeOffset>();
 
         public InMemoryCacheInstallationLookup(
             IGitHubAppTokenProvider tokens,
@@ -45,6 +48,19 @@ namespace Microsoft.DotNet.GitHub.Authentication
             string org = segments[^2].TrimEnd('/').ToLowerInvariant();
             
             return await GetInstallationIdForOrg(org);
+        }
+
+        public async Task<long> GetInstallationIdForApp(string appName, string repositoryUrl)
+        {
+            string[] segments = new Uri(repositoryUrl, UriKind.Absolute).Segments;
+            string org = segments[^2].TrimEnd('/').ToLowerInvariant();
+
+            return await GetInstallationIdForAppForOrg(appName, org);
+        }
+
+        public async Task<bool> IsOrganizationSupportedForApp(string appName, string org)
+        {
+            return await GetInstallationIdForAppForOrg(appName, org.ToLowerInvariant()) != 0;
         }
 
         private async Task<long> GetInstallationIdForOrg(string org)
@@ -116,6 +132,78 @@ namespace Microsoft.DotNet.GitHub.Authentication
             }
         }
 
+        private async Task<long> GetInstallationIdForAppForOrg(string appName, string org)
+        {
+            string[] allowed = _options.Value.AllowOrgs;
+            if (allowed != null && !allowed.Contains(org))
+            {
+                // We have an allow list, and this org isn't in it, bail
+                return 0;
+            }
+
+            if (HasCachedValueForApp(appName, org, out long installation))
+            {
+                return installation;
+            }
+
+            await _sem.WaitAsync();
+            try
+            {
+                if (HasCachedValueForApp(appName, org, out installation))
+                {
+                    return installation;
+                }
+
+                _log.LogInformation("No cached installation token found for {org} for app {app}", org, appName);
+
+                string appToken = _tokens.GetAppToken(appName);
+                var client = new GitHubAppsClient(
+                    new ApiConnection(
+                        new Connection(_options.Value.ProductHeader)
+                        {
+                            Credentials = new Credentials(appToken, AuthenticationType.Bearer)
+                        }
+                    )
+                );
+
+                ImmutableDictionary<string, long>.Builder newCache = ImmutableDictionary.CreateBuilder<string, long>();
+                foreach (Installation i in await client.GetAllInstallationsForCurrent())
+                {
+                    string installedOrg = i.Account.Login.ToLowerInvariant();
+                    _log.LogInformation("Found installation token for {org}, with id {id} for app {app}", installedOrg, i.Id, appName);
+                    newCache.Add(installedOrg, i.Id);
+                }
+
+                _cacheForApp.TryGetValue(appName, out ImmutableDictionary<string, long> cacheForApp);
+                cacheForApp ??= ImmutableDictionary<string, long>.Empty;
+                foreach (string key in cacheForApp.Keys)
+                {
+                    // Anything we had before but don't have now has been uninstalled, remove it
+                    if (newCache.TryAdd(key, 0))
+                    {
+                        _log.LogInformation("Removed uninstalled org {org} for app {app}", key, appName);
+                    }
+                }
+
+                // If the current thing wasn't in this list, it's not installed, record that so when they ask again in
+                // a few seconds, we don't have to re-query GitHub
+                if (newCache.TryAdd(org, 0))
+                {
+                    _log.LogInformation("Removed uninstalled, but requested org {org} for app {app}", org, appName);
+                }
+
+                Interlocked.Exchange(ref cacheForApp, newCache.ToImmutable());
+                _cacheForApp[appName] = cacheForApp;
+                _lastCachedForApp[appName] = DateTimeOffset.UtcNow;
+
+                return _cacheForApp[appName][org];
+            }
+            finally
+            {
+                _sem.Release();
+            }
+        }
+
         private bool HasCachedValue(string repositoryUrl, out long installation)
         {
             if (_lastCached + TimeSpan.FromMinutes(15) < DateTimeOffset.UtcNow)
@@ -125,6 +213,18 @@ namespace Microsoft.DotNet.GitHub.Authentication
             }
 
             return _cache.TryGetValue(repositoryUrl, out installation);
+        }
+
+        private bool HasCachedValueForApp(string appName, string repositoryUrl, out long installation)
+        {
+            DateTimeOffset lastCached = _lastCachedForApp.GetValueOrDefault(appName, DateTimeOffset.MinValue);
+            if (lastCached + TimeSpan.FromMinutes(15) < DateTimeOffset.UtcNow)
+            {
+                installation = 0;
+                return false;
+            }
+
+            return _cacheForApp[appName].TryGetValue(repositoryUrl, out installation);
         }
     }
 }

--- a/src/Shared/Microsoft.DotNet.GitHub.Authentication/InstallationLookup.cs
+++ b/src/Shared/Microsoft.DotNet.GitHub.Authentication/InstallationLookup.cs
@@ -9,7 +9,9 @@ namespace Microsoft.DotNet.GitHub.Authentication
     public interface IInstallationLookup
     {
         Task<long> GetInstallationId(string repositoryUrl);
+        Task<long> GetInstallationIdForApp(string appName, string repositoryUrl);
         Task<bool> IsOrganizationSupported(string org);
+        Task<bool> IsOrganizationSupportedForApp(string appName, string org);
     }
 
     public static class InstallationLookup


### PR DESCRIPTION
This is part of the work for: https://github.com/dotnet/arcade/issues/9221

When .NET Helix GitHub app be into its own App, the Helix API is going to be able to interact with multiple applications which is not able to handle by the GitHub application client factory  right now. 