### PR TITLE
Upgrade RolloutScorerAzureFunction to work with net6.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,7 +57,7 @@
     <PackageVersion Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Core" Version="3.0.23" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.4" />
     <PackageVersion Include="Microsoft.Bcl" Version="1.1.10" />
     <PackageVersion Include="Microsoft.Build" Version="17.1.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.1.0" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -229,7 +229,7 @@ stages:
             artifact: DotNetStatus
             displayName: Publish DotNet.Status.Web
 
-          - script: $(Build.SourcesDirectory)\.dotnet\dotnet publish -o $(Build.ArtifactStagingDirectory)\RolloutScorerAzureFunction\publish -f net5.0
+          - script: $(Build.SourcesDirectory)\.dotnet\dotnet publish -o $(Build.ArtifactStagingDirectory)\RolloutScorerAzureFunction\publish -f net6.0
             workingDirectory: src/RolloutScorer/RolloutScorerAzureFunction
             displayName: dotnet publish RolloutScorerAzureFunction
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -229,7 +229,7 @@ stages:
             artifact: DotNetStatus
             displayName: Publish DotNet.Status.Web
 
-          - script: $(Build.SourcesDirectory)\.dotnet\dotnet publish -o $(Build.ArtifactStagingDirectory)\RolloutScorerAzureFunction\publish -f net6.0
+          - script: $(Build.SourcesDirectory)\.dotnet\dotnet publish -o $(Build.ArtifactStagingDirectory)\RolloutScorerAzureFunction\publish -f net5.0
             workingDirectory: src/RolloutScorer/RolloutScorerAzureFunction
             displayName: dotnet publish RolloutScorerAzureFunction
 

--- a/src/RolloutScorer/RolloutScorerAzureFunction/RolloutScorerAzureFunction.csproj
+++ b/src/RolloutScorer/RolloutScorerAzureFunction/RolloutScorerAzureFunction.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
   <PropertyGroup>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <FileUpgradeFlags>40</FileUpgradeFlags>
     <SignAssembly>false</SignAssembly>
     <OldToolsVersion>2.0</OldToolsVersion>


### PR DESCRIPTION
Azure functions don't seem to support net6.0, reverting to net5.0 to unbreak the rollout scorer.

Closes https://github.com/dotnet/arcade/issues/9816.

The error that this should resolve:
```
System.Private.CoreLib: Could not load type 'System.Diagnostics.DebuggerStepThroughAttribute' from assembly 'System.Runtime, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
```