### PR TITLE
Increase header size limits

### DIFF
--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHostWebSite.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHostWebSite.cs
@@ -28,11 +28,16 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
 
         private static void NonServiceFabricMain()
         {
-            new WebHostBuilder().UseKestrel()
+            new WebHostBuilder().UseKestrel(o =>
+                    {
+                        // Default 32k, which isn't enough for oauth cookies from GitHub for people with many teams/claims
+                        o.Limits.MaxRequestHeadersTotalSize = 65536;
+                    }
+                )
                 .UseContentRoot(AppContext.BaseDirectory)
                 .ConfigureAppConfiguration((context, builder) =>
                 {
-                    builder.AddDefaultJsonConfiguration(context.HostingEnvironment, serviceProvider: null);
+                    builder.AddDefaultJsonConfiguration(context.HostingEnvironment, serviceProvider: null)
                 })
                 .ConfigureServices(ServiceHost.ConfigureDefaultServices)
                 .ConfigureServices(services =>

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHostWebSite.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHostWebSite.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost
                 .UseContentRoot(AppContext.BaseDirectory)
                 .ConfigureAppConfiguration((context, builder) =>
                 {
-                    builder.AddDefaultJsonConfiguration(context.HostingEnvironment, serviceProvider: null)
+                    builder.AddDefaultJsonConfiguration(context.HostingEnvironment, serviceProvider: null);
                 })
                 .ConfigureServices(ServiceHost.ConfigureDefaultServices)
                 .ConfigureServices(services =>


### PR DESCRIPTION
The OAuth bounce from GitHub sends some very large cookie
tokens, and the default limits are small enough that, for some
some users with many teams/claims, they get rejected with
400 : Headers too large