### PR TITLE
Add the Grafana Init code to SDL scans

### DIFF
--- a/azure-pipeline-codeql.yml
+++ b/azure-pipeline-codeql.yml
@@ -136,7 +136,7 @@ stages:
             -ConfigurationPath $(Build.SourcesDirectory)\.gdn\r\semmle-javascript-configure.gdnconfig
         displayName: 'CodeQL: maestro-angular (typescript)'
 
-        - pwsh: |
+      - pwsh: |
           . $(Build.SourcesDirectory)\eng\codeql.ps1
           Invoke-GdnSemmle -GuardianCliLocation $(GuardianCliLocation) `
             -WorkingDirectory $(Build.SourcesDirectory) `

--- a/azure-pipeline-codeql.yml
+++ b/azure-pipeline-codeql.yml
@@ -110,7 +110,17 @@ stages:
             -SourceCodeDirectory $(Build.SourcesDirectory)\src\Maestro\maestro-angular `
             -OutputPath $(Build.SourcesDirectory)\.gdn\r\semmle-javascript-configure.gdnconfig `
             -AdditionalSemmleParameters @("Typescript < $true")
-        displayName: 'CodeQL: Create Typescript configuration'
+        displayName: 'CodeQL: Create maestro-angular (typescript) configuration'
+
+      - pwsh: |
+          . $(Build.SourcesDirectory)\eng\codeql.ps1
+          New-GdnSemmleConfig -GuardianCliLocation $(GuardianCliLocation) `
+            -LoggerLevel 'Standard' `
+            -Language 'python' `
+            -WorkingDirectory $(Build.SourcesDirectory) `
+            -SourceCodeDirectory $(Build.SourcesDirectory)\src\Monitoring\grafana-init `
+            -OutputPath $(Build.SourcesDirectory)\.gdn\r\semmle-python-configure.gdnconfig
+        displayName: 'CodeQL: Create Grafana Init (python) configuration'
 
       - pwsh: |
           . $(Build.SourcesDirectory)\eng\codeql.ps1
@@ -124,7 +134,14 @@ stages:
           Invoke-GdnSemmle -GuardianCliLocation $(GuardianCliLocation) `
             -WorkingDirectory $(Build.SourcesDirectory) `
             -ConfigurationPath $(Build.SourcesDirectory)\.gdn\r\semmle-javascript-configure.gdnconfig
-        displayName: 'CodeQL: Typescript'
+        displayName: 'CodeQL: maestro-angular (typescript)'
+
+        - pwsh: |
+          . $(Build.SourcesDirectory)\eng\codeql.ps1
+          Invoke-GdnSemmle -GuardianCliLocation $(GuardianCliLocation) `
+            -WorkingDirectory $(Build.SourcesDirectory) `
+            -ConfigurationPath $(Build.SourcesDirectory)\.gdn\r\semmle-python-configure.gdnconfig
+        displayName: 'CodeQL: Grafana Init (python)'
 
       - pwsh: |
           . $(Build.SourcesDirectory)\eng\codeql.ps1

--- a/eng/codeql.ps1
+++ b/eng/codeql.ps1
@@ -1,9 +1,20 @@
 function Install-Gdn {
     param(
-        [string]$Path
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [string]$Version
     )
 
-    Start-Process nuget -Verbose -ArgumentList "install", "Microsoft.Guardian.Cli", "-Source https://securitytools.pkgs.visualstudio.com/_packaging/Guardian/nuget/v3/index.json", "-OutputDirectory $Path", "-NonInteractive", "-NoCache" -NoNewWindow -Wait
+    $installArgs = @("install", "Microsoft.Guardian.Cli", "-Source https://securitytools.pkgs.visualstudio.com/_packaging/Guardian/nuget/v3/index.json", "-OutputDirectory $Path", "-NonInteractive", "-NoCache")
+
+    if($Version)
+    {
+        $installArgs += "-Version $Version"
+    }
+
+    Start-Process nuget -Verbose -ArgumentList $installArgs -NoNewWindow -Wait
+    
     $gdnCliPath = Get-ChildItem -Filter guardian.cmd -Recurse -Path $Path
     return $gdnCliPath.FullName
 }


### PR DESCRIPTION
This adds the Grafana Init python code to the weekly CodeQL scans. 

See also [build 20220718.2](https://dev.azure.com/dnceng/internal/_build/results?buildId=1889568) for a test run.