### PR TITLE
Fix PAT generator not working for domain accounts

### DIFF
--- a/src/Microsoft.DncEng.PatGeneratorTool/Program.cs
+++ b/src/Microsoft.DncEng.PatGeneratorTool/Program.cs
@@ -124,6 +124,12 @@ namespace Microsoft.DncEng.PatGeneratorTool
             VssCredentials credentials;
             if (!string.IsNullOrEmpty(user))
             {
+                // rewrite REDMOND\account -> account@microsoft.com
+                if (user.Contains("\\"))
+                {
+                    user = $"{user.Split('\\').Last()}@microsoft.com";
+                }
+
                 credentials = new VssAadCredential(user, password);
             }
             else


### PR DESCRIPTION
`dotnet run --user redmond\dn-bot --password <password> --organizations dnceng --scopes build_execute code_write release_execute` now works 😃 

With Azure AD, using the account `redmond\dn-bot`, the TFS library makes a GET request to `https://login.microsoftonline.com/common/userrealm/redmond\dn-bot?api-version=1.0` causing a 404, and failing the authentication.  Rewriting `redmond\dn-bot` to `dn-bot@microsoft.com` allows the home realm discovery to succeed and thus the OAuth2 authentication.

Fixes https://github.com/dotnet/arcade/issues/9414
