### PR TITLE
Dogfood new MSAL AzDo client libraries

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,6 +5,7 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="Codex-Deps" value="https://mseng.pkgs.visualstudio.com/_packaging/Codex-Deps/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/src/Microsoft.DncEng.PatGenerator.Tests/Microsoft.DncEng.PatGenerator.Tests.csproj
+++ b/src/Microsoft.DncEng.PatGenerator.Tests/Microsoft.DncEng.PatGenerator.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
@@ -10,6 +10,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DncEng.PatGenerator\Microsoft.DncEng.PatGenerator.csproj" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" VersionOverride="5.2.7"/>
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" VersionOverride="19.208.0-preview"/>
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" VersionOverride="19.208.0-preview"/>
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DncEng.PatGenerator/Microsoft.DncEng.PatGenerator.csproj
+++ b/src/Microsoft.DncEng.PatGenerator/Microsoft.DncEng.PatGenerator.csproj
@@ -1,9 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" VersionOverride="19.208.0-preview"/>
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" VersionOverride="5.2.7" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" VersionOverride="19.208.0-preview" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DncEng.PatGenerator/Microsoft.DncEng.PatGenerator.csproj
+++ b/src/Microsoft.DncEng.PatGenerator/Microsoft.DncEng.PatGenerator.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" VersionOverride="19.208.0-preview"/>
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" VersionOverride="19.209.0-preview"/>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" VersionOverride="5.2.7" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.Client" VersionOverride="19.208.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" VersionOverride="19.209.0-preview" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DncEng.PatGeneratorTool/Microsoft.DncEng.PatGeneratorTool.csproj
+++ b/src/Microsoft.DncEng.PatGeneratorTool/Microsoft.DncEng.PatGeneratorTool.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -17,10 +17,16 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" VersionOverride="1.5.0-beta.1" />
-    <PackageReference Include="Microsoft.Identity.Client" />
+
+    <!-- 
+      We're dogfooding new TFS libraries that support MSAL. If you cannot restore these packages, follow these instructions: 
+      https://mseng.visualstudio.com/AzureDevOps/_wiki/wikis/AzureDevOps.wiki/17849/Engineering-Environment-Setup?anchor=nuget-credential-provider
+    -->
+    <PackageReference Include="Microsoft.Identity.Client" VersionOverride="4.44.0" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" VersionOverride="5.2.7" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" VersionOverride="19.208.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" VersionOverride="19.208.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" VersionOverride="19.208.0-preview" />
     <PackageReference Include="System.CommandLine" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.Client" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DncEng.PatGeneratorTool/Microsoft.DncEng.PatGeneratorTool.csproj
+++ b/src/Microsoft.DncEng.PatGeneratorTool/Microsoft.DncEng.PatGeneratorTool.csproj
@@ -22,11 +22,11 @@
       We're dogfooding new TFS libraries that support MSAL. If you cannot restore these packages, follow these instructions: 
       https://mseng.visualstudio.com/AzureDevOps/_wiki/wikis/AzureDevOps.wiki/17849/Engineering-Environment-Setup?anchor=nuget-credential-provider
     -->
-    <PackageReference Include="Microsoft.Identity.Client" VersionOverride="4.44.0" />
+    <PackageReference Include="Microsoft.Identity.Client" VersionOverride="4.46.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" VersionOverride="5.2.7" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" VersionOverride="19.208.0-preview" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.Client" VersionOverride="19.208.0-preview" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" VersionOverride="19.208.0-preview" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" VersionOverride="19.209.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" VersionOverride="19.209.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" VersionOverride="19.209.0-preview" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DncEng.PatGeneratorTool/Program.cs
+++ b/src/Microsoft.DncEng.PatGeneratorTool/Program.cs
@@ -137,10 +137,7 @@ namespace Microsoft.DncEng.PatGeneratorTool
                     .WithAuthority("https://login.microsoftonline.com/microsoft.com/")
                     .Build();
 
-                var passwordSecureStr = new SecureString();
-                Array.ForEach(password!.ToCharArray(), passwordSecureStr.AppendChar);
-
-                var authResult = await app.AcquireTokenByUsernamePassword(AzureDevOpsAuthScopes, user, passwordSecureStr).ExecuteAsync();
+                var authResult = await app.AcquireTokenByUsernamePassword(AzureDevOpsAuthScopes, user, password).ExecuteAsync();
                 credentials = new VssCredentials(new VssOAuthAccessTokenCredential(authResult.AccessToken));
             }
             else


### PR DESCRIPTION
Use preview Azure DevOps client libraries to authenticate with MSAL. This forces us to authenticate with an OAuth 2 resource owner password credentials (ROPC) grant.

I'm also not sure if CI can access the Codex-Deps NuGet feed.

Closes https://github.com/dotnet/arcade/issues/9588