### PR TITLE
Add multiple service support for account SAS tokens

### DIFF
--- a/src/Microsoft.DncEng.SecretManager/Readme.md
+++ b/src/Microsoft.DncEng.SecretManager/Readme.md
@@ -222,7 +222,9 @@ parameters:
 type: azure-storage-account-sas-token
 parameters:
   connectionString: SecretReference to the connection string for the account
+  service: Service i.e (blob, queue, table, file) that the token is for. Can specify more than one by separating them with |, i.e (blob|queue)
   permissions: permissions needed for the sas e.g. 'racwd'
+```
 
 #### Container Sas Uri
 ```yaml

--- a/src/Microsoft.DncEng.SecretManager/StorageUtils.cs
+++ b/src/Microsoft.DncEng.SecretManager/StorageUtils.cs
@@ -76,43 +76,26 @@ namespace Microsoft.DncEng.SecretManager
         {
             CloudStorageAccount account = CloudStorageAccount.Parse(connectionString);
             SharedAccessAccountServices serviceList = default(SharedAccessAccountServices);
-            if(service.Contains("|"))
+
+            HashSet<string> servicesUsed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach(var serviceString in service.Split("|"))
             {
-                HashSet<string> servicesUsed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                foreach(var serviceString in service.Split("|"))
+                if(!servicesUsed.Add(serviceString))
                 {
-                    if(!servicesUsed.Add(serviceString))
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(service));
-                    }
-                    switch(serviceString.ToLowerInvariant())
-                    {
-                        case "blob": serviceList |= SharedAccessAccountServices.Blob;
-                            break;
-                        case "table": serviceList |= SharedAccessAccountServices.Table;
-                            break;
-                        case "file": serviceList |= SharedAccessAccountServices.File;
-                            break;
-                        case "queue": serviceList |= SharedAccessAccountServices.Queue;
-                            break;
-                        default: throw new ArgumentOutOfRangeException(nameof(service));
-                    }
+                    throw new ArgumentOutOfRangeException(nameof(service));
                 }
-            }
-            else
-            {
-                switch(service.ToLowerInvariant())
-                    {
-                        case "blob": serviceList = SharedAccessAccountServices.Blob;
-                            break;
-                        case "table": serviceList = SharedAccessAccountServices.Table;
-                            break;
-                        case "file": serviceList = SharedAccessAccountServices.File;
-                            break;
-                        case "queue": serviceList = SharedAccessAccountServices.Queue;
-                            break;
-                        default: throw new ArgumentOutOfRangeException(nameof(service));
-                    }
+                switch(serviceString.ToLowerInvariant())
+                {
+                    case "blob": serviceList |= SharedAccessAccountServices.Blob;
+                        break;
+                    case "table": serviceList |= SharedAccessAccountServices.Table;
+                        break;
+                    case "file": serviceList |= SharedAccessAccountServices.File;
+                        break;
+                    case "queue": serviceList |= SharedAccessAccountServices.Queue;
+                        break;
+                    default: throw new ArgumentOutOfRangeException(nameof(service));
+                }
             }
 
             string sas = account.GetSharedAccessSignature(new SharedAccessAccountPolicy

--- a/src/Microsoft.DncEng.SecretManager/StorageUtils.cs
+++ b/src/Microsoft.DncEng.SecretManager/StorageUtils.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DncEng.SecretManager
                         default: throw new ArgumentOutOfRangeException(nameof(service));
                     }
             }
-            Console.WriteLine(serviceList);
+
             string sas = account.GetSharedAccessSignature(new SharedAccessAccountPolicy
             {
                 SharedAccessExpiryTime = expiryTime,

--- a/src/Microsoft.DncEng.SecretManager/StorageUtils.cs
+++ b/src/Microsoft.DncEng.SecretManager/StorageUtils.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
+using System.Collections.Generic;
 using Azure.Core;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.DncEng.CommandLineLib.Authentication;
@@ -74,22 +75,54 @@ namespace Microsoft.DncEng.SecretManager
         public static string GenerateBlobAccountSas(string connectionString, string permissions, string service, DateTimeOffset expiryTime)
         {
             CloudStorageAccount account = CloudStorageAccount.Parse(connectionString);
+            SharedAccessAccountServices serviceList = default(SharedAccessAccountServices);
+            if(service.Contains("|"))
+            {
+                HashSet<string> servicesUsed = new HashSet<string>();
+                foreach(var serviceString in service.Split("|"))
+                {
+                    if(!servicesUsed.Add(serviceString))
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(service));
+                    }
+                    switch(serviceString)
+                    {
+                        case "blob": serviceList |= SharedAccessAccountServices.Blob;
+                            break;
+                        case "table": serviceList |= SharedAccessAccountServices.Table;
+                            break;
+                        case "file": serviceList |= SharedAccessAccountServices.File;
+                            break;
+                        case "queue": serviceList |= SharedAccessAccountServices.Queue;
+                            break;
+                        default: throw new ArgumentOutOfRangeException(nameof(service));
+                    }
+                }
+            }
+            else
+            {
+                switch(service)
+                    {
+                        case "blob": serviceList = SharedAccessAccountServices.Blob;
+                            break;
+                        case "table": serviceList = SharedAccessAccountServices.Table;
+                            break;
+                        case "file": serviceList = SharedAccessAccountServices.File;
+                            break;
+                        case "queue": serviceList = SharedAccessAccountServices.Queue;
+                            break;
+                        default: throw new ArgumentOutOfRangeException(nameof(service));
+                    }
+            }
+            Console.WriteLine(serviceList);
             string sas = account.GetSharedAccessSignature(new SharedAccessAccountPolicy
             {
                 SharedAccessExpiryTime = expiryTime,
                 Permissions = AccountPermissionsFromString(permissions),
-                Services = service.ToLowerInvariant() switch
-                {
-                    "blob" => SharedAccessAccountServices.Blob,
-                    "table" => SharedAccessAccountServices.Table,
-                    "file" => SharedAccessAccountServices.File,
-                    "queue" => SharedAccessAccountServices.Queue,
-                    _ => throw new ArgumentOutOfRangeException(nameof(service)),
-                },
+                Services = serviceList,
                 ResourceTypes = SharedAccessAccountResourceTypes.Service | SharedAccessAccountResourceTypes.Container | SharedAccessAccountResourceTypes.Object,
                 Protocols = SharedAccessProtocol.HttpsOnly,
             });
-
             return sas;
         }
 

--- a/src/Microsoft.DncEng.SecretManager/StorageUtils.cs
+++ b/src/Microsoft.DncEng.SecretManager/StorageUtils.cs
@@ -78,14 +78,14 @@ namespace Microsoft.DncEng.SecretManager
             SharedAccessAccountServices serviceList = default(SharedAccessAccountServices);
             if(service.Contains("|"))
             {
-                HashSet<string> servicesUsed = new HashSet<string>();
+                HashSet<string> servicesUsed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 foreach(var serviceString in service.Split("|"))
                 {
                     if(!servicesUsed.Add(serviceString))
                     {
                         throw new ArgumentOutOfRangeException(nameof(service));
                     }
-                    switch(serviceString)
+                    switch(serviceString.ToLowerInvariant())
                     {
                         case "blob": serviceList |= SharedAccessAccountServices.Blob;
                             break;
@@ -101,7 +101,7 @@ namespace Microsoft.DncEng.SecretManager
             }
             else
             {
-                switch(service)
+                switch(service.ToLowerInvariant())
                     {
                         case "blob": serviceList = SharedAccessAccountServices.Blob;
                             break;


### PR DESCRIPTION
This change adds the ability to specify more than one service when
generating an account SAS token. The previous implementation assumed
that only one service would ever be specifed.

This change also updates the Readme.md to account for this change.