### PR TITLE
Add source build patch support to VMR manager

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/VirtualMonoRepo/SourceMapping.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/VirtualMonoRepo/SourceMapping.cs
@@ -16,4 +16,5 @@ public record SourceMapping(
     string DefaultRef,
     IReadOnlyCollection<string> Include,
     IReadOnlyCollection<string> Exclude,
+    IReadOnlyCollection<string> VmrPatches,
     string? Version = null);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -44,7 +44,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
             throw new EmptySyncException($"Repository {mapping.Name} already exists");
         }
 
-        _logger.LogInformation("Initializing {name} at {revision}", mapping.Name, targetRevision ?? mapping.DefaultRef);
+        _logger.LogInformation("Initializing {name} at {revision}..", mapping.Name, targetRevision ?? mapping.DefaultRef);
 
         string clonePath = await CloneOrPull(mapping);
         cancellationToken.ThrowIfCancellationRequested();
@@ -68,5 +68,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         // Commit but do not add files (they were added to index directly)
         var message = PrepareCommitMessage(InitializationCommitMessage, mapping, newSha: commit.Id.Sha);
         Commit(message, DotnetBotCommitSignature);
+
+        _logger.LogInformation("Initialization of {name} finished", mapping.Name);
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -62,7 +62,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         cancellationToken.ThrowIfCancellationRequested();
         await ApplyVmrPatches(mapping, cancellationToken);
 
-        var message = PrepareCommitMessage(InitializationCommitMessage, mapping, oldSha: null, commit.Id.Sha, null);
+        var message = PrepareCommitMessage(InitializationCommitMessage, mapping, newSha: commit.Id.Sha);
 
         // Commit but do not add files (they were added to index directly)
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -59,11 +59,13 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         await ApplyPatch(mapping, patchPath, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
         await TagRepo(mapping, commit.Id.Sha);
+        cancellationToken.ThrowIfCancellationRequested();
+        await ApplyVmrPatches(mapping, cancellationToken);
 
-        var description = PrepareCommitMessage(InitializationCommitMessage, mapping, null, commit.Id.Sha, null);
+        var message = PrepareCommitMessage(InitializationCommitMessage, mapping, oldSha: null, commit.Id.Sha, null);
 
         // Commit but do not add files (they were added to index directly)
         cancellationToken.ThrowIfCancellationRequested();
-        Commit(description, DotnetBotCommitSignature);
+        Commit(message, DotnetBotCommitSignature);
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -47,13 +47,12 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         _logger.LogInformation("Initializing {name} at {revision}", mapping.Name, targetRevision ?? mapping.DefaultRef);
 
         string clonePath = await CloneOrPull(mapping);
-        string patchPath = GetPatchFilePath(mapping);
-
         cancellationToken.ThrowIfCancellationRequested();
 
         using var clone = new Repository(clonePath);
         var commit = GetCommit(clone, (targetRevision is null || targetRevision == HEAD) ? null : targetRevision);
 
+        string patchPath = GetPatchFilePath(mapping);
         await CreatePatch(mapping, clonePath, Constants.EmptyGitObject, commit.Id.Sha, patchPath, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -262,7 +262,20 @@ public abstract class VmrManagerBase
     
     protected string GetClonePath(SourceMapping mapping) => Path.Combine(_tmpPath, mapping.Name);
 
-    protected static string PrepareCommitMessage(string template, SourceMapping mapping, string? oldSha, string? newSha, string? commitMessage)
+    /// <summary>
+    /// Takes a given commit message template and populates it with given values, URLs and others.
+    /// </summary>
+    /// <param name="template">Template into which the values are filled into</param>
+    /// <param name="mapping">Repository mapping</param>
+    /// <param name="oldSha">SHA we are updating from</param>
+    /// <param name="newSha">SHA we are updating to</param>
+    /// <param name="additionalMessage">Additional message inserted in the commit body</param>
+    protected static string PrepareCommitMessage(
+        string template,
+        SourceMapping mapping,
+        string? oldSha = null,
+        string? newSha = null,
+        string? additionalMessage = null)
     {
         var replaces = new Dictionary<string, string?>
         {
@@ -270,9 +283,9 @@ public abstract class VmrManagerBase
             { "remote", mapping.DefaultRemote },
             { "oldSha", oldSha },
             { "newSha", newSha },
-            { "oldShaShort", oldSha is null ? null : ShortenId(oldSha) },
-            { "newShaShort", newSha is null ? null : ShortenId(newSha) },
-            { "commitMessage", commitMessage },
+            { "oldShaShort", oldSha is null ? string.Empty : ShortenId(oldSha) },
+            { "newShaShort", newSha is null ? string.Empty : ShortenId(newSha) },
+            { "commitMessage", additionalMessage ?? string.Empty },
         };
 
         foreach (var replace in replaces)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -23,12 +23,17 @@ public abstract class VmrManagerBase
     private const string KeepAttribute = "vmr-preserve";
     private const string IgnoreAttribute = "vmr-ignore";
 
+    public const string VmrSourcesPath = "src";
+    public const string VmrPatchesPath = "patches";
+    public const string SourceMappingsFileName = "source-mappings.json";
+
     private readonly ILogger<VmrUpdater> _logger;
     private readonly IProcessManager _processManager;
     private readonly IRemoteFactory _remoteFactory;
-    private readonly string _vmrPath;
     private readonly string _tagsPath;
     private readonly string _tmpPath;
+
+    protected string VmrPath { get; }
 
     protected string SourcesPath { get; }
 
@@ -46,9 +51,9 @@ public abstract class VmrManagerBase
         _processManager = processManager;
         _remoteFactory = remoteFactory;
         _tmpPath = tmpPath;
-        _vmrPath = vmrPath;
-        SourcesPath = Path.Join(vmrPath, "src");
-        _tagsPath = Path.Join(SourcesPath, ".tags");
+        VmrPath = vmrPath;
+        SourcesPath = Path.Combine(vmrPath, "src");
+        _tagsPath = Path.Combine(SourcesPath, ".tags");
 
         Mappings = mappings;
     }
@@ -60,7 +65,7 @@ public abstract class VmrManagerBase
     /// <returns>Path to the cloned repo</returns>
     protected async Task<string> CloneOrPull(SourceMapping mapping)
     {
-        var clonePath = Path.Combine(_tmpPath, mapping.Name);
+        var clonePath = GetClonePath(mapping);
         if (Directory.Exists(clonePath))
         {
             _logger.LogInformation("Clone of {repo} found, pulling new changes...", mapping.DefaultRemote);
@@ -97,7 +102,7 @@ public abstract class VmrManagerBase
         await File.WriteAllTextAsync(tagFile, commitId);
 
         // Stage the tag file
-        using var repository = new Repository(_vmrPath);
+        using var repository = new Repository(VmrPath);
         Commands.Stage(repository, tagFile);
     }
 
@@ -172,14 +177,14 @@ public abstract class VmrManagerBase
     {
         // We have to give git a relative path with forward slashes where to apply the patch
         var destPath = Path.Combine(SourcesPath, mapping.Name)
-            .Replace(_vmrPath, null)
+            .Replace(VmrPath, null)
             .Replace("\\", "/")
             [1..];
 
-        _logger.LogInformation("Applying patch to {path}...", destPath);
+        _logger.LogInformation("Applying patch {patchPath} to {path}...", patchPath, destPath);
 
         // This will help ignore some CR/LF issues (e.g. files with both endings)
-        (await _processManager.ExecuteGit(_vmrPath, new[] { "config", "apply.ignoreWhitespace", "change" }, cancellationToken: cancellationToken))
+        (await _processManager.ExecuteGit(VmrPath, new[] { "config", "apply.ignoreWhitespace", "change" }, cancellationToken: cancellationToken))
             .ThrowIfFailed("Failed to set git config whitespace settings");
 
         Directory.CreateDirectory(destPath);
@@ -205,7 +210,7 @@ public abstract class VmrManagerBase
             patchPath,
         };
 
-        var result = await _processManager.ExecuteGit(_vmrPath, args, cancellationToken: CancellationToken.None);
+        var result = await _processManager.ExecuteGit(VmrPath, args, cancellationToken: CancellationToken.None);
         result.ThrowIfFailed($"Failed to apply the patch for {destPath}");
         _logger.LogDebug("{output}", result.ToString());
 
@@ -214,9 +219,31 @@ public abstract class VmrManagerBase
         // This will end up having the working tree all staged
         _logger.LogInformation("Resetting the working tree...");
         args = new[] { "checkout", destPath };
-        result = await _processManager.ExecuteGit(_vmrPath, args, cancellationToken: CancellationToken.None);
+        result = await _processManager.ExecuteGit(VmrPath, args, cancellationToken: CancellationToken.None);
         result.ThrowIfFailed($"Failed to clean the working tree");
         _logger.LogDebug("{output}", result.ToString());
+    }
+
+    /// <summary>
+    /// Applies VMR patches onto files of given mapping's subrepository.
+    /// </summary>
+    /// <param name="mapping">Mapping</param>
+    protected async Task ApplyVmrPatches(SourceMapping mapping, CancellationToken cancellationToken)
+    {
+        if (!mapping.VmrPatches.Any())
+        {
+            return;
+        }
+
+        _logger.LogInformation("Applying VMR patches for {mappingName}..", mapping.Name);
+
+        foreach (var patchFile in mapping.VmrPatches)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            _logger.LogDebug("Applying {patch}..", patchFile);
+            await ApplyPatch(mapping, patchFile, cancellationToken);
+        }
     }
 
     protected void Commit(string commitMessage, Signature author)
@@ -224,7 +251,7 @@ public abstract class VmrManagerBase
         _logger.LogInformation("Committing..");
 
         var watch = Stopwatch.StartNew();
-        using var repository = new Repository(_vmrPath);
+        using var repository = new Repository(VmrPath);
         var commit = repository.Commit(commitMessage, author, DotnetBotCommitSignature);
 
         _logger.LogInformation("Created {sha} in {duration} seconds", ShortenId(commit.Id.Sha), (int) watch.Elapsed.TotalSeconds);
@@ -233,6 +260,8 @@ public abstract class VmrManagerBase
     protected string GetPatchFilePath(SourceMapping mapping) => Path.Combine(_tmpPath, $"{mapping.Name}.patch");
 
     protected string GetTagFilePath(SourceMapping mapping) => Path.Combine(_tagsPath, $".{mapping.Name}");
+    
+    protected string GetClonePath(SourceMapping mapping) => Path.Combine(_tmpPath, mapping.Name);
 
     protected static string PrepareCommitMessage(string template, SourceMapping mapping, string? oldSha, string? newSha, string? commitMessage)
     {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -24,7 +24,6 @@ public abstract class VmrManagerBase
     private const string IgnoreAttribute = "vmr-ignore";
 
     public const string VmrSourcesPath = "src";
-    public const string VmrPatchesPath = "patches";
     public const string SourceMappingsFileName = "source-mappings.json";
 
     private readonly ILogger<VmrUpdater> _logger;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerFactory.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerFactory.cs
@@ -12,9 +12,9 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 public interface IVmrManagerFactory
 {
     Task<IVmrInitializer> CreateVmrInitializer();
-    Task<IVmrInitializer> CreateVmrInitializer(string vmrPath, string tmpPath);
+    Task<IVmrInitializer> CreateVmrInitializer(IVmrManagerConfiguration configuration);
     Task<IVmrUpdater> CreateVmrUpdater();
-    Task<IVmrUpdater> CreateVmrUpdater(string vmrPath, string tmpPath);
+    Task<IVmrUpdater> CreateVmrUpdater(IVmrManagerConfiguration configuration);
 }
 
 public class VmrManagerFactory : IVmrManagerFactory
@@ -36,14 +36,14 @@ public class VmrManagerFactory : IVmrManagerFactory
     public Task<IVmrInitializer> CreateVmrInitializer()
         => CreateVmrManager<IVmrInitializer, VmrInitializer>();
 
-    public Task<IVmrInitializer> CreateVmrInitializer(string vmrPath, string tmpPath)
-        => CreateVmrManager<IVmrInitializer, VmrInitializer>(vmrPath, tmpPath);
+    public Task<IVmrInitializer> CreateVmrInitializer(IVmrManagerConfiguration configuration)
+        => CreateVmrManager<IVmrInitializer, VmrInitializer>(configuration);
 
     public Task<IVmrUpdater> CreateVmrUpdater()
         => CreateVmrManager<IVmrUpdater, VmrUpdater>();
 
-    public Task<IVmrUpdater> CreateVmrUpdater(string vmrPath, string tmpPath)
-        => CreateVmrManager<IVmrUpdater, VmrUpdater>(vmrPath, tmpPath);
+    public Task<IVmrUpdater> CreateVmrUpdater(IVmrManagerConfiguration configuration)
+        => CreateVmrManager<IVmrUpdater, VmrUpdater>(configuration);
 
     private async Task<R> CreateVmrManager<R, T>() where T : R
     {
@@ -51,9 +51,9 @@ public class VmrManagerFactory : IVmrManagerFactory
         return ActivatorUtilities.CreateInstance<T>(_serviceProvider, mappings);
     }
 
-    private async Task<R> CreateVmrManager<R, T>(string vmrPath, string tmpPath) where T : R
+    private async Task<R> CreateVmrManager<R, T>(IVmrManagerConfiguration configuration) where T : R
     {
-        var mappings = await _sourceMappingParser.ParseMappings(_configuration.VmrPath);
-        return ActivatorUtilities.CreateInstance<T>(_serviceProvider, new VmrManagerConfiguration(vmrPath, tmpPath), mappings);
+        var mappings = await _sourceMappingParser.ParseMappings(configuration.VmrPath);
+        return ActivatorUtilities.CreateInstance<T>(_serviceProvider, configuration, mappings);
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -5,7 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
@@ -39,7 +41,16 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         {commitMessage}
         """;
 
+    /// <summary>
+    /// Matches output of `git apply --numstat` which lists files contained in a patch file.
+    /// Example output:
+    /// 0       14      /s/vmr/src/roslyn-analyzers/eng/Versions.props
+    /// -       -       /s/vmr/src/roslyn-analyzers/some-binary.dll
+    /// </summary>
+    private static readonly Regex GitPatchSummaryLine = new(@"^[\-0-9]+\s+[\-0-9]+\s+(?<file>[^\s]+)$", RegexOptions.Compiled);
+
     private readonly ILogger<VmrUpdater> _logger;
+    private readonly IProcessManager _processManager;
     private readonly IRemoteFactory _remoteFactory;
 
     public VmrUpdater(
@@ -51,6 +62,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         : base(processManager, remoteFactory, logger, mappings, configuration.VmrPath, configuration.TmpPath)
     {
         _logger = logger;
+        _processManager = processManager;
         _remoteFactory = remoteFactory;
     }
 
@@ -217,6 +229,9 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             throw new InvalidOperationException($"Failed to find the patch at {patchPath}");
         }
 
+        await RestorePatchedFilesFromRepo(mapping, fromRevision, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (info.Length == 0)
         {
             _logger.LogInformation("No changes for {repo} in given commits (maybe only excluded files changed?)", mapping.Name);
@@ -227,7 +242,9 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         }
 
         await TagRepo(mapping, toRevision);
-
+        cancellationToken.ThrowIfCancellationRequested();
+        await ApplyVmrPatches(mapping, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         Commit(commitMessage, author);
     }
 
@@ -239,5 +256,82 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         var remoteRepo = await _remoteFactory.GetRemoteAsync(mapping.DefaultRemote, _logger);
         var lastCommit = await remoteRepo.GetLatestCommitAsync(mapping.DefaultRemote, mapping.DefaultRef);
         return !lastCommit.Equals(currentSha, StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    /// <summary>
+    /// For all files for which we have patches in VMR, restore their original version from the repo.
+    /// This is because VMR contains already patched versions of these files and new updates from the repo wouldn't apply.
+    /// </summary>
+    /// <param name="mapping">Mapping</param>
+    /// <param name="originalRevision">Revision from which we were updating</param>
+    private async Task RestorePatchedFilesFromRepo(SourceMapping mapping, string originalRevision, CancellationToken cancellationToken)
+    {
+        if (!mapping.VmrPatches.Any())
+        {
+            return;
+        }
+
+        _logger.LogInformation("Restoring files with patches for {mappingName}..", mapping.Name);
+
+        // We checkout the clone to the given revision once for all its patches
+        var clonePath = GetClonePath(mapping);
+        if (!Directory.Exists(clonePath))
+        {
+            await CloneOrPull(mapping);
+        }
+
+        var localRepo = new LocalGitClient(_processManager.GitExecutable, _logger);
+        localRepo.Checkout(clonePath, originalRevision);
+
+        foreach (var patch in mapping.VmrPatches)
+        {
+            _logger.LogDebug("Processing VMR patch `{patch}`..", patch);
+
+            foreach (var patchedFile in await GetFilesInPatch(clonePath, patch, cancellationToken))
+            {
+                // git always works with forward slashes (even on Windows)
+                string relativePath = Path.DirectorySeparatorChar != '/'
+                    ? patchedFile.Replace('/', Path.DirectorySeparatorChar)
+                    : patchedFile;
+
+                var originalFile = Path.Combine(clonePath, relativePath);
+                var destination = Path.Combine(SourcesPath, mapping.Name, relativePath);
+
+                _logger.LogDebug("Restoring file `{originalFile}` to `{destination}`..", originalFile, destination);
+
+                // Copy old revision to VMR
+                File.Copy(originalFile, destination, overwrite: true);
+            }
+        }
+
+        // Stage the restored files (all future patches are applied to index directly)
+        using var repository = new Repository(VmrPath);
+        Commands.Stage(repository, $"{VmrSourcesPath}/{mapping.Name}");
+
+        _logger.LogDebug("Files from VMR patches for {mappingName} restored", mapping.Name);
+    }
+
+    /// <summary>
+    /// Resolves a list of all files that are part of a given patch diff.
+    /// </summary>
+    /// <param name="repoPath">Path (to the repo) the patch applies onto</param>
+    /// <param name="patchPath">Path to the patch file</param>
+    /// <returns>List of all files (paths relative to repo's root) that are part of a given patch diff</returns>
+    private async Task<IReadOnlyCollection<string>> GetFilesInPatch(string repoPath, string patchPath, CancellationToken cancellationToken)
+    {
+        var result = await _processManager.ExecuteGit(repoPath, new[] { "apply", "--numstat", patchPath }, cancellationToken);
+        result.ThrowIfFailed($"Failed to enumerate files from a patch at `{patchPath}`");
+
+        var files = new List<string>();
+        foreach (var line in result.StandardOutput.Split(Environment.NewLine))
+        {
+            var match = GitPatchSummaryLine.Match(line);
+            if (match.Success)
+            {
+                files.Add(match.Groups["file"].Value);
+            }
+        }
+
+        return files;
     }
 }


### PR DESCRIPTION
Handles Source Build patches during initialization/synchronization of the VMR

Expects a new property in `source-mappings.json` pointing to where the patches are located in the VMR (later they can be moved):
```
{
    "patchesPath": "src/installer/src/SourceBuild/tarball/patches",
    ...
}
```

Consider we're updating repo `A` from `sha1` to `sha2`, the new synchronization algorithm is as follows:

1. Checkout VMR
2. Clone individual repo A to temp
3. For each file that has a patch in the VMR, copy its `sha1` version from the clone to the VMR (to working tree only)
4. Prepare a diff from `A` for `sha1..sha2` and apply it onto the VMR
5. Apply any Source Build patches associated with the repo
6. Commit all above to the VMR

Resolves https://github.com/dotnet/arcade/issues/10261