### PR TITLE
Add Do Not Automerge Downgrades policy to UX

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Constants.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Constants.cs
@@ -50,10 +50,12 @@ namespace Microsoft.DotNet.Darc
             "The standard github merge policy is:",
             $"- {MergePolicyConstants.AllCheckSuccessfulMergePolicyName} with the 'WIP' and 'license/cla' checks ignored.",
             $"- {MergePolicyConstants.NoRequestedChangesMergePolicyName}",
+            $"- {MergePolicyConstants.DontAutomergeDowngradesPolicyName}",
             "The standard Azure DevOps merge policy is:",
             $"- {MergePolicyConstants.AllCheckSuccessfulMergePolicyName} with the 'Comment requirements', 'Minimum number of reviewers', 'Required reviewers',",
             "  and 'Work item linking' checks ignored.",
             $"- {MergePolicyConstants.NoRequestedChangesMergePolicyName}",
+            $"- {MergePolicyConstants.DontAutomergeDowngradesPolicyName}",
             "YAML format:",
             $"- Name: {MergePolicyConstants.StandardMergePolicyName}",
             "",
@@ -71,6 +73,10 @@ namespace Microsoft.DotNet.Darc
             $"{MergePolicyConstants.NoRequestedChangesMergePolicyName} - If changes are requested on the PR (or the PR is rejected), it will not be merged.",
             "YAML format:",
             $"- Name: {MergePolicyConstants.NoRequestedChangesMergePolicyName}",
+            "",
+            $"{MergePolicyConstants.DontAutomergeDowngradesPolicyName} - If any version change is a downgrade, it will not be merged.",
+            "YAML format:",
+            $"- Name: {MergePolicyConstants.DontAutomergeDowngradesPolicyName}",
         };
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/MergePoliciesPopUpHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/MergePoliciesPopUpHelpers.cs
@@ -38,7 +38,8 @@ namespace Microsoft.DotNet.Darc.Models.PopUps
                         }
                     }
                     else if (policy.Name.Equals(MergePolicyConstants.StandardMergePolicyName, StringComparison.OrdinalIgnoreCase) ||
-                             policy.Name.Equals(MergePolicyConstants.NoRequestedChangesMergePolicyName, StringComparison.OrdinalIgnoreCase))
+                             policy.Name.Equals(MergePolicyConstants.NoRequestedChangesMergePolicyName, StringComparison.OrdinalIgnoreCase) ||
+                             policy.Name.Equals(MergePolicyConstants.DontAutomergeDowngradesPolicyName, StringComparison.OrdinalIgnoreCase))
                     {
                         // All good
                     }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddSubscriptionOperation.cs
@@ -68,6 +68,16 @@ namespace Microsoft.DotNet.Darc.Operations
                     });
             }
 
+            if (_options.DontAutomergeDowngradesMergePolicy)
+            {
+                mergePolicies.Add(
+                    new MergePolicy
+                    {
+                        Name = MergePolicyConstants.DontAutomergeDowngradesPolicyName,
+                        Properties = ImmutableDictionary.Create<string, JToken>()
+                    });
+            }
+
             if (_options.StandardAutoMergePolicies)
             {
                 mergePolicies.Add(

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
@@ -63,6 +63,16 @@ namespace Microsoft.DotNet.Darc.Operations
                     });
             }
 
+            if (_options.DontAutomergeDowngradesMergePolicy)
+            {
+                mergePolicies.Add(
+                    new MergePolicy
+                    {
+                        Name = MergePolicyConstants.DontAutomergeDowngradesPolicyName,
+                        Properties = ImmutableDictionary.Create<string, JToken>()
+                    });
+            }
+
             if (_options.StandardAutoMergePolicies)
             {
                 mergePolicies.Add(

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AddSubscriptionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AddSubscriptionCommandLineOptions.cs
@@ -43,6 +43,9 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("no-requested-changes", HelpText = "PR is not merged if there are changes requested or the PR has been rejected.")]
         public bool NoRequestedChangesMergePolicy { get; set; }
 
+        [Option("no-downgrades", HelpText = "PR is not merged if there are version downgrades.")]
+        public bool DontAutomergeDowngradesMergePolicy { get; set; }
+
         [Option('q', "quiet", HelpText = "Non-interactive mode (requires all elements to be passed on the command line).")]
         public bool Quiet { get; set; }
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/SetRepositoryMergePoliciesCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/SetRepositoryMergePoliciesCommandLineOptions.cs
@@ -31,6 +31,9 @@ namespace Microsoft.DotNet.Darc.Options
         [Option("no-requested-changes", HelpText = "PR is not merged if there are changes requested or the PR has been rejected.")]
         public bool NoRequestedChangesMergePolicy { get; set; }
 
+        [Option("no-downgrades", HelpText = "PR is not merged if there are version downgrades.")]
+        public bool DontAutomergeDowngradesMergePolicy { get; set; }
+
         [Option('q', "quiet", HelpText = "Non-interactive mode (requires all elements to be passed on the command line).")]
         public bool Quiet { get; set; }
 


### PR DESCRIPTION
This got missed when the policy was added at some time back. It's part of the standard policy but not settable independently. Add to the UX