### PR TITLE
Add DontAutomergeDowngrades as a separately addressable policy

### DIFF
--- a/src/Maestro/Maestro.MergePolicies/MergePolicyServiceCollectionExtensions.cs
+++ b/src/Maestro/Maestro.MergePolicies/MergePolicyServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ namespace Maestro.MergePolicies
         {
             services.AddTransient<IMergePolicyBuilder, AllChecksSuccessfulMergePolicyBuilder>();
             services.AddTransient<IMergePolicyBuilder, NoRequestedChangesMergePolicyBuilder>();
+            services.AddTransient<IMergePolicyBuilder, DontAutomergeDowngradesMergePolicyBuilder>();
             services.AddTransient<IMergePolicyBuilder, StandardMergePolicyBuilder>();
             return services;
         }


### PR DESCRIPTION
This policy was added but only as part of the standard merge policy. It's currently not separately addressable. A previous commit added support in the Darc UX, but we still needed a little tweak in Maestro.