### PR TITLE
Compile the `.gitmodules` file on every VMR commit

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+public interface IVmrInitializer : IVmrManager
+{
+    /// <summary>
+    /// Initializes new repo that hasn't been synchronized into the VMR yet.
+    /// </summary>
+    /// <param name="mappingName">Name of a repository mapping</param>
+    /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task InitializeVmr(string mappingName, string? targetRevision, CancellationToken cancellationToken)
+    {
+        var mapping = Mappings.FirstOrDefault(m => m.Name == mappingName)
+            ?? throw new Exception($"No repository mapping named `{mappingName}` found!");
+
+        return InitializeVmr(mapping, targetRevision, cancellationToken);
+    }
+
+    /// <summary>
+    /// Initializes new repo that hasn't been synchronized into the VMR yet.
+    /// </summary>
+    /// <param name="mapping">Repository mapping</param>
+    /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task InitializeVmr(SourceMapping mapping, string? targetRevision, CancellationToken cancellationToken);
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrManager.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 
 #nullable enable
@@ -15,61 +11,4 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 public interface IVmrManager
 {
     IReadOnlyCollection<SourceMapping> Mappings { get; }
-}
-
-public interface IVmrInitializer : IVmrManager
-{
-    /// <summary>
-    /// Initializes new repo that hasn't been synchronized into the VMR yet.
-    /// </summary>
-    /// <param name="mappingName">Name of a repository mapping</param>
-    /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    Task InitializeVmr(
-        string mappingName,
-        string? targetRevision,
-        bool ignoreWorkingTree,
-        CancellationToken cancellationToken)
-    {
-        var mapping = Mappings.FirstOrDefault(m => m.Name == mappingName)
-            ?? throw new Exception($"No repository mapping named `{mappingName}` found!");
-
-        return InitializeVmr(mapping, targetRevision, cancellationToken);
-    }
-
-    /// <summary>
-    /// Initializes new repo that hasn't been synchronized into the VMR yet.
-    /// </summary>
-    /// <param name="mapping">Repository mapping</param>
-    /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
-    /// <param name="ignoreWorkingTree">Does not keep working tree clean after commits for faster synchronization (changes are applied into the index directly)</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    Task InitializeVmr(SourceMapping mapping, string? targetRevision, CancellationToken cancellationToken);
-}
-
-public interface IVmrUpdater : IVmrManager
-{
-    /// <summary>
-    /// Updates repo in the VMR to given revision.
-    /// </summary>
-    /// <param name="mappingName">Name of a repository mapping</param>
-    /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
-    /// <param name="noSquash">Whether to pull changes commit by commit instead of squashing all updates into one</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    Task UpdateVmr(string mappingName, string? targetRevision, bool noSquash, CancellationToken cancellationToken)
-    {
-        var mapping = Mappings.FirstOrDefault(m => m.Name == mappingName)
-            ?? throw new Exception($"No repository mapping named `{mappingName}` found!");
-
-        return UpdateVmr(mapping, targetRevision, noSquash, cancellationToken);
-    }
-
-    /// <summary>
-    /// Updates repo in the VMR to given revision.
-    /// </summary>
-    /// <param name="mapping">Repository mapping</param>
-    /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
-    /// <param name="noSquash">Whether to pull changes commit by commit instead of squashing all updates into one</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    Task UpdateVmr(SourceMapping mapping, string? targetRevision, bool noSquash, CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+public interface IVmrUpdater : IVmrManager
+{
+    /// <summary>
+    /// Updates repo in the VMR to given revision.
+    /// </summary>
+    /// <param name="mappingName">Name of a repository mapping</param>
+    /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
+    /// <param name="noSquash">Whether to pull changes commit by commit instead of squashing all updates into one</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task UpdateVmr(string mappingName, string? targetRevision, bool noSquash, CancellationToken cancellationToken)
+    {
+        var mapping = Mappings.FirstOrDefault(m => m.Name == mappingName)
+            ?? throw new Exception($"No repository mapping named `{mappingName}` found!");
+
+        return UpdateVmr(mapping, targetRevision, noSquash, cancellationToken);
+    }
+
+    /// <summary>
+    /// Updates repo in the VMR to given revision.
+    /// </summary>
+    /// <param name="mapping">Repository mapping</param>
+    /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
+    /// <param name="noSquash">Whether to pull changes commit by commit instead of squashing all updates into one</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task UpdateVmr(SourceMapping mapping, string? targetRevision, bool noSquash, CancellationToken cancellationToken);
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -39,7 +39,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
 
     public async Task InitializeVmr(SourceMapping mapping, string? targetRevision, CancellationToken cancellationToken)
     {
-        if (File.Exists(Path.Combine(SourcesPath, $".{mapping.Name}")))
+        if (File.Exists(GetTagFilePath(mapping)))
         {
             throw new EmptySyncException($"Repository {mapping.Name} already exists");
         }
@@ -63,6 +63,9 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         cancellationToken.ThrowIfCancellationRequested();
 
         await ApplyVmrPatches(mapping, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await UpdateGitmodules(cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 
         // Commit but do not add files (they were added to index directly)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
@@ -51,7 +52,7 @@ public abstract class VmrManagerBase
         _remoteFactory = remoteFactory;
         _tmpPath = tmpPath;
         VmrPath = vmrPath;
-        SourcesPath = Path.Combine(vmrPath, "src");
+        SourcesPath = Path.Combine(vmrPath, VmrSourcesPath);
         _tagsPath = Path.Combine(SourcesPath, ".tags");
 
         Mappings = mappings;
@@ -175,7 +176,7 @@ public abstract class VmrManagerBase
     protected async Task ApplyPatch(SourceMapping mapping, string patchPath, CancellationToken cancellationToken)
     {
         // We have to give git a relative path with forward slashes where to apply the patch
-        var destPath = Path.Combine(SourcesPath, mapping.Name)
+        var destPath = GetRepoSourcesPath(mapping)
             .Replace(VmrPath, null)
             .Replace("\\", "/")
             [1..];
@@ -245,6 +246,58 @@ public abstract class VmrManagerBase
         }
     }
 
+    /// <summary>
+    /// Gets information about submodules from individual repos and compiles a .gitmodules file for the VMR.
+    /// We also need to replace the submodule paths with the src/[repo] prefixes.
+    /// The .gitmodules file is only relevant in the root of the repo. We can leave the old files behind.
+    /// The information about the commit the submodule is referencing is stored in the git tree.
+    /// </summary>
+    protected async Task UpdateGitmodules(CancellationToken cancellationToken)
+    {
+        const string gitmodulesFileName = ".gitmodules";
+
+        _logger.LogInformation("Updating .gitmodules file..");
+
+        // Matches the 'path = ' setting from the .gitmodules file so that we can prefix it
+        var pathSettingRegex = new Regex(@"(\bpath[ \t]*\=[ \t]*\b)");
+
+        using (var vmrGitmodule = File.Open(Path.Combine(VmrPath, gitmodulesFileName), FileMode.Create))
+        using (var writer = new StreamWriter(vmrGitmodule))
+        {
+            foreach (var mapping in Mappings)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var repoGitmodulePath = Path.Combine(GetRepoSourcesPath(mapping), gitmodulesFileName);
+                if (!File.Exists(repoGitmodulePath))
+                {
+                    continue;
+                }
+
+                _logger.LogDebug("Copying .gitmodules from {repo}..", mapping.Name);
+
+                // Header for the repo
+                await writer.WriteAsync("# ");
+                await writer.WriteLineAsync(mapping.Name);
+                await writer.WriteLineAsync();
+
+                // Copy contents
+                var content = await File.ReadAllTextAsync(repoGitmodulePath, cancellationToken);
+
+                // Add src/[repo]/ prefixes to paths
+                content = pathSettingRegex.Replace(content, $"$1{VmrSourcesPath}/{mapping.Name}/");
+                await writer.WriteAsync(content);
+
+                // Add some spacing
+                await writer.WriteLineAsync();
+                await writer.WriteLineAsync();
+            }
+        }
+
+        (await _processManager.ExecuteGit(VmrPath, new[] { "add", gitmodulesFileName }, cancellationToken))
+            .ThrowIfFailed("Failed to stage the .gitmodules file!");
+    }
+
     protected void Commit(string commitMessage, Signature author)
     {
         _logger.LogInformation("Committing..");
@@ -259,8 +312,10 @@ public abstract class VmrManagerBase
     protected string GetPatchFilePath(SourceMapping mapping) => Path.Combine(_tmpPath, $"{mapping.Name}.patch");
 
     protected string GetTagFilePath(SourceMapping mapping) => Path.Combine(_tagsPath, $".{mapping.Name}");
-    
+
     protected string GetClonePath(SourceMapping mapping) => Path.Combine(_tmpPath, mapping.Name);
+
+    protected string GetRepoSourcesPath(SourceMapping mapping) => Path.Combine(SourcesPath, mapping.Name);
 
     /// <summary>
     /// Takes a given commit message template and populates it with given values, URLs and others.

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -262,7 +262,7 @@ public abstract class VmrManagerBase
         var pathSettingRegex = new Regex(@"(\bpath[ \t]*\=[ \t]*\b)");
 
         using (var vmrGitmodule = File.Open(Path.Combine(VmrPath, gitmodulesFileName), FileMode.Create))
-        using (var writer = new StreamWriter(vmrGitmodule))
+        using (var writer = new StreamWriter(vmrGitmodule) { NewLine = "\n" })
         {
             foreach (var mapping in Mappings)
             {
@@ -285,7 +285,10 @@ public abstract class VmrManagerBase
                 var content = await File.ReadAllTextAsync(repoGitmodulePath, cancellationToken);
 
                 // Add src/[repo]/ prefixes to paths
-                content = pathSettingRegex.Replace(content, $"$1{VmrSourcesPath}/{mapping.Name}/");
+                content = pathSettingRegex
+                    .Replace(content, $"$1{VmrSourcesPath}/{mapping.Name}/")
+                    .Replace("\r\n", "\n");
+
                 await writer.WriteAsync(content);
 
                 // Add some spacing

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -243,8 +243,13 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
         await TagRepo(mapping, toRevision);
         cancellationToken.ThrowIfCancellationRequested();
+
         await ApplyVmrPatches(mapping, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
+
+        await UpdateGitmodules(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
         Commit(commitMessage, author);
     }
 


### PR DESCRIPTION
The `.gitmodules` file, that has information about git submodules in a repository, is only relevant in the root of the repository. This means that we need to gather all `.gitmodules` files from all individual repos that we are synchronizing, compile a single file with all of them and place it in the root of the VMR.

This needs to happen at every commit. Additionally, we need to modify the paths to point into the `src/[repo]/..` paths. 

Also splits `IVmrManager` into `IVmrInitializer` and `IVmrUpdater` files and removes a forgotten `ignoreWorkingTree` parameter.

https://github.com/dotnet/arcade/issues/10583