### PR TITLE
Refactor parsing of Version.Details.xml to its own class

### DIFF
--- a/src/Maestro/DependencyUpdater/Program.cs
+++ b/src/Maestro/DependencyUpdater/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Reflection;
 using Maestro.AzureDevOps;
 using Maestro.Data;
 using Maestro.DataProviders;
@@ -10,11 +11,8 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.DotNet.Kusto;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using System.Reflection;
-using Microsoft.DotNet.Internal.DependencyInjection;
 
 namespace DependencyUpdater
 {
@@ -70,6 +68,7 @@ namespace DependencyUpdater
             // in such a way that will work with sizing.
             services.AddSingleton<DarcRemoteMemoryCache>();
 
+            services.AddTransient<IVersionDetailsParser, VersionDetailsParser>();
             services.AddScoped<IRemoteFactory, DarcRemoteFactory>();
             services.AddKustoClientProvider("Kusto");
         }

--- a/src/Maestro/Maestro.DataProviders/DarcRemoteFactory.cs
+++ b/src/Maestro/Maestro.DataProviders/DarcRemoteFactory.cs
@@ -16,6 +16,7 @@ namespace Maestro.DataProviders
 {
     public class DarcRemoteFactory : IRemoteFactory
     {
+        private readonly IVersionDetailsParser _versionDetailsParser;
         private readonly OperationManager _operations;
 
         public DarcRemoteFactory(
@@ -23,6 +24,7 @@ namespace Maestro.DataProviders
             IKustoClientProvider kustoClientProvider,
             IGitHubTokenProvider gitHubTokenProvider,
             IAzureDevOpsTokenProvider azureDevOpsTokenProvider,
+            IVersionDetailsParser versionDetailsParser,
             DarcRemoteMemoryCache memoryCache,
             OperationManager operations)
         {
@@ -31,6 +33,7 @@ namespace Maestro.DataProviders
             KustoClientProvider = (KustoClientProvider)kustoClientProvider;
             GitHubTokenProvider = gitHubTokenProvider;
             AzureDevOpsTokenProvider = azureDevOpsTokenProvider;
+            _versionDetailsParser = versionDetailsParser;
             Cache = memoryCache;
         }
 
@@ -46,7 +49,7 @@ namespace Maestro.DataProviders
 
         public Task<IRemote> GetBarOnlyRemoteAsync(ILogger logger)
         {
-            return Task.FromResult((IRemote)new Remote(null, new MaestroBarClient(Context, KustoClientProvider), logger));
+            return Task.FromResult((IRemote)new Remote(null, new MaestroBarClient(Context, KustoClientProvider), _versionDetailsParser, logger));
         }
 
         public async Task<IRemote> GetRemoteAsync(string repoUrl, ILogger logger)
@@ -81,7 +84,7 @@ namespace Maestro.DataProviders
                         throw new NotImplementedException($"Unknown repo url type {normalizedUrl}");
                 };
 
-                return new Remote(gitClient, new MaestroBarClient(Context, KustoClientProvider), logger);
+                return new Remote(gitClient, new MaestroBarClient(Context, KustoClientProvider), _versionDetailsParser, logger);
             }
         }
     }

--- a/src/Maestro/Maestro.Web/Startup.cs
+++ b/src/Maestro/Maestro.Web/Startup.cs
@@ -256,6 +256,7 @@ namespace Maestro.Web
             // in such a way that will work with sizing.
             services.AddSingleton<DarcRemoteMemoryCache>();
 
+            services.AddTransient<IVersionDetailsParser, VersionDetailsParser>();
             services.AddScoped<IRemoteFactory, DarcRemoteFactory>();
             services.AddSingleton(typeof(IActorProxyFactory<>), typeof(ActorProxyFactory<>));
 

--- a/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
+++ b/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
@@ -26,11 +26,13 @@ namespace SubscriptionActorService
             BuildAssetRegistryContext context,
             TemporaryFiles tempFiles,
             ILocalGit localGit,
+            IVersionDetailsParser versionDetailsParser,
             OperationManager operations,
             ExponentialRetry retry)
         {
             _tempFiles = tempFiles;
             _localGit = localGit;
+            _versionDetailsParser = versionDetailsParser;
             _operations = operations;
             _retry = retry;
             _configuration = configuration;
@@ -48,13 +50,14 @@ namespace SubscriptionActorService
 
         private readonly TemporaryFiles _tempFiles;
         private readonly ILocalGit _localGit;
+        private readonly IVersionDetailsParser _versionDetailsParser;
         private readonly OperationManager _operations;
         private readonly ExponentialRetry _retry;
 
 
         public Task<IRemote> GetBarOnlyRemoteAsync(ILogger logger)
         {
-            return Task.FromResult((IRemote)new Remote(null, new MaestroBarClient(_context), logger));
+            return Task.FromResult((IRemote)new Remote(null, new MaestroBarClient(_context), _versionDetailsParser, logger));
         }
 
         public async Task<IRemote> GetRemoteAsync(string repoUrl, ILogger logger)
@@ -98,7 +101,7 @@ namespace SubscriptionActorService
                         throw new NotImplementedException($"Unknown repo url type {normalizedUrl}");
                 };
 
-                return new Remote(gitClient, new MaestroBarClient(_context), logger);
+                return new Remote(gitClient, new MaestroBarClient(_context), _versionDetailsParser, logger);
             }
         }
     }

--- a/src/Maestro/SubscriptionActorService/Program.cs
+++ b/src/Maestro/SubscriptionActorService/Program.cs
@@ -39,6 +39,7 @@ namespace SubscriptionActorService
             services.AddSingleton<IActionRunner, ActionRunner>();
             services.AddSingleton<IMergePolicyEvaluator, MergePolicyEvaluator>();
             services.AddSingleton<ILocalGit, LocalGit>();
+            services.AddTransient<IVersionDetailsParser, VersionDetailsParser>();
             services.AddScoped<IRemoteFactory, DarcRemoteFactory>();
             services.AddSingleton<TemporaryFiles>();
             services.AddGitHubTokenProvider();

--- a/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.GitHub.Authentication;
@@ -11,10 +15,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using ClientModels = Microsoft.DotNet.Maestro.Client.Models;
 
 namespace SubscriptionActorService.Tests
@@ -86,11 +86,11 @@ namespace SubscriptionActorService.Tests
                            checksToReturn.Add(new Check(CheckState.Failure, "Important PR Check", "", false));
                        }
 
-                       return Task.FromResult((IList<Check>)checksToReturn);
+                       return Task.FromResult((IList<Check>) checksToReturn);
                    });
 
 
-            MockRemote = new Remote(GitRepo.Object, BarClient.Object, NullLogger.Instance);
+            MockRemote = new Remote(GitRepo.Object, BarClient.Object, new VersionDetailsParser(NullLogger.Instance), NullLogger.Instance);
             RemoteFactory = new Mock<IRemoteFactory>(MockBehavior.Strict);
             RemoteFactory.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(MockRemote);
             Provider = services.BuildServiceProvider();

--- a/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -90,7 +90,7 @@ namespace SubscriptionActorService.Tests
                    });
 
 
-            MockRemote = new Remote(GitRepo.Object, BarClient.Object, new VersionDetailsParser(NullLogger.Instance), NullLogger.Instance);
+            MockRemote = new Remote(GitRepo.Object, BarClient.Object, new VersionDetailsParser(), NullLogger.Instance);
             RemoteFactory = new Mock<IRemoteFactory>(MockBehavior.Strict);
             RemoteFactory.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(MockRemote);
             Provider = services.BuildServiceProvider();

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/RemoteFactory.cs
@@ -67,7 +67,10 @@ namespace Microsoft.DotNet.Darc.Helpers
                 barClient = new MaestroApiBarClient(darcSettings.BuildAssetRegistryPassword,
                                                     darcSettings.BuildAssetRegistryBaseUri);
             }
-            return new Remote(gitClient, barClient, logger);
+
+            var versionDetailsParser = new VersionDetailsParser(logger);
+
+            return new Remote(gitClient, barClient, versionDetailsParser, logger);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/RemoteFactory.cs
@@ -68,9 +68,7 @@ namespace Microsoft.DotNet.Darc.Helpers
                                                     darcSettings.BuildAssetRegistryBaseUri);
             }
 
-            var versionDetailsParser = new VersionDetailsParser(logger);
-
-            return new Remote(gitClient, barClient, versionDetailsParser, logger);
+            return new Remote(gitClient, barClient, new VersionDetailsParser(), logger);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.DarcLib
         {
             _repo = overrideRootPath ?? LocalHelpers.GetRootDir(GitExecutable, logger);
             _logger = logger;
-            _versionDetailsParser = new VersionDetailsParser(logger);
+            _versionDetailsParser = new VersionDetailsParser();
             _gitClient = new LocalGitClient(GitExecutable, _logger);
             _fileManager = new GitFileManager(_gitClient, _versionDetailsParser, _logger);
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -8,6 +8,7 @@ using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.DarcLib
@@ -144,7 +145,15 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns></returns>
         public IEnumerable<DependencyDetail> GetDependenciesFromFileContents(string fileContents, bool includePinned = true)
         {
-            return _versionDetailsParser.ParseVersionDetailsXml(fileContents, includePinned);
+            try
+            {
+                return _versionDetailsParser.ParseVersionDetailsXml(fileContents, includePinned);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"There was an error while parsing '{VersionFiles.VersionDetailsXml}'");
+                return Enumerable.Empty<DependencyDetail>();
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.DarcLib
     {
         private readonly GitFileManager _fileManager;
         private readonly ILocalGitRepo _gitClient;
+        private readonly IVersionDetailsParser _versionDetailsParser;
 
         private readonly ILogger _logger;
 
@@ -31,8 +32,9 @@ namespace Microsoft.DotNet.DarcLib
         {
             _repo = overrideRootPath ?? LocalHelpers.GetRootDir(GitExecutable, logger);
             _logger = logger;
+            _versionDetailsParser = new VersionDetailsParser(logger);
             _gitClient = new LocalGitClient(GitExecutable, _logger);
-            _fileManager = new GitFileManager(_gitClient, _logger);
+            _fileManager = new GitFileManager(_gitClient, _versionDetailsParser, _logger);
         }
 
         /// <summary>
@@ -142,7 +144,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns></returns>
         public IEnumerable<DependencyDetail> GetDependenciesFromFileContents(string fileContents, bool includePinned = true)
         {
-            return _fileManager.ParseVersionDetailsXml(fileContents, includePinned);
+            return _versionDetailsParser.ParseVersionDetailsXml(fileContents, includePinned);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -8,7 +8,6 @@ using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection.Metadata;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.DarcLib
@@ -145,15 +144,7 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns></returns>
         public IEnumerable<DependencyDetail> GetDependenciesFromFileContents(string fileContents, bool includePinned = true)
         {
-            try
-            {
-                return _versionDetailsParser.ParseVersionDetailsXml(fileContents, includePinned);
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, $"There was an error while parsing '{VersionFiles.VersionDetailsXml}'");
-                return Enumerable.Empty<DependencyDetail>();
-            }
+            return _versionDetailsParser.ParseVersionDetailsXml(fileContents, includePinned);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.DarcLib
     public sealed class Remote : IRemote
     {
         private readonly IBarClient _barClient;
+        private readonly IVersionDetailsParser _versionDetailsParser;
         private readonly GitFileManager _fileManager;
         private readonly IGitRepo _gitClient;
         private readonly ILogger _logger;
@@ -35,15 +36,16 @@ namespace Microsoft.DotNet.DarcLib
         private static readonly Regex DependencyUpdatesPattern =
             new Regex(@"\[DependencyUpdate\]: <> \(Begin\)([^\[]+)\[DependencyUpdate\]: <> \(End\)");
 
-        public Remote(IGitRepo gitClient, IBarClient barClient, ILogger logger)
+        public Remote(IGitRepo gitClient, IBarClient barClient, IVersionDetailsParser versionDetailsParser, ILogger logger)
         {
             _logger = logger;
             _barClient = barClient;
             _gitClient = gitClient;
+            _versionDetailsParser = versionDetailsParser;
 
             if (_gitClient != null)
             {
-                _fileManager = new GitFileManager(_gitClient, _logger);
+                _fileManager = new GitFileManager(_gitClient, _versionDetailsParser, _logger);
             }
         }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -105,7 +105,15 @@ namespace Microsoft.DotNet.DarcLib
 
             XmlDocument document = await ReadVersionDetailsXmlAsync(repoUri, branch);
 
-            return _versionDetailsParser.ParseVersionDetailsXml(document, includePinned);
+            try
+            {
+                return _versionDetailsParser.ParseVersionDetailsXml(document, includePinned);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"There was an error while parsing '{VersionFiles.VersionDetailsXml}'");
+                return Enumerable.Empty<DependencyDetail>();
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -105,15 +105,7 @@ namespace Microsoft.DotNet.DarcLib
 
             XmlDocument document = await ReadVersionDetailsXmlAsync(repoUri, branch);
 
-            try
-            {
-                return _versionDetailsParser.ParseVersionDetailsXml(document, includePinned);
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, $"There was an error while parsing '{VersionFiles.VersionDetailsXml}'");
-                return Enumerable.Empty<DependencyDetail>();
-            }
+            return _versionDetailsParser.ParseVersionDetailsXml(document, includePinned);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionDetailsParser.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionDetailsParser.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -18,19 +19,9 @@ public interface IVersionDetailsParser
 
 public class VersionDetailsParser : IVersionDetailsParser
 {
-    private readonly ILogger _logger;
-
-    public VersionDetailsParser(ILogger logger)
-    {
-        _logger = logger;
-    }
-
     public IList<DependencyDetail> ParseVersionDetailsXml(string fileContents, bool includePinned = true)
     {
-        _logger.LogInformation($"Getting a collection of dependencies from '{VersionFiles.VersionDetailsXml}'...");
-
         XmlDocument document = GetXmlDocument(fileContents);
-
         return ParseVersionDetailsXml(document, includePinned: includePinned);
     }
 
@@ -95,7 +86,7 @@ public class VersionDetailsParser : IVersionDetailsParser
         }
         else
         {
-            _logger.LogError($"There was an error while reading '{VersionFiles.VersionDetailsXml}' and it came back empty. " +
+            throw new Exception($"There was an error while reading '{VersionFiles.VersionDetailsXml}' and it came back empty. " +
                 $"Look for exceptions above.");
         }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionDetailsParser.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionDetailsParser.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionDetailsParser.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionDetailsParser.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+
+namespace Microsoft.DotNet.DarcLib;
+
+public interface IVersionDetailsParser
+{
+    IList<DependencyDetail> ParseVersionDetailsXml(string fileContents, bool includePinned = true);
+
+    IList<DependencyDetail> ParseVersionDetailsXml(XmlDocument document, bool includePinned = true);
+}
+
+public class VersionDetailsParser : IVersionDetailsParser
+{
+    private readonly ILogger _logger;
+
+    public VersionDetailsParser(ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    public IList<DependencyDetail> ParseVersionDetailsXml(string fileContents, bool includePinned = true)
+    {
+        _logger.LogInformation($"Getting a collection of dependencies from '{VersionFiles.VersionDetailsXml}'...");
+
+        XmlDocument document = GetXmlDocument(fileContents);
+
+        return ParseVersionDetailsXml(document, includePinned: includePinned);
+    }
+
+    public IList<DependencyDetail> ParseVersionDetailsXml(XmlDocument document, bool includePinned = true)
+    {
+        List<DependencyDetail> dependencyDetails = new List<DependencyDetail>();
+
+        if (document != null)
+        {
+            BuildDependencies(document.DocumentElement.SelectNodes("//Dependency"));
+
+            void BuildDependencies(XmlNodeList dependencies)
+            {
+                if (dependencies.Count > 0)
+                {
+                    foreach (XmlNode dependency in dependencies)
+                    {
+                        if (dependency.NodeType != XmlNodeType.Comment && dependency.NodeType != XmlNodeType.Whitespace)
+                        {
+                            DependencyType type;
+                            switch (dependency.ParentNode.Name)
+                            {
+                                case "ProductDependencies":
+                                    type = DependencyType.Product;
+                                    break;
+                                case "ToolsetDependencies":
+                                    type = DependencyType.Toolset;
+                                    break;
+                                default:
+                                    throw new DarcException($"Unknown dependency type '{dependency.ParentNode.Name}'");
+                            }
+
+                            bool isPinned = false;
+
+                            // If the 'Pinned' attribute does not exist or if it is set to false we just not update it
+                            if (dependency.Attributes[VersionFiles.PinnedAttributeName] != null)
+                            {
+                                if (!bool.TryParse(dependency.Attributes[VersionFiles.PinnedAttributeName].Value, out isPinned))
+                                {
+                                    throw new DarcException($"The '{VersionFiles.PinnedAttributeName}' attribute is set but the value " +
+                                        $"'{dependency.Attributes[VersionFiles.PinnedAttributeName].Value}' " +
+                                        $"is not a valid boolean...");
+                                }
+                            }
+
+                            DependencyDetail dependencyDetail = new DependencyDetail
+                            {
+                                Name = dependency.Attributes[VersionFiles.NameAttributeName].Value?.Trim(),
+                                RepoUri = dependency.SelectSingleNode(VersionFiles.UriElementName).InnerText?.Trim(),
+                                Commit = dependency.SelectSingleNode(VersionFiles.ShaElementName)?.InnerText?.Trim(),
+                                Version = dependency.Attributes[VersionFiles.VersionAttributeName].Value?.Trim(),
+                                CoherentParentDependencyName = dependency.Attributes[VersionFiles.CoherentParentAttributeName]?.Value?.Trim(),
+                                Pinned = isPinned,
+                                Type = type
+                            };
+
+                            dependencyDetails.Add(dependencyDetail);
+                        }
+                    }
+                }
+            }
+        }
+        else
+        {
+            _logger.LogError($"There was an error while reading '{VersionFiles.VersionDetailsXml}' and it came back empty. " +
+                $"Look for exceptions above.");
+        }
+
+        if (includePinned)
+        {
+            return dependencyDetails;
+        }
+
+        return dependencyDetails.Where(d => !d.Pinned).ToList();
+    }
+
+    private static XmlDocument GetXmlDocument(string fileContent)
+    {
+        XmlDocument document = new XmlDocument
+        {
+            PreserveWhitespace = true
+        };
+
+        document.LoadXml(fileContent);
+
+        return document;
+    }
+}

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Darc.Tests
         [Test]
         public async Task CoherencyUpdateTests1()
         {
-            Remote remote = new Remote(null, null, NullLogger.Instance);
+            Remote remote = new Remote(null, null, null, NullLogger.Instance);
 
             List<DependencyDetail> existingDetails = new List<DependencyDetail>();
             DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Darc.Tests
         [Test]
         public async Task CoherencyUpdateTests2()
         {
-            Remote remote = new Remote(null, null, NullLogger.Instance);
+            Remote remote = new Remote(null, null, null, NullLogger.Instance);
 
             List<DependencyDetail> existingDetails = new List<DependencyDetail>();
             DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Darc.Tests
         [Test]
         public async Task CoherencyUpdateTests3()
         {
-            Remote remote = new Remote(null, null, NullLogger.Instance);
+            Remote remote = new Remote(null, null, null, NullLogger.Instance);
 
             List<DependencyDetail> existingDetails = new List<DependencyDetail>();
             DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.Darc.Tests
         [Test]
         public async Task CoherencyUpdateTests4()
         {
-            Remote remote = new Remote(null, null, NullLogger.Instance);
+            Remote remote = new Remote(null, null, null, NullLogger.Instance);
 
             List<DependencyDetail> existingDetails = new List<DependencyDetail>();
             DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.Darc.Tests
         [Test]
         public async Task CoherencyUpdateTests5()
         {
-            Remote remote = new Remote(null, null, NullLogger.Instance);
+            Remote remote = new Remote(null, null, null, NullLogger.Instance);
 
             List<DependencyDetail> existingDetails = new List<DependencyDetail>();
             DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: true);
@@ -181,7 +181,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             var barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             var dependencyGraphRemoteMock = new Mock<IRemote>();
@@ -265,7 +265,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             var barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             var dependencyGraphRemoteMock = new Mock<IRemote>();
@@ -328,7 +328,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             var barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             var dependencyGraphRemoteMock = new Mock<IRemote>();
@@ -388,7 +388,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> dependencyGraphRemoteMock = new Mock<IRemote>();
@@ -458,7 +458,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> dependencyGraphRemoteMock = new Mock<IRemote>();
@@ -541,7 +541,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -589,7 +589,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -625,7 +625,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -662,7 +662,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -703,7 +703,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -759,7 +759,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -823,7 +823,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -870,7 +870,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -921,7 +921,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -980,7 +980,7 @@ namespace Microsoft.DotNet.Darc.Tests
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
             Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
-            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -1051,7 +1051,7 @@ namespace Microsoft.DotNet.Darc.Tests
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
             Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
-            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -1120,7 +1120,7 @@ namespace Microsoft.DotNet.Darc.Tests
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
             Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
-            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -1193,7 +1193,7 @@ namespace Microsoft.DotNet.Darc.Tests
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
             Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
-            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -1267,7 +1267,7 @@ namespace Microsoft.DotNet.Darc.Tests
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
             Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
-            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -1339,7 +1339,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -1383,7 +1383,7 @@ namespace Microsoft.DotNet.Darc.Tests
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
             Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
-            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, NullLogger.Instance);
+            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
@@ -28,6 +28,7 @@ namespace Microsoft.DotNet.Darc.Tests
     {
         private string _testName;
         private LocalGitClient _gitClient;
+        private VersionDetailsParser _versionDetailsParser;
         private GitFileManager _gitFileManager;
         private const string inputRootDir = "inputs";
         private const string inputDir = "input";
@@ -67,7 +68,8 @@ namespace Microsoft.DotNet.Darc.Tests
 
             // Set up a git file manager
             _gitClient = new LocalGitClient("git", NullLogger.Instance);
-            _gitFileManager = new GitFileManager(GitClient, NullLogger.Instance);
+            _versionDetailsParser = new VersionDetailsParser(NullLogger.Instance);
+            _gitFileManager = new GitFileManager(GitClient, _versionDetailsParser, NullLogger.Instance);
         }
 
         public async Task AddDependencyAsync(DependencyDetail dependency)
@@ -94,7 +96,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             string testVersionDetailsXmlPath = Path.Combine(RootExpectedOutputsPath, VersionFiles.VersionDetailsXml);
             string versionDetailsContents = File.ReadAllText(testVersionDetailsXmlPath);
-            IEnumerable<DependencyDetail> dependencies = _gitFileManager.ParseVersionDetailsXml(versionDetailsContents, false);
+            IEnumerable<DependencyDetail> dependencies = _versionDetailsParser.ParseVersionDetailsXml(versionDetailsContents, false);
 
             GitFileContentContainer container = await _gitFileManager.UpdateDependencyFiles(
                 dependencies,

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Darc.Tests
 
             // Set up a git file manager
             _gitClient = new LocalGitClient("git", NullLogger.Instance);
-            _versionDetailsParser = new VersionDetailsParser(NullLogger.Instance);
+            _versionDetailsParser = new VersionDetailsParser();
             _gitFileManager = new GitFileManager(GitClient, _versionDetailsParser, NullLogger.Instance);
         }
 

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Darc.Tests
             "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-4ac4c036/nuget/v3/index.json" })]
         public async Task UpdatePackageSourcesTests(string testName, string[] managedFeeds)
         {
-            GitFileManager gitFileManager = new GitFileManager(null, NullLogger.Instance);
+            GitFileManager gitFileManager = new GitFileManager(null, new VersionDetailsParser(NullLogger.Instance), NullLogger.Instance);
 
             string inputNugetPath = Path.Combine(
                 Environment.CurrentDirectory,
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Darc.Tests
                 testName,
                 InputNugetConfigFile);
             string inputXmlContent = await File.ReadAllTextAsync(inputNugetPath);
-            var inputNuGetConfigFile = GitFileManager.ReadXmlFile(inputXmlContent);
+            var inputNuGetConfigFile = GitFileManager.GetXmlDocument(inputXmlContent);
 
             Dictionary<string, HashSet<string>> configFileUpdateData = new Dictionary<string, HashSet<string>>();
             configFileUpdateData.Add("testKey", new HashSet<string>(managedFeeds));
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.Darc.Tests
         [TestCase("NoDuplicatedDifferentConditions.props", false)]
         public void VerifyNoDuplicatedPropertiesTests(string inputFileName, bool hasDuplicatedProps)
         {
-            GitFileManager gitFileManager = new GitFileManager(null, NullLogger.Instance);
+            GitFileManager gitFileManager = new GitFileManager(null, new VersionDetailsParser(NullLogger.Instance), NullLogger.Instance);
 
             string inputVersionPropsPath = Path.Combine(
                 Environment.CurrentDirectory,

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/GitFileManagerTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Darc.Tests
             "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-4ac4c036/nuget/v3/index.json" })]
         public async Task UpdatePackageSourcesTests(string testName, string[] managedFeeds)
         {
-            GitFileManager gitFileManager = new GitFileManager(null, new VersionDetailsParser(NullLogger.Instance), NullLogger.Instance);
+            GitFileManager gitFileManager = new GitFileManager(null, new VersionDetailsParser(), NullLogger.Instance);
 
             string inputNugetPath = Path.Combine(
                 Environment.CurrentDirectory,
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.Darc.Tests
         [TestCase("NoDuplicatedDifferentConditions.props", false)]
         public void VerifyNoDuplicatedPropertiesTests(string inputFileName, bool hasDuplicatedProps)
         {
-            GitFileManager gitFileManager = new GitFileManager(null, new VersionDetailsParser(NullLogger.Instance), NullLogger.Instance);
+            GitFileManager gitFileManager = new GitFileManager(null, new VersionDetailsParser(), NullLogger.Instance);
 
             string inputVersionPropsPath = Path.Combine(
                 Environment.CurrentDirectory,

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
@@ -79,7 +79,9 @@ Coherency Update:
             client.Setup(x => x.MergeDependencyPullRequestAsync(It.IsAny<string>(),
                 It.IsAny<MergePullRequestParameters>(), Moq.Capture.In(commitToMerge))).Returns(Task.CompletedTask);
 
-            Remote remote = new Remote(client.Object, barClient.Object, new NUnitLogger());
+            var logger = new NUnitLogger();
+
+            Remote remote = new Remote(client.Object, barClient.Object, new VersionDetailsParser(logger), logger);
 
             await remote.MergeDependencyPullRequestAsync(
                 "https://github.com/test/test2",

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
@@ -81,7 +81,7 @@ Coherency Update:
 
             var logger = new NUnitLogger();
 
-            Remote remote = new Remote(client.Object, barClient.Object, new VersionDetailsParser(logger), logger);
+            Remote remote = new Remote(client.Object, barClient.Object, new VersionDetailsParser(), logger);
 
             await remote.MergeDependencyPullRequestAsync(
                 "https://github.com/test/test2",


### PR DESCRIPTION
Another small step to untangling `DarcLib` a bit more so that we can re-use the code for VMR flows.

No functional changes, just copy-pasting the code out to a re-usable component. Improvements to the class itself (such as support for SourceBuild tags) will come as a follow-up.

https://github.com/dotnet/arcade/issues/10264