### PR TITLE
List the unsuccessful checks when AllChecksSuccessful fails

### DIFF
--- a/src/Maestro/Maestro.Contracts/MergePolicyEvalutationResult.cs
+++ b/src/Maestro/Maestro.Contracts/MergePolicyEvalutationResult.cs
@@ -27,7 +27,7 @@ namespace Maestro.Contracts
 
     public class MergePolicyEvaluationResult
     {
-        public MergePolicyEvaluationResult(MergePolicyEvaluationStatus status, string message, IMergePolicyInfo mergePolicy)
+        public MergePolicyEvaluationResult(MergePolicyEvaluationStatus status, string title, string message, IMergePolicyInfo mergePolicy)
         {
             if (mergePolicy == null)
             {
@@ -43,12 +43,14 @@ namespace Maestro.Contracts
             }
 
             Status = status;
+            Title = title;
             Message = message;
             MergePolicyInfo = mergePolicy;
         }
 
         public MergePolicyEvaluationStatus Status { get; }
-        public string Message { get; }
+        public string Title { get; }
+        public string Message { get;}
         public IMergePolicyInfo MergePolicyInfo { get; }
     }
 

--- a/src/Maestro/Maestro.MergePolicies/AllChecksSuccessfulMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/AllChecksSuccessfulMergePolicy.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Maestro.Contracts;
 using Microsoft.DotNet.DarcLib;
@@ -57,7 +58,12 @@ namespace Maestro.MergePolicies
 
             if (statuses.Contains(CheckState.Error))
             {
-                return Fail($"Unsuccessful checks: {ListChecksCount(CheckState.Error)}");
+                StringBuilder listChecks = new StringBuilder();
+                foreach(var status in statuses[CheckState.Error])
+                {
+                    listChecks.AppendLine($"[{status.Name}]({status.Url})");
+                }
+                return Fail($"Unsuccessful checks: {ListChecksCount(CheckState.Error)}", $"{listChecks.ToString()}");
             }
 
             if (statuses.Contains(CheckState.Pending))

--- a/src/Maestro/Maestro.MergePolicies/MergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/MergePolicy.cs
@@ -51,11 +51,13 @@ namespace Maestro.MergePolicies
 
         public abstract Task<MergePolicyEvaluationResult> EvaluateAsync(IPullRequest pr, IRemote darc);
 
-        public MergePolicyEvaluationResult Pending(string message) => new MergePolicyEvaluationResult(MergePolicyEvaluationStatus.Pending, message, this);
+        public MergePolicyEvaluationResult Pending(string title) => new MergePolicyEvaluationResult(MergePolicyEvaluationStatus.Pending, title, string.Empty, this);
 
-        public MergePolicyEvaluationResult Succeed(string message) => new MergePolicyEvaluationResult(MergePolicyEvaluationStatus.Success, message, this);
+        public MergePolicyEvaluationResult Succeed(string title) => new MergePolicyEvaluationResult(MergePolicyEvaluationStatus.Success, title, string.Empty, this);
 
-        public MergePolicyEvaluationResult Fail(string message) => new MergePolicyEvaluationResult(MergePolicyEvaluationStatus.Failure, message, this);
+        public MergePolicyEvaluationResult Fail(string title) => new MergePolicyEvaluationResult(MergePolicyEvaluationStatus.Failure, title, string.Empty, this);
+
+        public MergePolicyEvaluationResult Fail(string title, string message) => new MergePolicyEvaluationResult(MergePolicyEvaluationStatus.Failure, title, message, this);
     }
 
     public interface IMergePolicy : IMergePolicyInfo

--- a/src/Maestro/SubscriptionActorService/MergePolicyEvaluator.cs
+++ b/src/Maestro/SubscriptionActorService/MergePolicyEvaluator.cs
@@ -49,7 +49,7 @@ namespace SubscriptionActorService
                 else
                 {
                     var notImplemented = new NotImplementedMergePolicy(definition.Name);
-                    results.Add(new MergePolicyEvaluationResult(MergePolicyEvaluationStatus.Failure, $"Unknown Merge Policy: '{definition.Name}'", notImplemented));
+                    results.Add(new MergePolicyEvaluationResult(MergePolicyEvaluationStatus.Failure, $"Unknown Merge Policy: '{definition.Name}'", string.Empty, notImplemented));
                 }
             }
 

--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -509,14 +509,14 @@ namespace SubscriptionActorService
             // As soon as one policy is actively failed, we enter a failed state.
             if (result.Failed)
             {
-                Logger.LogInformation($"NOT Merged: PR '{pr.Url}' failed policies {string.Join(", ", result.Results.Where(r => r.Status != MergePolicyEvaluationStatus.Success).Select(r => r.MergePolicyInfo.Name + r.Message))}");
+                Logger.LogInformation($"NOT Merged: PR '{pr.Url}' failed policies {string.Join(", ", result.Results.Where(r => r.Status != MergePolicyEvaluationStatus.Success).Select(r => r.MergePolicyInfo.Name + r.Title))}");
                 return ActionResult.Create(MergePolicyCheckResult.FailedPolicies,
-                    $"NOT Merged: PR '{pr.Url}' has failed policies {string.Join(", ", result.Results.Where(r => r.Status == MergePolicyEvaluationStatus.Failure).Select(r => r.MergePolicyInfo.Name + r.Message))}");
+                    $"NOT Merged: PR '{pr.Url}' has failed policies {string.Join(", ", result.Results.Where(r => r.Status == MergePolicyEvaluationStatus.Failure).Select(r => r.MergePolicyInfo.Name + r.Title))}");
             }
             else if (result.Pending)
             {
                 return ActionResult.Create(MergePolicyCheckResult.PendingPolicies,
-                    $"NOT Merged: PR '{pr.Url}' has pending policies {string.Join(", ", result.Results.Where(r => r.Status == MergePolicyEvaluationStatus.Pending).Select(r => r.MergePolicyInfo.Name + r.Message))}");
+                    $"NOT Merged: PR '{pr.Url}' has pending policies {string.Join(", ", result.Results.Where(r => r.Status == MergePolicyEvaluationStatus.Pending).Select(r => r.MergePolicyInfo.Name + r.Title))}");
             }
             if (result.Succeeded)
             {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -539,17 +539,17 @@ This pull request has not been merged because Maestro++ is waiting on the follow
         {
             if (result.Status == MergePolicyEvaluationStatus.Pending)
             {
-                return $"- ❓ **{result.Message}**";
+                return $"- ❓ **{result.Title}**";
             }
 
             if (result.Status == MergePolicyEvaluationStatus.Success)
             {
-                return $"- ✔️ **{result.MergePolicyInfo.DisplayName}** Succeeded" + (result.Message == null
+                return $"- ✔️ **{result.MergePolicyInfo.DisplayName}** Succeeded" + (result.Title == null
                            ? ""
-                           : $" - {result.Message}");
+                           : $" - {result.Title}");
             }
 
-            return $"- ❌ **{result.MergePolicyInfo.DisplayName}** {result.Message}";
+            return $"- ❌ **{result.MergePolicyInfo.DisplayName}** {result.Title}";
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -551,7 +551,7 @@ namespace Microsoft.DotNet.DarcLib
 
         private static NewCheckRunOutput FormatOutput(MergePolicyEvaluationResult result)
         {
-            return new NewCheckRunOutput(result.Message ?? "no details", string.Empty);
+            return new NewCheckRunOutput(result.Title ?? "no details", result.Message);
         }
 
         /// <summary>


### PR DESCRIPTION
When we inform the user that checks were unsuccessful, we need to tell them which checks to look at as well, so they have an easier way to see why the dependency update isn't auto-completing.

Addresses https://github.com/dotnet/arcade/issues/10071