### PR TITLE
Make add-build-to-channel use a build pool matching the branch

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -262,6 +262,11 @@ namespace Microsoft.DotNet.Darc.Operations
                 { "ArtifactsPublishingAdditionalParameters", _options.ArtifactPublishingAdditionalParameters }
             };
 
+            if (build.GitHubBranch.Contains("release/", StringComparison.InvariantCultureIgnoreCase))
+            {
+                promotionPipelineVariables.Add("UseServicingBuildPool", true.ToString());
+            }
+
             if (_options.DoSDLValidation)
             {
                 promotionPipelineVariables.Add("EnableSDLValidation", _options.DoSDLValidation.ToString());

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddBuildToChannelOperation.cs
@@ -262,7 +262,8 @@ namespace Microsoft.DotNet.Darc.Operations
                 { "ArtifactsPublishingAdditionalParameters", _options.ArtifactPublishingAdditionalParameters }
             };
 
-            if (build.GitHubBranch.Contains("release/", StringComparison.InvariantCultureIgnoreCase))
+            if ((build.GitHubBranch?.Contains("release/", StringComparison.InvariantCultureIgnoreCase)) == true ||
+                (build.AzureDevOpsBranch?.Contains("release/", StringComparison.InvariantCultureIgnoreCase) == true))
             {
                 promotionPipelineVariables.Add("UseServicingBuildPool", true.ToString());
             }


### PR DESCRIPTION
Along with https://github.com/dotnet/arcade/pull/10638, cause usage of the -Svc build pool if running on dnceng organization