### PR TITLE
Refactor VersionDetails parser, add support for SourceBuild tags

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionDetailsParser.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionDetailsParser.cs
@@ -71,7 +71,9 @@ public class VersionDetailsParser : IVersionDetailsParser
 
             SourceBuildInfo? sourceBuildInfo = null;
 
-            XmlNode? sourceBuildNode = dependency.SelectSingleNode(VersionFiles.SourceBuildElementName);
+            XmlNode? sourceBuildNode = dependency.SelectSingleNode(VersionFiles.SourceBuildElementName)
+                ?? dependency.SelectSingleNode(VersionFiles.SourceBuildOldElementName); // Workaround for https://github.com/dotnet/source-build/issues/2481
+
             if (sourceBuildNode is XmlElement sourceBuildElement)
             {
                 string repoName = sourceBuildElement.Attributes[VersionFiles.RepoNameAttributeName]?.Value

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
@@ -31,6 +31,9 @@ namespace Microsoft.DotNet.DarcLib
         public const string ClearElement = "clear";
         public const string KeyAttributeName = "key";
         public const string ValueAttributeName = "value";
+        public const string SourceBuildElementName = "SourceBuild";
+        public const string RepoNameAttributeName = "RepoName";
+        public const string ManagedOnlyAttributeName = "ManagedOnly";
 
         private static string GetVersionPropsElementBaseName(string dependencyName)
         {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
@@ -32,6 +32,7 @@ namespace Microsoft.DotNet.DarcLib
         public const string KeyAttributeName = "key";
         public const string ValueAttributeName = "value";
         public const string SourceBuildElementName = "SourceBuild";
+        public const string SourceBuildOldElementName = "SourceBuildTarball";
         public const string RepoNameAttributeName = "RepoName";
         public const string ManagedOnlyAttributeName = "ManagedOnly";
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyDetail.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/DependencyDetail.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.Maestro.Client.Models;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Microsoft.DotNet.DarcLib
@@ -95,5 +93,10 @@ namespace Microsoft.DotNet.DarcLib
         /// Asset locations for the dependency
         /// </summary>
         public IEnumerable<string> Locations { get; set; }
+
+        /// <summary>
+        /// Information whether dependency is needed for source-build.
+        /// </summary>
+        public SourceBuildInfo SourceBuild { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/SourceBuildInfo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/SourceBuildInfo.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.DarcLib;
+
+public class SourceBuildInfo
+{
+    /// <summary>
+    /// Name of the repository during the source-build.
+    /// </summary>
+    public string RepoName { get; set; }
+
+    /// <summary>
+    /// Indicates whether a dependency depends only on managed inputs.
+    /// </summary>
+    public bool ManagedOnly { get; set; }
+}

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/Microsoft.DotNet.DarcLib.Tests.csproj
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/Microsoft.DotNet.DarcLib.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <SignAssembly>false</SignAssembly>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VersionDetailsParserTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VersionDetailsParserTests.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Microsoft.DotNet.DarcLib.Tests;
+
+[TestFixture]
+public class VersionDetailsParserTests
+{
+    const string VersionDetailsXml =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <Dependencies>
+          <ProductDependencies>
+            <Dependency Name="NETStandard.Library.Ref" Version="2.1.0" Pinned="true">
+              <Uri>https://github.com/dotnet/core-setup</Uri>
+              <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
+            </Dependency>
+            <Dependency Name="NuGet.Build.Tasks" Version="6.4.0-preview.1.51" CoherentParentDependency="Microsoft.NET.Sdk">
+              <Uri>https://github.com/nuget/nuget.client</Uri>
+              <Sha>745617ea6fc239737c80abb424e13faca4249bf1</Sha>
+              <SourceBuildTarball RepoName="nuget-client" />
+            </Dependency>
+          </ProductDependencies>
+          <ToolsetDependencies>
+            <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22426.1">
+              <Uri>https://github.com/dotnet/arcade</Uri>
+              <Sha>692746db3f08766bc29e91e826ff15e5e8a82b44</Sha>
+              <SourceBuild RepoName="arcade" ManagedOnly="true" />
+            </Dependency>
+          </ToolsetDependencies>
+        </Dependencies>
+        """;
+    
+    [Test]
+    public void AreDependencyMetadataParsedTest()
+    {
+        var parser = new VersionDetailsParser();
+        var dependencies = parser.ParseVersionDetailsXml(VersionDetailsXml);
+
+        dependencies.Count.Should().Be(3);
+        dependencies.Should().Contain(d => d.Name == "NETStandard.Library.Ref"
+            && d.Version == "2.1.0"
+            && d.RepoUri == "https://github.com/dotnet/core-setup"
+            && d.Commit == "7d57652f33493fa022125b7f63aad0d70c52d810"
+            && d.Pinned
+            && d.CoherentParentDependencyName == null
+            && d.SourceBuild == null
+            && d.Type == DependencyType.Product);
+
+        dependencies.Should().Contain(d => d.Name == "NuGet.Build.Tasks"
+            && d.Version == "6.4.0-preview.1.51"
+            && d.RepoUri == "https://github.com/nuget/nuget.client"
+            && d.Commit == "745617ea6fc239737c80abb424e13faca4249bf1"
+            && !d.Pinned
+            && d.CoherentParentDependencyName == "Microsoft.NET.Sdk"
+            && d.SourceBuild != null
+            && d.SourceBuild.RepoName == "nuget-client"
+            && !d.SourceBuild.ManagedOnly
+            && d.Type == DependencyType.Product);
+
+        dependencies.Should().Contain(d => d.Name == "Microsoft.DotNet.Arcade.Sdk"
+            && d.Version == "7.0.0-beta.22426.1"
+            && d.RepoUri == "https://github.com/dotnet/arcade"
+            && d.Commit == "692746db3f08766bc29e91e826ff15e5e8a82b44"
+            && !d.Pinned
+            && d.CoherentParentDependencyName == null
+            && d.SourceBuild != null
+            && d.SourceBuild.RepoName == "arcade"
+            && d.SourceBuild.ManagedOnly
+            && d.Type == DependencyType.Toolset);
+    }
+}


### PR DESCRIPTION
Extended the parser to support the `<SourceBuild>` tags in `VersionDetails.xml`. The source-build metadata will be used in the VMR tooling (darc).

Additionally, the code was simplified, nullability enabled + some potential NREs dealt with.

https://github.com/dotnet/arcade/issues/10264