### PR TITLE
Add helix-service and helix-machines weekly to monitored definitions

### DIFF
--- a/src/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/.config/settings.json
@@ -63,6 +63,18 @@
         },
         {
           "Project": "internal",
+          "DefinitionPath": "\\dotnet\\helix-service\\dotnet-helix-service-weekly",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-arcade-first-responder"
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet\\helix-machines\\dotnet-helix-machines-weekly",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-arcade-first-responder"
+        },
+        {
+          "Project": "internal",
           "DefinitionPath": "\\dotnet-release\\Validate-DotNet",
           "Branches": [ "main" ],
           "IssuesId": "dotnet-aspnetcore-infra",

--- a/src/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/.config/settings.json
@@ -37,7 +37,7 @@
         },
         {
           "Project": "internal",
-          "DefinitionPath": "\\dotnet-source-indexer\\dotnet-source-indexer CI",
+          "DefinitionPath": "\\dotnet\\source-indexer\\dotnet-source-indexer CI",
           "Branches": [ "main" ],
           "Assignee": "alperovi",
           "IssuesId": "dotnet-arcade"


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/10656

This adds monitoring to the weekly secret synchronization builds for helix-machines and helix-service. We've had good results with having arcade-services monitored in this fashion and it will help increase the visibility of any failures so that we have enough time to react to them. 