### PR TITLE
Add recursive VMR init / sync

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
@@ -22,7 +22,8 @@ internal class InitializeOperation : VmrOperationBase<IVmrInitializer>
         IVmrInitializer vmrManager,
         SourceMapping mapping,
         string? targetRevision,
+        bool recursive,
         CancellationToken cancellationToken)
         =>
-        await vmrManager.InitializeVmr(mapping, targetRevision, cancellationToken);
+        await vmrManager.InitializeRepository(mapping, targetRevision, recursive, cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
@@ -25,7 +25,8 @@ internal class UpdateOperation : VmrOperationBase<IVmrUpdater>
         IVmrUpdater vmrManager,
         SourceMapping mapping,
         string? targetRevision,
+        bool recursive,
         CancellationToken cancellationToken)
         =>
-        await vmrManager.UpdateVmr(mapping, targetRevision, _options.NoSquash, cancellationToken);
+        await vmrManager.UpdateRepository(mapping, targetRevision, _options.NoSquash, recursive, cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/VmrOperationBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/VmrOperationBase.cs
@@ -48,7 +48,7 @@ internal abstract class VmrOperationBase<TVmrManager> : Operation where TVmrMana
         IEnumerable<(SourceMapping Mapping, string? Revision)> reposToSync;
 
         // 'all' means sync all of the repos
-        if (repositories.Count() == 1 && repositories.First() == "all")
+        if (repositories.Count == 1 && repositories.First() == "all")
         {
             reposToSync = vmrManager.Mappings.Select<SourceMapping, (SourceMapping Mapping, string? Revision)>(m => (m, null));
         }
@@ -81,7 +81,7 @@ internal abstract class VmrOperationBase<TVmrManager> : Operation where TVmrMana
             foreach (var (mapping, revision) in reposToSync)
             {
                 listener.Token.ThrowIfCancellationRequested();
-                success &= await ExecuteAsync(vmrManager, mapping, revision, listener.Token);
+                success &= await ExecuteAsync(vmrManager, mapping, revision, _options.Recursive, listener.Token);
             }
         }
         catch (OperationCanceledException)
@@ -101,19 +101,21 @@ internal abstract class VmrOperationBase<TVmrManager> : Operation where TVmrMana
         TVmrManager vmrManager,
         SourceMapping mapping,
         string? targetRevision,
+        bool recursive,
         CancellationToken cancellationToken);
 
     private async Task<bool> ExecuteAsync(
         TVmrManager vmrManager,
         SourceMapping mapping,
         string? targetRevision,
+        bool recursive,
         CancellationToken cancellationToken)
     {
         using (Logger.BeginScope(mapping.Name))
         {
             try
             {
-                await ExecuteInternalAsync(vmrManager, mapping, targetRevision, cancellationToken);
+                await ExecuteInternalAsync(vmrManager, mapping, targetRevision, recursive, cancellationToken);
                 return true;
             }
             catch (EmptySyncException e)

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrCommandLineOptions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using CommandLine;
+using Microsoft.DotNet.DarcLib;
 
 namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
@@ -21,6 +22,6 @@ internal abstract class VmrCommandLineOptions : CommandLineOptions
     [Option("tmp", Required = false, HelpText = "Temporary path where intermediate files are stored (e.g. cloned repos, patch files); defaults to usual TEMP.")]
     public string TmpPath { get; set; }
 
-    [Option('r', "recursive", Required = false, HelpText = "Process also dependencies (from Version.Details.xml) recursively.")]
+    [Option('r', "recursive", Required = false, HelpText = $"Process also dependencies (from {VersionFiles.VersionDetailsXml}) recursively.")]
     public bool Recursive { get; set; } = false;
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrCommandLineOptions.cs
@@ -20,4 +20,7 @@ internal abstract class VmrCommandLineOptions : CommandLineOptions
 
     [Option("tmp", Required = false, HelpText = "Temporary path where intermediate files are stored (e.g. cloned repos, patch files); defaults to usual TEMP.")]
     public string TmpPath { get; set; }
+
+    [Option('r', "recursive", Required = false, HelpText = "Process also dependencies (from Version.Details.xml) recursively.")]
+    public bool Recursive { get; set; } = false;
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
@@ -18,7 +18,7 @@ public interface IVmrInitializer : IVmrManager
     /// </summary>
     /// <param name="mappingName">Name of a repository mapping</param>
     /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
-    /// <param name="initializeDependencies">When true, initialize dependency repos based on the Version.Details.xml of the currently initialized repo</param>
+    /// <param name="initializeDependencies">When true, initializes dependencies (from Version.Details.xml) recursively</param>
     /// <param name="cancellationToken">Cancellation token</param>
     Task InitializeRepository(string mappingName, string? targetRevision, bool initializeDependencies, CancellationToken cancellationToken)
     {
@@ -33,7 +33,7 @@ public interface IVmrInitializer : IVmrManager
     /// </summary>
     /// <param name="mapping">Repository mapping</param>
     /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
-    /// <param name="initializeDependencies">When true, initialize dependency repos based on the Version.Details.xml of the currently initialized repo</param>
+    /// <param name="initializeDependencies">When true, initializes dependencies (from Version.Details.xml) recursively</param>
     /// <param name="cancellationToken">Cancellation token</param>
     Task InitializeRepository(SourceMapping mapping, string? targetRevision, bool initializeDependencies, CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -18,13 +18,14 @@ public interface IVmrInitializer : IVmrManager
     /// </summary>
     /// <param name="mappingName">Name of a repository mapping</param>
     /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
+    /// <param name="initializeDependencies">When true, initialize dependency repos based on the Version.Details.xml of the currently initialized repo</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    Task InitializeVmr(string mappingName, string? targetRevision, CancellationToken cancellationToken)
+    Task InitializeRepository(string mappingName, string? targetRevision, bool initializeDependencies, CancellationToken cancellationToken)
     {
         var mapping = Mappings.FirstOrDefault(m => m.Name == mappingName)
             ?? throw new Exception($"No repository mapping named `{mappingName}` found!");
 
-        return InitializeVmr(mapping, targetRevision, cancellationToken);
+        return InitializeRepository(mapping, targetRevision, initializeDependencies, cancellationToken);
     }
 
     /// <summary>
@@ -32,6 +33,7 @@ public interface IVmrInitializer : IVmrManager
     /// </summary>
     /// <param name="mapping">Repository mapping</param>
     /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
+    /// <param name="initializeDependencies">When true, initialize dependency repos based on the Version.Details.xml of the currently initialized repo</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    Task InitializeVmr(SourceMapping mapping, string? targetRevision, CancellationToken cancellationToken);
+    Task InitializeRepository(SourceMapping mapping, string? targetRevision, bool initializeDependencies, CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -19,13 +19,19 @@ public interface IVmrUpdater : IVmrManager
     /// <param name="mappingName">Name of a repository mapping</param>
     /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
     /// <param name="noSquash">Whether to pull changes commit by commit instead of squashing all updates into one</param>
+    /// <param name="updateDependencies">When true, updates dependencies (from Version.Details.xml) recursively</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    Task UpdateVmr(string mappingName, string? targetRevision, bool noSquash, CancellationToken cancellationToken)
+    Task UpdateRepository(
+        string mappingName,
+        string? targetRevision,
+        bool noSquash,
+        bool updateDependencies,
+        CancellationToken cancellationToken)
     {
         var mapping = Mappings.FirstOrDefault(m => m.Name == mappingName)
             ?? throw new Exception($"No repository mapping named `{mappingName}` found!");
 
-        return UpdateVmr(mapping, targetRevision, noSquash, cancellationToken);
+        return UpdateRepository(mapping, targetRevision, noSquash, updateDependencies, cancellationToken);
     }
 
     /// <summary>
@@ -34,6 +40,12 @@ public interface IVmrUpdater : IVmrManager
     /// <param name="mapping">Repository mapping</param>
     /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
     /// <param name="noSquash">Whether to pull changes commit by commit instead of squashing all updates into one</param>
+    /// <param name="updateDependencies">When true, updates dependencies (from Version.Details.xml) recursively</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    Task UpdateVmr(SourceMapping mapping, string? targetRevision, bool noSquash, CancellationToken cancellationToken);
+    Task UpdateRepository(
+        SourceMapping mapping,
+        string? targetRevision,
+        bool noSquash,
+        bool updateDependencies,
+        CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
@@ -26,7 +24,6 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         Original commit: {remote}/commit/{newSha}
         """;
 
-    private readonly IVersionDetailsParser _versionDetailsParser;
     private readonly ILogger<VmrUpdater> _logger;
 
     public VmrInitializer(
@@ -36,9 +33,8 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         ILogger<VmrUpdater> logger,
         IVmrManagerConfiguration configuration,
         IReadOnlyCollection<SourceMapping> mappings)
-        : base(processManager, remoteFactory, logger, mappings, configuration.VmrPath, configuration.TmpPath)
+        : base(processManager, remoteFactory, versionDetailsParser, logger, mappings, configuration.VmrPath, configuration.TmpPath)
     {
-        _versionDetailsParser = versionDetailsParser;
         _logger = logger;
     }
 
@@ -91,25 +87,8 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
 
     private async Task InitializeDependencies(SourceMapping mapping, CancellationToken cancellationToken)
     {
-        var versionDetailsPath = Path.Combine(
-            GetRepoSourcesPath(mapping),
-            VersionFiles.VersionDetailsXml.Replace("/", Environment.NewLine));
-
-        var versionDetailsContent = await File.ReadAllTextAsync(versionDetailsPath, cancellationToken);
-
-        var dependencies = _versionDetailsParser.ParseVersionDetailsXml(versionDetailsContent, true)
-            .Where(d => d.Type == DependencyType.Product && d.SourceBuild is not null);
-
-        foreach (var dependency in dependencies)
+        foreach (var (dependency, dependencyMapping) in await GetDependencies(mapping, cancellationToken))
         {
-            var dependencyMapping = Mappings.FirstOrDefault(m => m.Name == dependency.SourceBuild.RepoName);
-
-            if (dependencyMapping is null)
-            {
-                throw new Exception($"No source mapping named '{dependency.SourceBuild.RepoName}' found " +
-                                    $"for a {VersionFiles.VersionDetailsXml} dependency {dependency.Name}");
-            }
-
             if (Directory.Exists(GetRepoSourcesPath(dependencyMapping)))
             {
                 _logger.LogDebug("Dependency {repo} has already been initialized", dependencyMapping.Name);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
@@ -24,20 +26,27 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         Original commit: {remote}/commit/{newSha}
         """;
 
+    private readonly IVersionDetailsParser _versionDetailsParser;
     private readonly ILogger<VmrUpdater> _logger;
 
     public VmrInitializer(
         IProcessManager processManager,
         IRemoteFactory remoteFactory,
+        IVersionDetailsParser versionDetailsParser,
         ILogger<VmrUpdater> logger,
         IVmrManagerConfiguration configuration,
         IReadOnlyCollection<SourceMapping> mappings)
         : base(processManager, remoteFactory, logger, mappings, configuration.VmrPath, configuration.TmpPath)
     {
+        _versionDetailsParser = versionDetailsParser;
         _logger = logger;
     }
 
-    public async Task InitializeVmr(SourceMapping mapping, string? targetRevision, CancellationToken cancellationToken)
+    public async Task InitializeRepository(
+        SourceMapping mapping,
+        string? targetRevision,
+        bool initializeDependencies,
+        CancellationToken cancellationToken)
     {
         if (File.Exists(GetTagFilePath(mapping)))
         {
@@ -73,5 +82,46 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         Commit(message, DotnetBotCommitSignature);
 
         _logger.LogInformation("Initialization of {name} finished", mapping.Name);
+
+        if (initializeDependencies)
+        {
+            await InitializeDependencies(mapping, cancellationToken);
+        }
+    }
+
+    private async Task InitializeDependencies(SourceMapping mapping, CancellationToken cancellationToken)
+    {
+        var versionDetailsPath = Path.Combine(
+            GetRepoSourcesPath(mapping),
+            VersionFiles.VersionDetailsXml.Replace("/", Environment.NewLine));
+
+        var versionDetailsContent = await File.ReadAllTextAsync(versionDetailsPath, cancellationToken);
+
+        var dependencies = _versionDetailsParser.ParseVersionDetailsXml(versionDetailsContent, true)
+            .Where(d => d.Type == DependencyType.Product && d.SourceBuild is not null);
+
+        foreach (var dependency in dependencies)
+        {
+            var dependencyMapping = Mappings.FirstOrDefault(m => m.Name == dependency.SourceBuild.RepoName);
+
+            if (dependencyMapping is null)
+            {
+                throw new Exception($"No source mapping named '{dependency.SourceBuild.RepoName}' found " +
+                                    $"for a {VersionFiles.VersionDetailsXml} dependency {dependency.Name}");
+            }
+
+            if (Directory.Exists(GetRepoSourcesPath(dependencyMapping)))
+            {
+                _logger.LogDebug("Dependency {repo} has already been initialized", dependencyMapping.Name);
+                continue;
+            }
+
+            _logger.LogInformation("Recursively initializing dependency {repo} / {commit} ({version})",
+                dependencyMapping.Name,
+                dependency.Commit,
+                dependency.Version);
+
+            await InitializeRepository(dependencyMapping, dependency.Commit, true, cancellationToken);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -324,7 +324,7 @@ public abstract class VmrManagerBase
     {
         var versionDetailsPath = Path.Combine(
             GetRepoSourcesPath(mapping),
-            VersionFiles.VersionDetailsXml.Replace("/", Environment.NewLine));
+            VersionFiles.VersionDetailsXml.Replace('/', Path.DirectorySeparatorChar));
 
         var versionDetailsContent = await File.ReadAllTextAsync(versionDetailsPath, cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -30,6 +30,7 @@ public abstract class VmrManagerBase
     private readonly ILogger<VmrUpdater> _logger;
     private readonly IProcessManager _processManager;
     private readonly IRemoteFactory _remoteFactory;
+    private readonly IVersionDetailsParser _versionDetailsParser;
     private readonly string _tagsPath;
     private readonly string _tmpPath;
 
@@ -42,6 +43,7 @@ public abstract class VmrManagerBase
     protected VmrManagerBase(
         IProcessManager processManager,
         IRemoteFactory remoteFactory,
+        IVersionDetailsParser versionDetailsParser,
         ILogger<VmrUpdater> logger,
         IReadOnlyCollection<SourceMapping> mappings,
         string vmrPath,
@@ -50,6 +52,7 @@ public abstract class VmrManagerBase
         _logger = logger;
         _processManager = processManager;
         _remoteFactory = remoteFactory;
+        _versionDetailsParser = versionDetailsParser;
         _tmpPath = tmpPath;
         VmrPath = vmrPath;
         SourcesPath = Path.Combine(vmrPath, VmrSourcesPath);
@@ -310,6 +313,41 @@ public abstract class VmrManagerBase
         var commit = repository.Commit(commitMessage, author, DotnetBotCommitSignature);
 
         _logger.LogInformation("Created {sha} in {duration} seconds", ShortenId(commit.Id.Sha), (int) watch.Elapsed.TotalSeconds);
+    }
+
+    /// <summary>
+    /// Parses Version.Details.xml of a given mapping and returns the list of source build dependencies (+ their mapping).
+    /// </summary>
+    protected async Task<IList<(DependencyDetail dependency, SourceMapping mapping)>> GetDependencies(
+        SourceMapping mapping,
+        CancellationToken cancellationToken)
+    {
+        var versionDetailsPath = Path.Combine(
+            GetRepoSourcesPath(mapping),
+            VersionFiles.VersionDetailsXml.Replace("/", Environment.NewLine));
+
+        var versionDetailsContent = await File.ReadAllTextAsync(versionDetailsPath, cancellationToken);
+
+        var dependencies = _versionDetailsParser.ParseVersionDetailsXml(versionDetailsContent, true)
+            .Where(dep => dep.SourceBuild is not null);
+
+        var result = new List<(DependencyDetail, SourceMapping)>();
+
+        foreach (var dependency in dependencies)
+        {
+            var dependencyMapping = Mappings.FirstOrDefault(m => m.Name == dependency.SourceBuild.RepoName);
+
+            if (dependencyMapping is null)
+            {
+                throw new InvalidOperationException(
+                    $"No source mapping named '{dependency.SourceBuild.RepoName}' found " +
+                    $"for a {VersionFiles.VersionDetailsXml} dependency {dependency.Name}");
+            }
+
+            result.Add((dependency, dependencyMapping));
+        }
+
+        return result;
     }
 
     protected string GetPatchFilePath(SourceMapping mapping) => Path.Combine(_tmpPath, $"{mapping.Name}.patch");

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -37,6 +37,7 @@ public static class VmrRegistrations
     {
         services.TryAddTransient<IProcessManager>(sp => ActivatorUtilities.CreateInstance<ProcessManager>(sp, gitLocation));
         services.TryAddTransient<ISourceMappingParser, SourceMappingParser>();
+        services.TryAddTransient<IVersionDetailsParser, VersionDetailsParser>();
         services.TryAddTransient<IVmrManagerFactory, VmrManagerFactory>();
         services.TryAddTransient<IVmrUpdater>(sp => sp.GetRequiredService<IVmrManagerFactory>().CreateVmrUpdater().GetAwaiter().GetResult());
         services.TryAddTransient<IVmrInitializer>(sp => sp.GetRequiredService<IVmrManagerFactory>().CreateVmrInitializer().GetAwaiter().GetResult());

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -56,28 +56,36 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
     public VmrUpdater(
         IProcessManager processManager,
         IRemoteFactory remoteFactory,
+        IVersionDetailsParser versionDetailsParser,
         ILogger<VmrUpdater> logger,
         IVmrManagerConfiguration configuration,
         IReadOnlyCollection<SourceMapping> mappings)
-        : base(processManager, remoteFactory, logger, mappings, configuration.VmrPath, configuration.TmpPath)
+        : base(processManager, remoteFactory, versionDetailsParser, logger, mappings, configuration.VmrPath, configuration.TmpPath)
     {
         _logger = logger;
         _processManager = processManager;
         _remoteFactory = remoteFactory;
     }
 
-    public async Task UpdateVmr(SourceMapping mapping, string? targetRevision, bool noSquash, CancellationToken cancellationToken)
+    public Task UpdateRepository(
+        SourceMapping mapping,
+        string? targetRevision,
+        bool noSquash,
+        bool updateDependencies,
+        CancellationToken cancellationToken)
     {
-        var tagFile = GetTagFilePath(mapping);
-        string currentSha;
-        try
-        {
-            currentSha = File.ReadAllText(tagFile).Trim();
-        }
-        catch (FileNotFoundException)
-        {
-            throw new InvalidOperationException($"Missing tag file for {mapping.Name} - please init the individual repo first");
-        }
+        return updateDependencies
+            ? UpdateRepositoryRecursively(mapping, targetRevision, noSquash, cancellationToken)
+            : UpdateRepository(mapping, targetRevision, noSquash, cancellationToken);
+    }
+
+    private async Task UpdateRepository(
+        SourceMapping mapping,
+        string? targetRevision,
+        bool noSquash,
+        CancellationToken cancellationToken)
+    {
+        var currentSha = await GetCurrentVersion(mapping);
 
         if (!await HasRemoteUpdates(mapping, currentSha))
         {
@@ -143,7 +151,9 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
         if (commitsToCopy.Count == 0)
         {
-            throw new EmptySyncException($"Found no commits between {currentSha} and {targetRevision} when synchronizing {mapping.Name}");
+            // TODO: https://github.com/dotnet/arcade/issues/10550 - enable synchronization between arbitrary commits
+            throw new EmptySyncException($"Found no commits between {currentSha} and {targetRevision} " +
+                $"when synchronizing {mapping.Name}");
         }
 
         // When we go one by one, we basically "copy" the commits.
@@ -201,6 +211,51 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 message,
                 DotnetBotCommitSignature,
                 cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Updates a repository and all of it's dependencies recursively starting with a given mapping.
+    /// Always updates to the first version found per repository in the dependency tree.
+    /// </summary>
+    private async Task UpdateRepositoryRecursively(
+        SourceMapping mapping,
+        string? targetRevision,
+        bool noSquash,
+        CancellationToken cancellationToken)
+    {
+        var reposToUpdate = new Queue<(SourceMapping mapping, string? targetRevision)>();
+        reposToUpdate.Enqueue((mapping, targetRevision));
+
+        var updatedDependencies = new HashSet<SourceMapping>();
+
+        while (reposToUpdate.TryDequeue(out var repoToUpdate))
+        {
+            var mappingToUpdate = repoToUpdate.mapping;
+
+            _logger.LogInformation("Recursively updating dependency {repo} / {commit}",
+                mappingToUpdate.Name,
+                repoToUpdate.targetRevision);
+
+            await UpdateRepository(mappingToUpdate, repoToUpdate.targetRevision, noSquash, cancellationToken);
+            updatedDependencies.Add(mappingToUpdate);
+
+            foreach (var (dependency, dependencyMapping) in await GetDependencies(mappingToUpdate, cancellationToken))
+            {
+                if (updatedDependencies.Contains(dependencyMapping))
+                {
+                    continue;
+                }
+
+                var dependencySha = await GetCurrentVersion(dependencyMapping);
+                if (dependencySha == dependency.Commit)
+                {
+                    _logger.LogDebug("Dependency {name} is already at {sha}, skipping..", dependency.Name, dependencySha);
+                    continue;
+                }
+
+                reposToUpdate.Enqueue((dependencyMapping, dependency.Commit));
+            }
         }
     }
 
@@ -338,5 +393,21 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         }
 
         return files;
+    }
+
+    private async Task<string> GetCurrentVersion(SourceMapping mapping)
+    {
+        var tagFile = GetTagFilePath(mapping);
+        string currentSha;
+        try
+        {
+            currentSha = (await File.ReadAllTextAsync(tagFile)).Trim();
+        }
+        catch (FileNotFoundException)
+        {
+            throw new InvalidOperationException($"Missing tag file for {mapping.Name} - please initialize the individual repo first");
+        }
+
+        return currentSha;
     }
 }


### PR DESCRIPTION
The initialize/synchronize operation will parse `Version.Details.xml` of each processed individual repository and recursively process all other SourceBuild dependencies.

This is a copy of what the tarball initialization does (but in MSBuild):  https://github.com/dotnet/installer/blob/12d0e4ba18890eae857199ada80b1debdf892e41/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets#L117

https://github.com/dotnet/arcade/issues/10268