### PR TITLE
Read the source-build `TarballOnly` attribute in `Version.Details.xml`

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
@@ -25,6 +25,8 @@ namespace Microsoft.DotNet.DarcLib
         public const string NameAttributeName = "Name";
         public const string VersionAttributeName = "Version";
         public const string CoherentParentAttributeName = "CoherentParentDependency";
+        public const string ProductDependencyElementName = "ProductDependencies";
+        public const string ToolsetDependencyElementName = "ToolsetDependencies";
         public const string PinnedAttributeName = "Pinned";
         public const string NugetConfig = "NuGet.config";
         public const string AddElement = "add";
@@ -35,6 +37,7 @@ namespace Microsoft.DotNet.DarcLib
         public const string SourceBuildOldElementName = "SourceBuildTarball";
         public const string RepoNameAttributeName = "RepoName";
         public const string ManagedOnlyAttributeName = "ManagedOnly";
+        public const string TarballOnlyAttributeName = "TarballOnly";
 
         private static string GetVersionPropsElementBaseName(string dependencyName)
         {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/SourceBuildInfo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/Darc/SourceBuildInfo.cs
@@ -15,4 +15,9 @@ public class SourceBuildInfo
     /// Indicates whether a dependency depends only on managed inputs.
     /// </summary>
     public bool ManagedOnly { get; set; }
+
+    /// <summary>
+    /// Indicates whether a dependency is only used in the tarball builds.
+    /// </summary>
+    public bool TarballOnly { get; set; }
 }

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VersionDetailsParserTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VersionDetailsParserTests.cs
@@ -10,38 +10,38 @@ namespace Microsoft.DotNet.DarcLib.Tests;
 [TestFixture]
 public class VersionDetailsParserTests
 {
-    const string VersionDetailsXml =
-        """
-        <?xml version="1.0" encoding="utf-8"?>
-        <Dependencies>
-          <ProductDependencies>
-            <Dependency Name="NETStandard.Library.Ref" Version="2.1.0" Pinned="true">
-              <Uri>https://github.com/dotnet/core-setup</Uri>
-              <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
-            </Dependency>
-            <Dependency Name="NuGet.Build.Tasks" Version="6.4.0-preview.1.51" CoherentParentDependency="Microsoft.NET.Sdk">
-              <Uri>https://github.com/nuget/nuget.client</Uri>
-              <Sha>745617ea6fc239737c80abb424e13faca4249bf1</Sha>
-              <SourceBuildTarball RepoName="nuget-client" />
-            </Dependency>
-          </ProductDependencies>
-          <ToolsetDependencies>
-            <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22426.1">
-              <Uri>https://github.com/dotnet/arcade</Uri>
-              <Sha>692746db3f08766bc29e91e826ff15e5e8a82b44</Sha>
-              <SourceBuild RepoName="arcade" ManagedOnly="true" />
-            </Dependency>
-          </ToolsetDependencies>
-        </Dependencies>
-        """;
-    
     [Test]
     public void AreDependencyMetadataParsedTest()
     {
+        const string VersionDetailsXml =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Dependencies>
+              <ProductDependencies>
+                <Dependency Name="NETStandard.Library.Ref" Version="2.1.0" Pinned="true">
+                  <Uri>https://github.com/dotnet/core-setup</Uri>
+                  <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
+                </Dependency>
+                <Dependency Name="NuGet.Build.Tasks" Version="6.4.0-preview.1.51" CoherentParentDependency="Microsoft.NET.Sdk">
+                  <Uri>https://github.com/nuget/nuget.client</Uri>
+                  <Sha>745617ea6fc239737c80abb424e13faca4249bf1</Sha>
+                  <SourceBuildTarball RepoName="nuget-client" />
+                </Dependency>
+              </ProductDependencies>
+              <ToolsetDependencies>
+                <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22426.1">
+                  <Uri>https://github.com/dotnet/arcade</Uri>
+                  <Sha>692746db3f08766bc29e91e826ff15e5e8a82b44</Sha>
+                  <SourceBuild RepoName="arcade" ManagedOnly="true" TarballOnly="true" />
+                </Dependency>
+              </ToolsetDependencies>
+            </Dependencies>
+            """;
+        
         var parser = new VersionDetailsParser();
         var dependencies = parser.ParseVersionDetailsXml(VersionDetailsXml);
 
-        dependencies.Count.Should().Be(3);
+        dependencies.Should().HaveCount(3);
         dependencies.Should().Contain(d => d.Name == "NETStandard.Library.Ref"
             && d.Version == "2.1.0"
             && d.RepoUri == "https://github.com/dotnet/core-setup"
@@ -71,6 +71,65 @@ public class VersionDetailsParserTests
             && d.SourceBuild != null
             && d.SourceBuild.RepoName == "arcade"
             && d.SourceBuild.ManagedOnly
+            && d.SourceBuild.TarballOnly
             && d.Type == DependencyType.Toolset);
+    }
+
+    [Test]
+    public void EmptyXmlIsHandledTest()
+    {
+        const string VersionDetailsXml =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Dependencies></Dependencies>
+            """;
+        
+        var parser = new VersionDetailsParser();
+        var dependencies = parser.ParseVersionDetailsXml(VersionDetailsXml);
+        dependencies.Should().BeEmpty();
+    }
+
+    [Test]
+    public void UnknownCategoryIsRecognizedTest()
+    {
+        const string VersionDetailsXml =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Dependencies>
+              <Something>
+                <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22426.1">
+                  <Uri>https://github.com/dotnet/arcade</Uri>
+                  <Sha>692746db3f08766bc29e91e826ff15e5e8a82b44</Sha>
+                  <SourceBuild RepoName="arcade" ManagedOnly="true" TarballOnly="true" />
+                </Dependency>
+              </Something>
+            </Dependencies>
+            """;
+
+        var parser = new VersionDetailsParser();
+        var action = () => parser.ParseVersionDetailsXml(VersionDetailsXml);
+        action.Should().Throw<DarcException>().WithMessage("Unknown dependency type*Something*");
+    }
+
+    [Test]
+    public void InvalidBooleanIsRecognizedTest()
+    {
+        const string VersionDetailsXml =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Dependencies>
+              <ProductDependencies>
+                <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22426.1">
+                  <Uri>https://github.com/dotnet/arcade</Uri>
+                  <Sha>692746db3f08766bc29e91e826ff15e5e8a82b44</Sha>
+                  <SourceBuild RepoName="arcade" ManagedOnly="foobar" />
+                </Dependency>
+              </ProductDependencies>
+            </Dependencies>
+            """;
+
+        var parser = new VersionDetailsParser();
+        var action = () => parser.ParseVersionDetailsXml(VersionDetailsXml);
+        action.Should().Throw<DarcException>().WithMessage("*is not a valid boolean*");
     }
 }


### PR DESCRIPTION
- Adds attribute needed for https://github.com/dotnet/source-build/issues/2481
- Resolves nullability problems and handles non-happy paths
- Adds tests for invalid XMLs
- Uses constants from `VersionFiles` more