### PR TITLE
Update public pool names

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ stages:
             name: NetCore1ESPool-Internal
             demands: ImageOverride -equals 1es-windows-2019
           ${{ if eq(variables['System.TeamProject'], 'public')}}:
-            name: NetCore1ESPool-Public          
+            name: NetCore-Public          
             demands: ImageOverride -equals 1es-windows-2019-open
 
         variables:

--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -46,7 +46,7 @@ jobs:
     # source-build builds run in Docker, including the default managed platform.
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Svc-Public
+        name: NetCore-Svc-Public
         demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: NetCore1ESPool-Svc-Internal

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -35,7 +35,7 @@ steps:
     arguments: -Path "$(Build.ArtifactStagingDirectory)\TestResults" -NugetPackagesPath "$(Build.SourcesDirectory)\.packages"
   displayName: Convert Code Coverage to XML (powershell)
 
-- task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
+- task: reportgenerator@5
   displayName: ReportGenerator
   inputs:
     reports: $(Build.ArtifactStagingDirectory)\TestResults\codecoverage.coveragexml


### PR DESCRIPTION
This change is required for builds to continue working in the new org, dev.azure.com/dnceng-public.