### PR TITLE
Fixing version of report generator for code coverage report

### DIFF
--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -35,7 +35,7 @@ steps:
     arguments: -Path "$(Build.ArtifactStagingDirectory)\TestResults" -NugetPackagesPath "$(Build.SourcesDirectory)\.packages"
   displayName: Convert Code Coverage to XML (powershell)
 
-- task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
+- task: reportgenerator@5
   displayName: ReportGenerator
   inputs:
     reports: $(Build.ArtifactStagingDirectory)\TestResults\codecoverage.coveragexml


### PR DESCRIPTION
Dnceng-public has a newer version of the ReportGenerator plugin than dnceng had, so updating. 

(for reference https://marketplace.visualstudio.com/items?itemName=Palmmedia.reportgenerator)