### PR TITLE
Print darc version + arguments in debug mode

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
@@ -27,6 +27,15 @@ namespace Microsoft.DotNet.Darc
         {
             InitializeTelemetry();
 
+            if (args.Contains("--debug"))
+            {
+                // Print header (version, sha, arguments)
+                var version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location);
+                Console.WriteLine(
+                    $"[{version.ProductVersion} / {version.OriginalFilename}] " +
+                    "darc command issued: " + string.Join(' ', args));
+            }
+
             try
             {
                 Type[] options;


### PR DESCRIPTION
I found this very useful in `dotnet/xharness`.

Hopefully no one is dependent on parsing darc's debug output?