### PR TITLE
Extract VMR patch handling into a separate file

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+public interface IVmrPatchHandler
+{
+    Task ApplyPatch(
+        SourceMapping mapping,
+        string patchPath,
+        CancellationToken cancellationToken);
+    
+    Task CreatePatch(
+        SourceMapping mapping,
+        string repoPath,
+        string sha1,
+        string sha2,
+        string destPath,
+        CancellationToken cancellationToken);
+
+    Task RestorePatchedFilesFromRepo(
+        SourceMapping mapping,
+        string clonePath,
+        string originalRevision,
+        CancellationToken cancellationToken);
+
+    Task ApplyVmrPatches(
+        SourceMapping mapping,
+        CancellationToken cancellationToken);
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -24,21 +24,21 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         """;
     
     private readonly IVmrDependencyTracker _dependencyTracker;
-    private readonly IVmrPatchProvider _patchProvider;
+    private readonly IVmrPatchHandler _patchHandler;
     private readonly ILogger<VmrUpdater> _logger;
 
     public VmrInitializer(
         IVmrDependencyTracker dependencyTracker,
-        IVmrPatchProvider patchProvider,
+        IVmrPatchHandler patchHandler,
         IProcessManager processManager,
         IRemoteFactory remoteFactory,
         IVersionDetailsParser versionDetailsParser,
         ILogger<VmrUpdater> logger,
         IVmrManagerConfiguration configuration)
-        : base(dependencyTracker, patchProvider, processManager, remoteFactory, versionDetailsParser, logger, configuration.TmpPath)
+        : base(dependencyTracker, patchHandler, processManager, remoteFactory, versionDetailsParser, logger, configuration.TmpPath)
     {
         _dependencyTracker = dependencyTracker;
-        _patchProvider = patchProvider;
+        _patchHandler = patchHandler;
         _logger = logger;
     }
 
@@ -63,10 +63,10 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         var commit = GetCommit(clone, (targetRevision is null || targetRevision == HEAD) ? null : targetRevision);
 
         string patchPath = GetPatchFilePath(mapping);
-        await _patchProvider.CreatePatch(mapping, clonePath, Constants.EmptyGitObject, commit.Id.Sha, patchPath, cancellationToken);
+        await _patchHandler.CreatePatch(mapping, clonePath, Constants.EmptyGitObject, commit.Id.Sha, patchPath, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 
-        await _patchProvider.ApplyPatch(mapping, patchPath, cancellationToken);
+        await _patchHandler.ApplyPatch(mapping, patchPath, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 
         _dependencyTracker.UpdateDependencyVersion(mapping, new(commit.Id.Sha, targetVersion));

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -13,6 +13,11 @@ using Microsoft.Extensions.Logging;
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
+/// <summary>
+/// This class is able to initialize an individual repository within the VMR for the first time.
+/// It pulls in the new sources adhering to cloaking rules, accommodating for patched files, resolving submodules.
+/// It can also initialize all other repositories recursively based on the dependencies stored in Version.Details.xml.
+/// </summary>
 public class VmrInitializer : VmrManagerBase, IVmrInitializer
 {
     // Message shown when initializing an individual repo for the first time

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -73,7 +73,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         Commands.Stage(new Repository(_dependencyTracker.VmrPath), VmrDependencyTracker.GitInfoSourcesDir);
         cancellationToken.ThrowIfCancellationRequested();
 
-        await ApplyVmrPatches(mapping, cancellationToken);
+        await _patchHandler.ApplyVmrPatches(mapping, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 
         await UpdateGitmodules(cancellationToken);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -23,7 +23,7 @@ public abstract class VmrManagerBase : IVmrManager
     protected const string HEAD = "HEAD";
 
     private readonly IVmrDependencyTracker _dependencyInfo;
-    private readonly IVmrPatchProvider _patchProvider;
+    private readonly IVmrPatchHandler _patchHandler;
     private readonly IProcessManager _processManager;
     private readonly IRemoteFactory _remoteFactory;
     private readonly IVersionDetailsParser _versionDetailsParser;
@@ -35,7 +35,7 @@ public abstract class VmrManagerBase : IVmrManager
 
     protected VmrManagerBase(
         IVmrDependencyTracker dependencyInfo,
-        IVmrPatchProvider patchProvider,
+        IVmrPatchHandler patchHandler,
         IProcessManager processManager,
         IRemoteFactory remoteFactory,
         IVersionDetailsParser versionDetailsParser,
@@ -44,7 +44,7 @@ public abstract class VmrManagerBase : IVmrManager
     {
         _logger = logger;
         _dependencyInfo = dependencyInfo;
-        _patchProvider = patchProvider;
+        _patchHandler = patchHandler;
         _processManager = processManager;
         _remoteFactory = remoteFactory;
         _versionDetailsParser = versionDetailsParser;
@@ -77,28 +77,6 @@ public abstract class VmrManagerBase : IVmrManager
         remoteRepo.Clone(mapping.DefaultRemote, mapping.DefaultRef, clonePath, checkoutSubmodules: false, null);
 
         return clonePath;
-    }
-
-    /// <summary>
-    /// Applies VMR patches onto files of given mapping's subrepository.
-    /// </summary>
-    /// <param name="mapping">Mapping</param>
-    protected async Task ApplyVmrPatches(SourceMapping mapping, CancellationToken cancellationToken)
-    {
-        if (!mapping.VmrPatches.Any())
-        {
-            return;
-        }
-
-        _logger.LogInformation("Applying VMR patches for {mappingName}..", mapping.Name);
-
-        foreach (var patchFile in mapping.VmrPatches)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            _logger.LogDebug("Applying {patch}..", patchFile);
-            await _patchProvider.ApplyPatch(mapping, patchFile, cancellationToken);
-        }
     }
 
     /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -2,11 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
@@ -14,25 +17,23 @@ using Microsoft.Extensions.Logging;
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
-public interface IVmrPatchHandler
-{
-    Task ApplyPatch(SourceMapping mapping, string patchPath, CancellationToken cancellationToken);
-    
-    Task CreatePatch(
-        SourceMapping mapping,
-        string repoPath,
-        string sha1,
-        string sha2,
-        string destPath,
-        CancellationToken cancellationToken);
-
-    Task ApplyVmrPatches(SourceMapping mapping, CancellationToken cancellationToken);
-}
-
+/// <summary>
+/// This class handles git patches during VMR synchronization.
+/// It can create/apply diffs and handle VMR patches which are additional patches stored in the VMR
+/// that are applied on top of individual repositories.
+/// </summary>
 public class VmrPatchHandler : IVmrPatchHandler
 {
     private const string KeepAttribute = "vmr-preserve";
     private const string IgnoreAttribute = "vmr-ignore";
+
+    /// <summary>
+    /// Matches output of `git apply --numstat` which lists files contained in a patch file.
+    /// Example output:
+    /// 0       14      /s/vmr/src/roslyn-analyzers/eng/Versions.props
+    /// -       -       /s/vmr/src/roslyn-analyzers/some-binary.dll
+    /// </summary>
+    private static readonly Regex GitPatchSummaryLine = new(@"^[\-0-9]+\s+[\-0-9]+\s+(?<file>[^\s]+)$", RegexOptions.Compiled);
 
     private readonly IVmrDependencyTracker _vmrInfo;
     private readonly IProcessManager _processManager;
@@ -172,6 +173,59 @@ public class VmrPatchHandler : IVmrPatchHandler
     }
 
     /// <summary>
+    /// For all files for which we have patches in VMR, restore their original version from the repo.
+    /// This is because VMR contains already patched versions of these files and new updates from the repo wouldn't apply.
+    /// </summary>
+    /// <param name="mapping">Mapping</param>
+    /// <param name="clonePath">Path were the individual repo was cloned to</param>
+    /// <param name="originalRevision">Revision from which we were updating</param>
+    public async Task RestorePatchedFilesFromRepo(
+        SourceMapping mapping,
+        string clonePath,
+        string originalRevision,
+        CancellationToken cancellationToken)
+    {
+        if (!mapping.VmrPatches.Any())
+        {
+            return;
+        }
+
+        _logger.LogInformation("Restoring files with patches for {mappingName}..", mapping.Name);
+
+        var localRepo = new LocalGitClient(_processManager.GitExecutable, _logger);
+        localRepo.Checkout(clonePath, originalRevision);
+
+        var repoSourcesPath = _vmrInfo.GetRepoSourcesPath(mapping);
+
+        foreach (var patch in mapping.VmrPatches)
+        {
+            _logger.LogDebug("Processing VMR patch `{patch}`..", patch);
+
+            foreach (var patchedFile in await GetFilesInPatch(clonePath, patch, cancellationToken))
+            {
+                // git always works with forward slashes (even on Windows)
+                string relativePath = Path.DirectorySeparatorChar != '/'
+                    ? patchedFile.Replace('/', Path.DirectorySeparatorChar)
+                    : patchedFile;
+
+                var originalFile = Path.Combine(clonePath, relativePath);
+                var destination = Path.Combine(repoSourcesPath, relativePath);
+
+                _logger.LogDebug("Restoring file `{originalFile}` to `{destination}`..", originalFile, destination);
+
+                // Copy old revision to VMR
+                File.Copy(originalFile, destination, overwrite: true);
+            }
+        }
+
+        // Stage the restored files (all future patches are applied to index directly)
+        using var repository = new Repository(_vmrInfo.VmrPath);
+        Commands.Stage(repository, repoSourcesPath);
+
+        _logger.LogDebug("Files from VMR patches for {mappingName} restored", mapping.Name);
+    }
+
+    /// <summary>
     /// Applies VMR patches onto files of given mapping's subrepository.
     /// These files are stored in the VMR and applied on top of the individual repos.
     /// </summary>
@@ -192,5 +246,29 @@ public class VmrPatchHandler : IVmrPatchHandler
             _logger.LogDebug("Applying {patch}..", patchFile);
             await ApplyPatch(mapping, patchFile, cancellationToken);
         }
+    }
+
+    /// <summary>
+    /// Resolves a list of all files that are part of a given patch diff.
+    /// </summary>
+    /// <param name="repoPath">Path (to the repo) the patch applies onto</param>
+    /// <param name="patchPath">Path to the patch file</param>
+    /// <returns>List of all files (paths relative to repo's root) that are part of a given patch diff</returns>
+    private async Task<IReadOnlyCollection<string>> GetFilesInPatch(string repoPath, string patchPath, CancellationToken cancellationToken)
+    {
+        var result = await _processManager.ExecuteGit(repoPath, new[] { "apply", "--numstat", patchPath }, cancellationToken);
+        result.ThrowIfFailed($"Failed to enumerate files from a patch at `{patchPath}`");
+
+        var files = new List<string>();
+        foreach (var line in result.StandardOutput.Split(Environment.NewLine))
+        {
+            var match = GitPatchSummaryLine.Match(line);
+            if (match.Success)
+            {
+                files.Add(match.Groups["file"].Value);
+            }
+        }
+
+        return files;
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchProvider.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchProvider.cs
@@ -1,0 +1,175 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.Logging;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+public interface IVmrPatchProvider
+{
+    Task ApplyPatch(
+        SourceMapping mapping,
+        string patchPath,
+        CancellationToken cancellationToken);
+    
+    Task CreatePatch(
+        SourceMapping mapping,
+        string repoPath,
+        string sha1,
+        string sha2,
+        string destPath,
+        CancellationToken cancellationToken);
+}
+
+public class VmrPatchProvider : IVmrPatchProvider
+{
+    private const string KeepAttribute = "vmr-preserve";
+    private const string IgnoreAttribute = "vmr-ignore";
+    private const string GitmodulesFileName = ".gitmodules";
+
+    private readonly IVmrDependencyTracker _vmrInfo;
+    private readonly IProcessManager _processManager;
+    private readonly ILogger<VmrPatchProvider> _logger;
+
+    public VmrPatchProvider(
+        IVmrDependencyTracker dependencyInfo,
+        IProcessManager processManager,
+        ILogger<VmrPatchProvider> logger)
+    {
+        _vmrInfo = dependencyInfo;
+        _processManager = processManager;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Creates a patch file (a diff) for given two commits in a repo adhering to the in/exclusion filters of the mapping.
+    /// </summary>
+    public async Task CreatePatch(
+        SourceMapping mapping,
+        string repoPath,
+        string sha1,
+        string sha2,
+        string destPath,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Creating diff in {path}..", destPath);
+
+        var args = new List<string>
+        {
+            "diff",
+            "--patch",
+            "--binary", // Include binary contents as base64
+            "--output", // Store the diff in a .patch file
+            destPath,
+            $"{sha1}..{sha2}",
+            "--",
+        };
+
+        if (!mapping.Include.Any())
+        {
+            mapping = mapping with
+            {
+                Include = new[] { "**/*" }
+            };
+        }
+
+        if (repoPath.EndsWith(".git"))
+        {
+            repoPath = Path.GetDirectoryName(repoPath)!;
+        }
+
+        args.AddRange(mapping.Include.Select(p => $":(glob,attr:!{IgnoreAttribute}){p}"));
+        args.AddRange(mapping.Exclude.Select(p => $":(exclude,glob,attr:!{KeepAttribute}){p}"));
+
+        // Other git commands are executed from whichever folder and use `-C [path to repo]` 
+        // However, here we must execute in repo's dir because attribute filters work against the working tree
+        // We also need to do call this from the repo root and not from repo/.git
+        var result = await _processManager.Execute(
+            _processManager.GitExecutable,
+            args,
+            workingDir: repoPath,
+            cancellationToken: cancellationToken);
+
+        result.ThrowIfFailed($"Failed to create an initial diff for {mapping.Name}");
+
+        _logger.LogDebug("{output}", result.ToString());
+
+        args = new List<string>
+        {
+            "rev-list",
+            "--count",
+            $"{sha1}..{sha2}",
+        };
+
+        var distance = (await _processManager.ExecuteGit(repoPath, args, cancellationToken)).StandardOutput.Trim();
+
+        _logger.LogInformation("Diff created at {path} - {distance} commit{s}, {size}",
+            destPath, distance, distance == "1" ? string.Empty : "s", StringUtils.GetHumanReadableFileSize(destPath));
+    }
+
+    /// <summary>
+    /// Applies a given patch file onto given mapping's subrepository.
+    /// </summary>
+    /// <param name="mapping">Mapping</param>
+    /// <param name="patchPath">Path to the patch file with the diff</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    public async Task ApplyPatch(SourceMapping mapping, string patchPath, CancellationToken cancellationToken)
+    {
+        // We have to give git a relative path with forward slashes where to apply the patch
+        var destPath = _vmrInfo.GetRepoSourcesPath(mapping)
+            .Replace(_vmrInfo.VmrPath, null)
+            .Replace("\\", "/")
+            [1..];
+
+        _logger.LogInformation("Applying patch {patchPath} to {path}...", patchPath, destPath);
+
+        // This will help ignore some CR/LF issues (e.g. files with both endings)
+        (await _processManager.ExecuteGit(_vmrInfo.VmrPath, new[] { "config", "apply.ignoreWhitespace", "change" }, cancellationToken: cancellationToken))
+            .ThrowIfFailed("Failed to set git config whitespace settings");
+
+        Directory.CreateDirectory(destPath);
+
+        IEnumerable<string> args = new[]
+        {
+            "apply",
+
+            // Apply diff to index right away, not the working tree
+            // This is faster when we don't care about the working tree
+            // Additionally works around the fact that "git apply" failes with "already exists in working directory"
+            // This happens only when case sensitive renames happened in the history
+            // More details: https://lore.kernel.org/git/YqEiPf%2FJR%2FMEc3C%2F@camp.crustytoothpaste.net/t/
+            "--cached",
+
+            // Options to help with CR/LF and similar problems
+            "--ignore-space-change",
+
+            // Where to apply the patch into
+            "--directory",
+            destPath,
+
+            patchPath,
+        };
+
+        var result = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args, cancellationToken: CancellationToken.None);
+        result.ThrowIfFailed($"Failed to apply the patch for {destPath}");
+        _logger.LogDebug("{output}", result.ToString());
+
+        // After we apply the diff to the index, working tree won't have the files so they will be missing
+        // We have to reset working tree to the index then
+        // This will end up having the working tree all staged
+        _logger.LogInformation("Resetting the working tree...");
+        args = new[] { "checkout", destPath };
+        result = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args, cancellationToken: CancellationToken.None);
+        result.ThrowIfFailed($"Failed to clean the working tree");
+        _logger.LogDebug("{output}", result.ToString());
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -41,7 +41,7 @@ public static class VmrRegistrations
         services.TryAddTransient<ISourceMappingParser, SourceMappingParser>();
         services.TryAddTransient<IVersionDetailsParser, VersionDetailsParser>();
         services.TryAddTransient<IVmrDependencyTracker, VmrDependencyTracker>();
-        services.TryAddTransient<IVmrPatchProvider, VmrPatchProvider>();
+        services.TryAddTransient<IVmrPatchHandler, VmrPatchHandler>();
         services.TryAddTransient<IVmrUpdater, VmrUpdater>();
         services.TryAddTransient<IVmrInitializer, VmrInitializer>();
         services.TryAddSingleton<IReadOnlyCollection<SourceMapping>>(sp =>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -41,6 +41,7 @@ public static class VmrRegistrations
         services.TryAddTransient<ISourceMappingParser, SourceMappingParser>();
         services.TryAddTransient<IVersionDetailsParser, VersionDetailsParser>();
         services.TryAddTransient<IVmrDependencyTracker, VmrDependencyTracker>();
+        services.TryAddTransient<IVmrPatchProvider, VmrPatchProvider>();
         services.TryAddTransient<IVmrUpdater, VmrUpdater>();
         services.TryAddTransient<IVmrInitializer, VmrInitializer>();
         services.TryAddSingleton<IReadOnlyCollection<SourceMapping>>(sp =>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -17,6 +17,11 @@ using Microsoft.Extensions.Logging;
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
+/// <summary>
+/// This class is able to update an individual repository within the VMR from one commit to another.
+/// It creates git diffs while adhering to cloaking rules, accommodating for patched files, resolving submodules.
+/// It can also update other repositories recursively based on the dependencies stored in Version.Details.xml.
+/// </summary>
 public class VmrUpdater : VmrManagerBase, IVmrUpdater
 {
     // Message shown when synchronizing a single commit
@@ -42,7 +47,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
     private readonly ILogger<VmrUpdater> _logger;
     private readonly IVmrDependencyTracker _dependencyTracker;
-    private readonly IProcessManager _processManager;
     private readonly IRemoteFactory _remoteFactory;
     private readonly IVmrPatchHandler _patchHandler;
 
@@ -58,7 +62,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
     {
         _logger = logger;
         _dependencyTracker = dependencyTracker;
-        _processManager = processManager;
         _remoteFactory = remoteFactory;
         _patchHandler = patchHandler;
     }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
@@ -40,14 +39,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         Commits:
         {commitMessage}
         """;
-
-    /// <summary>
-    /// Matches output of `git apply --numstat` which lists files contained in a patch file.
-    /// Example output:
-    /// 0       14      /s/vmr/src/roslyn-analyzers/eng/Versions.props
-    /// -       -       /s/vmr/src/roslyn-analyzers/some-binary.dll
-    /// </summary>
-    private static readonly Regex GitPatchSummaryLine = new(@"^[\-0-9]+\s+[\-0-9]+\s+(?<file>[^\s]+)$", RegexOptions.Compiled);
 
     private readonly ILogger<VmrUpdater> _logger;
     private readonly IVmrDependencyTracker _dependencyTracker;
@@ -299,7 +290,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             throw new InvalidOperationException($"Failed to find the patch at {patchPath}");
         }
 
-        await RestorePatchedFilesFromRepo(mapping, fromRevision, cancellationToken);
+        await _patchHandler.RestorePatchedFilesFromRepo(mapping, clonePath, fromRevision, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 
         if (info.Length == 0)
@@ -329,85 +320,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         var remoteRepo = await _remoteFactory.GetRemoteAsync(mapping.DefaultRemote, _logger);
         var lastCommit = await remoteRepo.GetLatestCommitAsync(mapping.DefaultRemote, mapping.DefaultRef);
         return !lastCommit.Equals(currentSha, StringComparison.InvariantCultureIgnoreCase);
-    }
-
-    /// <summary>
-    /// For all files for which we have patches in VMR, restore their original version from the repo.
-    /// This is because VMR contains already patched versions of these files and new updates from the repo wouldn't apply.
-    /// </summary>
-    /// <param name="mapping">Mapping</param>
-    /// <param name="originalRevision">Revision from which we were updating</param>
-    private async Task RestorePatchedFilesFromRepo(SourceMapping mapping, string originalRevision, CancellationToken cancellationToken)
-    {
-        if (!mapping.VmrPatches.Any())
-        {
-            return;
-        }
-
-        _logger.LogInformation("Restoring files with patches for {mappingName}..", mapping.Name);
-
-        // We checkout the clone to the given revision once for all its patches
-        var clonePath = GetClonePath(mapping);
-        if (!Directory.Exists(clonePath))
-        {
-            await CloneOrPull(mapping);
-        }
-
-        var localRepo = new LocalGitClient(_processManager.GitExecutable, _logger);
-        localRepo.Checkout(clonePath, originalRevision);
-
-        var repoSourcesPath = _dependencyTracker.GetRepoSourcesPath(mapping);
-
-        foreach (var patch in mapping.VmrPatches)
-        {
-            _logger.LogDebug("Processing VMR patch `{patch}`..", patch);
-
-            foreach (var patchedFile in await GetFilesInPatch(clonePath, patch, cancellationToken))
-            {
-                // git always works with forward slashes (even on Windows)
-                string relativePath = Path.DirectorySeparatorChar != '/'
-                    ? patchedFile.Replace('/', Path.DirectorySeparatorChar)
-                    : patchedFile;
-
-                var originalFile = Path.Combine(clonePath, relativePath);
-                var destination = Path.Combine(repoSourcesPath, relativePath);
-
-                _logger.LogDebug("Restoring file `{originalFile}` to `{destination}`..", originalFile, destination);
-
-                // Copy old revision to VMR
-                File.Copy(originalFile, destination, overwrite: true);
-            }
-        }
-
-        // Stage the restored files (all future patches are applied to index directly)
-        using var repository = new Repository(_dependencyTracker.VmrPath);
-        Commands.Stage(repository, repoSourcesPath);
-
-        _logger.LogDebug("Files from VMR patches for {mappingName} restored", mapping.Name);
-    }
-
-    /// <summary>
-    /// Resolves a list of all files that are part of a given patch diff.
-    /// </summary>
-    /// <param name="repoPath">Path (to the repo) the patch applies onto</param>
-    /// <param name="patchPath">Path to the patch file</param>
-    /// <returns>List of all files (paths relative to repo's root) that are part of a given patch diff</returns>
-    private async Task<IReadOnlyCollection<string>> GetFilesInPatch(string repoPath, string patchPath, CancellationToken cancellationToken)
-    {
-        var result = await _processManager.ExecuteGit(repoPath, new[] { "apply", "--numstat", patchPath }, cancellationToken);
-        result.ThrowIfFailed($"Failed to enumerate files from a patch at `{patchPath}`");
-
-        var files = new List<string>();
-        foreach (var line in result.StandardOutput.Split(Environment.NewLine))
-        {
-            var match = GitPatchSummaryLine.Match(line);
-            if (match.Success)
-            {
-                files.Add(match.Groups["file"].Value);
-            }
-        }
-
-        return files;
     }
 
     private string GetCurrentVersion(SourceMapping mapping)


### PR DESCRIPTION
This PR is pure refactoring, no functional changes apart from a small one-line fix in `VmrUpdater:88`.

Logic for handling patches is getting long (and will get longer soon) so let's extract it from the already long `VmrManager` classes.
We will add tests for this code later too.