### PR TITLE
Split `IGitRepo`, `ILocalGitRepo`, enable listing git submodules

### DIFF
--- a/src/Maestro/Maestro.DataProviders/DarcRemoteFactory.cs
+++ b/src/Maestro/Maestro.DataProviders/DarcRemoteFactory.cs
@@ -49,7 +49,7 @@ namespace Maestro.DataProviders
 
         public Task<IRemote> GetBarOnlyRemoteAsync(ILogger logger)
         {
-            return Task.FromResult((IRemote)new Remote(null, new MaestroBarClient(Context, KustoClientProvider), _versionDetailsParser, logger));
+            return Task.FromResult((IRemote)new Remote(null, null, new MaestroBarClient(Context, KustoClientProvider), _versionDetailsParser, logger));
         }
 
         public async Task<IRemote> GetRemoteAsync(string repoUrl, ILogger logger)
@@ -84,7 +84,7 @@ namespace Maestro.DataProviders
                         throw new NotImplementedException($"Unknown repo url type {normalizedUrl}");
                 };
 
-                return new Remote(gitClient, new MaestroBarClient(Context, KustoClientProvider), _versionDetailsParser, logger);
+                return new Remote(gitClient, new LocalGitClient("git", logger), new MaestroBarClient(Context, KustoClientProvider), _versionDetailsParser, logger);
             }
         }
     }

--- a/src/Maestro/Maestro.DataProviders/DarcRemoteFactory.cs
+++ b/src/Maestro/Maestro.DataProviders/DarcRemoteFactory.cs
@@ -49,7 +49,7 @@ namespace Maestro.DataProviders
 
         public Task<IRemote> GetBarOnlyRemoteAsync(ILogger logger)
         {
-            return Task.FromResult((IRemote)new Remote(null, null, new MaestroBarClient(Context, KustoClientProvider), _versionDetailsParser, logger));
+            return Task.FromResult((IRemote)new Remote(null, null, new MaestroBarClient(Context, KustoClientProvider), logger));
         }
 
         public async Task<IRemote> GetRemoteAsync(string repoUrl, ILogger logger)
@@ -84,7 +84,12 @@ namespace Maestro.DataProviders
                         throw new NotImplementedException($"Unknown repo url type {normalizedUrl}");
                 };
 
-                return new Remote(gitClient, new LocalGitClient("git", logger), new MaestroBarClient(Context, KustoClientProvider), _versionDetailsParser, logger);
+                var gitFileManager = new GitFileManager(
+                    new LocalGitClient("git", logger),
+                    _versionDetailsParser,
+                    logger);
+
+                return new Remote(gitClient, gitFileManager, new MaestroBarClient(Context, KustoClientProvider), logger);
             }
         }
     }

--- a/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
+++ b/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
@@ -57,7 +57,7 @@ namespace SubscriptionActorService
 
         public Task<IRemote> GetBarOnlyRemoteAsync(ILogger logger)
         {
-            return Task.FromResult((IRemote)new Remote(null, new MaestroBarClient(_context), _versionDetailsParser, logger));
+            return Task.FromResult((IRemote)new Remote(null, null, new MaestroBarClient(_context), _versionDetailsParser, logger));
         }
 
         public async Task<IRemote> GetRemoteAsync(string repoUrl, ILogger logger)
@@ -101,7 +101,7 @@ namespace SubscriptionActorService
                         throw new NotImplementedException($"Unknown repo url type {normalizedUrl}");
                 };
 
-                return new Remote(gitClient, new MaestroBarClient(_context), _versionDetailsParser, logger);
+                return new Remote(gitClient, new LocalGitClient(gitExe, logger), new MaestroBarClient(_context), _versionDetailsParser, logger);
             }
         }
     }

--- a/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
+++ b/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
@@ -57,7 +57,7 @@ namespace SubscriptionActorService
 
         public Task<IRemote> GetBarOnlyRemoteAsync(ILogger logger)
         {
-            return Task.FromResult((IRemote)new Remote(null, null, new MaestroBarClient(_context), _versionDetailsParser, logger));
+            return Task.FromResult((IRemote)new Remote(null, null, new MaestroBarClient(_context), logger));
         }
 
         public async Task<IRemote> GetRemoteAsync(string repoUrl, ILogger logger)
@@ -101,7 +101,12 @@ namespace SubscriptionActorService
                         throw new NotImplementedException($"Unknown repo url type {normalizedUrl}");
                 };
 
-                return new Remote(gitClient, new LocalGitClient(gitExe, logger), new MaestroBarClient(_context), _versionDetailsParser, logger);
+                var gitFileManager = new GitFileManager(
+                    new LocalGitClient(gitExe, logger),
+                    new VersionDetailsParser(),
+                    logger);
+
+                return new Remote(gitClient, gitFileManager, new MaestroBarClient(_context), logger);
             }
         }
     }

--- a/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -24,6 +24,7 @@ namespace SubscriptionActorService.Tests
     {
         protected Mock<IBarClient> BarClient;
         protected Mock<IGitRepo> GitRepo;
+        protected Mock<IGitFileManager> GitFileManager;
         protected Mock<IRemoteFactory> RemoteFactory;
         protected Mock<IHostEnvironment> Env;
         protected Mock<Octokit.IGitHubClient> GithubClient;
@@ -89,8 +90,9 @@ namespace SubscriptionActorService.Tests
                        return Task.FromResult((IList<Check>) checksToReturn);
                    });
 
+            GitFileManager = new Mock<IGitFileManager>(MockBehavior.Strict);
 
-            MockRemote = new Remote(GitRepo.Object, BarClient.Object, new VersionDetailsParser(), NullLogger.Instance);
+            MockRemote = new Remote(GitRepo.Object, GitFileManager.Object, BarClient.Object, NullLogger.Instance);
             RemoteFactory = new Mock<IRemoteFactory>(MockBehavior.Strict);
             RemoteFactory.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(MockRemote);
             Provider = services.BuildServiceProvider();

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/RemoteFactory.cs
@@ -5,7 +5,6 @@
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.Extensions.Logging;
-using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -68,7 +67,7 @@ namespace Microsoft.DotNet.Darc.Helpers
                                                     darcSettings.BuildAssetRegistryBaseUri);
             }
 
-            return new Remote(gitClient, barClient, new VersionDetailsParser(), logger);
+            return new Remote(gitClient, new LocalGitClient(options.GitLocation, logger), barClient, new VersionDetailsParser(), logger);
         }
 
         /// <summary>
@@ -91,12 +90,12 @@ namespace Microsoft.DotNet.Darc.Helpers
         /// <returns>New remote</returns>
         public Task<IRemote> GetRemoteAsync(string repoUrl, ILogger logger)
         {
-            return Task.FromResult(GetRemote(this._options, repoUrl, logger));
+            return Task.FromResult(GetRemote(_options, repoUrl, logger));
         }
 
         public Task<IRemote> GetBarOnlyRemoteAsync(ILogger logger)
         {
-            return Task.FromResult(GetRemote(this._options, null, logger));
+            return Task.FromResult(GetRemote(_options, null, logger));
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/RemoteFactory.cs
@@ -67,7 +67,12 @@ namespace Microsoft.DotNet.Darc.Helpers
                                                     darcSettings.BuildAssetRegistryBaseUri);
             }
 
-            return new Remote(gitClient, new LocalGitClient(options.GitLocation, logger), barClient, new VersionDetailsParser(), logger);
+            var gitFileManager = new GitFileManager(
+                new LocalGitClient(options.GitLocation, logger),
+                new VersionDetailsParser(),
+                logger);
+
+            return new Remote(gitClient, gitFileManager, barClient, logger);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -73,20 +73,6 @@ namespace Microsoft.DotNet.DarcLib
 
         public bool AllowRetries { get; set; } = true;
 
-        /// <summary>
-        /// Retrieve the contents of a text file in a repo on a specific branch
-        /// </summary>
-        /// <param name="filePath">Path to file within the repo</param>
-        /// <param name="repoUri">Repository url</param>
-        /// <param name="branch">Branch or commit</param>
-        /// <returns>Content of file</returns>
-        public Task<string> GetFileContentsAsync(string filePath, string repoUri, string branch)
-        {
-            (string accountName, string projectName, string repoName) = ParseRepoUri(repoUri);
-
-            return GetFileContentsAsync(accountName, projectName, repoName, filePath, branch);
-        }
-
         private static readonly List<string> VersionTypes = new List<string>() { "branch", "commit", "tag" };
         /// <summary>
         ///     Retrieve the contents of a text file in a repo on a specific branch
@@ -890,7 +876,7 @@ This pull request has not been merged because Maestro++ is waiting on the follow
         /// <param name="input">String that must have 'shouldEndWith' at the end.</param>
         /// <param name="shouldEndWith">Character that must be present at end of 'input' string.</param>
         /// <returns>Input string appended with 'shouldEndWith'</returns>
-        private string EnsureEndsWith(string input, char shouldEndWith)
+        private static string EnsureEndsWith(string input, char shouldEndWith)
         {
             if (input == null) return null;
 
@@ -940,18 +926,6 @@ This pull request has not been merged because Maestro++ is waiting on the follow
             Uri accountUri = new Uri($"https://dev.azure.com/{accountName}");
             var creds = new VssCredentials(new VssBasicCredential("", _personalAccessToken));
             return new VssConnection(accountUri, creds);
-        }
-
-        private (int threadId, int commentId) ParseCommentId(string commentId)
-        {
-            string[] parts = commentId.Split('-');
-            if (parts.Length != 2 || int.TryParse(parts[0], out int threadId) ||
-                int.TryParse(parts[1], out int commentIdValue))
-            {
-                throw new ArgumentException("The comment id '{commentId}' is in an invalid format", nameof(commentId));
-            }
-
-            return (threadId, commentIdValue);
         }
 
         /// <summary>
@@ -1489,25 +1463,6 @@ This pull request has not been merged because Maestro++ is waiting on the follow
         public void Clone(string repoUri, string commit, string targetDirectory, bool checkoutSubmodules, string gitDirectory = null)
         {
             Clone(repoUri, commit, targetDirectory, checkoutSubmodules, _logger, _personalAccessToken, gitDirectory);
-        }
-
-        /// <summary>
-        ///     Does not apply to remote repositories.
-        /// </summary>
-        /// <param name="commit">Ignored</param>
-        public void Checkout(string repoPath, string commit, bool force)
-        {
-            throw new NotImplementedException($"Cannot checkout a remote repo.");
-        }
-
-        /// <summary>
-        ///     Does not apply to remote repositories.
-        /// </summary>
-        /// <param name="repoDir">Ignored</param>
-        /// <param name="repoUrl">Ignored</param>
-        public void AddRemoteIfMissing(string repoDir, string repoUrl)
-        {
-            throw new NotImplementedException("Cannot add a remote to a remote repo.");
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -36,16 +36,16 @@ namespace Microsoft.DotNet.DarcLib
         private static readonly Regex DependencyUpdatesPattern =
             new Regex(@"\[DependencyUpdate\]: <> \(Begin\)([^\[]+)\[DependencyUpdate\]: <> \(End\)");
 
-        public Remote(IGitRepo gitClient, IBarClient barClient, IVersionDetailsParser versionDetailsParser, ILogger logger)
+        public Remote(IGitRepo gitClient, ILocalGitRepo localGitRepo, IBarClient barClient, IVersionDetailsParser versionDetailsParser, ILogger logger)
         {
             _logger = logger;
             _barClient = barClient;
             _gitClient = gitClient;
             _versionDetailsParser = versionDetailsParser;
 
-            if (_gitClient != null)
+            if (localGitRepo != null)
             {
-                _fileManager = new GitFileManager(_gitClient, _versionDetailsParser, _logger);
+                _fileManager = new GitFileManager(localGitRepo, _versionDetailsParser, _logger);
             }
         }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.DarcLib
     public sealed class Remote : IRemote
     {
         private readonly IBarClient _barClient;
-        private readonly GitFileManager _fileManager;
+        private readonly IGitFileManager _fileManager;
         private readonly IGitRepo _gitClient;
         private readonly ILogger _logger;
 
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.DarcLib
         private static readonly Regex DependencyUpdatesPattern =
             new Regex(@"\[DependencyUpdate\]: <> \(Begin\)([^\[]+)\[DependencyUpdate\]: <> \(End\)");
 
-        public Remote(IGitRepo gitClient, GitFileManager gitFileManager, IBarClient barClient, ILogger logger)
+        public Remote(IGitRepo gitClient, IGitFileManager gitFileManager, IBarClient barClient, ILogger logger)
         {
             _logger = logger;
             _barClient = barClient;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -32,8 +32,7 @@ namespace Microsoft.DotNet.DarcLib
         //- **Foo**: from to 1.2.0
         //- **Bar**: from to 2.2.0
         //[DependencyUpdate]: <> (End)
-        private static readonly Regex DependencyUpdatesPattern =
-            new Regex(@"\[DependencyUpdate\]: <> \(Begin\)([^\[]+)\[DependencyUpdate\]: <> \(End\)");
+        private static readonly Regex DependencyUpdatesPattern = new(@"\[DependencyUpdate\]: <> \(Begin\)([^\[]+)\[DependencyUpdate\]: <> \(End\)");
 
         public Remote(IGitRepo gitClient, IGitFileManager gitFileManager, IBarClient barClient, ILogger logger)
         {
@@ -253,7 +252,7 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         /// <param name="subscriptionId">ID of subscription.</param>
         /// <returns>New guid</returns>
-        private Guid GetSubscriptionGuid(string subscriptionId)
+        private static Guid GetSubscriptionGuid(string subscriptionId)
         {
             if (!Guid.TryParse(subscriptionId, out Guid subscriptionGuid))
             {
@@ -318,17 +317,6 @@ namespace Microsoft.DotNet.DarcLib
             CheckForValidGitClient();
             _logger.LogInformation($"Getting reviews for pull request '{pullRequestUrl}'...");
             return await _gitClient.GetLatestPullRequestReviewsAsync(pullRequestUrl);
-        }
-
-        public async Task<IEnumerable<int>> SearchPullRequestsAsync(
-            string repoUri,
-            string pullRequestBranch,
-            PrStatus status,
-            string keyword = null,
-            string author = null)
-        {
-            CheckForValidGitClient();
-            return await _gitClient.SearchPullRequestsAsync(repoUri, pullRequestBranch, status, keyword, author);
         }
 
         public Task CreateOrUpdatePullRequestMergeStatusInfoAsync(string pullRequestUrl, IReadOnlyList<MergePolicyEvaluationResult> evaluations)
@@ -427,7 +415,7 @@ namespace Microsoft.DotNet.DarcLib
         ///         - None
         /// </remarks>
         /// <returns>Leaves of coherency trees</returns>
-        private IEnumerable<DependencyDetail> CalculateLeavesOfCoherencyTrees(IEnumerable<DependencyDetail> dependencies)
+        private static IEnumerable<DependencyDetail> CalculateLeavesOfCoherencyTrees(IEnumerable<DependencyDetail> dependencies)
         {
             // First find dependencies with coherent parent pointers.
             IEnumerable<DependencyDetail> leavesOfCoherencyTrees =
@@ -812,19 +800,17 @@ namespace Microsoft.DotNet.DarcLib
                     }
                 }
 
-                DependencyGraphNode rootNode = null;
-
                 // Build the graph to find the assets if we don't have the root in the cache.
                 // The graph build is automatically broken when
                 // all the desired assets are found (breadth first search). This means the cache may or
                 // may not contain a complete graph for a given node. So, we first search the cache for the desired assets,
                 // then if not found (or if there was no cache), we then build the graph from that node.
-                bool nodeFromCache = nodeCache.TryGetValue($"{currentDependency.RepoUri}@{currentDependency.Commit}", out rootNode);
+                bool nodeFromCache = nodeCache.TryGetValue($"{currentDependency.RepoUri}@{currentDependency.Commit}", out DependencyGraphNode rootNode);
                 if (!nodeFromCache)
                 {
                     _logger.LogInformation($"Node not found in cache, starting graph build at " +
                         $"{currentDependency.RepoUri}@{currentDependency.Commit}");
-                    rootNode = await BuildGraphAtDependencyAsync(remoteFactory, currentDependency, updateList, nodeCache);
+                    rootNode = await BuildGraphAtDependencyAsync(remoteFactory, currentDependency, nodeCache);
                 }
 
                 // Now do the lookup to find the element in the tree for each item in the update list
@@ -883,7 +869,6 @@ namespace Microsoft.DotNet.DarcLib
         private async Task<DependencyGraphNode> BuildGraphAtDependencyAsync(
             IRemoteFactory remoteFactory,
             DependencyDetail rootDependency,
-            List<DependencyDetail> updateList,
             Dictionary<string, DependencyGraphNode> nodeCache)
         {
             DependencyGraphBuildOptions dependencyGraphBuildOptions = new DependencyGraphBuildOptions()
@@ -1053,15 +1038,12 @@ namespace Microsoft.DotNet.DarcLib
             CoherencyMode coherencyMode)
         {
             _logger.LogInformation($"Running coherency update using the {coherencyMode} algorithm");
-            switch (coherencyMode)
+            return coherencyMode switch
             {
-                case CoherencyMode.Strict:
-                    return await GetRequiredStrictCoherencyUpdatesAsync(dependencies, remoteFactory);
-                case CoherencyMode.Legacy:
-                    return await GetRequiredLegacyCoherencyUpdatesAsync(dependencies, remoteFactory);
-                default:
-                    throw new NotImplementedException($"Coherency mode {coherencyMode} is not supported.");
-            }
+                CoherencyMode.Strict => await GetRequiredStrictCoherencyUpdatesAsync(dependencies, remoteFactory),
+                CoherencyMode.Legacy => await GetRequiredLegacyCoherencyUpdatesAsync(dependencies, remoteFactory),
+                _ => throw new NotImplementedException($"Coherency mode {coherencyMode} is not supported."),
+            };
         }
 
         /// <summary>
@@ -1464,11 +1446,9 @@ namespace Microsoft.DotNet.DarcLib
 
             _logger.LogInformation("Reading dotnet version from global.json succeeded!");
 
-            SemanticVersion.TryParse(dotnet.ToString(), out SemanticVersion dotnetVersion);
-
-            if (dotnetVersion == null)
+            if (!SemanticVersion.TryParse(dotnet.ToString(), out SemanticVersion dotnetVersion))
             {
-                _logger.LogError($"Failed to parse dotnet version from global.json from repo: {repoUri} at commit {commit}. Version: {dotnet.ToString()}");
+                _logger.LogError($"Failed to parse dotnet version from global.json from repo: {repoUri} at commit {commit}. Version: {dotnet}");
             }
 
             return dotnetVersion;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -23,7 +23,6 @@ namespace Microsoft.DotNet.DarcLib
     public sealed class Remote : IRemote
     {
         private readonly IBarClient _barClient;
-        private readonly IVersionDetailsParser _versionDetailsParser;
         private readonly GitFileManager _fileManager;
         private readonly IGitRepo _gitClient;
         private readonly ILogger _logger;
@@ -36,17 +35,12 @@ namespace Microsoft.DotNet.DarcLib
         private static readonly Regex DependencyUpdatesPattern =
             new Regex(@"\[DependencyUpdate\]: <> \(Begin\)([^\[]+)\[DependencyUpdate\]: <> \(End\)");
 
-        public Remote(IGitRepo gitClient, ILocalGitRepo localGitRepo, IBarClient barClient, IVersionDetailsParser versionDetailsParser, ILogger logger)
+        public Remote(IGitRepo gitClient, GitFileManager gitFileManager, IBarClient barClient, ILogger logger)
         {
             _logger = logger;
             _barClient = barClient;
             _gitClient = gitClient;
-            _versionDetailsParser = versionDetailsParser;
-
-            if (localGitRepo != null)
-            {
-                _fileManager = new GitFileManager(localGitRepo, _versionDetailsParser, _logger);
-            }
+            _fileManager = gitFileManager;
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitSubmoduleInfo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitSubmoduleInfo.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib;
+
+public record GitSubmoduleInfo(
+    string Name,
+    string Path,
+    string Url,
+    string Commit);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -168,15 +168,6 @@ namespace Microsoft.DotNet.DarcLib
             return element;
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="itemsToUpdate"></param>
-        /// <param name="repoUri"></param>
-        /// <param name="branch"></param>
-        /// <param name="oldDependencies"></param>
-        /// <param name="incomingDotNetSdkVersion"></param>
-        /// <returns></returns>
         public async Task<GitFileContentContainer> UpdateDependencyFiles(
             IEnumerable<DependencyDetail> itemsToUpdate,
             string repoUri,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -16,7 +16,7 @@ using System.Xml;
 
 namespace Microsoft.DotNet.DarcLib
 {
-    public class GitFileManager
+    public class GitFileManager : IGitFileManager
     {
         private readonly ILocalGitRepo _gitClient;
         private readonly IVersionDetailsParser _versionDetailsParser;
@@ -1445,8 +1445,8 @@ namespace Microsoft.DotNet.DarcLib
             }
             else
             {
-                _logger.LogError($"Unable to parse feed { feed } as a Maestro managed feed");
-                throw new ArgumentException($"feed { feed } is not a valid Maestro managed feed");
+                _logger.LogError($"Unable to parse feed {feed} as a Maestro managed feed");
+                throw new ArgumentException($"feed {feed} is not a valid Maestro managed feed");
             }
         }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/IGitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/IGitFileManager.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,12 +10,40 @@ using Newtonsoft.Json.Linq;
 using NuGet.Versioning;
 
 namespace Microsoft.DotNet.DarcLib;
+
 public interface IGitFileManager
 {
+    /// <summary>
+    /// Add a new dependency to the repository
+    /// </summary>
+    /// <param name="dependency">Dependency to add.</param>
+    /// <param name="repoUri">Repository URI to add the dependency to.</param>
+    /// <param name="branch">Branch to add the dependency to.</param>
+    /// <returns>Async task.</returns>
     Task AddDependencyAsync(DependencyDetail dependency, string repoUri, string branch);
     Task AddDependencyToGlobalJson(string repo, string branch, string parentField, string dependencyName, string version);
     Task AddDependencyToVersionDetailsAsync(string repo, string branch, DependencyDetail dependency);
+
+    /// <summary>
+    ///     <!-- Package versions -->
+    ///     <PropertyGroup>
+    ///         <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.18478.5</MicrosoftDotNetApiCompatPackageVersion>
+    ///     </PropertyGroup>
+    ///
+    ///     See https://github.com/dotnet/arcade/blob/main/Documentation/DependencyDescriptionFormat.md for more
+    ///     information.
+    /// </summary>
+    /// <param name="repo">Path to Versions.props file</param>
+    /// <param name="dependency">Dependency information to add.</param>
+    /// <returns>Async task.</returns>
     Task AddDependencyToVersionsPropsAsync(string repo, string branch, DependencyDetail dependency);
+
+    /// <summary>
+    ///  Infer repo names from feeds using regex.
+    ///  If any feed name resolution fails, we'll just put it into an "unknown" bucket.
+    /// </summary>
+    /// <param name="assetLocationMap">Dictionary of all feeds by their location</param>
+    /// <returns>Dictionary with key = repo name for logging, value = hashset of feeds</returns>
     Dictionary<string, HashSet<string>> FlattenLocationsAndSplitIntoGroups(Dictionary<string, HashSet<string>> assetLocationMap);
     List<(string key, string feed)> GetPackageSources(XmlDocument nugetConfig, Func<string, bool> filter = null);
     Task<IEnumerable<DependencyDetail>> ParseVersionDetailsXmlAsync(string repoUri, string branch, bool includePinned = true);
@@ -26,6 +54,23 @@ public interface IGitFileManager
     Task<XmlDocument> ReadVersionPropsAsync(string repoUri, string branch);
     Task<GitFileContentContainer> UpdateDependencyFiles(IEnumerable<DependencyDetail> itemsToUpdate, string repoUri, string branch, IEnumerable<DependencyDetail> oldDependencies, SemanticVersion incomingDotNetSdkVersion);
     XmlDocument UpdatePackageSources(XmlDocument nugetConfig, Dictionary<string, HashSet<string>> maestroManagedFeedsByRepo);
+
+    /// <summary>
+    ///     Verify the local repository has correct and consistent dependency information.
+    ///     Currently, this implementation checks:
+    ///     - global.json, Version.props and Version.Details.xml can be parsed.
+    ///     - There are no duplicated dependencies in Version.Details.xml
+    ///     - If a dependency exists in Version.Details.xml and in version.props/global.json, the versions match.
+    /// </summary>
+    /// <param name="repo"></param>
+    /// <param name="branch"></param>
+    /// <returns>Async task</returns>
     Task<bool> Verify(string repo, string branch);
+
+    /// <summary>
+    ///     Ensure that there is a unique propertyName + condition on the list.
+    /// </summary>
+    /// <param name="versionProps">Xml object representing MSBuild properties file.</param>
+    /// <returns>True if there are no duplicated properties.</returns>
     Task<bool> VerifyNoDuplicatedProperties(XmlDocument versionProps);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/IGitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/IGitFileManager.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Xml;
+using Newtonsoft.Json.Linq;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.DarcLib;
+public interface IGitFileManager
+{
+    Task AddDependencyAsync(DependencyDetail dependency, string repoUri, string branch);
+    Task AddDependencyToGlobalJson(string repo, string branch, string parentField, string dependencyName, string version);
+    Task AddDependencyToVersionDetailsAsync(string repo, string branch, DependencyDetail dependency);
+    Task AddDependencyToVersionsPropsAsync(string repo, string branch, DependencyDetail dependency);
+    Dictionary<string, HashSet<string>> FlattenLocationsAndSplitIntoGroups(Dictionary<string, HashSet<string>> assetLocationMap);
+    List<(string key, string feed)> GetPackageSources(XmlDocument nugetConfig, Func<string, bool> filter = null);
+    Task<IEnumerable<DependencyDetail>> ParseVersionDetailsXmlAsync(string repoUri, string branch, bool includePinned = true);
+    Task<JObject> ReadDotNetToolsConfigJsonAsync(string repoUri, string branch);
+    Task<JObject> ReadGlobalJsonAsync(string repoUri, string branch);
+    Task<XmlDocument> ReadNugetConfigAsync(string repoUri, string branch);
+    Task<XmlDocument> ReadVersionDetailsXmlAsync(string repoUri, string branch);
+    Task<XmlDocument> ReadVersionPropsAsync(string repoUri, string branch);
+    Task<GitFileContentContainer> UpdateDependencyFiles(IEnumerable<DependencyDetail> itemsToUpdate, string repoUri, string branch, IEnumerable<DependencyDetail> oldDependencies, SemanticVersion incomingDotNetSdkVersion);
+    XmlDocument UpdatePackageSources(XmlDocument nugetConfig, Dictionary<string, HashSet<string>> maestroManagedFeedsByRepo);
+    Task<bool> Verify(string repo, string branch);
+    Task<bool> VerifyNoDuplicatedProperties(XmlDocument versionProps);
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.DarcLib
 {
-    public interface IGitRepo : ILocalGitRepo
+    public interface IGitRepo
     {
         /// <summary>
         /// Specifies whether functions with a retry field should employ retries
@@ -125,6 +125,19 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns>Return the commit matching the specified sha. Null if no commit were found.</returns>
         Task<Commit> GetCommitAsync(string repoUri, string sha);
 
+        /// <summary>
+        ///     Updates local copies of the files.
+        /// </summary>
+        /// <param name="filesToCommit">Files to update locally</param>
+        /// <param name="repoUri">Base path of the repo</param>
+        /// <param name="branch">Unused</param>
+        /// <param name="commitMessage">Unused</param>
+        Task CommitFilesAsync(List<GitFile> filesToCommit, string repoUri, string branch, string commitMessage);
+
+        /// <summary>
+        /// Gets a list of file under a given path in a given revision.
+        /// </summary>
+        Task<List<GitFile>> GetFilesAtCommitAsync(string repoUri, string commit, string path);
 
         /// <summary>
         /// Retrieve the list of status checks on a PR.

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
@@ -5,32 +5,36 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace Microsoft.DotNet.DarcLib
+namespace Microsoft.DotNet.DarcLib;
+
+public interface ILocalGitRepo
 {
-    public interface ILocalGitRepo
-    {
-        /// <summary>
-        ///     Add a remote to a local repo if does not already exist, and attempt to fetch commits.
-        /// </summary>
-        void AddRemoteIfMissing(string repoDir, string repoUrl);
+    /// <summary>
+    ///     Add a remote to a local repo if does not already exist, and attempt to fetch commits.
+    /// </summary>
+    void AddRemoteIfMissing(string repoDir, string repoUrl);
 
-        /// <summary>
-        ///     Checkout the repo to the specified state.
-        /// </summary>
-        /// <param name="commit">Tag, branch, or commit to checkout.</param>
-        void Checkout(string repoDir, string commit, bool force = false);
+    /// <summary>
+    ///     Checkout the repo to the specified state.
+    /// </summary>
+    /// <param name="commit">Tag, branch, or commit to checkout.</param>
+    void Checkout(string repoDir, string commit, bool force = false);
 
-        /// <summary>
-        ///     Updates local copies of the files.
-        /// </summary>
-        /// <param name="filesToCommit">Files to update locally</param>
-        /// <param name="repoUri">Base path of the repo</param>
-        /// <param name="branch">Unused</param>
-        /// <param name="commitMessage">Unused</param>
-        Task CommitFilesAsync(List<GitFile> filesToCommit, string repoUri, string branch, string commitMessage);
+    /// <summary>
+    ///     Updates local copies of the files.
+    /// </summary>
+    /// <param name="filesToCommit">Files to update locally</param>
+    /// <param name="repoUri">Base path of the repo</param>
+    /// <param name="branch">Unused</param>
+    /// <param name="commitMessage">Unused</param>
+    Task CommitFilesAsync(List<GitFile> filesToCommit, string repoUri, string branch, string commitMessage);
 
-        Task<string> GetFileContentsAsync(string relativeFilePath, string repoUri, string branch);
+    Task<string> GetFileContentsAsync(string relativeFilePath, string repoUri, string branch);
 
-        Task<List<GitFile>> GetFilesAtCommitAsync(string repoUri, string commit, string path);
-    }
+    /// <summary>
+    /// Parses the .gitmodule file and retrieves a list of git submodules registered in a given repository.
+    /// </summary>
+    /// <param name="repoDir">Path to a git repository</param>
+    /// <param name="commit">Which commit the info is retrieved for</param>
+    List<GitSubmoduleInfo> GetGitSubmodules(string repoDir, string commit);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
 
@@ -54,24 +55,6 @@ namespace Microsoft.DotNet.DarcLib
             {
                 return await streamReader.ReadToEndAsync();
             }
-        }
-
-        public Task<List<GitFile>> GetFilesAtCommitAsync(string repoUri, string commit, string path)
-        {
-            string repoDir = LocalHelpers.GetRootDir(_gitExecutable, _logger);
-            string sourceFolder = Path.Combine(repoDir, path);
-            return Task.Run(() => Directory.GetFiles(
-                sourceFolder,
-                "*.*",
-                SearchOption.AllDirectories).Select(
-                    file =>
-                    {
-                        return new GitFile(
-                            file.Remove(0, repoDir.Length + 1).Replace("\\", "/"),
-                            File.ReadAllText(file)
-                            );
-                    }
-                ).ToList());
         }
 
         /// <summary>
@@ -260,7 +243,7 @@ namespace Microsoft.DotNet.DarcLib
             }
         }
 
-        private static void CleanRepoAndSubmodules(LibGit2Sharp.Repository repo, ILogger log)
+        private static void CleanRepoAndSubmodules(Repository repo, ILogger log)
         {
             using (log.BeginScope($"Beginning clean of {repo.Info.WorkingDirectory} and {repo.Submodules.Count()} submodules"))
             {
@@ -383,6 +366,23 @@ namespace Microsoft.DotNet.DarcLib
             repo.Network.Remotes.Add(remoteName, repoUrl);
             _logger.LogDebug($"Fetching new commits from {repoUrl} into {repoDir}");
             LibGit2Sharp.Commands.Fetch(repo, remoteName, new[] { $"+refs/heads/*:refs/remotes/{remoteName}/*" }, new LibGit2Sharp.FetchOptions(), $"Fetching {repoUrl} into {repoDir}");
+        }
+
+        public List<GitSubmoduleInfo> GetGitSubmodules(string repoDir, string commit)
+        {
+            if (commit == Constants.EmptyGitObject)
+            {
+                return new();
+            }
+
+            var repository = new Repository(repoDir);
+            
+            // I haven't found a way to do this with LibGit2Sharp without checking out the commit
+            Commands.Checkout(repository, commit);
+
+            return repository.Submodules
+                .Select(s => new GitSubmoduleInfo(s.Name, s.Path, s.Url, s.IndexCommitId.Sha))
+                .ToList();
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.DarcLib;
@@ -15,7 +14,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
-using Octokit;
 
 namespace Microsoft.DotNet.Darc.Tests
 {
@@ -70,7 +68,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> updates =
                 await remote.GetRequiredNonCoherencyUpdatesAsync("repoA", "commit2", assets, existingDetails);
 
-            updates.Should().SatisfyRespectively(            u =>
+            updates.Should().SatisfyRespectively(u =>
             {
                 u.From.Should().Be(depA);
                 u.To.Version.Should().Be("v2");
@@ -105,7 +103,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> updates =
                 await remote.GetRequiredNonCoherencyUpdatesAsync("repoA", "commit2", assets, existingDetails);
 
-            updates.Should().SatisfyRespectively(            u =>
+            updates.Should().SatisfyRespectively(u =>
             {
                 u.From.Should().Be(depA);
                 u.To.Version.Should().Be("v2");
@@ -136,7 +134,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> updates =
                 await remote.GetRequiredNonCoherencyUpdatesAsync("repoA", "commit2", assets, existingDetails);
 
-            updates.Should().SatisfyRespectively(            u =>
+            updates.Should().SatisfyRespectively(u =>
             {
                 u.From.Should().Be(depA);
                 u.To.Version.Should().Be("v2");
@@ -181,7 +179,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             var barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             var dependencyGraphRemoteMock = new Mock<IRemote>();
@@ -229,7 +227,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> nonCoherencyUpdates =
                 await remote.GetRequiredNonCoherencyUpdatesAsync("repoA", "commit2", assets, existingDetails);
 
-            nonCoherencyUpdates.Should().SatisfyRespectively(            u =>
+            nonCoherencyUpdates.Should().SatisfyRespectively(u =>
             {
                 u.From.Should().Be(depA);
                 u.To.Version.Should().Be("v2");
@@ -241,7 +239,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Legacy);
 
-            coherencyUpdates.Should().SatisfyRespectively(            u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
             {
                 u.From.Should().Be(depB);
                 u.To.Version.Should().Be("v10");
@@ -265,7 +263,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             var barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             var dependencyGraphRemoteMock = new Mock<IRemote>();
@@ -303,7 +301,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> nonCoherencyUpdates =
                 await remote.GetRequiredNonCoherencyUpdatesAsync("repoA", "commit2", assets, existingDetails);
 
-            nonCoherencyUpdates.Should().SatisfyRespectively(            u =>
+            nonCoherencyUpdates.Should().SatisfyRespectively(u =>
             {
                 u.From.Should().Be(depA);
                 u.To.Version.Should().Be("v2");
@@ -328,7 +326,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             var barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             var dependencyGraphRemoteMock = new Mock<IRemote>();
@@ -365,7 +363,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> nonCoherencyUpdates =
                 await remote.GetRequiredNonCoherencyUpdatesAsync("repoA", "commit2", assets, existingDetails);
 
-            nonCoherencyUpdates.Should().SatisfyRespectively(            u =>
+            nonCoherencyUpdates.Should().SatisfyRespectively(u =>
             {
                 u.From.Should().Be(depA);
                 u.To.Version.Should().Be("v2");
@@ -388,7 +386,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> dependencyGraphRemoteMock = new Mock<IRemote>();
@@ -432,7 +430,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Legacy);
 
-            coherencyUpdates.Should().SatisfyRespectively(            u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
             {
                 u.From.Should().Be(depC);
                 u.To.Version.Should().Be("v1000");
@@ -458,7 +456,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> dependencyGraphRemoteMock = new Mock<IRemote>();
@@ -511,7 +509,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Legacy);
 
-            coherencyUpdates.Should().SatisfyRespectively(            u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
             {
                 u.From.Should().Be(depC);
                 u.To.Version.Should().Be("v1000");
@@ -541,7 +539,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -589,7 +587,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -625,7 +623,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -662,7 +660,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -683,7 +681,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> coherencyUpdates = 
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Strict);
 
-            coherencyUpdates.Should().SatisfyRespectively(                u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
                 {
                     u.From.Should().Be(depB);
                     u.To.Version.Should().Be("v42");
@@ -703,7 +701,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -734,7 +732,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Strict);
 
-            coherencyUpdates.Should().SatisfyRespectively(                u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
                 {
                     u.From.Should().Be(depB);
                     u.To.Version.Should().Be("v42");
@@ -759,7 +757,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -796,7 +794,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Strict);
 
-            coherencyUpdates.Should().SatisfyRespectively(                u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
                 {
                     u.From.Should().Be(depB);
                     u.To.Version.Should().Be("v42");
@@ -823,7 +821,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -849,7 +847,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Strict);
 
-            coherencyUpdates.Should().SatisfyRespectively(                u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
                 {
                     u.From.Should().Be(depB);
                     u.To.Version.Should().Be("v42");
@@ -870,7 +868,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -896,14 +894,14 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Strict);
 
-            coherencyUpdates.Should().SatisfyRespectively(                u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
                 {
                     u.From.Should().Be(depB);
                     u.To.Version.Should().Be("v42");
                     u.To.Commit.Should().Be("commit5");
                     u.To.RepoUri.Should().Be(depB.RepoUri);
                     u.To.Name.Should().Be(depB.Name);
-                    u.To.Locations.Should().SatisfyRespectively(                        u =>
+                    u.To.Locations.Should().SatisfyRespectively(u =>
                         {
                             u.Should().Be("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json");
                         }
@@ -921,7 +919,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -950,14 +948,14 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Strict);
 
-            coherencyUpdates.Should().SatisfyRespectively(                u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
                 {
                     u.From.Should().Be(depB);
                     u.To.Version.Should().Be("v42");
                     u.To.Commit.Should().Be("commit5");
                     u.To.RepoUri.Should().Be(depB.RepoUri);
                     u.To.Name.Should().Be(depB.Name);
-                    u.To.Locations.Should().SatisfyRespectively(                        u =>
+                    u.To.Locations.Should().SatisfyRespectively(u =>
                         {
                             u.Should().Be("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json");
                         }, u =>
@@ -980,7 +978,8 @@ namespace Microsoft.DotNet.Darc.Tests
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
             Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
-            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Mock<IGitFileManager> gitFileManagerMock = new Mock<IGitFileManager>();
+            Remote remote = new Remote(gitRepoMock.Object, gitFileManagerMock.Object, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -1015,20 +1014,17 @@ namespace Microsoft.DotNet.Darc.Tests
                     }, 1)
                 });
 
-            // Repo has no feeds
-            RepositoryHasFeeds(gitRepoMock, "repoA", "commit1", new string[] { });
-
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Strict);
 
-            coherencyUpdates.Should().SatisfyRespectively(                u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
                 {
                     u.From.Should().Be(depB);
                     u.To.Version.Should().Be("v42");
                     u.To.Commit.Should().Be("commit5");
                     u.To.RepoUri.Should().Be(depB.RepoUri);
                     u.To.Name.Should().Be(depB.Name);
-                    u.To.Locations.Should().SatisfyRespectively(                        u =>
+                    u.To.Locations.Should().SatisfyRespectively(u =>
                         {
                             u.Should().Be("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json");
                         }, u =>
@@ -1051,7 +1047,8 @@ namespace Microsoft.DotNet.Darc.Tests
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
             Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
-            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Mock<IGitFileManager> gitFileManagerMock = new Mock<IGitFileManager>();
+            Remote remote = new Remote(gitRepoMock.Object, gitFileManagerMock.Object, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -1090,14 +1087,14 @@ namespace Microsoft.DotNet.Darc.Tests
             List <DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Strict);
 
-            coherencyUpdates.Should().SatisfyRespectively(                u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
                 {
                     u.From.Should().Be(depB);
                     u.To.Version.Should().Be("v42");
                     u.To.Commit.Should().Be("commit5");
                     u.To.RepoUri.Should().Be(depB.RepoUri);
                     u.To.Name.Should().Be(depB.Name);
-                    u.To.Locations.Should().SatisfyRespectively(                        u =>
+                    u.To.Locations.Should().SatisfyRespectively(u =>
                         {
                             u.Should().Be("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json");
                         }, u =>
@@ -1120,7 +1117,8 @@ namespace Microsoft.DotNet.Darc.Tests
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
             Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
-            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Mock<IGitFileManager> gitFileManagerMock = new Mock<IGitFileManager>();
+            Remote remote = new Remote(gitRepoMock.Object, gitFileManagerMock.Object, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -1157,20 +1155,17 @@ namespace Microsoft.DotNet.Darc.Tests
                     }, 10)
                 });
 
-            RepositoryHasFeeds(gitRepoMock, "repoA", "commit1",
-                new string[] { "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet566/nuget/v3/index.json" });
-
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Strict);
 
-            coherencyUpdates.Should().SatisfyRespectively(                u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
                 {
                     u.From.Should().Be(depB);
                     u.To.Version.Should().Be("v42");
                     u.To.Commit.Should().Be("commit5");
                     u.To.RepoUri.Should().Be(depB.RepoUri);
                     u.To.Name.Should().Be(depB.Name);
-                    u.To.Locations.Should().SatisfyRespectively(                        u =>
+                    u.To.Locations.Should().SatisfyRespectively(u =>
                         {
                             u.Should().Be("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json");
                         }, u =>
@@ -1193,7 +1188,8 @@ namespace Microsoft.DotNet.Darc.Tests
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
             Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
-            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Mock<IGitFileManager> gitFileManagerMock = new Mock<IGitFileManager>();
+            Remote remote = new Remote(gitRepoMock.Object, gitFileManagerMock.Object, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -1231,20 +1227,17 @@ namespace Microsoft.DotNet.Darc.Tests
                     }, 11)
                 });
 
-            RepositoryHasFeeds(gitRepoMock, "repoA", "commit1",
-                new string[] { "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet566/nuget/v3/index.json" });
-
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Strict);
 
-            coherencyUpdates.Should().SatisfyRespectively(                u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
                 {
                     u.From.Should().Be(depB);
                     u.To.Version.Should().Be("v42");
                     u.To.Commit.Should().Be("commit5");
                     u.To.RepoUri.Should().Be(depB.RepoUri);
                     u.To.Name.Should().Be(depB.Name);
-                    u.To.Locations.Should().SatisfyRespectively(                        u =>
+                    u.To.Locations.Should().SatisfyRespectively(u =>
                         {
                             u.Should().Be("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json");
                         }, u =>
@@ -1267,7 +1260,8 @@ namespace Microsoft.DotNet.Darc.Tests
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
             Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
-            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Mock<IGitFileManager> gitFileManagerMock = new Mock<IGitFileManager>();
+            Remote remote = new Remote(gitRepoMock.Object, gitFileManagerMock.Object, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -1305,20 +1299,17 @@ namespace Microsoft.DotNet.Darc.Tests
                     }, 11)
                 });
 
-            RepositoryHasFeeds(gitRepoMock, "repoA", "commit1",
-                new string[] { "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet566/nuget/v3/index.json" });
-
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Strict);
 
-            coherencyUpdates.Should().SatisfyRespectively(                u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
                 {
                     u.From.Should().Be(depB);
                     u.To.Version.Should().Be("v42");
                     u.To.Commit.Should().Be("commit5");
                     u.To.RepoUri.Should().Be(depB.RepoUri);
                     u.To.Name.Should().Be(depB.Name);
-                    u.To.Locations.Should().SatisfyRespectively(                        u =>
+                    u.To.Locations.Should().SatisfyRespectively(u =>
                         {
                             u.Should().Be("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet566/nuget/v3/index.json");
                         }, u =>
@@ -1339,7 +1330,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Remote remote = new Remote(null, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Remote remote = new Remote(null, null, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -1362,7 +1353,7 @@ namespace Microsoft.DotNet.Darc.Tests
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Strict);
 
-            coherencyUpdates.Should().SatisfyRespectively(                u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
                 {
                     u.From.Should().Be(depB);
                     u.To.Version.Should().Be("v42");
@@ -1383,7 +1374,8 @@ namespace Microsoft.DotNet.Darc.Tests
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
             Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
-            Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
+            Mock<IGitFileManager> gitFileManagerMock = new Mock<IGitFileManager>();
+            Remote remote = new Remote(gitRepoMock.Object, gitFileManagerMock.Object, barClientMock.Object, NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
             Mock<IRemote> remoteMock = new Mock<IRemote>();
@@ -1418,20 +1410,17 @@ namespace Microsoft.DotNet.Darc.Tests
                     }, 1)
                 });
 
-            // Repo has no feeds
-            RepositoryHasFeeds(gitRepoMock, "repoA", "commit1", new string[] { });
-
             List<DependencyUpdate> coherencyUpdates =
                 await remote.GetRequiredCoherencyUpdatesAsync(existingDetails, remoteFactoryMock.Object, CoherencyMode.Strict);
 
-            coherencyUpdates.Should().SatisfyRespectively(                u =>
+            coherencyUpdates.Should().SatisfyRespectively(u =>
                 {
                     u.From.Should().Be(depB);
                     u.To.Version.Should().Be("v42");
                     u.To.Commit.Should().Be("commit5");
                     u.To.RepoUri.Should().Be(depB.RepoUri);
                     u.To.Name.Should().Be(depB.Name);
-                    u.To.Locations.Should().SatisfyRespectively(                        u =>
+                    u.To.Locations.Should().SatisfyRespectively(u =>
                         {
                             u.Should().Be("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json");
                         }, u =>
@@ -1498,22 +1487,6 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             Build build = CreateBuild(repo, commit, assets, buildId);
             barClientMock.Setup(m => m.GetBuildsAsync(repo, commit)).ReturnsAsync(new List<Build> { build });
-        }
-
-        private void RepositoryHasFeeds(Mock<IGitRepo> barClientMock,
-            string repo, string commit, string[] feeds)
-        {
-            const string baseNugetConfig = @"<?xml version=""1.0"" encoding=""utf - 8""?>
-<configuration>
-<packageSources>
-<clear/>
-FEEDSHERE
-</packageSources>
-</configuration>";
-            string nugetConfig = baseNugetConfig.Replace("FEEDSHERE",
-                string.Join(Environment.NewLine, feeds.Select(feed => $@"<add key = ""{GetRandomId()}"" value = ""{feed}"" />")));
-
-            barClientMock.Setup(m => m.GetFileContentsAsync(VersionFiles.NugetConfig, repo, commit)).ReturnsAsync(nugetConfig);
         }
 
         private Random _randomIdGenerator = new Random();

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/GitHubClientTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/GitHubClientTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.DarcLib.Tests
     #region Fakes
     public class SimpleCacheEntry : ICacheEntry
     {
-        private object _key;
+        private readonly object _key;
         private object _value;
         private long? _size;
 
@@ -411,7 +411,7 @@ namespace Microsoft.DotNet.DarcLib.Tests
 
         #region Functions for creating fake review data
 
-        private Dictionary<Tuple<string, string, int>, List<PullRequestReview>> GetApprovingPullRequestData(string owner, string repoName, int requestId, int userCount, bool commentAfter)
+        private static Dictionary<Tuple<string, string, int>, List<PullRequestReview>> GetApprovingPullRequestData(string owner, string repoName, int requestId, int userCount, bool commentAfter)
         {
             var data = new Dictionary<Tuple<string, string, int>, List<PullRequestReview>>();
             var keyValue = new Tuple<string, string, int>(owner, repoName, requestId);
@@ -429,7 +429,7 @@ namespace Microsoft.DotNet.DarcLib.Tests
             return data;
         }
 
-        private Dictionary<Tuple<string, string, int>, List<PullRequestReview>> GetMixedPullRequestData(string owner, string repoName, int requestId, int userCount, bool commentAfter)
+        private static Dictionary<Tuple<string, string, int>, List<PullRequestReview>> GetMixedPullRequestData(string owner, string repoName, int requestId, int userCount, bool commentAfter)
         {
             var data = new Dictionary<Tuple<string, string, int>, List<PullRequestReview>>();
             var keyValue = new Tuple<string, string, int>(owner, repoName, requestId);
@@ -449,7 +449,7 @@ namespace Microsoft.DotNet.DarcLib.Tests
             return data;
         }
 
-        private Dictionary<Tuple<string, string, int>, List<PullRequestReview>> GetOnlyCommentsPullRequestData(string owner, string repoName, int requestId, int userCount)
+        private static Dictionary<Tuple<string, string, int>, List<PullRequestReview>> GetOnlyCommentsPullRequestData(string owner, string repoName, int requestId, int userCount)
         {
             var data = new Dictionary<Tuple<string, string, int>, List<PullRequestReview>>();
             var keyValue = new Tuple<string, string, int>(owner, repoName, requestId);
@@ -463,7 +463,7 @@ namespace Microsoft.DotNet.DarcLib.Tests
             return data;
         }
 
-        private PullRequestReview CreateFakePullRequestReview(PullRequestReviewState reviewState, string owner, string repoName, int requestId, DateTimeOffset reviewTime, string userName)
+        private static PullRequestReview CreateFakePullRequestReview(PullRequestReviewState reviewState, string owner, string repoName, int requestId, DateTimeOffset reviewTime, string userName)
         {
             return new PullRequestReview(
                 0,
@@ -478,7 +478,7 @@ namespace Microsoft.DotNet.DarcLib.Tests
                 reviewTime);
         }
 
-        private User GetFakeUser(string userId)
+        private static User GetFakeUser(string userId)
         {
             // We mostly only care about the user's login id (userId)", this ctor is huge, sorry about that.
             return new User(null, null, null, 0, null, DateTimeOffset.MinValue, DateTimeOffset.MinValue,

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.DarcLib.Tests
         {
             Mock<IGitRepo> client = new Mock<IGitRepo>();
             Mock<IBarClient> barClient = new Mock<IBarClient>();
+            Mock<IGitFileManager> gitFileManagerMock = new Mock<IGitFileManager>();
             MergePullRequestParameters mergePullRequest = new MergePullRequestParameters
             {
                 DeleteSourceBranch = true,
@@ -81,7 +82,7 @@ Coherency Update:
 
             var logger = new NUnitLogger();
 
-            Remote remote = new Remote(client.Object, barClient.Object, new VersionDetailsParser(), logger);
+            Remote remote = new Remote(client.Object, gitFileManagerMock.Object, barClient.Object, logger);
 
             await remote.MergeDependencyPullRequestAsync(
                 "https://github.com/test/test2",


### PR DESCRIPTION
This PR:
- is a first step in untangling the `Remote` class and removes following inheritance `IGitRepo : ILocalGitRepo`,
- adds the ability to use and extend `ILocalGitRepo` with functionality tied to local `.git` folders which will be needed in the VMR later,
- adds the capability to list git submodules to `ILocalGitRepo`.

Problems this solves:
- Many implementations of `IGitRepo` that had to implement `ILocalGitRepo` too had `throw new NotImplemented..`.
- The only method used from `ILocalGitRepo` via `IGitRepo` was `GetFilesAtCommitAsync` whose implementation in `ILocalGitRepo` didn't make sense - it accepted URI and SHA but didn't use either, just listed files in a folder. It only was used in one place though `Local.cs` so I moved it there
- I removed a lot of dead code (`ILocalGitRepo` methods on `IGitRepo` classes that are not used).
- I removed some dead code in unit tests which was setting up things that were not used in the tests.

The largest weirdness that I haven't dealt with so far comes from `RemoteFactory` implementations where we supply `null` instead of `IGitRepo` often. In those cases, we supply the `ILocalGitRepo` as `null` too, not breaking anything. For instance, we have things like "BAR only client" that only has the `BarClient` set inside `Remote` and this will obviously break if we try to invoke any of the non-bar methods but this is not changed in this PR.