### PR TITLE
Disable nullable annotations and standardize on C# 11

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,8 @@
     -->   
     <NoWarn>$(NoWarn);MSB3270</NoWarn>
     <WarningsAsErrors>true</WarningsAsErrors>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>preview</LangVersion>
+    <Nullable>annotations</Nullable>
     <IsShipping>false</IsShipping>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <DebugType>Full</DebugType>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,7 +29,7 @@
     <NoWarn>$(NoWarn);MSB3270</NoWarn>
     <WarningsAsErrors>true</WarningsAsErrors>
     <LangVersion>preview</LangVersion>
-    <Nullable>annotations</Nullable>
+    <Nullable>disable</Nullable>
     <IsShipping>false</IsShipping>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <DebugType>Full</DebugType>

--- a/src/Maestro/Client/src/Microsoft.DotNet.Maestro.Client.csproj
+++ b/src/Maestro/Client/src/Microsoft.DotNet.Maestro.Client.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <Description>This package provides access to the Maestro Api</Description>
-    <LangVersion>8.0</LangVersion>
 
     <SwaggerOutputDirectory>$(MSBuildProjectDirectory)\Generated</SwaggerOutputDirectory>
     <SwaggerClientName>MaestroApi</SwaggerClientName>

--- a/src/Maestro/Maestro.Data/Migrations/BuildAssetRegistryContextModelSnapshot.cs
+++ b/src/Maestro/Maestro.Data/Migrations/BuildAssetRegistryContextModelSnapshot.cs
@@ -6,7 +6,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-#nullable disable
 
 namespace Maestro.Data.Migrations
 {

--- a/src/Maestro/Maestro.MergePolicies/Maestro.MergePolicies.csproj
+++ b/src/Maestro/Maestro.MergePolicies/Maestro.MergePolicies.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>latest</LangVersion>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 

--- a/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
@@ -132,6 +132,6 @@
     <DefaultRunAsPolicy UserRef="MaestroUser" />
   </Policies>
   <Certificates>
-    <EndpointCertificate X509FindType="FindBySubjectName" X509FindValue="[WebCertName]" Name="WebSslCert" />
+    <EndpointCertificate X509FindValue="[WebCertName]" Name="WebSslCert" />
   </Certificates>
 </ApplicationManifest>

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/Microsoft.DotNet.Maestro.Tasks.csproj
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/Microsoft.DotNet.Maestro.Tasks.csproj
@@ -9,7 +9,6 @@
     <SignAssembly>false</SignAssembly>
     <!-- Build Tasks should not include any dependencies -->
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Maestro/tests/Maestro.ScenarioTests/Maestro.ScenarioTests.csproj
+++ b/src/Maestro/tests/Maestro.ScenarioTests/Maestro.ScenarioTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <SignAssembly>false</SignAssembly>
-    <LangVersion>8.0</LangVersion>
     <UserSecretsId>a523e3e9-b284-4c40-962d-e06de454891e</UserSecretsId>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Microsoft.DncEng.Configuration.Extensions/SentinelFileLock.cs
+++ b/src/Microsoft.DncEng.Configuration.Extensions/SentinelFileLock.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
-#nullable disable // this is copied code, don't want to mess with it
 
 namespace Microsoft.DncEng.Configuration.Extensions
 {

--- a/src/Microsoft.DncEng.DeployServiceFabricCluster/ClusterSettings.cs
+++ b/src/Microsoft.DncEng.DeployServiceFabricCluster/ClusterSettings.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 
 // These types must have public {get; set;} properties, those make nullable act weird
-#nullable disable
 
 namespace Microsoft.DncEng.DeployServiceFabricCluster
 {

--- a/src/Microsoft.DncEng.SecretManager.ScenarioTests/Microsoft.DncEng.SecretManager.ScenarioTests.csproj
+++ b/src/Microsoft.DncEng.SecretManager.ScenarioTests/Microsoft.DncEng.SecretManager.ScenarioTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <SignAssembly>false</SignAssembly>
-    <LangVersion>8.0</LangVersion>
     <UserSecretsId>a523e3e9-b284-4c40-962d-e06de454891e</UserSecretsId>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/CancellationKeyListener.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/CancellationKeyListener.cs
@@ -6,7 +6,6 @@ using System;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
 namespace Microsoft.DotNet.Darc
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/CancellationKeyListener.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/CancellationKeyListener.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Darc
                 cancellationSource.Cancel();
             }
 
-            Console.CancelKeyPress += new ConsoleCancelEventHandler((object? sender, ConsoleCancelEventArgs args) =>
+            Console.CancelKeyPress += new ConsoleCancelEventHandler((object sender, ConsoleCancelEventArgs args) =>
             {
                 args.Cancel = true;
                 listener.CancelledByKeyPress = true;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
     <SignAssembly>false</SignAssembly>
     <IsPackable>true</IsPackable>
     <Description>Darc CLI</Description>

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/Operation.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
         protected ILogger<Operation> Logger { get; }
 
-        protected Operation(CommandLineOptions options, IServiceCollection? services = null)
+        protected Operation(CommandLineOptions options, IServiceCollection services = null)
         {
             // Because the internal logging in DarcLib tends to be chatty and non-useful,
             // we remap the --verbose switch onto 'info', --debug onto highest level, and the

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/Operation.cs
@@ -8,7 +8,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
 namespace Microsoft.DotNet.Darc.Operations
 {
     public abstract class Operation : IDisposable

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
@@ -8,7 +8,6 @@ using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
-#nullable enable
 namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
 internal class InitializeOperation : VmrOperationBase<IVmrInitializer>

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
@@ -20,7 +20,7 @@ internal class InitializeOperation : VmrOperationBase<IVmrInitializer>
     protected override async Task ExecuteInternalAsync(
         IVmrInitializer vmrManager,
         SourceMapping mapping,
-        string? targetRevision,
+        string targetRevision,
         bool recursive,
         CancellationToken cancellationToken)
         =>

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
@@ -23,7 +23,7 @@ internal class UpdateOperation : VmrOperationBase<IVmrUpdater>
     protected override async Task ExecuteInternalAsync(
         IVmrUpdater vmrManager,
         SourceMapping mapping,
-        string? targetRevision,
+        string targetRevision,
         bool recursive,
         CancellationToken cancellationToken)
         =>

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
@@ -8,7 +8,6 @@ using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
-#nullable enable
 namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
 internal class UpdateOperation : VmrOperationBase<IVmrUpdater>

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/VmrOperationBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/VmrOperationBase.cs
@@ -18,7 +18,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
 namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
 internal abstract class VmrOperationBase<TVmrManager> : Operation where TVmrManager : IVmrManager

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/VmrOperationBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/VmrOperationBase.cs
@@ -44,16 +44,16 @@ internal abstract class VmrOperationBase<TVmrManager> : Operation where TVmrMana
 
         TVmrManager vmrManager = Provider.GetRequiredService<TVmrManager>();
 
-        IEnumerable<(SourceMapping Mapping, string? Revision)> reposToSync;
+        IEnumerable<(SourceMapping Mapping, string Revision)> reposToSync;
 
         // 'all' means sync all of the repos
         if (repositories.Count == 1 && repositories.First() == "all")
         {
-            reposToSync = vmrManager.Mappings.Select<SourceMapping, (SourceMapping Mapping, string? Revision)>(m => (m, null));
+            reposToSync = vmrManager.Mappings.Select<SourceMapping, (SourceMapping Mapping, string Revision)>(m => (m, null));
         }
         else
         {
-            IEnumerable<(string Name, string? Revision)> repoNamesWithRevisions = repositories
+            IEnumerable<(string Name, string Revision)> repoNamesWithRevisions = repositories
                 .Select(a => a.Split(':') is string[] parts && parts.Length == 2
                     ? (Name: parts[0], Revision: parts[1])
                     : (a, null));
@@ -99,14 +99,14 @@ internal abstract class VmrOperationBase<TVmrManager> : Operation where TVmrMana
     protected abstract Task ExecuteInternalAsync(
         TVmrManager vmrManager,
         SourceMapping mapping,
-        string? targetRevision,
+        string targetRevision,
         bool recursive,
         CancellationToken cancellationToken);
 
     private async Task<bool> ExecuteAsync(
         TVmrManager vmrManager,
         SourceMapping mapping,
-        string? targetRevision,
+        string targetRevision,
         bool recursive,
         CancellationToken cancellationToken)
     {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/ProcessManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/ProcessManager.cs
@@ -12,7 +12,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Threading;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.Helpers;
 
 public interface IProcessManager
@@ -21,7 +20,7 @@ public interface IProcessManager
         string executable,
         IEnumerable<string> arguments,
         TimeSpan? timeout = null,
-        string? workingDir = null,
+        string workingDir = null,
         CancellationToken cancellationToken = default);
 
     Task<ProcessExecutionResult> ExecuteGit(string repoPath, string[] arguments, CancellationToken cancellationToken);
@@ -59,7 +58,7 @@ public class ProcessManager : IProcessManager
         string executable,
         IEnumerable<string> arguments,
         TimeSpan? timeout = null,
-        string? workingDir = null,
+        string workingDir = null,
         CancellationToken cancellationToken = default)
     {
         var processStartInfo = new ProcessStartInfo()

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/StringUtils.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/StringUtils.cs
@@ -4,7 +4,6 @@
 
 using System.IO;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.Helpers;
 
 public class StringUtils

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionDetailsParser.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionDetailsParser.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib;
 
 public interface IVersionDetailsParser
@@ -50,7 +49,7 @@ public class VersionDetailsParser : IVersionDetailsParser
 
     public IList<DependencyDetail> ParseVersionDetailsXml(XmlDocument document, bool includePinned = true)
     {
-        XmlNodeList? dependencyNodes = document?.DocumentElement?.SelectNodes($"//{DependencyElementName}");
+        XmlNodeList dependencyNodes = document?.DocumentElement?.SelectNodes($"//{DependencyElementName}");
         if (dependencyNodes == null)
         {
             throw new Exception($"There was an error while reading '{VersionFiles.VersionDetailsXml}' and it came back empty. " +
@@ -93,10 +92,10 @@ public class VersionDetailsParser : IVersionDetailsParser
             // If the 'Pinned' attribute does not exist or if it is set to false we just not update it
             bool isPinned = ParseBooleanAttribute(dependency.Attributes, PinnedAttributeName);
 
-            XmlNode? sourceBuildNode = dependency.SelectSingleNode(SourceBuildElementName)
+            XmlNode sourceBuildNode = dependency.SelectSingleNode(SourceBuildElementName)
                 ?? dependency.SelectSingleNode(SourceBuildOldElementName); // Workaround for https://github.com/dotnet/source-build/issues/2481
 
-            SourceBuildInfo? sourceBuildInfo = null;
+            SourceBuildInfo sourceBuildInfo = null;
             if (sourceBuildNode is XmlElement sourceBuildElement)
             {
                 string repoName = sourceBuildElement.Attributes[RepoNameAttributeName]?.Value
@@ -132,7 +131,7 @@ public class VersionDetailsParser : IVersionDetailsParser
     private static bool ParseBooleanAttribute(XmlAttributeCollection attributes, string attributeName)
     {
         var result = false;
-        XmlAttribute? attribute = attributes[attributeName];
+        XmlAttribute attribute = attributes[attributeName];
         if (attribute is not null && !bool.TryParse(attribute.Value, out result))
         {
             throw new DarcException($"The '{attributeName}' attribute is set but the value " +

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
@@ -6,7 +6,6 @@
     <IsPackable>true</IsPackable>
     <Description>Darc Library</Description>
     <PackageTags>Arcade Darc Dependency Flow</PackageTags>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/MsBuildPropsFile.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/MsBuildPropsFile.cs
@@ -10,7 +10,6 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Serialization;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.Models;
 
 public interface IMsBuildPropsFile

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/VirtualMonoRepo/AllVersionsPropsFile.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/VirtualMonoRepo/AllVersionsPropsFile.cs
@@ -8,14 +8,13 @@ using System.Xml;
 using Microsoft.DotNet.DarcLib.Models;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
-#nullable enable
 namespace Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 
 public interface IAllVersionsPropsFile : IMsBuildPropsFile
 {
     Dictionary<string, string> Versions { get; }
 
-    VmrDependencyVersion? GetVersion(string repository);
+    VmrDependencyVersion GetVersion(string repository);
     void UpdateVersion(string repository, string sha, string packageVersion);
 }
 
@@ -37,7 +36,7 @@ public class AllVersionsPropsFile : MsBuildPropsFile, IAllVersionsPropsFile
         Versions = versions;
     }
 
-    public VmrDependencyVersion? GetVersion(string repository)
+    public VmrDependencyVersion GetVersion(string repository)
     {
         var key = SanitizePropertyName(repository) + ShaPropertyName;
         Versions.TryGetValue(key, out var sha);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/VirtualMonoRepo/SourceMapping.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/VirtualMonoRepo/SourceMapping.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
 namespace Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 
 /// <summary>
@@ -17,4 +16,4 @@ public record SourceMapping(
     IReadOnlyCollection<string> Include,
     IReadOnlyCollection<string> Exclude,
     IReadOnlyCollection<string> VmrPatches,
-    string? Version = null);
+    string Version = null);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/EmptySyncException.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/EmptySyncException.cs
@@ -4,7 +4,6 @@
 
 using System;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public class EmptySyncException : Exception

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IVmrInitializer : IVmrManager
@@ -23,8 +22,8 @@ public interface IVmrInitializer : IVmrManager
     /// <param name="cancellationToken">Cancellation token</param>
     Task InitializeRepository(
         string mappingName,
-        string? targetRevision,
-        string? targetVersion,
+        string targetRevision,
+        string targetVersion,
         bool initializeDependencies,
         CancellationToken cancellationToken)
     {
@@ -44,8 +43,8 @@ public interface IVmrInitializer : IVmrManager
     /// <param name="cancellationToken">Cancellation token</param>
     Task InitializeRepository(
         SourceMapping mapping,
-        string? targetRevision,
-        string? targetVersion,
+        string targetRevision,
+        string targetVersion,
         bool initializeDependencies,
         CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrManager.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IVmrManager

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IVmrPatchHandler

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IVmrUpdater : IVmrManager
@@ -24,8 +23,8 @@ public interface IVmrUpdater : IVmrManager
     /// <param name="cancellationToken">Cancellation token</param>
     Task UpdateRepository(
         string mappingName,
-        string? targetRevision,
-        string? targetVersion,
+        string targetRevision,
+        string targetVersion,
         bool noSquash,
         bool updateDependencies,
         CancellationToken cancellationToken)
@@ -47,8 +46,8 @@ public interface IVmrUpdater : IVmrManager
     /// <param name="cancellationToken">Cancellation token</param>
     Task UpdateRepository(
         SourceMapping mapping,
-        string? targetRevision,
-        string? targetVersion,
+        string targetRevision,
+        string targetVersion,
         bool noSquash,
         bool updateDependencies,
         CancellationToken cancellationToken);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
@@ -11,7 +11,6 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface ISourceMappingParser
@@ -54,7 +53,7 @@ public class SourceMappingParser : ISourceMappingParser
             .ToImmutableArray();
     }
 
-    private static SourceMapping CreateMapping(SourceMappingSetting defaults, SourceMappingSetting setting, string? patchesPath)
+    private static SourceMapping CreateMapping(SourceMappingSetting defaults, SourceMappingSetting setting, string patchesPath)
     {
         if (setting.Name is null)
         {
@@ -107,19 +106,19 @@ public class SourceMappingParser : ISourceMappingParser
             Exclude = Array.Empty<string>(),
         };
 
-        public string? PatchesPath { get; set; }
+        public string PatchesPath { get; set; }
 
         public List<SourceMappingSetting> Mappings { get; set; } = new();
     }
 
     private class SourceMappingSetting
     {
-        public string? Name { get; set; }
-        public string? Version { get; set; }
-        public string? DefaultRemote { get; set; }
-        public string? DefaultRef { get; set; }
-        public string[]? Include { get; set; }
-        public string[]? Exclude { get; set; }
+        public string Name { get; set; }
+        public string Version { get; set; }
+        public string DefaultRemote { get; set; }
+        public string DefaultRef { get; set; }
+        public string[] Include { get; set; }
+        public string[] Exclude { get; set; }
         public bool IgnoreDefaults { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
@@ -8,10 +8,9 @@ using System.IO;
 using System.Threading;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
-public record VmrDependencyVersion(string Sha, string? PackageVersion);
+public record VmrDependencyVersion(string Sha, string PackageVersion);
 
 public interface IVmrDependencyTracker
 {
@@ -25,7 +24,7 @@ public interface IVmrDependencyTracker
 
     void UpdateDependencyVersion(SourceMapping mapping, VmrDependencyVersion version);
 
-    VmrDependencyVersion? GetDependencyVersion(SourceMapping mapping);
+    VmrDependencyVersion GetDependencyVersion(SourceMapping mapping);
 }
 
 /// <summary>
@@ -62,7 +61,7 @@ public class VmrDependencyTracker : IVmrDependencyTracker
         _repoVersions = new Lazy<AllVersionsPropsFile>(LoadAllVersionsFile, LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
-    public VmrDependencyVersion? GetDependencyVersion(SourceMapping mapping)
+    public VmrDependencyVersion GetDependencyVersion(SourceMapping mapping)
         => _repoVersions.Value.GetVersion(mapping.Name);
 
     public void UpdateDependencyVersion(SourceMapping mapping, VmrDependencyVersion version)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -10,7 +10,6 @@ using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 /// <summary>
@@ -49,8 +48,8 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
 
     public async Task InitializeRepository(
         SourceMapping mapping,
-        string? targetRevision,
-        string? targetVersion,
+        string targetRevision,
+        string targetVersion,
         bool initializeDependencies,
         CancellationToken cancellationToken)
     {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -15,7 +15,6 @@ using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public abstract class VmrManagerBase : IVmrManager
@@ -195,11 +194,11 @@ public abstract class VmrManagerBase : IVmrManager
     protected static string PrepareCommitMessage(
         string template,
         SourceMapping mapping,
-        string? oldSha = null,
-        string? newSha = null,
-        string? additionalMessage = null)
+        string oldSha = null,
+        string newSha = null,
+        string additionalMessage = null)
     {
-        var replaces = new Dictionary<string, string?>
+        var replaces = new Dictionary<string, string>
         {
             { "name", mapping.Name },
             { "remote", mapping.DefaultRemote },
@@ -218,7 +217,7 @@ public abstract class VmrManagerBase : IVmrManager
         return template;
     }
 
-    protected static LibGit2Sharp.Commit GetCommit(Repository repository, string? sha)
+    protected static LibGit2Sharp.Commit GetCommit(Repository repository, string sha)
     {
         var commit = sha is null
             ? repository.Commits.FirstOrDefault()

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -14,7 +14,6 @@ using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -9,7 +9,6 @@ using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public static class VmrRegistrations

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -14,7 +14,6 @@ using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 /// <summary>
@@ -68,8 +67,8 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
     public Task UpdateRepository(
         SourceMapping mapping,
-        string? targetRevision,
-        string? targetVersion,
+        string targetRevision,
+        string targetVersion,
         bool noSquash,
         bool updateDependencies,
         CancellationToken cancellationToken)
@@ -81,8 +80,8 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
     private async Task UpdateRepository(
         SourceMapping mapping,
-        string? targetRevision,
-        string? targetVersion,
+        string targetRevision,
+        string targetVersion,
         bool noSquash,
         CancellationToken cancellationToken)
     {
@@ -155,7 +154,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         // Let's do the same in case we don't explicitly go one by one but we only have one commit..
         if (noSquash || commitsToCopy.Count == 1)
         {
-            while (commitsToCopy.TryPop(out LibGit2Sharp.Commit? commitToCopy))
+            while (commitsToCopy.TryPop(out LibGit2Sharp.Commit commitToCopy))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -185,7 +184,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         else
         {
             var commitMessages = new StringBuilder();
-            while (commitsToCopy.TryPop(out LibGit2Sharp.Commit? commit))
+            while (commitsToCopy.TryPop(out LibGit2Sharp.Commit commit))
             {
                 commitMessages
                     .AppendLine($"  - {commit.MessageShort}")
@@ -217,15 +216,15 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
     /// </summary>
     private async Task UpdateRepositoryRecursively(
         SourceMapping mapping,
-        string? targetRevision,
-        string? targetVersion,
+        string targetRevision,
+        string targetVersion,
         bool noSquash,
         CancellationToken cancellationToken)
     {
-        var reposToUpdate = new Queue<(SourceMapping mapping, string? targetRevision, string? targetVersion)>();
+        var reposToUpdate = new Queue<(SourceMapping mapping, string targetRevision, string targetVersion)>();
         reposToUpdate.Enqueue((mapping, targetRevision, targetVersion));
 
-        var updatedDependencies = new HashSet<(SourceMapping mapping, string? targetRevision, string? targetVersion)>();
+        var updatedDependencies = new HashSet<(SourceMapping mapping, string targetRevision, string targetVersion)>();
 
         while (reposToUpdate.TryDequeue(out var repoToUpdate))
         {
@@ -274,7 +273,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         SourceMapping mapping,
         string fromRevision,
         string toRevision,
-        string? targetVersion,
+        string targetVersion,
         string clonePath,
         string commitMessage,
         Signature author,

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/Microsoft.DotNet.DarcLib.Tests.csproj
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/Microsoft.DotNet.DarcLib.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <SignAssembly>false</SignAssembly>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/Models/VirtualMonoRepo/AllVersionsPropsFileTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/Models/VirtualMonoRepo/AllVersionsPropsFileTests.cs
@@ -9,7 +9,6 @@ using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using NUnit.Framework;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.Tests.Models.VirtualMonoRepo;
 
 [TestFixture]

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/Models/VirtualMonoRepo/AllVersionsPropsFileTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/Models/VirtualMonoRepo/AllVersionsPropsFileTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.DarcLib.Tests.Models.VirtualMonoRepo;
 [TestFixture]
 public class AllVersionsPropsFileTests
 {
-    private string? _outputFile;
+    private string _outputFile;
 
     [SetUp]
     public void SetUpOutputFile()

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/Models/VirtualMonoRepo/GitInfoFileTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/Models/VirtualMonoRepo/GitInfoFileTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.DarcLib.Tests.Models.VirtualMonoRepo;
 [TestFixture]
 public class GitInfoFileTests
 {
-    private string? _outputFile;
+    private string _outputFile;
 
     [SetUp]
     public void SetUpOutputFile()

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/Models/VirtualMonoRepo/GitInfoFileTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/Models/VirtualMonoRepo/GitInfoFileTests.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using NUnit.Framework;
 
-#nullable enable
 namespace Microsoft.DotNet.DarcLib.Tests.Models.VirtualMonoRepo;
 
 [TestFixture]

--- a/src/Monitoring/Microsoft.DotNet.Metrics/Microsoft.DotNet.Metrics.csproj
+++ b/src/Monitoring/Microsoft.DotNet.Metrics/Microsoft.DotNet.Metrics.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>latest</LangVersion>
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
   </PropertyGroup>

--- a/src/Monitoring/Microsoft.DotNet.Monitoring.Sdk.Tests/Microsoft.DotNet.Monitoring.Sdk.Tests.csproj
+++ b/src/Monitoring/Microsoft.DotNet.Monitoring.Sdk.Tests/Microsoft.DotNet.Monitoring.Sdk.Tests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-
-    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Monitoring/Sdk/Microsoft.DotNet.Monitoring.Sdk.csproj
+++ b/src/Monitoring/Sdk/Microsoft.DotNet.Monitoring.Sdk.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <PackageType>MSBuildSdk</PackageType>
-    <LangVersion>latest</LangVersion>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <NoWarn>$(NoWarn);NU5110,NU5111</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
It's difficult to work in a project when the rules of C# change from project to project (or for nullable, from file to file).

At least normalize on something that's usable and we can deal with changes without having lindmines of language features.