### PR TITLE
Update azure-devops-access-token secret type to produce instructions for pat-generator

### DIFF
--- a/.vault-config/maestrolocal.yaml
+++ b/.vault-config/maestrolocal.yaml
@@ -47,27 +47,27 @@ secrets:
     parameters:
       domainAccountName: dn-bot
       domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-dnceng-build
-      organization: dnceng
+        location: helixkv
+        name: dn-bot-account-redmond
+      organizations: dnceng
+      scopes: build_execute code_write release_execute
    
   dn-bot-devdiv-build-rw-code-rw-release-rw:
     type: azure-devops-access-token
     parameters:
       domainAccountName: dn-bot
       domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-devdiv-build
-      organization: devdiv
+        location: helixkv
+        name: dn-bot-account-redmond
+      organizations: devdiv
+      scopes: build_execute code_write release_execute
    
   dn-bot-dnceng-packaging-rwm:
     type: azure-devops-access-token
     parameters:
       domainAccountName: dn-bot
       domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-dnceng-build
-      organization: dnceng
+        location: helixkv
+        name: dn-bot-account-redmond
+      organizations: dnceng
+      scopes: packaging_manage

--- a/.vault-config/shared/dotneteng-status-secrets.yaml
+++ b/.vault-config/shared/dotneteng-status-secrets.yaml
@@ -41,8 +41,9 @@ dn-bot-dnceng-build-rw-code-rw-release-rw:
 dn-bot-dnceng-workitems-rw:
   type: azure-devops-access-token
   parameters:
-    organization: dnceng
-    requiredScopes: Work Items (Write)
+    organizations: dnceng
+    scopes: work_write
+    domainAccountName: dn-bot
     domainAccountSecret:
       name: dn-bot-account-redmond
       location: helixkv
@@ -50,8 +51,10 @@ dn-bot-dnceng-workitems-rw:
 dn-bot-dnceng-build-r-code-r-project-r-profile-r:
   type: azure-devops-access-token
   parameters:
-    organization: dnceng
+    organizations: dnceng
+    scopes: build code project profile
     requiredScopes: Build (Read) Code (Read) Project (Read) Profile (Read)
+    domainAccountName: dn-bot
     domainAccountSecret:
       name: dn-bot-account-redmond
       location: helixkv

--- a/.vault-config/shared/maestro-secrets.yaml
+++ b/.vault-config/shared/maestro-secrets.yaml
@@ -39,8 +39,8 @@ dn-bot-dnceng-build-rw-code-rw-release-rw:
     domainAccountSecret:
         location: helixkv
         name: dn-bot-account-redmond
-    name: dn-bot-dnceng-build
-    organization: dnceng
+    organizations: dnceng
+    scopes: build_execute code_write release_execute
 
 dn-bot-devdiv-build-rw-code-rw-release-rw:
   type: azure-devops-access-token
@@ -49,8 +49,8 @@ dn-bot-devdiv-build-rw-code-rw-release-rw:
     domainAccountSecret:
         location: helixkv
         name: dn-bot-account-redmond
-    name: dn-bot-devdiv-build
-    organization: devdiv
+    organizations: devdiv
+    scopes: build_execute code_write release_execute
 
 dn-bot-dnceng-packaging-rwm:
   type: azure-devops-access-token
@@ -59,5 +59,5 @@ dn-bot-dnceng-packaging-rwm:
     domainAccountSecret:
         location: helixkv
         name: dn-bot-account-redmond
-    name: dn-bot-dnceng-build
-    organization: dnceng
+    organizations: dnceng
+    scopes: packaging_write

--- a/src/Microsoft.DncEng.PatGenerator/AzureDevOpsPATScopes.cs
+++ b/src/Microsoft.DncEng.PatGenerator/AzureDevOpsPATScopes.cs
@@ -114,6 +114,14 @@ namespace Microsoft.DncEng.PatGenerator
         test = 0b1000_0000_0000_0000_0000_0000,
         [ScopeDescription("test", "rw", "Test Management (read and write)")]
         test_write = 0b1_0000_0000_0000_0000_0000_0000 | test,
+
+        // Project - Bits 0b1110_0000_0000_0000_0000_0000_0000
+        [ScopeDescription("project", "r", "Project and Team (read)")]
+        project = 0b0010_0000_0000_0000_0000_0000_0000,
+        [ScopeDescription("project", "rw", "Project and Team (read and write)")]
+        project_write = 0b0100_0000_0000_0000_0000_0000_0000 | project,
+        [ScopeDescription("project", "rwm", "Project and Team (read, write and manage)")]
+        project_manage = 0b1000_0000_0000_0000_0000_0000_0000 | project_write,
     }
 
     public static class AzureDevOpsPATScopesExtensions

--- a/src/Microsoft.DncEng.SecretManager/Readme.md
+++ b/src/Microsoft.DncEng.SecretManager/Readme.md
@@ -394,11 +394,10 @@ type: ad-application
 ```yaml
 type: azure-devops-access-token
 parameters:
-  organization: azure devops org
-  requiredScopes: string describing the required scopes
-  # only one of the following is required
+  organizations: space separate list of organizations
+  scopes: space separated list of scopes in the format accepted by pat-generator
+  domainAccountName: name of domain account
   domainAccountSecret: secret reference to a domain-account
-  gitHubBotAccountSecret: secret reference to a github-account
 ```
 
 ### Base64 Encode


### PR DESCRIPTION
Also removed the github account option for this secret type because we never actually use it, and pat-generator can't work with it.