### PR TITLE
Split `IGitRepo` and `ILocalGitRepo`, add submodule listing

### DIFF
--- a/src/Maestro/Maestro.DataProviders/DarcRemoteFactory.cs
+++ b/src/Maestro/Maestro.DataProviders/DarcRemoteFactory.cs
@@ -62,7 +62,7 @@ namespace Maestro.DataProviders
                 string normalizedUrl = AzureDevOpsClient.NormalizeUrl(repoUrl);
                 Uri normalizedRepoUri = new Uri(normalizedUrl);
 
-                IGitRepo gitClient;
+                IRemoteGitRepo gitClient;
 
                 long installationId = await Context.GetInstallationId(normalizedUrl);
 

--- a/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
+++ b/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
@@ -76,7 +76,7 @@ namespace SubscriptionActorService
                 {
                     temporaryRepositoryRoot = _tempFiles.GetFilePath("repos");
                 }
-                IGitRepo gitClient;
+                IRemoteGitRepo gitClient;
 
                 long installationId = await _context.GetInstallationId(normalizedUrl);
 

--- a/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -23,7 +23,7 @@ namespace SubscriptionActorService.Tests
     public class PullRequestPolicyFailureNotifierTests
     {
         protected Mock<IBarClient> BarClient;
-        protected Mock<IGitRepo> GitRepo;
+        protected Mock<IRemoteGitRepo> GitRepo;
         protected Mock<IRemoteFactory> RemoteFactory;
         protected Mock<IHostEnvironment> Env;
         protected Mock<Octokit.IGitHubClient> GithubClient;
@@ -73,7 +73,7 @@ namespace SubscriptionActorService.Tests
                               select subscription).FirstOrDefault());
                      });
 
-            GitRepo = new Mock<IGitRepo>(MockBehavior.Strict);
+            GitRepo = new Mock<IRemoteGitRepo>(MockBehavior.Strict);
             GitRepo.Setup(g => g.GetPullRequestChecksAsync(It.IsAny<string>()))
                    .Returns((string fakePrsUrl) =>
                    {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/RemoteFactory.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Darc.Helpers
                 temporaryRepositoryRoot = Path.GetTempPath();
             }
 
-            IGitRepo gitClient = null;
+            IRemoteGitRepo gitClient = null;
             if (darcSettings.GitType == GitRepoType.GitHub)
             {
                 gitClient = new GitHubClient(options.GitLocation, darcSettings.GitRepoPersonalAccessToken,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -890,7 +890,7 @@ This pull request has not been merged because Maestro++ is waiting on the follow
         /// <param name="input">String that must have 'shouldEndWith' at the end.</param>
         /// <param name="shouldEndWith">Character that must be present at end of 'input' string.</param>
         /// <returns>Input string appended with 'shouldEndWith'</returns>
-        private string EnsureEndsWith(string input, char shouldEndWith)
+        private static string EnsureEndsWith(string input, char shouldEndWith)
         {
             if (input == null) return null;
 
@@ -940,18 +940,6 @@ This pull request has not been merged because Maestro++ is waiting on the follow
             Uri accountUri = new Uri($"https://dev.azure.com/{accountName}");
             var creds = new VssCredentials(new VssBasicCredential("", _personalAccessToken));
             return new VssConnection(accountUri, creds);
-        }
-
-        private (int threadId, int commentId) ParseCommentId(string commentId)
-        {
-            string[] parts = commentId.Split('-');
-            if (parts.Length != 2 || int.TryParse(parts[0], out int threadId) ||
-                int.TryParse(parts[1], out int commentIdValue))
-            {
-                throw new ArgumentException("The comment id '{commentId}' is in an invalid format", nameof(commentId));
-            }
-
-            return (threadId, commentIdValue);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -23,7 +23,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.DotNet.DarcLib
 {
-    public class AzureDevOpsClient : RemoteRepoBase, IGitRepo, IAzureDevOpsClient
+    public class AzureDevOpsClient : RemoteRepoBase, IRemoteGitRepo, IAzureDevOpsClient
     {
         private const string DefaultApiVersion = "5.0";
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -86,7 +87,7 @@ namespace Microsoft.DotNet.DarcLib
                     List<GitFile> engCommonFiles = await arcadeRemote.GetCommonScriptFilesAsync(arcadeItem.RepoUri, arcadeItem.Commit);
                     filesToUpdate.AddRange(engCommonFiles);
 
-                    List<GitFile> localEngCommonFiles = await _gitClient.GetFilesAtCommitAsync(null, null, "eng/common");
+                    List<GitFile> localEngCommonFiles = GetFilesAtRelativeRepoPathAsync("eng/common");
 
                     foreach (GitFile file in localEngCommonFiles)
                     {
@@ -164,6 +165,18 @@ namespace Microsoft.DotNet.DarcLib
         public void AddRemoteIfMissing(string repoDir, string repoUrl)
         {
             _gitClient.AddRemoteIfMissing(repoDir, repoUrl);
+        }
+
+        private List<GitFile> GetFilesAtRelativeRepoPathAsync(string path)
+        {
+            string repoDir = LocalHelpers.GetRootDir(GitExecutable, _logger);
+            string sourceFolder = Path.Combine(repoDir, path);
+            var files = Directory.GetFiles(sourceFolder, "*.*", SearchOption.AllDirectories);
+            return files
+                .Select(file => new GitFile(
+                    file.Remove(0, repoDir.Length + 1).Replace("\\", "/"),
+                    File.ReadAllText(file)))
+                .ToList();
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.DarcLib
         private readonly IBarClient _barClient;
         private readonly IVersionDetailsParser _versionDetailsParser;
         private readonly GitFileManager _fileManager;
-        private readonly IGitRepo _gitClient;
+        private readonly IRemoteGitRepo _gitClient;
         private readonly ILogger _logger;
 
         //[DependencyUpdate]: <> (Begin)
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.DarcLib
         private static readonly Regex DependencyUpdatesPattern =
             new Regex(@"\[DependencyUpdate\]: <> \(Begin\)([^\[]+)\[DependencyUpdate\]: <> \(End\)");
 
-        public Remote(IGitRepo gitClient, IBarClient barClient, IVersionDetailsParser versionDetailsParser, ILogger logger)
+        public Remote(IRemoteGitRepo gitClient, IBarClient barClient, IVersionDetailsParser versionDetailsParser, ILogger logger)
         {
             _logger = logger;
             _barClient = barClient;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -69,20 +69,6 @@ namespace Microsoft.DotNet.DarcLib
 
         public bool AllowRetries { get; set; } = true;
 
-
-        /// <summary>
-        ///     Add a comment to the discussion of an existing pull request or issue (the APIs are the same)
-        /// </summary>
-        /// <param name="repoUri">Repository URI</param>
-        /// <param name="issueNumber">Issue or PR id</param>
-        /// <param name="message">Contents of the message (ideally in markdown format)</param>
-        public async Task AddIssueComment(string repoUri, int issueNumber, string message)
-        {
-            (string owner, string repo) = ParseRepoUri(repoUri);
-            await Client.Issue.Comment.Create(owner, repo, issueNumber, message);
-        }
-
-
         /// <summary>
         ///     Retrieve the contents of a repository file as a string
         /// </summary>
@@ -1071,7 +1057,7 @@ namespace Microsoft.DotNet.DarcLib
             }
         }
 
-        public async Task GetCommitMapForPathAsync(
+        private async Task GetCommitMapForPathAsync(
             string repoUri,
             string branch,
             string assetsProducedInCommit,
@@ -1230,25 +1216,6 @@ namespace Microsoft.DotNet.DarcLib
         public void Clone(string repoUri, string commit, string targetDirectory, bool checkoutSubmodules, string gitDirectory = null)
         {
             Clone(repoUri, commit, targetDirectory, checkoutSubmodules, _logger, _personalAccessToken, gitDirectory);
-        }
-
-        /// <summary>
-        ///     Does not apply to remote repositories.
-        /// </summary>
-        /// <param name="commit">Ignored</param>
-        public void Checkout(string repoPath, string commit, bool force)
-        {
-            throw new NotImplementedException($"Cannot checkout a remote repo.");
-        }
-
-        /// <summary>
-        ///     Does not apply to remote repositories.
-        /// </summary>
-        /// <param name="repoDir">Ignored</param>
-        /// <param name="repoUrl">Ignored</param>
-        public void AddRemoteIfMissing(string repoDir, string repoUrl)
-        {
-            throw new NotImplementedException($"Cannot add a remote to a remote repo.");
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -24,7 +24,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.DotNet.DarcLib
 {
-    public class GitHubClient : RemoteRepoBase, IGitRepo
+    public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
     {
         private const string GitHubApiUri = "https://api.github.com";
         private const string DarcLibVersion = "1.0.0";

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitSubmoduleInfo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitSubmoduleInfo.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib;
+
+public record GitSubmoduleInfo(
+    string Name,
+    string Path,
+    string Url,
+    string Commit);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitSubmoduleInfo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitSubmoduleInfo.cs
@@ -3,10 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
-namespace Microsoft.DotNet.DarcLib;
-
-public record GitSubmoduleInfo(
-    string Name,
-    string Path,
-    string Url,
-    string Commit);
+namespace Microsoft.DotNet.DarcLib
+{
+    public record GitSubmoduleInfo(
+        string Name,
+        string Path,
+        string Url,
+        string Commit);
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.DarcLib
 {
     public class GitFileManager
     {
-        private readonly ILocalGitRepo _gitClient;
+        private readonly IGitRepo _gitClient;
         private readonly IVersionDetailsParser _versionDetailsParser;
         private readonly ILogger _logger;
 
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.DarcLib
         private const string MaestroRepoSpecificBeginComment = "  Begin: Package sources from";
         private const string MaestroRepoSpecificEndComment = "  End: Package sources from";
 
-        public GitFileManager(ILocalGitRepo gitRepo, IVersionDetailsParser versionDetailsParser, ILogger logger)
+        public GitFileManager(IGitRepo gitRepo, IVersionDetailsParser versionDetailsParser, ILogger logger)
         {
             _gitClient = gitRepo;
             _versionDetailsParser = versionDetailsParser;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.DarcLib
 {
-    public interface IGitRepo : ILocalGitRepo
+    public interface IGitRepo
     {
         /// <summary>
         /// Specifies whether functions with a retry field should employ retries
@@ -125,6 +125,29 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns>Return the commit matching the specified sha. Null if no commit were found.</returns>
         Task<Commit> GetCommitAsync(string repoUri, string sha);
 
+        /// <summary>
+        ///     Retrieve the contents of a repository file as a string
+        /// </summary>
+        /// <param name="filePath">Path to file</param>
+        /// <param name="repoUri">Repository URI</param>
+        /// <param name="branch">Branch to get file contents from</param>
+        /// <returns>File contents or throws on file not found.</returns>
+        Task<string> GetFileContentsAsync(string filePath, string repoUri, string branch);
+
+        /// <summary>
+        /// Gets a list of file under a given path in a given revision.
+        /// </summary>
+        Task<List<GitFile>> GetFilesAtCommitAsync(string repoUri, string commit, string path);
+
+        /// <summary>
+        ///     Commit or update a set of files to a repo
+        /// </summary>
+        /// <param name="filesToCommit">Files to comit</param>
+        /// <param name="repoUri">Remote repository URI</param>
+        /// <param name="branch">Branch to push to</param>
+        /// <param name="commitMessage">Commit message</param>
+        /// <returns></returns>
+        Task CommitFilesAsync(List<GitFile> filesToCommit, string repoUri, string branch, string commitMessage);
 
         /// <summary>
         /// Retrieve the list of status checks on a PR.

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -1,8 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Maestro.Contracts;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -10,121 +9,6 @@ namespace Microsoft.DotNet.DarcLib
 {
     public interface IGitRepo
     {
-        /// <summary>
-        /// Specifies whether functions with a retry field should employ retries
-        /// Should default to true
-        /// </summary>
-        public bool AllowRetries { get; set; }
-
-        /// <summary>
-        /// Checks that a repository exists
-        /// </summary>
-        /// <param name="repoUri">Repository uri</param>
-        /// <returns>True if the repository exists, false otherwise.</returns>
-        Task<bool> RepoExistsAsync(string repoUri);
-
-        /// <summary>
-        /// Create a new branch in a repository
-        /// </summary>
-        /// <param name="repoUri">Repo to create a branch in</param>
-        /// <param name="newBranch">New branch name</param>
-        /// <param name="baseBranch">Base of new branch</param>
-        Task CreateBranchAsync(string repoUri, string newBranch, string baseBranch);
-
-        /// <summary>
-        /// Delete a branch from a repository
-        /// </summary>
-        /// <param name="repoUri">Repository where the branch lives</param>
-        /// <param name="branch">The branch to delete</param>
-        Task DeleteBranchAsync(string repoUri, string branch);
-
-        /// <summary>
-        ///     Search pull requests matching the specified criteria
-        /// </summary>
-        /// <param name="repoUri">URI of repo containing the pull request</param>
-        /// <param name="pullRequestBranch">Source branch for PR</param>
-        /// <param name="status">Current PR status</param>
-        /// <param name="keyword">Keyword</param>
-        /// <param name="author">Author</param>
-        /// <returns>List of pull requests matching the specified criteria</returns>
-        Task<IEnumerable<int>> SearchPullRequestsAsync(
-            string repoUri,
-            string pullRequestBranch,
-            PrStatus status,
-            string keyword = null,
-            string author = null);
-
-        /// <summary>
-        /// Get the status of a pull request
-        /// </summary>
-        /// <param name="pullRequestUrl">URI of pull request</param>
-        /// <returns>Pull request status</returns>
-        Task<PrStatus> GetPullRequestStatusAsync(string pullRequestUrl);
-
-        /// <summary>
-        ///     Retrieve information on a specific pull request
-        /// </summary>
-        /// <param name="pullRequestUrl">Uri of the pull request</param>
-        /// <returns>Information on the pull request.</returns>
-        Task<PullRequest> GetPullRequestAsync(string pullRequestUrl);
-
-        /// <summary>
-        ///     Retrieve information on commits of a specific pull request
-        /// </summary>
-        /// <param name="pullRequestUrl">Uri of the pull request</param>
-        /// <returns>Information on the pull request.</returns>
-        Task<IList<Commit>> GetPullRequestCommitsAsync(string pullRequestUrl );
-
-        /// <summary>
-        ///     Create a new pull request for a repository
-        /// </summary>
-        /// <param name="repoUri">Repo to create the pull request for.</param>
-        /// <param name="pullRequest">Pull request data</param>
-        /// <returns></returns>
-        Task<string> CreatePullRequestAsync(string repoUri, PullRequest pullRequest);
-
-        /// <summary>
-        ///     Update a pull request with new information
-        /// </summary>
-        /// <param name="pullRequestUri">Uri of pull request to update</param>
-        /// <param name="pullRequest">Pull request info to update</param>
-        /// <returns></returns>
-        Task UpdatePullRequestAsync(string pullRequestUri, PullRequest pullRequest);
-
-
-        /// <summary>
-        ///     Merges a Dependency update pull request
-        /// </summary>
-        /// <param name="pullRequestUrl">Uri of pull request to merge</param>
-        /// <param name="parameters">Settings for merge</param>
-        /// <param name="mergeCommitMessage">Commit message used to merge the pull request</param>
-        /// <returns></returns>
-        Task MergeDependencyPullRequestAsync(string pullRequestUrl, MergePullRequestParameters parameters, string mergeCommitMessage);
-
-        /// <summary>
-        ///     Create new check(s), update them with a new status,
-        ///     or remove each merge policy check that isn't in evaluations
-        /// </summary>
-        /// <param name="pullRequestUrl">Url of pull request</param>
-        /// <param name="evalutations">List of merge policies</param>
-        Task CreateOrUpdatePullRequestMergeStatusInfoAsync(string pullRequestUrl, IReadOnlyList<MergePolicyEvaluationResult> evaluations);
-
-        /// <summary>
-        ///     Get the latest commit in a repo on the specific branch 
-        /// </summary>
-        /// <param name="repoUri">Repository uri</param>
-        /// <param name="branch">Branch to retrieve the latest sha for</param>
-        /// <returns>Latest sha.  Null if no commits were found.</returns>
-        Task<string> GetLastCommitShaAsync(string repoUri, string branch);
-
-        /// <summary>
-        ///     Get a commit in a repo 
-        /// </summary>
-        /// <param name="repoUri">Repository URI</param>
-        /// <param name="sha">Sha of the commit</param>
-        /// <returns>Return the commit matching the specified sha. Null if no commit were found.</returns>
-        Task<Commit> GetCommitAsync(string repoUri, string sha);
-
         /// <summary>
         ///     Retrieve the contents of a repository file as a string
         /// </summary>
@@ -135,11 +19,6 @@ namespace Microsoft.DotNet.DarcLib
         Task<string> GetFileContentsAsync(string filePath, string repoUri, string branch);
 
         /// <summary>
-        /// Gets a list of file under a given path in a given revision.
-        /// </summary>
-        Task<List<GitFile>> GetFilesAtCommitAsync(string repoUri, string commit, string path);
-
-        /// <summary>
         ///     Commit or update a set of files to a repo
         /// </summary>
         /// <param name="filesToCommit">Files to comit</param>
@@ -148,53 +27,5 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="commitMessage">Commit message</param>
         /// <returns></returns>
         Task CommitFilesAsync(List<GitFile> filesToCommit, string repoUri, string branch, string commitMessage);
-
-        /// <summary>
-        /// Retrieve the list of status checks on a PR.
-        /// </summary>
-        /// <param name="pullRequestUrl">Uri of pull request</param>
-        /// <returns>List of status checks.</returns>
-        Task<IList<Check>> GetPullRequestChecksAsync(string pullRequestUrl);
-
-        /// <summary>
-        /// Retrieve the list of reviews on a PR.
-        /// </summary>
-        /// <param name="pullRequestUrl">Uri of pull request</param>
-        /// <returns>List of pull request reviews.</returns>
-        Task<IList<Review>> GetLatestPullRequestReviewsAsync(string pullRequestUrl);
-
-        /// <summary>
-        ///     Diff two commits in a repository and return information about them.
-        /// </summary>
-        /// <param name="repoUri">Repository uri</param>
-        /// <param name="baseVersion">Base version</param>
-        /// <param name="targetVersion">Target version</param>
-        /// <returns>Diff information</returns>
-        Task<GitDiff> GitDiffAsync(string repoUri, string baseVersion, string targetVersion);
-
-        /// <summary>
-        ///     Clone a remote repository.
-        /// </summary>
-        /// <param name="repoUri">Repository uri</param>
-        /// <param name="commit">Branch, commit, or tag to checkout</param>
-        /// <param name="targetDirectory">Directory to clone to</param>
-        /// <param name="checkoutSubmodules">Indicates whether submodules should be checked out as well</param>
-        /// <param name="gitDirectory">Location for .git directory, or null for default</param>
-        void Clone(string repoUri, string commit, string targetDirectory, bool checkoutSubmodules, string gitDirectory = null);
-
-        /// <summary>
-        ///     Delete a pull request's branch if it still exists
-        /// </summary>
-        /// <param name="pullRequestUri"></param>
-        /// <returns>Async task</returns>
-        Task DeletePullRequestBranchAsync(string pullRequestUri);
-    }
-
-    public class PullRequest
-    {
-        public string Title { get; set; }
-        public string Description { get; set; }
-        public string BaseBranch { get; set; }
-        public string HeadBranch { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoExtension.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoExtension.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.DarcLib
 {
     public static class IGitRepoExtension
     {
-        public static string GetDecodedContent(this IGitRepo gitRepo, string encodedContent)
+        public static string GetDecodedContent(this IRemoteGitRepo gitRepo, string encodedContent)
         {
             try
             {
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.DarcLib
             }
         }
 
-        public static byte[] GetContentBytes(this IGitRepo gitRepo, string content)
+        public static byte[] GetContentBytes(this IRemoteGitRepo gitRepo, string content)
         {
             string decodedContent = GetDecodedContent(gitRepo, content);
             return Encoding.UTF8.GetBytes(decodedContent);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
@@ -3,11 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.DarcLib
 {
-    public interface ILocalGitRepo
+    public interface ILocalGitRepo : IGitRepo
     {
         /// <summary>
         ///     Add a remote to a local repo if does not already exist, and attempt to fetch commits.
@@ -19,17 +18,6 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         /// <param name="commit">Tag, branch, or commit to checkout.</param>
         void Checkout(string repoDir, string commit, bool force = false);
-
-        /// <summary>
-        ///     Updates local copies of the files.
-        /// </summary>
-        /// <param name="filesToCommit">Files to update locally</param>
-        /// <param name="repoDir">Base path of the repo</param>
-        /// <param name="branch">Unused</param>
-        /// <param name="commitMessage">Unused</param>
-        Task CommitFilesAsync(List<GitFile> filesToCommit, string repoDir, string branch, string commitMessage);
-
-        Task<string> GetFileContentsAsync(string relativeFilePath, string repoDir, string branch);
 
         /// <summary>
         /// Parses the .gitmodule file and retrieves a list of git submodules registered in a given repository.

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.DarcLib
         void Checkout(string repoDir, string commit, bool force = false);
 
         /// <summary>
-        /// Parses the .gitmodule file and retrieves a list of git submodules registered in a given repository.
+        /// Returns a list of git submodules registered in a given repository.
         /// </summary>
         /// <param name="repoDir">Path to a git repository</param>
         /// <param name="commit">Which commit the info is retrieved for</param>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
@@ -24,13 +24,18 @@ namespace Microsoft.DotNet.DarcLib
         ///     Updates local copies of the files.
         /// </summary>
         /// <param name="filesToCommit">Files to update locally</param>
-        /// <param name="repoUri">Base path of the repo</param>
+        /// <param name="repoDir">Base path of the repo</param>
         /// <param name="branch">Unused</param>
         /// <param name="commitMessage">Unused</param>
-        Task CommitFilesAsync(List<GitFile> filesToCommit, string repoUri, string branch, string commitMessage);
+        Task CommitFilesAsync(List<GitFile> filesToCommit, string repoDir, string branch, string commitMessage);
 
-        Task<string> GetFileContentsAsync(string relativeFilePath, string repoUri, string branch);
+        Task<string> GetFileContentsAsync(string relativeFilePath, string repoDir, string branch);
 
-        Task<List<GitFile>> GetFilesAtCommitAsync(string repoUri, string commit, string path);
+        /// <summary>
+        /// Parses the .gitmodule file and retrieves a list of git submodules registered in a given repository.
+        /// </summary>
+        /// <param name="repoDir">Path to a git repository</param>
+        /// <param name="commit">Which commit the info is retrieved for</param>
+        List<GitSubmoduleInfo> GetGitSubmodules(string repoDir, string commit);
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemoteGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemoteGitRepo.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.DarcLib
         /// Specifies whether functions with a retry field should employ retries
         /// Should default to true
         /// </summary>
-        public bool AllowRetries { get; set; }
+        bool AllowRetries { get; set; }
 
         /// <summary>
         /// Checks that a repository exists

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemoteGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemoteGitRepo.cs
@@ -1,0 +1,181 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Maestro.Contracts;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.DarcLib
+{
+    public interface IRemoteGitRepo : IGitRepo
+    {
+        /// <summary>
+        /// Specifies whether functions with a retry field should employ retries
+        /// Should default to true
+        /// </summary>
+        public bool AllowRetries { get; set; }
+
+        /// <summary>
+        /// Checks that a repository exists
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <returns>True if the repository exists, false otherwise.</returns>
+        Task<bool> RepoExistsAsync(string repoUri);
+
+        /// <summary>
+        /// Create a new branch in a repository
+        /// </summary>
+        /// <param name="repoUri">Repo to create a branch in</param>
+        /// <param name="newBranch">New branch name</param>
+        /// <param name="baseBranch">Base of new branch</param>
+        Task CreateBranchAsync(string repoUri, string newBranch, string baseBranch);
+
+        /// <summary>
+        /// Delete a branch from a repository
+        /// </summary>
+        /// <param name="repoUri">Repository where the branch lives</param>
+        /// <param name="branch">The branch to delete</param>
+        Task DeleteBranchAsync(string repoUri, string branch);
+
+        /// <summary>
+        ///     Search pull requests matching the specified criteria
+        /// </summary>
+        /// <param name="repoUri">URI of repo containing the pull request</param>
+        /// <param name="pullRequestBranch">Source branch for PR</param>
+        /// <param name="status">Current PR status</param>
+        /// <param name="keyword">Keyword</param>
+        /// <param name="author">Author</param>
+        /// <returns>List of pull requests matching the specified criteria</returns>
+        Task<IEnumerable<int>> SearchPullRequestsAsync(
+            string repoUri,
+            string pullRequestBranch,
+            PrStatus status,
+            string keyword = null,
+            string author = null);
+
+        /// <summary>
+        /// Get the status of a pull request
+        /// </summary>
+        /// <param name="pullRequestUrl">URI of pull request</param>
+        /// <returns>Pull request status</returns>
+        Task<PrStatus> GetPullRequestStatusAsync(string pullRequestUrl);
+
+        /// <summary>
+        ///     Retrieve information on a specific pull request
+        /// </summary>
+        /// <param name="pullRequestUrl">Uri of the pull request</param>
+        /// <returns>Information on the pull request.</returns>
+        Task<PullRequest> GetPullRequestAsync(string pullRequestUrl);
+
+        /// <summary>
+        ///     Retrieve information on commits of a specific pull request
+        /// </summary>
+        /// <param name="pullRequestUrl">Uri of the pull request</param>
+        /// <returns>Information on the pull request.</returns>
+        Task<IList<Commit>> GetPullRequestCommitsAsync(string pullRequestUrl );
+
+        /// <summary>
+        ///     Create a new pull request for a repository
+        /// </summary>
+        /// <param name="repoUri">Repo to create the pull request for.</param>
+        /// <param name="pullRequest">Pull request data</param>
+        /// <returns></returns>
+        Task<string> CreatePullRequestAsync(string repoUri, PullRequest pullRequest);
+
+        /// <summary>
+        ///     Update a pull request with new information
+        /// </summary>
+        /// <param name="pullRequestUri">Uri of pull request to update</param>
+        /// <param name="pullRequest">Pull request info to update</param>
+        /// <returns></returns>
+        Task UpdatePullRequestAsync(string pullRequestUri, PullRequest pullRequest);
+
+
+        /// <summary>
+        ///     Merges a Dependency update pull request
+        /// </summary>
+        /// <param name="pullRequestUrl">Uri of pull request to merge</param>
+        /// <param name="parameters">Settings for merge</param>
+        /// <param name="mergeCommitMessage">Commit message used to merge the pull request</param>
+        /// <returns></returns>
+        Task MergeDependencyPullRequestAsync(string pullRequestUrl, MergePullRequestParameters parameters, string mergeCommitMessage);
+
+        /// <summary>
+        ///     Create new check(s), update them with a new status,
+        ///     or remove each merge policy check that isn't in evaluations
+        /// </summary>
+        /// <param name="pullRequestUrl">Url of pull request</param>
+        /// <param name="evalutations">List of merge policies</param>
+        Task CreateOrUpdatePullRequestMergeStatusInfoAsync(string pullRequestUrl, IReadOnlyList<MergePolicyEvaluationResult> evaluations);
+
+        /// <summary>
+        ///     Get the latest commit in a repo on the specific branch 
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <param name="branch">Branch to retrieve the latest sha for</param>
+        /// <returns>Latest sha.  Null if no commits were found.</returns>
+        Task<string> GetLastCommitShaAsync(string repoUri, string branch);
+
+        /// <summary>
+        ///     Get a commit in a repo 
+        /// </summary>
+        /// <param name="repoUri">Repository URI</param>
+        /// <param name="sha">Sha of the commit</param>
+        /// <returns>Return the commit matching the specified sha. Null if no commit were found.</returns>
+        Task<Commit> GetCommitAsync(string repoUri, string sha);
+
+        /// <summary>
+        /// Gets a list of file under a given path in a given revision.
+        /// </summary>
+        Task<List<GitFile>> GetFilesAtCommitAsync(string repoUri, string commit, string path);
+
+        /// <summary>
+        /// Retrieve the list of status checks on a PR.
+        /// </summary>
+        /// <param name="pullRequestUrl">Uri of pull request</param>
+        /// <returns>List of status checks.</returns>
+        Task<IList<Check>> GetPullRequestChecksAsync(string pullRequestUrl);
+
+        /// <summary>
+        /// Retrieve the list of reviews on a PR.
+        /// </summary>
+        /// <param name="pullRequestUrl">Uri of pull request</param>
+        /// <returns>List of pull request reviews.</returns>
+        Task<IList<Review>> GetLatestPullRequestReviewsAsync(string pullRequestUrl);
+
+        /// <summary>
+        ///     Diff two commits in a repository and return information about them.
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <param name="baseVersion">Base version</param>
+        /// <param name="targetVersion">Target version</param>
+        /// <returns>Diff information</returns>
+        Task<GitDiff> GitDiffAsync(string repoUri, string baseVersion, string targetVersion);
+
+        /// <summary>
+        ///     Clone a remote repository.
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <param name="commit">Branch, commit, or tag to checkout</param>
+        /// <param name="targetDirectory">Directory to clone to</param>
+        /// <param name="checkoutSubmodules">Indicates whether submodules should be checked out as well</param>
+        /// <param name="gitDirectory">Location for .git directory, or null for default</param>
+        void Clone(string repoUri, string commit, string targetDirectory, bool checkoutSubmodules, string gitDirectory = null);
+
+        /// <summary>
+        ///     Delete a pull request's branch if it still exists
+        /// </summary>
+        /// <param name="pullRequestUri"></param>
+        /// <returns>Async task</returns>
+        Task DeletePullRequestBranchAsync(string pullRequestUri);
+    }
+
+    public class PullRequest
+    {
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public string BaseBranch { get; set; }
+        public string HeadBranch { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -37,11 +37,11 @@ namespace Microsoft.DotNet.DarcLib
                 string parentTwoDirectoriesUp = Path.GetDirectoryName(Path.GetDirectoryName(fullPath));
                 if (Directory.Exists(parentTwoDirectoriesUp))
                 {
-                    throw new DependencyFileNotFoundException("Found parent-directory path ('{parentTwoDirectoriesUp}') but unable to find specified file ('{relativeFilePath}')");
+                    throw new DependencyFileNotFoundException($"Found parent-directory path ('{parentTwoDirectoriesUp}') but unable to find specified file ('{relativeFilePath}')");
                 }
                 else
                 {
-                    throw new InvalidOperationException("Neither parent-directory path ('{parentTwoDirectoriesUp}') nor specified file ('{relativeFilePath}') found.");
+                    throw new InvalidOperationException($"Neither parent-directory path ('{parentTwoDirectoriesUp}') nor specified file ('{relativeFilePath}') found.");
                 }
             }
 

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
@@ -979,7 +979,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> gitRepoMock = new Mock<IRemoteGitRepo>();
             Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
@@ -1050,7 +1050,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> gitRepoMock = new Mock<IRemoteGitRepo>();
             Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
@@ -1119,7 +1119,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> gitRepoMock = new Mock<IRemoteGitRepo>();
             Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
@@ -1192,7 +1192,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> gitRepoMock = new Mock<IRemoteGitRepo>();
             Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
@@ -1266,7 +1266,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> gitRepoMock = new Mock<IRemoteGitRepo>();
             Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
@@ -1382,7 +1382,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> gitRepoMock = new Mock<IRemoteGitRepo>();
             Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
@@ -1500,7 +1500,7 @@ namespace Microsoft.DotNet.Darc.Tests
             barClientMock.Setup(m => m.GetBuildsAsync(repo, commit)).ReturnsAsync(new List<Build> { build });
         }
 
-        private void RepositoryHasFeeds(Mock<IGitRepo> barClientMock,
+        private void RepositoryHasFeeds(Mock<IRemoteGitRepo> barClientMock,
             string repo, string commit, string[] feeds)
         {
             const string baseNugetConfig = @"<?xml version=""1.0"" encoding=""utf - 8""?>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.DarcLib.Tests
         [Test]
         public async Task ValidateCommitMessageTest()
         {
-            Mock<IGitRepo> client = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> client = new Mock<IRemoteGitRepo>();
             Mock<IBarClient> barClient = new Mock<IBarClient>();
             MergePullRequestParameters mergePullRequest = new MergePullRequestParameters
             {


### PR DESCRIPTION
This is another attempt at refactoring out the `ILocalGitRepo` interface after the previous change was reverted (https://github.com/dotnet/arcade-services/pull/2030).

This change is much less invasive and tackles the problem in a better way than before. I have already ran the scenario tests locally and they pass.

#### This change:
- is a first step in untangling the `Remote` class and removes following inheritance `IGitRepo : ILocalGitRepo`,
- adds the ability to use and extend `ILocalGitRepo` with functionality tied to local `.git` folders which will be needed in the VMR later,
- adds the capability to list git submodules to `ILocalGitRepo`,
- removes some dead code.

#### TLDR
This change removes following inheritance `IGitRepo : ILocalGitRepo`. It then splits `IGitRepo` into `IGitRemoteRepo` and `IGitRepo`. `IGitRepo` is then re-used in `ILocalGitRepo`.
The outcome is that `GitHubClient` and `AzDOGitClient` implement `IGitRemoteRepo` which also makes more sense from the naming perspective.

#### Problems this solves:
- Many implementations of `IGitRepo` that had to implement `ILocalGitRepo` too had `throw new NotImplemented..`.
- The only method used from `ILocalGitRepo` via `IGitRepo` was `GetFilesAtCommitAsync` whose implementation in `ILocalGitRepo` didn't make sense - it accepted URI and SHA but didn't use either, just listed files in a folder. It only was used in one place though `Local.cs` so I moved it there
- I removed a lot of dead code (`ILocalGitRepo` methods on `IGitRepo` classes that are not used).
- I removed some dead code in unit tests which was setting up things that were not used in the tests.

The largest weirdness that I haven't dealt with so far comes from `RemoteFactory` implementations where we supply `null` instead of `IGitRepo` often. In those cases, we supply the `ILocalGitRepo` as `null` too, not breaking anything. For instance, we have things like "BAR only client" that only has the `BarClient` set inside `Remote` and this will obviously break if we try to invoke any of the non-bar methods but this is not changed in this PR.