### PR TITLE
Add a custom compact console formatter to darc CLI

### DIFF
--- a/src/Maestro/Maestro.DataProviders/DarcRemoteFactory.cs
+++ b/src/Maestro/Maestro.DataProviders/DarcRemoteFactory.cs
@@ -62,7 +62,7 @@ namespace Maestro.DataProviders
                 string normalizedUrl = AzureDevOpsClient.NormalizeUrl(repoUrl);
                 Uri normalizedRepoUri = new Uri(normalizedUrl);
 
-                IGitRepo gitClient;
+                IRemoteGitRepo gitClient;
 
                 long installationId = await Context.GetInstallationId(normalizedUrl);
 

--- a/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
+++ b/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
@@ -76,7 +76,7 @@ namespace SubscriptionActorService
                 {
                     temporaryRepositoryRoot = _tempFiles.GetFilePath("repos");
                 }
-                IGitRepo gitClient;
+                IRemoteGitRepo gitClient;
 
                 long installationId = await _context.GetInstallationId(normalizedUrl);
 

--- a/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/src/Maestro/tests/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -23,7 +23,7 @@ namespace SubscriptionActorService.Tests
     public class PullRequestPolicyFailureNotifierTests
     {
         protected Mock<IBarClient> BarClient;
-        protected Mock<IGitRepo> GitRepo;
+        protected Mock<IRemoteGitRepo> GitRepo;
         protected Mock<IRemoteFactory> RemoteFactory;
         protected Mock<IHostEnvironment> Env;
         protected Mock<Octokit.IGitHubClient> GithubClient;
@@ -73,7 +73,7 @@ namespace SubscriptionActorService.Tests
                               select subscription).FirstOrDefault());
                      });
 
-            GitRepo = new Mock<IGitRepo>(MockBehavior.Strict);
+            GitRepo = new Mock<IRemoteGitRepo>(MockBehavior.Strict);
             GitRepo.Setup(g => g.GetPullRequestChecksAsync(It.IsAny<string>()))
                    .Returns((string fakePrsUrl) =>
                    {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/RemoteFactory.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Darc.Helpers
                 temporaryRepositoryRoot = Path.GetTempPath();
             }
 
-            IGitRepo gitClient = null;
+            IRemoteGitRepo gitClient = null;
             if (darcSettings.GitType == GitRepoType.GitHub)
             {
                 gitClient = new GitHubClient(options.GitLocation, darcSettings.GitRepoPersonalAccessToken,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -890,7 +890,7 @@ This pull request has not been merged because Maestro++ is waiting on the follow
         /// <param name="input">String that must have 'shouldEndWith' at the end.</param>
         /// <param name="shouldEndWith">Character that must be present at end of 'input' string.</param>
         /// <returns>Input string appended with 'shouldEndWith'</returns>
-        private string EnsureEndsWith(string input, char shouldEndWith)
+        private static string EnsureEndsWith(string input, char shouldEndWith)
         {
             if (input == null) return null;
 
@@ -940,18 +940,6 @@ This pull request has not been merged because Maestro++ is waiting on the follow
             Uri accountUri = new Uri($"https://dev.azure.com/{accountName}");
             var creds = new VssCredentials(new VssBasicCredential("", _personalAccessToken));
             return new VssConnection(accountUri, creds);
-        }
-
-        private (int threadId, int commentId) ParseCommentId(string commentId)
-        {
-            string[] parts = commentId.Split('-');
-            if (parts.Length != 2 || int.TryParse(parts[0], out int threadId) ||
-                int.TryParse(parts[1], out int commentIdValue))
-            {
-                throw new ArgumentException("The comment id '{commentId}' is in an invalid format", nameof(commentId));
-            }
-
-            return (threadId, commentIdValue);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -23,7 +23,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.DotNet.DarcLib
 {
-    public class AzureDevOpsClient : RemoteRepoBase, IGitRepo, IAzureDevOpsClient
+    public class AzureDevOpsClient : RemoteRepoBase, IRemoteGitRepo, IAzureDevOpsClient
     {
         private const string DefaultApiVersion = "5.0";
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -86,7 +87,7 @@ namespace Microsoft.DotNet.DarcLib
                     List<GitFile> engCommonFiles = await arcadeRemote.GetCommonScriptFilesAsync(arcadeItem.RepoUri, arcadeItem.Commit);
                     filesToUpdate.AddRange(engCommonFiles);
 
-                    List<GitFile> localEngCommonFiles = await _gitClient.GetFilesAtCommitAsync(null, null, "eng/common");
+                    List<GitFile> localEngCommonFiles = GetFilesAtRelativeRepoPathAsync("eng/common");
 
                     foreach (GitFile file in localEngCommonFiles)
                     {
@@ -164,6 +165,18 @@ namespace Microsoft.DotNet.DarcLib
         public void AddRemoteIfMissing(string repoDir, string repoUrl)
         {
             _gitClient.AddRemoteIfMissing(repoDir, repoUrl);
+        }
+
+        private List<GitFile> GetFilesAtRelativeRepoPathAsync(string path)
+        {
+            string repoDir = LocalHelpers.GetRootDir(GitExecutable, _logger);
+            string sourceFolder = Path.Combine(repoDir, path);
+            var files = Directory.GetFiles(sourceFolder, "*.*", SearchOption.AllDirectories);
+            return files
+                .Select(file => new GitFile(
+                    file.Remove(0, repoDir.Length + 1).Replace("\\", "/"),
+                    File.ReadAllText(file)))
+                .ToList();
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.DarcLib
         private readonly IBarClient _barClient;
         private readonly IVersionDetailsParser _versionDetailsParser;
         private readonly GitFileManager _fileManager;
-        private readonly IGitRepo _gitClient;
+        private readonly IRemoteGitRepo _gitClient;
         private readonly ILogger _logger;
 
         //[DependencyUpdate]: <> (Begin)
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.DarcLib
         private static readonly Regex DependencyUpdatesPattern =
             new Regex(@"\[DependencyUpdate\]: <> \(Begin\)([^\[]+)\[DependencyUpdate\]: <> \(End\)");
 
-        public Remote(IGitRepo gitClient, IBarClient barClient, IVersionDetailsParser versionDetailsParser, ILogger logger)
+        public Remote(IRemoteGitRepo gitClient, IBarClient barClient, IVersionDetailsParser versionDetailsParser, ILogger logger)
         {
             _logger = logger;
             _barClient = barClient;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Commit.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Commit.cs
@@ -16,5 +16,7 @@ namespace Microsoft.DotNet.DarcLib
         public string Author { get; }
         public string Sha { get; }
         public string Message { get; }
+
+        public static string GetShortSha(string commitSha) => commitSha[..7];
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -69,20 +69,6 @@ namespace Microsoft.DotNet.DarcLib
 
         public bool AllowRetries { get; set; } = true;
 
-
-        /// <summary>
-        ///     Add a comment to the discussion of an existing pull request or issue (the APIs are the same)
-        /// </summary>
-        /// <param name="repoUri">Repository URI</param>
-        /// <param name="issueNumber">Issue or PR id</param>
-        /// <param name="message">Contents of the message (ideally in markdown format)</param>
-        public async Task AddIssueComment(string repoUri, int issueNumber, string message)
-        {
-            (string owner, string repo) = ParseRepoUri(repoUri);
-            await Client.Issue.Comment.Create(owner, repo, issueNumber, message);
-        }
-
-
         /// <summary>
         ///     Retrieve the contents of a repository file as a string
         /// </summary>
@@ -1071,7 +1057,7 @@ namespace Microsoft.DotNet.DarcLib
             }
         }
 
-        public async Task GetCommitMapForPathAsync(
+        private async Task GetCommitMapForPathAsync(
             string repoUri,
             string branch,
             string assetsProducedInCommit,
@@ -1230,25 +1216,6 @@ namespace Microsoft.DotNet.DarcLib
         public void Clone(string repoUri, string commit, string targetDirectory, bool checkoutSubmodules, string gitDirectory = null)
         {
             Clone(repoUri, commit, targetDirectory, checkoutSubmodules, _logger, _personalAccessToken, gitDirectory);
-        }
-
-        /// <summary>
-        ///     Does not apply to remote repositories.
-        /// </summary>
-        /// <param name="commit">Ignored</param>
-        public void Checkout(string repoPath, string commit, bool force)
-        {
-            throw new NotImplementedException($"Cannot checkout a remote repo.");
-        }
-
-        /// <summary>
-        ///     Does not apply to remote repositories.
-        /// </summary>
-        /// <param name="repoDir">Ignored</param>
-        /// <param name="repoUrl">Ignored</param>
-        public void AddRemoteIfMissing(string repoDir, string repoUrl)
-        {
-            throw new NotImplementedException($"Cannot add a remote to a remote repo.");
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -24,7 +24,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.DotNet.DarcLib
 {
-    public class GitHubClient : RemoteRepoBase, IGitRepo
+    public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
     {
         private const string GitHubApiUri = "https://api.github.com";
         private const string DarcLibVersion = "1.0.0";

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitSubmoduleInfo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitSubmoduleInfo.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib;
+
+public record GitSubmoduleInfo(
+    string Name,
+    string Path,
+    string Url,
+    string Commit);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitSubmoduleInfo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitSubmoduleInfo.cs
@@ -3,10 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
-namespace Microsoft.DotNet.DarcLib;
-
-public record GitSubmoduleInfo(
-    string Name,
-    string Path,
-    string Url,
-    string Commit);
+namespace Microsoft.DotNet.DarcLib
+{
+    public record GitSubmoduleInfo(
+        string Name,
+        string Path,
+        string Url,
+        string Commit);
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.DarcLib
 {
     public class GitFileManager
     {
-        private readonly ILocalGitRepo _gitClient;
+        private readonly IGitRepo _gitClient;
         private readonly IVersionDetailsParser _versionDetailsParser;
         private readonly ILogger _logger;
 
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.DarcLib
         private const string MaestroRepoSpecificBeginComment = "  Begin: Package sources from";
         private const string MaestroRepoSpecificEndComment = "  End: Package sources from";
 
-        public GitFileManager(ILocalGitRepo gitRepo, IVersionDetailsParser versionDetailsParser, ILogger logger)
+        public GitFileManager(IGitRepo gitRepo, IVersionDetailsParser versionDetailsParser, ILogger logger)
         {
             _gitClient = gitRepo;
             _versionDetailsParser = versionDetailsParser;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.DarcLib
 {
-    public interface IGitRepo : ILocalGitRepo
+    public interface IGitRepo
     {
         /// <summary>
         /// Specifies whether functions with a retry field should employ retries
@@ -125,6 +125,29 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns>Return the commit matching the specified sha. Null if no commit were found.</returns>
         Task<Commit> GetCommitAsync(string repoUri, string sha);
 
+        /// <summary>
+        ///     Retrieve the contents of a repository file as a string
+        /// </summary>
+        /// <param name="filePath">Path to file</param>
+        /// <param name="repoUri">Repository URI</param>
+        /// <param name="branch">Branch to get file contents from</param>
+        /// <returns>File contents or throws on file not found.</returns>
+        Task<string> GetFileContentsAsync(string filePath, string repoUri, string branch);
+
+        /// <summary>
+        /// Gets a list of file under a given path in a given revision.
+        /// </summary>
+        Task<List<GitFile>> GetFilesAtCommitAsync(string repoUri, string commit, string path);
+
+        /// <summary>
+        ///     Commit or update a set of files to a repo
+        /// </summary>
+        /// <param name="filesToCommit">Files to comit</param>
+        /// <param name="repoUri">Remote repository URI</param>
+        /// <param name="branch">Branch to push to</param>
+        /// <param name="commitMessage">Commit message</param>
+        /// <returns></returns>
+        Task CommitFilesAsync(List<GitFile> filesToCommit, string repoUri, string branch, string commitMessage);
 
         /// <summary>
         /// Retrieve the list of status checks on a PR.

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepo.cs
@@ -1,8 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Maestro.Contracts;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -10,121 +9,6 @@ namespace Microsoft.DotNet.DarcLib
 {
     public interface IGitRepo
     {
-        /// <summary>
-        /// Specifies whether functions with a retry field should employ retries
-        /// Should default to true
-        /// </summary>
-        public bool AllowRetries { get; set; }
-
-        /// <summary>
-        /// Checks that a repository exists
-        /// </summary>
-        /// <param name="repoUri">Repository uri</param>
-        /// <returns>True if the repository exists, false otherwise.</returns>
-        Task<bool> RepoExistsAsync(string repoUri);
-
-        /// <summary>
-        /// Create a new branch in a repository
-        /// </summary>
-        /// <param name="repoUri">Repo to create a branch in</param>
-        /// <param name="newBranch">New branch name</param>
-        /// <param name="baseBranch">Base of new branch</param>
-        Task CreateBranchAsync(string repoUri, string newBranch, string baseBranch);
-
-        /// <summary>
-        /// Delete a branch from a repository
-        /// </summary>
-        /// <param name="repoUri">Repository where the branch lives</param>
-        /// <param name="branch">The branch to delete</param>
-        Task DeleteBranchAsync(string repoUri, string branch);
-
-        /// <summary>
-        ///     Search pull requests matching the specified criteria
-        /// </summary>
-        /// <param name="repoUri">URI of repo containing the pull request</param>
-        /// <param name="pullRequestBranch">Source branch for PR</param>
-        /// <param name="status">Current PR status</param>
-        /// <param name="keyword">Keyword</param>
-        /// <param name="author">Author</param>
-        /// <returns>List of pull requests matching the specified criteria</returns>
-        Task<IEnumerable<int>> SearchPullRequestsAsync(
-            string repoUri,
-            string pullRequestBranch,
-            PrStatus status,
-            string keyword = null,
-            string author = null);
-
-        /// <summary>
-        /// Get the status of a pull request
-        /// </summary>
-        /// <param name="pullRequestUrl">URI of pull request</param>
-        /// <returns>Pull request status</returns>
-        Task<PrStatus> GetPullRequestStatusAsync(string pullRequestUrl);
-
-        /// <summary>
-        ///     Retrieve information on a specific pull request
-        /// </summary>
-        /// <param name="pullRequestUrl">Uri of the pull request</param>
-        /// <returns>Information on the pull request.</returns>
-        Task<PullRequest> GetPullRequestAsync(string pullRequestUrl);
-
-        /// <summary>
-        ///     Retrieve information on commits of a specific pull request
-        /// </summary>
-        /// <param name="pullRequestUrl">Uri of the pull request</param>
-        /// <returns>Information on the pull request.</returns>
-        Task<IList<Commit>> GetPullRequestCommitsAsync(string pullRequestUrl );
-
-        /// <summary>
-        ///     Create a new pull request for a repository
-        /// </summary>
-        /// <param name="repoUri">Repo to create the pull request for.</param>
-        /// <param name="pullRequest">Pull request data</param>
-        /// <returns></returns>
-        Task<string> CreatePullRequestAsync(string repoUri, PullRequest pullRequest);
-
-        /// <summary>
-        ///     Update a pull request with new information
-        /// </summary>
-        /// <param name="pullRequestUri">Uri of pull request to update</param>
-        /// <param name="pullRequest">Pull request info to update</param>
-        /// <returns></returns>
-        Task UpdatePullRequestAsync(string pullRequestUri, PullRequest pullRequest);
-
-
-        /// <summary>
-        ///     Merges a Dependency update pull request
-        /// </summary>
-        /// <param name="pullRequestUrl">Uri of pull request to merge</param>
-        /// <param name="parameters">Settings for merge</param>
-        /// <param name="mergeCommitMessage">Commit message used to merge the pull request</param>
-        /// <returns></returns>
-        Task MergeDependencyPullRequestAsync(string pullRequestUrl, MergePullRequestParameters parameters, string mergeCommitMessage);
-
-        /// <summary>
-        ///     Create new check(s), update them with a new status,
-        ///     or remove each merge policy check that isn't in evaluations
-        /// </summary>
-        /// <param name="pullRequestUrl">Url of pull request</param>
-        /// <param name="evalutations">List of merge policies</param>
-        Task CreateOrUpdatePullRequestMergeStatusInfoAsync(string pullRequestUrl, IReadOnlyList<MergePolicyEvaluationResult> evaluations);
-
-        /// <summary>
-        ///     Get the latest commit in a repo on the specific branch 
-        /// </summary>
-        /// <param name="repoUri">Repository uri</param>
-        /// <param name="branch">Branch to retrieve the latest sha for</param>
-        /// <returns>Latest sha.  Null if no commits were found.</returns>
-        Task<string> GetLastCommitShaAsync(string repoUri, string branch);
-
-        /// <summary>
-        ///     Get a commit in a repo 
-        /// </summary>
-        /// <param name="repoUri">Repository URI</param>
-        /// <param name="sha">Sha of the commit</param>
-        /// <returns>Return the commit matching the specified sha. Null if no commit were found.</returns>
-        Task<Commit> GetCommitAsync(string repoUri, string sha);
-
         /// <summary>
         ///     Retrieve the contents of a repository file as a string
         /// </summary>
@@ -135,11 +19,6 @@ namespace Microsoft.DotNet.DarcLib
         Task<string> GetFileContentsAsync(string filePath, string repoUri, string branch);
 
         /// <summary>
-        /// Gets a list of file under a given path in a given revision.
-        /// </summary>
-        Task<List<GitFile>> GetFilesAtCommitAsync(string repoUri, string commit, string path);
-
-        /// <summary>
         ///     Commit or update a set of files to a repo
         /// </summary>
         /// <param name="filesToCommit">Files to comit</param>
@@ -148,53 +27,5 @@ namespace Microsoft.DotNet.DarcLib
         /// <param name="commitMessage">Commit message</param>
         /// <returns></returns>
         Task CommitFilesAsync(List<GitFile> filesToCommit, string repoUri, string branch, string commitMessage);
-
-        /// <summary>
-        /// Retrieve the list of status checks on a PR.
-        /// </summary>
-        /// <param name="pullRequestUrl">Uri of pull request</param>
-        /// <returns>List of status checks.</returns>
-        Task<IList<Check>> GetPullRequestChecksAsync(string pullRequestUrl);
-
-        /// <summary>
-        /// Retrieve the list of reviews on a PR.
-        /// </summary>
-        /// <param name="pullRequestUrl">Uri of pull request</param>
-        /// <returns>List of pull request reviews.</returns>
-        Task<IList<Review>> GetLatestPullRequestReviewsAsync(string pullRequestUrl);
-
-        /// <summary>
-        ///     Diff two commits in a repository and return information about them.
-        /// </summary>
-        /// <param name="repoUri">Repository uri</param>
-        /// <param name="baseVersion">Base version</param>
-        /// <param name="targetVersion">Target version</param>
-        /// <returns>Diff information</returns>
-        Task<GitDiff> GitDiffAsync(string repoUri, string baseVersion, string targetVersion);
-
-        /// <summary>
-        ///     Clone a remote repository.
-        /// </summary>
-        /// <param name="repoUri">Repository uri</param>
-        /// <param name="commit">Branch, commit, or tag to checkout</param>
-        /// <param name="targetDirectory">Directory to clone to</param>
-        /// <param name="checkoutSubmodules">Indicates whether submodules should be checked out as well</param>
-        /// <param name="gitDirectory">Location for .git directory, or null for default</param>
-        void Clone(string repoUri, string commit, string targetDirectory, bool checkoutSubmodules, string gitDirectory = null);
-
-        /// <summary>
-        ///     Delete a pull request's branch if it still exists
-        /// </summary>
-        /// <param name="pullRequestUri"></param>
-        /// <returns>Async task</returns>
-        Task DeletePullRequestBranchAsync(string pullRequestUri);
-    }
-
-    public class PullRequest
-    {
-        public string Title { get; set; }
-        public string Description { get; set; }
-        public string BaseBranch { get; set; }
-        public string HeadBranch { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoExtension.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoExtension.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.DarcLib
 {
     public static class IGitRepoExtension
     {
-        public static string GetDecodedContent(this IGitRepo gitRepo, string encodedContent)
+        public static string GetDecodedContent(this IRemoteGitRepo gitRepo, string encodedContent)
         {
             try
             {
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.DarcLib
             }
         }
 
-        public static byte[] GetContentBytes(this IGitRepo gitRepo, string content)
+        public static byte[] GetContentBytes(this IRemoteGitRepo gitRepo, string content)
         {
             string decodedContent = GetDecodedContent(gitRepo, content);
             return Encoding.UTF8.GetBytes(decodedContent);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
@@ -3,11 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.DarcLib
 {
-    public interface ILocalGitRepo
+    public interface ILocalGitRepo : IGitRepo
     {
         /// <summary>
         ///     Add a remote to a local repo if does not already exist, and attempt to fetch commits.
@@ -19,17 +18,6 @@ namespace Microsoft.DotNet.DarcLib
         /// </summary>
         /// <param name="commit">Tag, branch, or commit to checkout.</param>
         void Checkout(string repoDir, string commit, bool force = false);
-
-        /// <summary>
-        ///     Updates local copies of the files.
-        /// </summary>
-        /// <param name="filesToCommit">Files to update locally</param>
-        /// <param name="repoDir">Base path of the repo</param>
-        /// <param name="branch">Unused</param>
-        /// <param name="commitMessage">Unused</param>
-        Task CommitFilesAsync(List<GitFile> filesToCommit, string repoDir, string branch, string commitMessage);
-
-        Task<string> GetFileContentsAsync(string relativeFilePath, string repoDir, string branch);
 
         /// <summary>
         /// Parses the .gitmodule file and retrieves a list of git submodules registered in a given repository.

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.DarcLib
         void Checkout(string repoDir, string commit, bool force = false);
 
         /// <summary>
-        /// Parses the .gitmodule file and retrieves a list of git submodules registered in a given repository.
+        /// Returns a list of git submodules registered in a given repository.
         /// </summary>
         /// <param name="repoDir">Path to a git repository</param>
         /// <param name="commit">Which commit the info is retrieved for</param>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
@@ -24,13 +24,18 @@ namespace Microsoft.DotNet.DarcLib
         ///     Updates local copies of the files.
         /// </summary>
         /// <param name="filesToCommit">Files to update locally</param>
-        /// <param name="repoUri">Base path of the repo</param>
+        /// <param name="repoDir">Base path of the repo</param>
         /// <param name="branch">Unused</param>
         /// <param name="commitMessage">Unused</param>
-        Task CommitFilesAsync(List<GitFile> filesToCommit, string repoUri, string branch, string commitMessage);
+        Task CommitFilesAsync(List<GitFile> filesToCommit, string repoDir, string branch, string commitMessage);
 
-        Task<string> GetFileContentsAsync(string relativeFilePath, string repoUri, string branch);
+        Task<string> GetFileContentsAsync(string relativeFilePath, string repoDir, string branch);
 
-        Task<List<GitFile>> GetFilesAtCommitAsync(string repoUri, string commit, string path);
+        /// <summary>
+        /// Parses the .gitmodule file and retrieves a list of git submodules registered in a given repository.
+        /// </summary>
+        /// <param name="repoDir">Path to a git repository</param>
+        /// <param name="commit">Which commit the info is retrieved for</param>
+        List<GitSubmoduleInfo> GetGitSubmodules(string repoDir, string commit);
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemoteGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemoteGitRepo.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.DarcLib
         /// Specifies whether functions with a retry field should employ retries
         /// Should default to true
         /// </summary>
-        public bool AllowRetries { get; set; }
+        bool AllowRetries { get; set; }
 
         /// <summary>
         /// Checks that a repository exists

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemoteGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemoteGitRepo.cs
@@ -1,0 +1,181 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Maestro.Contracts;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.DarcLib
+{
+    public interface IRemoteGitRepo : IGitRepo
+    {
+        /// <summary>
+        /// Specifies whether functions with a retry field should employ retries
+        /// Should default to true
+        /// </summary>
+        public bool AllowRetries { get; set; }
+
+        /// <summary>
+        /// Checks that a repository exists
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <returns>True if the repository exists, false otherwise.</returns>
+        Task<bool> RepoExistsAsync(string repoUri);
+
+        /// <summary>
+        /// Create a new branch in a repository
+        /// </summary>
+        /// <param name="repoUri">Repo to create a branch in</param>
+        /// <param name="newBranch">New branch name</param>
+        /// <param name="baseBranch">Base of new branch</param>
+        Task CreateBranchAsync(string repoUri, string newBranch, string baseBranch);
+
+        /// <summary>
+        /// Delete a branch from a repository
+        /// </summary>
+        /// <param name="repoUri">Repository where the branch lives</param>
+        /// <param name="branch">The branch to delete</param>
+        Task DeleteBranchAsync(string repoUri, string branch);
+
+        /// <summary>
+        ///     Search pull requests matching the specified criteria
+        /// </summary>
+        /// <param name="repoUri">URI of repo containing the pull request</param>
+        /// <param name="pullRequestBranch">Source branch for PR</param>
+        /// <param name="status">Current PR status</param>
+        /// <param name="keyword">Keyword</param>
+        /// <param name="author">Author</param>
+        /// <returns>List of pull requests matching the specified criteria</returns>
+        Task<IEnumerable<int>> SearchPullRequestsAsync(
+            string repoUri,
+            string pullRequestBranch,
+            PrStatus status,
+            string keyword = null,
+            string author = null);
+
+        /// <summary>
+        /// Get the status of a pull request
+        /// </summary>
+        /// <param name="pullRequestUrl">URI of pull request</param>
+        /// <returns>Pull request status</returns>
+        Task<PrStatus> GetPullRequestStatusAsync(string pullRequestUrl);
+
+        /// <summary>
+        ///     Retrieve information on a specific pull request
+        /// </summary>
+        /// <param name="pullRequestUrl">Uri of the pull request</param>
+        /// <returns>Information on the pull request.</returns>
+        Task<PullRequest> GetPullRequestAsync(string pullRequestUrl);
+
+        /// <summary>
+        ///     Retrieve information on commits of a specific pull request
+        /// </summary>
+        /// <param name="pullRequestUrl">Uri of the pull request</param>
+        /// <returns>Information on the pull request.</returns>
+        Task<IList<Commit>> GetPullRequestCommitsAsync(string pullRequestUrl );
+
+        /// <summary>
+        ///     Create a new pull request for a repository
+        /// </summary>
+        /// <param name="repoUri">Repo to create the pull request for.</param>
+        /// <param name="pullRequest">Pull request data</param>
+        /// <returns></returns>
+        Task<string> CreatePullRequestAsync(string repoUri, PullRequest pullRequest);
+
+        /// <summary>
+        ///     Update a pull request with new information
+        /// </summary>
+        /// <param name="pullRequestUri">Uri of pull request to update</param>
+        /// <param name="pullRequest">Pull request info to update</param>
+        /// <returns></returns>
+        Task UpdatePullRequestAsync(string pullRequestUri, PullRequest pullRequest);
+
+
+        /// <summary>
+        ///     Merges a Dependency update pull request
+        /// </summary>
+        /// <param name="pullRequestUrl">Uri of pull request to merge</param>
+        /// <param name="parameters">Settings for merge</param>
+        /// <param name="mergeCommitMessage">Commit message used to merge the pull request</param>
+        /// <returns></returns>
+        Task MergeDependencyPullRequestAsync(string pullRequestUrl, MergePullRequestParameters parameters, string mergeCommitMessage);
+
+        /// <summary>
+        ///     Create new check(s), update them with a new status,
+        ///     or remove each merge policy check that isn't in evaluations
+        /// </summary>
+        /// <param name="pullRequestUrl">Url of pull request</param>
+        /// <param name="evalutations">List of merge policies</param>
+        Task CreateOrUpdatePullRequestMergeStatusInfoAsync(string pullRequestUrl, IReadOnlyList<MergePolicyEvaluationResult> evaluations);
+
+        /// <summary>
+        ///     Get the latest commit in a repo on the specific branch 
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <param name="branch">Branch to retrieve the latest sha for</param>
+        /// <returns>Latest sha.  Null if no commits were found.</returns>
+        Task<string> GetLastCommitShaAsync(string repoUri, string branch);
+
+        /// <summary>
+        ///     Get a commit in a repo 
+        /// </summary>
+        /// <param name="repoUri">Repository URI</param>
+        /// <param name="sha">Sha of the commit</param>
+        /// <returns>Return the commit matching the specified sha. Null if no commit were found.</returns>
+        Task<Commit> GetCommitAsync(string repoUri, string sha);
+
+        /// <summary>
+        /// Gets a list of file under a given path in a given revision.
+        /// </summary>
+        Task<List<GitFile>> GetFilesAtCommitAsync(string repoUri, string commit, string path);
+
+        /// <summary>
+        /// Retrieve the list of status checks on a PR.
+        /// </summary>
+        /// <param name="pullRequestUrl">Uri of pull request</param>
+        /// <returns>List of status checks.</returns>
+        Task<IList<Check>> GetPullRequestChecksAsync(string pullRequestUrl);
+
+        /// <summary>
+        /// Retrieve the list of reviews on a PR.
+        /// </summary>
+        /// <param name="pullRequestUrl">Uri of pull request</param>
+        /// <returns>List of pull request reviews.</returns>
+        Task<IList<Review>> GetLatestPullRequestReviewsAsync(string pullRequestUrl);
+
+        /// <summary>
+        ///     Diff two commits in a repository and return information about them.
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <param name="baseVersion">Base version</param>
+        /// <param name="targetVersion">Target version</param>
+        /// <returns>Diff information</returns>
+        Task<GitDiff> GitDiffAsync(string repoUri, string baseVersion, string targetVersion);
+
+        /// <summary>
+        ///     Clone a remote repository.
+        /// </summary>
+        /// <param name="repoUri">Repository uri</param>
+        /// <param name="commit">Branch, commit, or tag to checkout</param>
+        /// <param name="targetDirectory">Directory to clone to</param>
+        /// <param name="checkoutSubmodules">Indicates whether submodules should be checked out as well</param>
+        /// <param name="gitDirectory">Location for .git directory, or null for default</param>
+        void Clone(string repoUri, string commit, string targetDirectory, bool checkoutSubmodules, string gitDirectory = null);
+
+        /// <summary>
+        ///     Delete a pull request's branch if it still exists
+        /// </summary>
+        /// <param name="pullRequestUri"></param>
+        /// <returns>Async task</returns>
+        Task DeletePullRequestBranchAsync(string pullRequestUri);
+    }
+
+    public class PullRequest
+    {
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public string BaseBranch { get; set; }
+        public string HeadBranch { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -37,11 +37,11 @@ namespace Microsoft.DotNet.DarcLib
                 string parentTwoDirectoriesUp = Path.GetDirectoryName(Path.GetDirectoryName(fullPath));
                 if (Directory.Exists(parentTwoDirectoriesUp))
                 {
-                    throw new DependencyFileNotFoundException("Found parent-directory path ('{parentTwoDirectoriesUp}') but unable to find specified file ('{relativeFilePath}')");
+                    throw new DependencyFileNotFoundException($"Found parent-directory path ('{parentTwoDirectoriesUp}') but unable to find specified file ('{relativeFilePath}')");
                 }
                 else
                 {
-                    throw new InvalidOperationException("Neither parent-directory path ('{parentTwoDirectoriesUp}') nor specified file ('{relativeFilePath}') found.");
+                    throw new InvalidOperationException($"Neither parent-directory path ('{parentTwoDirectoriesUp}') nor specified file ('{relativeFilePath}') found.");
                 }
             }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
@@ -16,12 +17,13 @@ public interface IVmrPatchHandler
         string patchPath,
         CancellationToken cancellationToken);
     
-    Task CreatePatch(
+    Task<List<VmrIngestionPatch>> CreatePatches(
         SourceMapping mapping,
         string repoPath,
         string sha1,
         string sha2,
-        string destPath,
+        string destDir,
+        string tmpPath,
         CancellationToken cancellationToken);
 
     Task RestorePatchedFilesFromRepo(
@@ -34,3 +36,5 @@ public interface IVmrPatchHandler
         SourceMapping mapping,
         CancellationToken cancellationToken);
 }
+
+public record VmrIngestionPatch(string RelativeFolder, string PatchPath);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -14,7 +14,7 @@ public interface IVmrPatchHandler
 {
     Task ApplyPatch(
         SourceMapping mapping,
-        string patchPath,
+        VmrIngestionPatch patch,
         CancellationToken cancellationToken);
     
     Task<List<VmrIngestionPatch>> CreatePatches(
@@ -37,4 +37,9 @@ public interface IVmrPatchHandler
         CancellationToken cancellationToken);
 }
 
-public record VmrIngestionPatch(string RelativeFolder, string PatchPath);
+/// <summary>
+/// Patch that is created/applied during sync of the VMR.
+/// </summary>
+/// <param name="Path">Path where the patch is located</param>
+/// <param name="ApplicationPath">Relative path within the VMR to which the patch is applied onto</param>
+public record VmrIngestionPatch(string Path, string ApplicationPath);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -81,9 +81,6 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         await _patchHandler.ApplyVmrPatches(mapping, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 
-        await UpdateGitmodules(cancellationToken);
-        cancellationToken.ThrowIfCancellationRequested();
-
         // Commit but do not add files (they were added to index directly)
         var message = PrepareCommitMessage(InitializationCommitMessage, mapping, newSha: commit.Id.Sha);
         Commit(message, DotnetBotCommitSignature);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -32,19 +32,23 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
     private readonly IVmrPatchHandler _patchHandler;
     private readonly ILogger<VmrUpdater> _logger;
 
+    private readonly string _tmpPath;
+
     public VmrInitializer(
         IVmrDependencyTracker dependencyTracker,
         IVmrPatchHandler patchHandler,
         IProcessManager processManager,
         IRemoteFactory remoteFactory,
+        ILocalGitRepo localGitRepo,
         IVersionDetailsParser versionDetailsParser,
         ILogger<VmrUpdater> logger,
         IVmrManagerConfiguration configuration)
-        : base(dependencyTracker, patchHandler, processManager, remoteFactory, versionDetailsParser, logger, configuration.TmpPath)
+        : base(dependencyTracker, processManager, remoteFactory, localGitRepo, versionDetailsParser, logger, configuration.TmpPath)
     {
         _dependencyTracker = dependencyTracker;
         _patchHandler = patchHandler;
         _logger = logger;
+        _tmpPath = configuration.TmpPath;
     }
 
     public async Task InitializeRepository(
@@ -67,12 +71,21 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         using var clone = new Repository(clonePath);
         var commit = GetCommit(clone, (targetRevision is null || targetRevision == HEAD) ? null : targetRevision);
 
-        string patchPath = GetPatchFilePath(mapping);
-        await _patchHandler.CreatePatch(mapping, clonePath, Constants.EmptyGitObject, commit.Id.Sha, patchPath, cancellationToken);
+        var patches = await _patchHandler.CreatePatches(
+            mapping,
+            clonePath,
+            Constants.EmptyGitObject,
+            commit.Id.Sha,
+            _tmpPath,
+            _tmpPath,
+            cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 
-        await _patchHandler.ApplyPatch(mapping, patchPath, cancellationToken);
-        cancellationToken.ThrowIfCancellationRequested();
+        foreach (var patch in patches)
+        {
+            await _patchHandler.ApplyPatch(mapping, patch, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+        }
 
         _dependencyTracker.UpdateDependencyVersion(mapping, new(commit.Id.Sha, targetVersion));
         Commands.Stage(new Repository(_dependencyTracker.VmrPath), VmrDependencyTracker.GitInfoSourcesDir);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -125,8 +125,6 @@ public abstract class VmrManagerBase : IVmrManager
         return result;
     }
 
-    protected string GetPatchFilePath(SourceMapping mapping) => Path.Combine(_tmpPath, $"{mapping.Name}.patch");
-
     protected string GetClonePath(SourceMapping mapping) => Path.Combine(_tmpPath, mapping.Name);
 
     /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -23,9 +23,9 @@ public abstract class VmrManagerBase : IVmrManager
     protected const string HEAD = "HEAD";
 
     private readonly IVmrDependencyTracker _dependencyInfo;
-    private readonly IVmrPatchHandler _patchHandler;
     private readonly IProcessManager _processManager;
     private readonly IRemoteFactory _remoteFactory;
+    private readonly ILocalGitRepo _localGitRepo;
     private readonly IVersionDetailsParser _versionDetailsParser;
     private readonly ILogger _logger;
     
@@ -35,22 +35,23 @@ public abstract class VmrManagerBase : IVmrManager
 
     protected VmrManagerBase(
         IVmrDependencyTracker dependencyInfo,
-        IVmrPatchHandler patchHandler,
         IProcessManager processManager,
         IRemoteFactory remoteFactory,
+        ILocalGitRepo localGitRepo,
         IVersionDetailsParser versionDetailsParser,
         ILogger<VmrUpdater> logger,
         string tmpPath)
     {
         _logger = logger;
         _dependencyInfo = dependencyInfo;
-        _patchHandler = patchHandler;
         _processManager = processManager;
         _remoteFactory = remoteFactory;
+        _localGitRepo = localGitRepo;
         _versionDetailsParser = versionDetailsParser;
         _tmpPath = tmpPath;
     }
 
+    // TODO (https://github.com/dotnet/arcade/issues/10870): Merge with IRemote.Clone
     /// <summary>
     /// Prepares a clone of given git repository either by cloning it to temp or if exists, pulling the newest changes.
     /// </summary>
@@ -63,8 +64,7 @@ public abstract class VmrManagerBase : IVmrManager
         {
             _logger.LogInformation("Clone of {repo} found, pulling new changes...", mapping.DefaultRemote);
 
-            var localRepo = new LocalGitClient(_processManager.GitExecutable, _logger);
-            localRepo.Checkout(clonePath, mapping.DefaultRef);
+            _localGitRepo.Checkout(clonePath, mapping.DefaultRef);
 
             var result = await _processManager.ExecuteGit(clonePath, "pull");
             result.ThrowIfFailed($"Failed to pull new changes from {mapping.DefaultRemote} into {clonePath}");
@@ -77,61 +77,6 @@ public abstract class VmrManagerBase : IVmrManager
         remoteRepo.Clone(mapping.DefaultRemote, mapping.DefaultRef, clonePath, checkoutSubmodules: false, null);
 
         return clonePath;
-    }
-
-    /// <summary>
-    /// Gets information about submodules from individual repos and compiles a .gitmodules file for the VMR.
-    /// We also need to replace the submodule paths with the src/[repo] prefixes.
-    /// The .gitmodules file is only relevant in the root of the repo. We can leave the old files behind.
-    /// The information about the commit the submodule is referencing is stored in the git tree.
-    /// </summary>
-    protected async Task UpdateGitmodules(CancellationToken cancellationToken)
-    {
-        const string gitmodulesFileName = ".gitmodules";
-
-        _logger.LogInformation("Updating .gitmodules file..");
-
-        // Matches the 'path = ' setting from the .gitmodules file so that we can prefix it
-        var pathSettingRegex = new Regex(@"(\bpath[ \t]*\=[ \t]*\b)");
-
-        using (var vmrGitmodule = File.Open(Path.Combine(_dependencyInfo.VmrPath, gitmodulesFileName), FileMode.Create))
-        using (var writer = new StreamWriter(vmrGitmodule) { NewLine = "\n" })
-        {
-            foreach (var mapping in Mappings)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var repoGitmodulePath = Path.Combine(_dependencyInfo.GetRepoSourcesPath(mapping), gitmodulesFileName);
-                if (!File.Exists(repoGitmodulePath))
-                {
-                    continue;
-                }
-
-                _logger.LogDebug("Copying .gitmodules from {repo}..", mapping.Name);
-
-                // Header for the repo
-                await writer.WriteAsync("# ");
-                await writer.WriteLineAsync(mapping.Name);
-                await writer.WriteLineAsync();
-
-                // Copy contents
-                var content = await File.ReadAllTextAsync(repoGitmodulePath, cancellationToken);
-
-                // Add src/[repo]/ prefixes to paths
-                content = pathSettingRegex
-                    .Replace(content, $"$1{VmrDependencyTracker.VmrSourcesDir}/{mapping.Name}/")
-                    .Replace("\r\n", "\n");
-
-                await writer.WriteAsync(content);
-
-                // Add some spacing
-                await writer.WriteLineAsync();
-                await writer.WriteLineAsync();
-            }
-        }
-
-        (await _processManager.ExecuteGit(_dependencyInfo.VmrPath, new[] { "add", gitmodulesFileName }, cancellationToken))
-            .ThrowIfFailed("Failed to stage the .gitmodules file!");
     }
 
     protected void Commit(string commitMessage, Signature author)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -172,5 +172,5 @@ public abstract class VmrManagerBase : IVmrManager
 
     protected static Signature DotnetBotCommitSignature => new(Constants.DarcBotName, Constants.DarcBotEmail, DateTimeOffset.Now);
 
-    protected static string ShortenId(string commitSha) => commitSha[..7];
+    public static string ShortenId(string commitSha) => commitSha[..7];
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -86,7 +86,7 @@ public abstract class VmrManagerBase : IVmrManager
         using var repository = new Repository(_dependencyInfo.VmrPath);
         var commit = repository.Commit(commitMessage, author, DotnetBotCommitSignature);
 
-        _logger.LogInformation("Created {sha} in {duration} seconds", ShortenId(commit.Id.Sha), (int) watch.Elapsed.TotalSeconds);
+        _logger.LogInformation("Created {sha} in {duration} seconds", DarcLib.Commit.GetShortSha(commit.Id.Sha), (int) watch.Elapsed.TotalSeconds);
     }
 
     /// <summary>
@@ -147,8 +147,8 @@ public abstract class VmrManagerBase : IVmrManager
             { "remote", mapping.DefaultRemote },
             { "oldSha", oldSha },
             { "newSha", newSha },
-            { "oldShaShort", oldSha is null ? string.Empty : ShortenId(oldSha) },
-            { "newShaShort", newSha is null ? string.Empty : ShortenId(newSha) },
+            { "oldShaShort", oldSha is null ? string.Empty : DarcLib.Commit.GetShortSha(oldSha) },
+            { "newShaShort", newSha is null ? string.Empty : DarcLib.Commit.GetShortSha(newSha) },
             { "commitMessage", additionalMessage ?? string.Empty },
         };
 
@@ -170,6 +170,4 @@ public abstract class VmrManagerBase : IVmrManager
     }
 
     protected static Signature DotnetBotCommitSignature => new(Constants.DarcBotName, Constants.DarcBotEmail, DateTimeOffset.Now);
-
-    public static string ShortenId(string commitSha) => commitSha[..7];
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -69,7 +69,7 @@ public class VmrPatchHandler : IVmrPatchHandler
     /// <param name="tmpPath">Directory where submodules can be cloned temporarily</param>
     /// <param name="cancellationToken">Cancellation is safe with regards to git operations</param>
     /// <returns>List of patch files that can be applied on the VMR</returns>
-    public Task<List<VmrIngestionPatch>> CreatePatches(
+    public async Task<List<VmrIngestionPatch>> CreatePatches(
         SourceMapping mapping,
         string repoPath,
         string sha1,
@@ -77,7 +77,15 @@ public class VmrPatchHandler : IVmrPatchHandler
         string destDir,
         string tmpPath,
         CancellationToken cancellationToken)
-        => CreatePatchesRecursive(mapping, repoPath, sha1, sha2, destDir, tmpPath, string.Empty, cancellationToken);
+    {
+        _logger.LogInformation("Creating patches in {path}..", destDir);
+
+        var patches = await CreatePatchesRecursive(mapping, repoPath, sha1, sha2, destDir, tmpPath, string.Empty, cancellationToken);
+
+        _logger.LogInformation("{count} patches created", patches.Count);
+
+        return patches;
+    }
 
     private async Task<List<VmrIngestionPatch>> CreatePatchesRecursive(
         SourceMapping mapping,
@@ -89,8 +97,6 @@ public class VmrPatchHandler : IVmrPatchHandler
         string relativePath,
         CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Creating patches in {path}..", destDir);
-
         if (repoPath.EndsWith(".git"))
         {
             repoPath = Path.GetDirectoryName(repoPath)!;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 /// </summary>
 public class VmrPatchHandler : IVmrPatchHandler
 {
-    // These git attributes catn override cloaking of files when set it individual repositories
+    // These git attributes can override cloaking of files when set it individual repositories
     private const string KeepAttribute = "vmr-preserve";
     private const string IgnoreAttribute = "vmr-ignore";
 
@@ -427,7 +427,7 @@ public class VmrPatchHandler : IVmrPatchHandler
     {
         var checkoutCommit = change.Before == Constants.EmptyGitObject ? change.After : change.Before;
 
-        var clonePath = Path.Combine(tmpPath, change.Name);
+        var clonePath = Path.Combine(tmpPath, change.Name.Replace('/', '-'));
         await CloneOrFetch(change.Url, checkoutCommit, clonePath);
 
         var submoduleMapping = new SourceMapping(

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -38,6 +38,7 @@ public static class VmrRegistrations
     private static void RegisterManagers(IServiceCollection services, string gitLocation)
     {
         services.TryAddTransient<IProcessManager>(sp => ActivatorUtilities.CreateInstance<ProcessManager>(sp, gitLocation));
+        services.TryAddTransient<ILocalGitRepo>(sp => ActivatorUtilities.CreateInstance<LocalGitClient>(sp, gitLocation));
         services.TryAddTransient<ISourceMappingParser, SourceMappingParser>();
         services.TryAddTransient<IVersionDetailsParser, VersionDetailsParser>();
         services.TryAddTransient<IVmrDependencyTracker, VmrDependencyTracker>();

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
@@ -39,6 +40,7 @@ public static class VmrRegistrations
     {
         services.TryAddTransient<IProcessManager>(sp => ActivatorUtilities.CreateInstance<ProcessManager>(sp, gitLocation));
         services.TryAddTransient<ILocalGitRepo>(sp => ActivatorUtilities.CreateInstance<LocalGitClient>(sp, gitLocation));
+        services.TryAddTransient<ILogger>(sp => sp.GetRequiredService<ILogger<IVmrManager>>());
         services.TryAddTransient<ISourceMappingParser, SourceMappingParser>();
         services.TryAddTransient<IVersionDetailsParser, VersionDetailsParser>();
         services.TryAddTransient<IVmrDependencyTracker, VmrDependencyTracker>();

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -148,16 +148,18 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             }
         }
 
-        if (commitsToCopy.Count == 0)
+        // When no path between two commits is found, force synchronization between arbitrary commits
+        // For this case, do not copy the commit with the same author so it doesn't seem like one commit
+        // from the individual repo
+        bool arbitraryCommits = commitsToCopy.Count == 0;
+        if (arbitraryCommits)
         {
-            // TODO: https://github.com/dotnet/arcade/issues/10550 - enable synchronization between arbitrary commits
-            throw new EmptySyncException($"Found no commits between {currentSha} and {targetRevision} " +
-                $"when synchronizing {mapping.Name}");
+            commitsToCopy.Push(repo.Lookup<LibGit2Sharp.Commit>(targetRevision));
         }
 
         // When we go one by one, we basically "copy" the commits.
         // Let's do the same in case we don't explicitly go one by one but we only have one commit..
-        if (noSquash || commitsToCopy.Count == 1)
+        if ((noSquash || commitsToCopy.Count == 1) && !arbitraryCommits)
         {
             while (commitsToCopy.TryPop(out LibGit2Sharp.Commit? commitToCopy))
             {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -164,7 +164,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 cancellationToken.ThrowIfCancellationRequested();
 
                 _logger.LogInformation("Updating {repo} from {current} to {next}..",
-                    mapping.Name, ShortenId(currentSha), ShortenId(commitToCopy.Id.Sha));
+                    mapping.Name, DarcLib.Commit.GetShortSha(currentSha), DarcLib.Commit.GetShortSha(commitToCopy.Id.Sha));
 
                 var message = PrepareCommitMessage(
                     SingleCommitMessage,

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
@@ -979,7 +979,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> gitRepoMock = new Mock<IRemoteGitRepo>();
             Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
@@ -1050,7 +1050,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> gitRepoMock = new Mock<IRemoteGitRepo>();
             Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
@@ -1119,7 +1119,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> gitRepoMock = new Mock<IRemoteGitRepo>();
             Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
@@ -1192,7 +1192,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> gitRepoMock = new Mock<IRemoteGitRepo>();
             Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
@@ -1266,7 +1266,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> gitRepoMock = new Mock<IRemoteGitRepo>();
             Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
@@ -1382,7 +1382,7 @@ namespace Microsoft.DotNet.Darc.Tests
         {
             // Initialize
             Mock<IBarClient> barClientMock = new Mock<IBarClient>();
-            Mock<IGitRepo> gitRepoMock = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> gitRepoMock = new Mock<IRemoteGitRepo>();
             Remote remote = new Remote(gitRepoMock.Object, barClientMock.Object, Mock.Of<IVersionDetailsParser>(), NullLogger.Instance);
 
             // Mock the remote used by build dependency graph to gather dependency details.
@@ -1500,7 +1500,7 @@ namespace Microsoft.DotNet.Darc.Tests
             barClientMock.Setup(m => m.GetBuildsAsync(repo, commit)).ReturnsAsync(new List<Build> { build });
         }
 
-        private void RepositoryHasFeeds(Mock<IGitRepo> barClientMock,
+        private void RepositoryHasFeeds(Mock<IRemoteGitRepo> barClientMock,
             string repo, string commit, string[] feeds)
         {
             const string baseNugetConfig = @"<?xml version=""1.0"" encoding=""utf - 8""?>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.DarcLib.Tests
         [Test]
         public async Task ValidateCommitMessageTest()
         {
-            Mock<IGitRepo> client = new Mock<IGitRepo>();
+            Mock<IRemoteGitRepo> client = new Mock<IRemoteGitRepo>();
             Mock<IBarClient> barClient = new Mock<IBarClient>();
             MergePullRequestParameters mergePullRequest = new MergePullRequestParameters
             {


### PR DESCRIPTION
Based on the Teams discussion, adding the custom console formatter that turns this:
```
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Synchronizing installer from fdc96a7d0f3780df1aaee687692ba4145bb61d85 to https://github.com/dotnet/installer@HEAD
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Clone of https://github.com/dotnet/installer found, pulling new changes...
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Creating diff in /data/tmp/installer.patch..
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Diff created at /data/tmp/installer.patch - 0 commits, 355.058 KB
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Applying patch /data/tmp/installer.patch to src/installer...
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Committing..
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Created 764adb0 in 4 seconds
```

into this

```
info: Synchronizing installer from fdc96a7d0f3780df1aaee687692ba4145bb61d85 to https://github.com/dotnet/installer@HEAD
info: Clone of https://github.com/dotnet/installer found, pulling new changes...
info: Creating diff in /data/tmp/installer.patch..
info: Diff created at /data/tmp/installer.patch - 0 commits, 355.058 KB
info: Applying patch /data/tmp/installer.patch to src/installer...
info: Committing..
info: Created 764adb0 in 4 seconds
```

Could not re-use the Arcade.Common one (https://github.com/dotnet/arcade/pull/10787) as we are on .NET 6.0 Arcade and it is probably not a great idea to backport this into the 6.0 Arcade branch. Once we clear the debt, we can kill this class. It still pays off to have it.