### PR TITLE
Disable internal grafana metrics

### DIFF
--- a/src/Monitoring/grafana-init/grafana.ini
+++ b/src/Monitoring/grafana-init/grafana.ini
@@ -84,3 +84,8 @@ mode = file syslog
 format = json
 facility = daemon
 tag = grafana
+
+#################################### Internal Grafana Metrics ############
+# Metrics available at HTTP URL /metrics and /metrics/plugins/:pluginId
+[metrics]
+enabled = false


### PR DESCRIPTION
This has already been disabled in both staging and production, adding to the config file for redeployments