### PR TITLE
Use CodeQL 3000 instead of Guardian

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{  
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\NET Fundamentals\\Infrastructure\\Arcade\\SDL",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "dnceng@microsoft.com" ],
+    "repositoryName":"Arcade-Services",
+    "codebaseName": "Arcade-Services"
+}

--- a/azure-pipeline-codeql.yml
+++ b/azure-pipeline-codeql.yml
@@ -12,6 +12,10 @@ variables:
   # Force CodeQL enabled so it may be run on any branch
 - name: Codeql.Enabled
   value: true
+  # Do not let CodeQL 3000 Extension gate scan frequency
+- name: Codeql.Cadence
+  value: 0
+  # Variables for building
 - name: _BuildConfig
   value: Release
 - name: _InternalBuildArgs

--- a/azure-pipeline-codeql.yml
+++ b/azure-pipeline-codeql.yml
@@ -1,14 +1,23 @@
 parameters:
+  # Optionally do not publish to TSA. Useful for e.g. verifying fixes before PR.
 - name: Codeql.TSAEnabled
   displayName: Publish results to TSA
   type: boolean
   default: true
 
 variables:
+  # CG is handled in the primary CI pipeline
 - name: skipComponentGovernanceDetection
   value: true
+  # Force CodeQL enabled so it may be run on any branch
 - name: Codeql.Enabled
   value: true
+- name: _BuildConfig
+  value: Release
+- name: _InternalBuildArgs
+  value: ''
+- name: _ProductionArgs
+  value: ''
 
 trigger: none
 

--- a/azure-pipeline-codeql.yml
+++ b/azure-pipeline-codeql.yml
@@ -1,172 +1,86 @@
+parameters:
+- name: Codeql.TSAEnabled
+  displayName: Publish results to TSA
+  type: boolean
+  default: true
+
 variables:
-  - name: _TeamName
-    value: DotNetCore
-  - group: SDL_Settings
+- name: skipComponentGovernanceDetection
+  value: true
+- name: Codeql.Enabled
+  value: true
 
 trigger: none
 
 schedules:
-  - cron: 0 12 * * 1
-    displayName: Weekly Monday CodeQL/Semmle run
-    branches:
-      include:
-      - main
-    always: true
+- cron: 0 12 * * 1
+  displayName: Weekly Monday CodeQL run
+  branches:
+    include:
+    - main
+  always: true
 
-stages:
-- stage: CodeQL
-  displayName: CodeQL
-
-  jobs:
-    - job: CSharp
-      timeoutInMinutes: 90
-      pool: 
-        name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals 1es-windows-2019
-      displayName: "CodeQL Scan"
-      steps:
-
-      # Guardian requirements
-      - task: NuGetToolInstaller@1
-        displayName: 'Install NuGet.exe'
-
-      - task: NuGetAuthenticate@0
-        displayName: 'Authenticate NuGet'
-        inputs:
-          nuGetServiceConnections: GuardianConnect
+jobs:
+- job: CSharp
+  timeoutInMinutes: 90
+  pool: 
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals 1es-windows-2019
+  displayName: "CodeQL Scan"
   
-      - pwsh: |
-          . $(Build.SourcesDirectory)\eng\CodeQL.ps1
-          $guardianCliLocation = Install-Gdn -Path $(Build.SourcesDirectory)\.artifacts
-          Write-Host "##vso[task.setvariable variable=GuardianCliLocation]$guardianCliLocation"
-        displayName: Install Guardian
+  steps:
+  - task: UseDotNet@2
+    displayName: Install Correct .NET Version
+    inputs:
+      useGlobalJson: true
 
-      # Project requirements
-      - task: UseDotNet@2
-        displayName: Install Correct .NET Version
-        inputs:
-          useGlobalJson: true
+  - task: NuGetToolInstaller@0
+    inputs:
+      versionSpec: 6.1.x
 
-      - task: UseDotNet@2
-        displayName: Install .NET Version 3.1
-        inputs:
-          version: 3.1.x
+  - task: NodeTool@0
+    inputs:
+      versionSpec: 12.x
 
-      - task: NodeTool@0
-        displayName: 'Install Node'
-        inputs:
-          versionSpec: '12.x'
+  - task: NuGetCommand@2
+    displayName: Restore Packages
+    inputs:
+      command: restore
+      solution: "**/*.sln"
+      feedstoUse: config
 
-      - task: NuGetCommand@2
-        displayName: Restore Packages
-        inputs:
-          command: restore
-          solution: "**/*.sln"
-          feedstoUse: config
+  - powershell: eng\set-version-parameters.ps1
+    displayName: Calculate release version variables
 
-      - pwsh: eng\set-version-parameters.ps1
-        displayName: Calculate release version variables
-        
-      - pwsh: |
-          [xml]$manifest = Get-Content src\Maestro\MaestroApplication\ApplicationPackageRoot\ApplicationManifest.xml
-          $manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Policies']").RemoveAll()
-          $manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Principals']").RemoveAll()
-          $manifest.Save("src\Maestro\MaestroApplication\ApplicationPackageRoot\ApplicationManifest.xml")
-          git diff
-        displayName: Remove Service Fabric RunAsPolicy from MaestroApplication
+  - powershell: |
+      [xml]$manifest = Get-Content src\Maestro\MaestroApplication\ApplicationPackageRoot\ApplicationManifest.xml
+      $manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Policies']").RemoveAll()
+      $manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Principals']").RemoveAll()
+      $manifest.Save("src\Maestro\MaestroApplication\ApplicationPackageRoot\ApplicationManifest.xml")
+      git diff
+    displayName: Remove Service Fabric RunAsPolicy from MaestroApplication
 
-      - pwsh: |
-          [xml]$manifest = Get-Content src\Telemetry\TelemetryApplication\ApplicationPackageRoot\ApplicationManifest.xml
-          $manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Policies']").RemoveAll()
-          $manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Principals']").RemoveAll()
-          $manifest.Save("src\Telemetry\TelemetryApplication\ApplicationPackageRoot\ApplicationManifest.xml")
-          git diff
-        displayName: Remove Service Fabric RunAsPolicy from TelemetryApplication
-      
-      - pwsh: |
-          . $(Build.SourcesDirectory)\eng\codeql.ps1
-          Initialize-Gdn -GuardianCliLocation $(GuardianCliLocation) `
-            -WorkingDirectory $(Build.SourcesDirectory) `
-            -LoggerLevel 'Standard'
-        displayName: 'CodeQL: Initialize'
+  - powershell: |
+      [xml]$manifest = Get-Content src\Telemetry\TelemetryApplication\ApplicationPackageRoot\ApplicationManifest.xml
+      $manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Policies']").RemoveAll()
+      $manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Principals']").RemoveAll()
+      $manifest.Save("src\Telemetry\TelemetryApplication\ApplicationPackageRoot\ApplicationManifest.xml")
+      git diff
+    displayName: Remove Service Fabric RunAsPolicy from TelemetryApplication
 
-      - pwsh: |
-          . $(Build.SourcesDirectory)\eng\codeql.ps1
-          New-GdnSemmleConfig -GuardianCliLocation $(GuardianCliLocation) `
-            -LoggerLevel 'Standard' `
-            -Language 'csharp' `
-            -WorkingDirectory $(Build.SourcesDirectory) `
-            -SourceCodeDirectory $(Build.SourcesDirectory)\src `
-            -BuildCommand "$(Build.SourcesDirectory)\build.cmd -configuration Release -prepareMachine /p:Test=false /P:Sign=false # rmdir /s /q $(Build.SourcesDirectory)\src\Maestro\maestro-angular\dist" `
-            -OutputPath $(Build.SourcesDirectory)\.gdn\r\semmle-csharp-configure.gdnconfig
-        displayName: 'CodeQL: Create C# configuration'
+  - task: CodeQL3000Init@0
+    displayName: CodeQL Initialize
 
-      - pwsh: |
-          . $(Build.SourcesDirectory)\eng\codeql.ps1
-          New-GdnSemmleConfig -GuardianCliLocation $(GuardianCliLocation) `
-            -LoggerLevel 'Standard' `
-            -Language 'javascript' `
-            -WorkingDirectory $(Build.SourcesDirectory) `
-            -SourceCodeDirectory $(Build.SourcesDirectory)\src\Maestro\maestro-angular `
-            -OutputPath $(Build.SourcesDirectory)\.gdn\r\semmle-javascript-configure.gdnconfig `
-            -AdditionalSemmleParameters @("Typescript < $true")
-        displayName: 'CodeQL: Create maestro-angular (typescript) configuration'
+  - script: eng\common\cibuild.cmd
+      -configuration $(_BuildConfig)
+      -prepareMachine
+      $(_InternalBuildArgs)
+      $(_ProductionArgs)
+      /p:Test=false
+      /P:Sign=false
+    name: Build
+    displayName: Build
+    condition: succeeded()
 
-      - pwsh: |
-          . $(Build.SourcesDirectory)\eng\codeql.ps1
-          New-GdnSemmleConfig -GuardianCliLocation $(GuardianCliLocation) `
-            -LoggerLevel 'Standard' `
-            -Language 'python' `
-            -WorkingDirectory $(Build.SourcesDirectory) `
-            -SourceCodeDirectory $(Build.SourcesDirectory)\src\Monitoring\grafana-init `
-            -OutputPath $(Build.SourcesDirectory)\.gdn\r\semmle-python-configure.gdnconfig
-        displayName: 'CodeQL: Create Grafana Init (python) configuration'
-
-      - pwsh: |
-          . $(Build.SourcesDirectory)\eng\codeql.ps1
-          Invoke-GdnSemmle -GuardianCliLocation $(GuardianCliLocation) `
-            -WorkingDirectory $(Build.SourcesDirectory) `
-            -ConfigurationPath $(Build.SourcesDirectory)\.gdn\r\semmle-csharp-configure.gdnconfig
-        displayName: 'CodeQL: C#'
-
-      - pwsh: |
-          . $(Build.SourcesDirectory)\eng\codeql.ps1
-          Invoke-GdnSemmle -GuardianCliLocation $(GuardianCliLocation) `
-            -WorkingDirectory $(Build.SourcesDirectory) `
-            -ConfigurationPath $(Build.SourcesDirectory)\.gdn\r\semmle-javascript-configure.gdnconfig
-        displayName: 'CodeQL: maestro-angular (typescript)'
-
-      - pwsh: |
-          . $(Build.SourcesDirectory)\eng\codeql.ps1
-          Invoke-GdnSemmle -GuardianCliLocation $(GuardianCliLocation) `
-            -WorkingDirectory $(Build.SourcesDirectory) `
-            -ConfigurationPath $(Build.SourcesDirectory)\.gdn\r\semmle-python-configure.gdnconfig
-        displayName: 'CodeQL: Grafana Init (python)'
-
-      - pwsh: |
-          . $(Build.SourcesDirectory)\eng\codeql.ps1
-          Publish-GdnArtifacts -GuardianCliLocation $(GuardianCliLocation) `
-            -WorkingDirectory $(Build.SourcesDirectory)
-        displayName: Publish results artifact
-
-      - pwsh: |
-          . $(Build.SourcesDirectory)\eng\CodeQL.ps1
-          Publish-GdnTsa -GuardianCliLocation $(GuardianCliLocation) `
-            -WorkingDirectory $(Build.SourcesDirectory) `
-            -LoggerLevel 'Standard' `
-            -TsaRepositoryName "Arcade-Services" `
-            -TsaCodebaseName "Arcade-Services" `
-            -TsaCodebaseAdmin $(_TsaCodebaseAdmin) `
-            -TsaNotificationEmail $(_TsaNotificationEmail) `
-            -TsaInstanceUrl $(_TsaInstanceURL) `
-            -TsaProjectName $(_TsaProjectName) `
-            -TsaBugAreaPath $(_TsaBugAreaPath) `
-            -TsaIterationPath $(_TsaIterationPath) `
-            -TsaPublish $true
-        displayName: Publish results to TSA
-
-      - pwsh: |
-          . $(Build.SourcesDirectory)\eng\codeql.ps1
-          Invoke-GdnBuildBreak -GuardianCliLocation $(GuardianCliLocation) `
-            -WorkingDirectory $(Build.SourcesDirectory)
-        displayName: Break On Failures
+  - task: CodeQL3000Finalize@0
+    displayName: CodeQL Finalize


### PR DESCRIPTION
Swap Guardian for CodeQL 3000 Azure DevOps extension for CodeQL static code analysis.

Successful test build (minus TSA publish): [Pipelines - Run 2012488](https://dev.azure.com/dnceng/internal/_build/results?buildId=2012488&view=results)

Part of dotnet/arcade#11151