### PR TITLE
Use breadth-first search when initializing VMR recursively

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -32,6 +32,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
     
     private readonly IVmrDependencyTracker _dependencyTracker;
     private readonly IVmrPatchHandler _patchHandler;
+    private readonly IFileSystem _fileSystem;
     private readonly ILogger<VmrUpdater> _logger;
 
     private readonly string _tmpPath;
@@ -43,12 +44,14 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         IRemoteFactory remoteFactory,
         ILocalGitRepo localGitRepo,
         IVersionDetailsParser versionDetailsParser,
+        IFileSystem fileSystem,
         ILogger<VmrUpdater> logger,
         IVmrManagerConfiguration configuration)
         : base(dependencyTracker, processManager, remoteFactory, localGitRepo, versionDetailsParser, logger, configuration.TmpPath)
     {
         _dependencyTracker = dependencyTracker;
         _patchHandler = patchHandler;
+        _fileSystem = fileSystem;
         _logger = logger;
         _tmpPath = configuration.TmpPath;
     }
@@ -79,7 +82,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
                         continue;
                     }
 
-                    if (Directory.Exists(_dependencyTracker.GetRepoSourcesPath(dependencyMapping)))
+                    if (_fileSystem.DirectoryExists(_dependencyTracker.GetRepoSourcesPath(dependencyMapping)))
                     {
                         // Repository has already been initialized
                         continue;

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -104,15 +104,14 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         SourceMapping mapping,
         string? targetRevision,
         string? targetVersion,
-        CancellationToken cancellationToken,
-        string? fromRepo = null)
+        CancellationToken cancellationToken)
     {
         if (_dependencyTracker.GetDependencyVersion(mapping) is not null)
         {
             throw new EmptySyncException($"Repository {mapping.Name} already exists");
         }
 
-        _logger.LogInformation("Initializing {name} at {revision} included by {parent}..", mapping.Name, targetRevision ?? mapping.DefaultRef, fromRepo ?? "__root");
+        _logger.LogInformation("Initializing {name} at {revision}..", mapping.Name, targetRevision ?? mapping.DefaultRef);
 
         string clonePath = await CloneOrPull(mapping);
         cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
This algorithm follows what the tarball initialization does and looks for dependencies in `Version.Details.xml` using BFS instead of DFS.

The SHAs synchronized into the tarball now match the ones in the VMR.