### PR TITLE
Checkout individual repo clones at target revision

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -35,6 +35,9 @@ public interface IVmrPatchHandler
     Task ApplyVmrPatches(
         SourceMapping mapping,
         CancellationToken cancellationToken);
+
+    // TODO (https://github.com/dotnet/arcade/issues/10870): Move to IRemote
+    Task CloneOrFetch(string repoUri, string checkoutRef, string destPath);
 }
 
 /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -42,14 +42,11 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
     public VmrInitializer(
         IVmrDependencyTracker dependencyTracker,
         IVmrPatchHandler patchHandler,
-        IProcessManager processManager,
-        IRemoteFactory remoteFactory,
-        ILocalGitRepo localGitRepo,
         IVersionDetailsParser versionDetailsParser,
         IFileSystem fileSystem,
         ILogger<VmrUpdater> logger,
         IVmrInfo vmrInfo)
-        : base(vmrInfo, dependencyTracker, processManager, remoteFactory, localGitRepo, versionDetailsParser, logger)
+        : base(vmrInfo, dependencyTracker, versionDetailsParser, logger)
     {
         _vmrInfo = vmrInfo;
         _dependencyTracker = dependencyTracker;
@@ -122,7 +119,8 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
     {
         _logger.LogInformation("Initializing {name} at {revision}..", mapping.Name, targetRevision ?? mapping.DefaultRef);
 
-        string clonePath = await CloneOrPull(mapping);
+        string clonePath = GetClonePath(mapping);
+        await _patchHandler.CloneOrFetch(mapping.DefaultRemote, targetRevision ?? mapping.DefaultRef, clonePath);
         cancellationToken.ThrowIfCancellationRequested();
 
         using var clone = new Repository(clonePath);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -554,8 +553,8 @@ public class VmrPatchHandler : IVmrPatchHandler
         return _fileSystem.GetFiles(mappingPatchesPath);
     }
 
-    // TODO (https://github.com/dotnet/arcade/issues/10870): Merge with IRemote
-    private async Task CloneOrFetch(string repoUri, string checkoutRef, string destPath)
+    // TODO (https://github.com/dotnet/arcade/issues/10870): Move to IRemote
+    public async Task CloneOrFetch(string repoUri, string checkoutRef, string destPath)
     {
         if (_fileSystem.DirectoryExists(destPath))
         {


### PR DESCRIPTION
Before, we were checking them out at `defaultRef` which might not be available always (like running a CI build from another branch).

This is needed for https://github.com/dotnet/arcade/issues/10891
Also fixes https://github.com/dotnet/arcade/issues/11324