### PR TITLE
Fix recursive updates of dependencies that differ on lower level

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -259,6 +259,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 if (dependencySha == dependency.Commit)
                 {
                     _logger.LogDebug("Dependency {name} is already at {sha}, skipping..", dependency.Name, dependencySha);
+                    updatedDependencies.Add(repoToUpdate);
                     continue;
                 }
 


### PR DESCRIPTION
When we see the dependency the first time, we skip an update in case it's on the same SHA. However, if we see it later under a different version of some other repo, we will try to update to that version.