### PR TITLE
Improve logging when recursively updating VMR

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -259,7 +259,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 if (dependencySha == dependency.Commit)
                 {
                     _logger.LogDebug("Dependency {name} is already at {sha}, skipping..", dependency.Name, dependencySha);
-                    updatedDependencies.Add(repoToUpdate);
+                    updatedDependencies.Add((dependencyMapping, dependency.Commit, dependency.Version));
                     continue;
                 }
 


### PR DESCRIPTION
- Logging now includes parent dependency, from/to SHAs
- Also contains a propert fix instead of #2066