### PR TITLE
Add a manager for temporary clones while synchronizing the VMR

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -35,9 +35,6 @@ public interface IVmrPatchHandler
     Task ApplyVmrPatches(
         SourceMapping mapping,
         CancellationToken cancellationToken);
-
-    // TODO (https://github.com/dotnet/arcade/issues/10870): Move to IRemote
-    Task CloneOrFetch(string repoUri, string checkoutRef, string destPath);
 }
 
 /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IRepositoryCloneManager
 {
-    Task<string> GetClone(string repoUri, string checkoutRef, CancellationToken cancellationToken);
+    Task<string> PrepareClone(string repoUri, string checkoutRef, CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -52,14 +52,14 @@ public class RepositoryCloneManager : IRepositoryCloneManager
         _logger = logger;
     }
 
-    public async Task<string> GetClone(string repoUri, string checkoutRef, CancellationToken cancellationToken)
+    public async Task<string> PrepareClone(string repoUri, string checkoutRef, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         var hash = CreateMD5(repoUri);
         var clonePath = _fileSystem.PathCombine(_vmrInfo.TmpPath, hash);
 
-        if (_upToDateRepos.Contains(hash))
+        if (_upToDateRepos.Contains(repoUri))
         {
             _localGitRepo.Checkout(clonePath, checkoutRef);
             cancellationToken.ThrowIfCancellationRequested();
@@ -84,7 +84,7 @@ public class RepositoryCloneManager : IRepositoryCloneManager
             _localGitRepo.Checkout(clonePath, checkoutRef);
         }
 
-        _upToDateRepos.Add(hash);
+        _upToDateRepos.Add(repoUri);
         return clonePath;
     }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.Logging;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+public interface IRepositoryCloneManager
+{
+    Task<string> GetClone(string repoUri, string checkoutRef);
+}
+
+/// <summary>
+/// When we are synchronizing other repositories into the VMR, we need to temporarily clone them.
+/// This class is responsible for managing the temporary clones so that:
+///   - Previously cloned repositories are re-used
+///   - Re-used clones pull newest updates once per run (the first time we use them)
+/// </summary>
+public class RepositoryCloneManager : IRepositoryCloneManager
+{
+    private readonly IVmrInfo _vmrInfo;
+    private readonly ILocalGitRepo _localGitRepo;
+    private readonly IRemoteFactory _remoteFactory;
+    private readonly IProcessManager _processManager;
+    private readonly IFileSystem _fileSystem;
+    private readonly ILogger<VmrPatchHandler> _logger;
+
+    private readonly List<string> _upToDateRepos = new();
+
+    public RepositoryCloneManager(
+        IVmrInfo vmrInfo,
+        ILocalGitRepo localGitRepo,
+        IRemoteFactory remoteFactory,
+        IProcessManager processManager,
+        IFileSystem fileSystem,
+        ILogger<VmrPatchHandler> logger)
+    {
+        _vmrInfo = vmrInfo;
+        _localGitRepo = localGitRepo;
+        _remoteFactory = remoteFactory;
+        _processManager = processManager;
+        _fileSystem = fileSystem;
+        _logger = logger;
+    }
+
+    public async Task<string> GetClone(string repoUri, string checkoutRef)
+    {
+        var hash = CreateMD5(repoUri);
+        var clonePath = _fileSystem.PathCombine(_vmrInfo.TmpPath, hash);
+
+        if (_upToDateRepos.Contains(hash))
+        {
+            _localGitRepo.Checkout(clonePath, checkoutRef);
+            return clonePath;
+        }
+
+        if (!_fileSystem.DirectoryExists(clonePath))
+        {
+            _logger.LogDebug("Cloning {repo} to {clonePath}", repoUri, clonePath);
+            var remoteRepo = await _remoteFactory.GetRemoteAsync(repoUri, _logger);
+            remoteRepo.Clone(repoUri, checkoutRef, clonePath, checkoutSubmodules: false, null);
+        }
+        else
+        {
+            _logger.LogDebug("Clone of {repo} found, pulling new changes...", repoUri);
+
+            var result = await _processManager.ExecuteGit(clonePath, "fetch", "--all");
+            result.ThrowIfFailed($"Failed to pull new changes from {repoUri} into {clonePath}");
+
+            _localGitRepo.Checkout(clonePath, checkoutRef);
+        }
+
+        _upToDateRepos.Add(hash);
+        return clonePath;
+    }
+
+    // We store clones in directories named as a hash of the repo URI
+    private static string CreateMD5(string input)
+    {
+        using var md5 = MD5.Create();
+        byte[] inputBytes = Encoding.ASCII.GetBytes(input);
+        byte[] hashBytes = md5.ComputeHash(inputBytes);
+        return Convert.ToHexString(hashBytes);
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -122,7 +122,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
     {
         _logger.LogInformation("Initializing {name} at {revision}..", mapping.Name, targetRevision ?? mapping.DefaultRef);
 
-        string clonePath = await _cloneManager.GetClone(mapping.DefaultRemote, targetRevision ?? mapping.DefaultRef, cancellationToken);
+        string clonePath = await _cloneManager.PrepareClone(mapping.DefaultRemote, targetRevision ?? mapping.DefaultRef, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 
         using var clone = new Repository(clonePath);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -34,6 +34,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
     private readonly IVmrInfo _vmrInfo;
     private readonly IVmrDependencyTracker _dependencyTracker;
     private readonly IVmrPatchHandler _patchHandler;
+    private readonly IRepositoryCloneManager _cloneManager;
     private readonly IFileSystem _fileSystem;
     private readonly ILogger<VmrUpdater> _logger;
 
@@ -43,6 +44,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         IVmrDependencyTracker dependencyTracker,
         IVmrPatchHandler patchHandler,
         IVersionDetailsParser versionDetailsParser,
+        IRepositoryCloneManager cloneManager,
         IFileSystem fileSystem,
         ILogger<VmrUpdater> logger,
         IVmrInfo vmrInfo)
@@ -51,6 +53,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         _vmrInfo = vmrInfo;
         _dependencyTracker = dependencyTracker;
         _patchHandler = patchHandler;
+        _cloneManager = cloneManager;
         _fileSystem = fileSystem;
         _logger = logger;
         _tmpPath = vmrInfo.TmpPath;
@@ -119,8 +122,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
     {
         _logger.LogInformation("Initializing {name} at {revision}..", mapping.Name, targetRevision ?? mapping.DefaultRef);
 
-        string clonePath = GetClonePath(mapping);
-        await _patchHandler.CloneOrFetch(mapping.DefaultRemote, targetRevision ?? mapping.DefaultRef, clonePath);
+        string clonePath = await _cloneManager.GetClone(mapping.DefaultRemote, targetRevision ?? mapping.DefaultRef, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 
         using var clone = new Repository(clonePath);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -87,8 +87,6 @@ public abstract class VmrManagerBase : IVmrManager
         return result;
     }
 
-    protected string GetClonePath(SourceMapping mapping) => Path.Combine(_vmrInfo.TmpPath, mapping.Name);
-
     /// <summary>
     /// Takes a given commit message template and populates it with given values, URLs and others.
     /// </summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -6,8 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,6 +39,7 @@ public class VmrPatchHandler : IVmrPatchHandler
     private readonly IVmrDependencyTracker _dependencyTracker;
     private readonly ILocalGitRepo _localGitRepo;
     private readonly IRemoteFactory _remoteFactory;
+    private readonly IRepositoryCloneManager _cloneManager;
     private readonly IProcessManager _processManager;
     private readonly IFileSystem _fileSystem;
     private readonly ILogger<VmrPatchHandler> _logger;
@@ -50,6 +49,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         IVmrDependencyTracker dependencyTracker,
         ILocalGitRepo localGitRepo,
         IRemoteFactory remoteFactory,
+        IRepositoryCloneManager cloneManager,
         IProcessManager processManager,
         IFileSystem fileSystem,
         ILogger<VmrPatchHandler> logger)
@@ -58,6 +58,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         _dependencyTracker = dependencyTracker;
         _localGitRepo = localGitRepo;
         _remoteFactory = remoteFactory;
+        _cloneManager = cloneManager;
         _processManager = processManager;
         _fileSystem = fileSystem;
         _logger = logger;
@@ -480,12 +481,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         CancellationToken cancellationToken)
     {
         var checkoutCommit = change.Before == Constants.EmptyGitObject ? change.After : change.Before;
-
-        // Clone path of submodules needs to be derived from the URL
-        // We can't use the path from the submodule as we could be changing the remote of the submodule
-        var urlHash = CreateMD5(change.Url);
-        var clonePath = _fileSystem.PathCombine(tmpPath, urlHash);
-        await CloneOrFetch(change.Url, checkoutCommit, clonePath);
+        var clonePath = await _cloneManager.GetClone(change.Url, checkoutCommit, cancellationToken);        
 
         // We are only interested in filters specific to submodule's path
         ImmutableArray<string> GetSubmoduleFilters(IReadOnlyCollection<string> filters)
@@ -548,33 +544,5 @@ public class VmrPatchHandler : IVmrPatchHandler
         return _fileSystem.GetFiles(mappingPatchesPath);
     }
 
-    // TODO (https://github.com/dotnet/arcade/issues/10870): Move to IRemote
-    public async Task CloneOrFetch(string repoUri, string checkoutRef, string destPath)
-    {
-        if (_fileSystem.DirectoryExists(destPath))
-        {
-            _logger.LogInformation("Clone of {repo} found, pulling new changes...", repoUri);
-
-            _localGitRepo.Checkout(destPath, checkoutRef);
-
-            var result = await _processManager.ExecuteGit(destPath, "fetch", "--all");
-            result.ThrowIfFailed($"Failed to pull new changes from {repoUri} into {destPath}");
-            _logger.LogDebug("{output}", result.ToString());
-
-            return;
-        }
-
-        var remoteRepo = await _remoteFactory.GetRemoteAsync(repoUri, _logger);
-        remoteRepo.Clone(repoUri, checkoutRef, destPath, checkoutSubmodules: false, null);
-    }
-
     private record SubmoduleChange(string Name, string Path, string Url, string Before, string After);
-
-    public static string CreateMD5(string input)
-    {
-        using var md5 = MD5.Create();
-        byte[] inputBytes = Encoding.ASCII.GetBytes(input);
-        byte[] hashBytes = md5.ComputeHash(inputBytes);
-        return Convert.ToHexString(hashBytes);
-    }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -478,7 +478,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         CancellationToken cancellationToken)
     {
         var checkoutCommit = change.Before == Constants.EmptyGitObject ? change.After : change.Before;
-        var clonePath = await _cloneManager.GetClone(change.Url, checkoutCommit, cancellationToken);   
+        var clonePath = await _cloneManager.PrepareClone(change.Url, checkoutCommit, cancellationToken);   
 
         // We are only interested in filters specific to submodule's path
         ImmutableArray<string> GetSubmoduleFilters(IReadOnlyCollection<string> filters)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -38,7 +38,6 @@ public class VmrPatchHandler : IVmrPatchHandler
     private readonly IVmrInfo _vmrInfo;
     private readonly IVmrDependencyTracker _dependencyTracker;
     private readonly ILocalGitRepo _localGitRepo;
-    private readonly IRemoteFactory _remoteFactory;
     private readonly IRepositoryCloneManager _cloneManager;
     private readonly IProcessManager _processManager;
     private readonly IFileSystem _fileSystem;
@@ -48,7 +47,6 @@ public class VmrPatchHandler : IVmrPatchHandler
         IVmrInfo vmrInfo,
         IVmrDependencyTracker dependencyTracker,
         ILocalGitRepo localGitRepo,
-        IRemoteFactory remoteFactory,
         IRepositoryCloneManager cloneManager,
         IProcessManager processManager,
         IFileSystem fileSystem,
@@ -57,7 +55,6 @@ public class VmrPatchHandler : IVmrPatchHandler
         _vmrInfo = vmrInfo;
         _dependencyTracker = dependencyTracker;
         _localGitRepo = localGitRepo;
-        _remoteFactory = remoteFactory;
         _cloneManager = cloneManager;
         _processManager = processManager;
         _fileSystem = fileSystem;
@@ -481,7 +478,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         CancellationToken cancellationToken)
     {
         var checkoutCommit = change.Before == Constants.EmptyGitObject ? change.After : change.Before;
-        var clonePath = await _cloneManager.GetClone(change.Url, checkoutCommit, cancellationToken);        
+        var clonePath = await _cloneManager.GetClone(change.Url, checkoutCommit, cancellationToken);   
 
         // We are only interested in filters specific to submodule's path
         ImmutableArray<string> GetSubmoduleFilters(IReadOnlyCollection<string> filters)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -45,6 +45,7 @@ public static class VmrRegistrations
         services.TryAddTransient<IVmrPatchHandler, VmrPatchHandler>();
         services.TryAddTransient<IVmrUpdater, VmrUpdater>();
         services.TryAddTransient<IVmrInitializer, VmrInitializer>();
+        services.TryAddSingleton<IRepositoryCloneManager, RepositoryCloneManager>();
         services.TryAddSingleton<IFileSystem, FileSystem>();
         services.TryAddSingleton<IVmrDependencyTracker>(sp =>
         {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -102,7 +102,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         _logger.LogInformation("Synchronizing {name} from {current} to {repo}@{revision}{oneByOne}",
             mapping.Name, currentSha, mapping.DefaultRemote, targetRevision ?? HEAD, noSquash ? " one commit at a time" : string.Empty);
 
-        string clonePath = await _cloneManager.GetClone(mapping.DefaultRemote, targetRevision ?? mapping.DefaultRef, cancellationToken);
+        string clonePath = await _cloneManager.PrepareClone(mapping.DefaultRemote, targetRevision ?? mapping.DefaultRef, cancellationToken);
 
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -50,6 +50,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
     private readonly IVmrInfo _vmrInfo;
     private readonly IVmrDependencyTracker _dependencyTracker;
     private readonly IRemoteFactory _remoteFactory;
+    private readonly IRepositoryCloneManager _cloneManager;
     private readonly IVmrPatchHandler _patchHandler;
     private readonly ILogger<VmrUpdater> _logger;
 
@@ -57,6 +58,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         IVmrDependencyTracker dependencyTracker,
         IRemoteFactory remoteFactory,
         IVersionDetailsParser versionDetailsParser,
+        IRepositoryCloneManager cloneManager,
         IVmrPatchHandler patchHandler,
         ILogger<VmrUpdater> logger,
         IVmrInfo vmrInfo)
@@ -66,6 +68,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         _vmrInfo = vmrInfo;
         _dependencyTracker = dependencyTracker;
         _remoteFactory = remoteFactory;
+        _cloneManager = cloneManager;
         _patchHandler = patchHandler;
     }
 
@@ -99,8 +102,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         _logger.LogInformation("Synchronizing {name} from {current} to {repo}@{revision}{oneByOne}",
             mapping.Name, currentSha, mapping.DefaultRemote, targetRevision ?? HEAD, noSquash ? " one commit at a time" : string.Empty);
 
-        string clonePath = GetClonePath(mapping);
-        await _patchHandler.CloneOrFetch(mapping.DefaultRemote, targetRevision ?? mapping.DefaultRef, clonePath);
+        string clonePath = await _cloneManager.GetClone(mapping.DefaultRemote, targetRevision ?? mapping.DefaultRef, cancellationToken);
 
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.Tests.VirtualMonoRepo;
+
+public class RepositoryCloneManagerTests
+{
+    private const string TmpDir = "/data/tmp";
+    private const string RepoUri = "https://github.com/dotnet/test-repo";
+    private const string Ref = "e7f4f5f758f08b1c5abb1e51ea735ca20e7f83a4";
+    private const string ClonePath = $"{TmpDir}/09223AF35006792CE00C85E10CC54588";
+
+    private readonly Mock<IVmrInfo> _vmrInfo = new();
+    private readonly Mock<ILocalGitRepo> _localGitRepo = new();
+    private readonly Mock<IProcessManager> _processManager = new();
+    private readonly Mock<IFileSystem> _fileSystem = new();
+    private readonly Mock<IRemoteFactory> _remoteFactory = new();
+    private readonly Mock<IRemote> _remote = new();
+
+    private RepositoryCloneManager _manager = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _vmrInfo.Reset();
+        _vmrInfo
+            .SetupGet(x => x.TmpPath)
+            .Returns(TmpDir);
+
+        _localGitRepo.Reset();
+
+        _processManager.Reset();
+        _processManager.SetReturnsDefault(Task.FromResult(new ProcessExecutionResult
+        {
+            ExitCode = 0,
+        }));
+
+        _fileSystem.Reset();
+        _fileSystem
+            .Setup(x => x.PathCombine(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns((string first, string second) => (first + "/" + second).Replace("//", null));
+
+        _remote.Reset();
+        _remoteFactory.Reset();
+        _remoteFactory.SetReturnsDefault(Task.FromResult(_remote.Object));
+
+        _manager = new RepositoryCloneManager(
+            _vmrInfo.Object,
+            _localGitRepo.Object,
+            _remoteFactory.Object,
+            _processManager.Object,
+            _fileSystem.Object,
+            new NullLogger<VmrPatchHandler>());
+    }
+
+    [Test]
+    public async Task RepoIsClonedOnceTest()
+    {
+        var path = await _manager.PrepareClone(RepoUri, Ref, default);
+        path.Should().Be(ClonePath);
+        path = await _manager.PrepareClone(RepoUri, "main", default);
+        path.Should().Be(ClonePath);
+        path = await _manager.PrepareClone(RepoUri, "main", default);
+        path.Should().Be(ClonePath);
+
+        _remoteFactory.Verify(x => x.GetRemoteAsync(RepoUri, It.IsAny<ILogger>()), Times.Once);
+        _remote.Verify(x => x.Clone(RepoUri, Ref, ClonePath, false, null), Times.Once);
+        _localGitRepo.Verify(x => x.Checkout(ClonePath, "main", false), Times.Exactly(2));
+    }
+
+    [Test]
+    public async Task CloneIsReusedTest()
+    {
+        _fileSystem
+            .Setup(x => x.DirectoryExists(ClonePath))
+            .Returns(true);
+        
+        var path = await _manager.PrepareClone(RepoUri, Ref, default);
+        path.Should().Be(ClonePath);
+        path = await _manager.PrepareClone(RepoUri, "main", default);
+        path.Should().Be(ClonePath);
+
+        _remoteFactory.Verify(x => x.GetRemoteAsync(RepoUri, It.IsAny<ILogger>()), Times.Never);
+        _remote.Verify(x => x.Clone(RepoUri, Ref, ClonePath, false, null), Times.Never);
+        _processManager.Verify(x => x.ExecuteGit(ClonePath, "fetch", "--all"), Times.Once);
+        _localGitRepo.Verify(x => x.Checkout(ClonePath, Ref, false), Times.Once);
+        _localGitRepo.Verify(x => x.Checkout(ClonePath, "main", false), Times.Once);
+    }
+}

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -10,7 +10,6 @@ using FluentAssertions;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
@@ -84,7 +83,7 @@ public class VmrPatchHandlerTests
 
         _cloneManager.Reset();
         _cloneManager
-            .Setup(x => x.GetClone(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.PrepareClone(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string uri, string _, CancellationToken _) => "/tmp/" + uri.Split("/").Last());
 
         _processManager.Reset();
@@ -327,7 +326,7 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.GetClone(_submoduleInfo.Url, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            .Verify(x => x.PrepareClone(_submoduleInfo.Url, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
 
         patches.Should().ContainSingle();
         patches.Single().Should().Be(new VmrIngestionPatch(expectedPatchName, IndividualRepoName));
@@ -394,7 +393,7 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.GetClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            .Verify(x => x.PrepareClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
         _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(2));
 
@@ -483,7 +482,7 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.GetClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            .Verify(x => x.PrepareClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
         // Verify diff for the nested submodule
         expectedArgs = GetExpectedGitDiffArguments(
@@ -499,7 +498,7 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.GetClone(nestedSubmoduleInfo.Url, nestedSubmoduleSha1, It.IsAny<CancellationToken>()), Times.Once);
+            .Verify(x => x.PrepareClone(nestedSubmoduleInfo.Url, nestedSubmoduleSha1, It.IsAny<CancellationToken>()), Times.Once);
 
         _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(3));
 
@@ -584,7 +583,7 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.GetClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            .Verify(x => x.PrepareClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
         _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(2));
 
@@ -658,7 +657,7 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.GetClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            .Verify(x => x.PrepareClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
         _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(2));
 
@@ -746,10 +745,10 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.GetClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            .Verify(x => x.PrepareClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
         _cloneManager
-            .Verify(x => x.GetClone("https://github.com/dotnet/external-2", SubmoduleSha2, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            .Verify(x => x.PrepareClone("https://github.com/dotnet/external-2", SubmoduleSha2, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
         _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(3));
 


### PR DESCRIPTION
Class that makes sure we don't clone/fetch unnecessarily. Will be more handy in a follow-up