### PR TITLE
Create a dedicated branch for the recursive VMR sync

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -104,7 +104,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
                         continue;
                     }
 
-                    _logger.LogDebug("Detected dependency of {parent} - {repo} / {commit} ({version})",
+                    _logger.LogInformation("Detected dependency of {parent} - {repo} / {commit} ({version})",
                         mapping.Name,
                         dependencyMapping.Name,
                         dependency.Commit,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -248,9 +248,11 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
         // When we synchronize in bulk, we do it in a separate branch that we then merge into the main one
         string syncBranchName = $"sync/{DarcLib.Commit.GetShortSha(GetCurrentVersion(mapping))}-{targetRevision}";
+        string currentBranch;
         using (var repo = new Repository(_vmrInfo.VmrPath))
         {
-            var branch = repo.Branches.Add(syncBranchName, HEAD, allowOverwrite: true);
+            currentBranch = repo.Head.FriendlyName;
+            Branch branch = repo.Branches.Add(syncBranchName, HEAD, allowOverwrite: true);
             Commands.Checkout(repo, branch);
         }
 
@@ -316,6 +318,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
         using (var repo = new Repository(_vmrInfo.VmrPath))
         {
+            Commands.Checkout(repo, currentBranch);
             repo.Merge(repo.Branches[syncBranchName], DotnetBotCommitSignature, new MergeOptions
             {
                 FastForwardStrategy = FastForwardStrategy.NoFastForward,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -322,7 +322,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 CommitOnSuccess = false,
             });
 
-            Commit(commitMessage, DotnetBotCommitSignature);
+            repo.Commit(commitMessage, DotnetBotCommitSignature, DotnetBotCommitSignature);
         }
     }
 


### PR DESCRIPTION
This makes the sync commits on a different branch and only makes a merge commit on the main branch so that main commits are always coherent and can be built okay.

Resolves https://github.com/dotnet/arcade/issues/11427