### PR TITLE
Trim commit list when VMR sync contains too many commits

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -204,7 +204,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         {
             // We squash commits and list them in the message
             var commitMessages = new StringBuilder();
-            var commitCount = 0;
+            var commitCount = 1;
             bool commitLimitHit = false;
             while (commitsToCopy.TryPop(out LibGit2Sharp.Commit? commit))
             {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -202,9 +202,27 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         }
         else
         {
+            // We squash commits and list them in the message
             var commitMessages = new StringBuilder();
+            var commitCount = 0;
+            bool commitLimitHit = false;
             while (commitsToCopy.TryPop(out LibGit2Sharp.Commit? commit))
             {
+                // Do not list over 23 commits in the message
+                // If there are more, list first 20
+                commitCount++;                
+                if (commitCount == 20 && commitsToCopy.Count > 3)
+                {
+                    commitLimitHit = true;
+                    commitMessages.AppendLine($"  [... commit list trimmed ...]");
+                    continue;
+                }
+
+                if (commitCount > 20 && commitLimitHit)
+                {
+                    continue;
+                }
+
                 commitMessages
                     .AppendLine($"  - {commit.MessageShort}")
                     .AppendLine($"    {mapping.DefaultRemote}/commit/{commit.Id.Sha}");

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -204,18 +204,18 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         {
             // We squash commits and list them in the message
             var commitMessages = new StringBuilder();
-            var commitCount = 1;
+            var commitCount = 0;
             while (commitsToCopy.TryPop(out LibGit2Sharp.Commit? commit))
             {
                 // Do not list over 23 commits in the message
-                // If there are more, list first 20
-                commitCount++;          
+                // If there are more, list first 20         
                 if (commitCount == 20 && commitsToCopy.Count > 3)
                 {
                     commitMessages.AppendLine("  [... commit list trimmed ...]");
                     break;
                 }
 
+                commitCount++;
                 commitMessages
                     .AppendLine($"  - {commit.MessageShort}")
                     .AppendLine($"    {mapping.DefaultRemote}/commit/{commit.Id.Sha}");

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -205,17 +205,15 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             // We squash commits and list them in the message
             var commitMessages = new StringBuilder();
             var commitCount = 1;
-            bool commitLimitHit = false;
-            while (!commitLimitHit && commitsToCopy.TryPop(out LibGit2Sharp.Commit? commit))
+            while (commitsToCopy.TryPop(out LibGit2Sharp.Commit? commit))
             {
                 // Do not list over 23 commits in the message
                 // If there are more, list first 20
                 commitCount++;          
                 if (commitCount == 20 && commitsToCopy.Count > 3)
                 {
-                    commitLimitHit = true;
                     commitMessages.AppendLine($"  [... commit list trimmed ...]");
-                    continue;
+                    break;
                 }
 
                 commitMessages

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -212,7 +212,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 commitCount++;          
                 if (commitCount == 20 && commitsToCopy.Count > 3)
                 {
-                    commitMessages.AppendLine($"  [... commit list trimmed ...]");
+                    commitMessages.AppendLine("  [... commit list trimmed ...]");
                     break;
                 }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -206,21 +206,16 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             var commitMessages = new StringBuilder();
             var commitCount = 1;
             bool commitLimitHit = false;
-            while (commitsToCopy.TryPop(out LibGit2Sharp.Commit? commit))
+            while (!commitLimitHit && commitsToCopy.TryPop(out LibGit2Sharp.Commit? commit))
             {
                 // Do not list over 23 commits in the message
                 // If there are more, list first 20
-                commitCount++;                
+                commitCount++;          
                 if (commitCount == 20 && commitsToCopy.Count > 3)
                 {
                     commitLimitHit = true;
                     commitMessages.AppendLine($"  [... commit list trimmed ...]");
                     continue;
-                }
-
-                if (commitCount > 20 && commitLimitHit)
-                {
-                    break;
                 }
 
                 commitMessages

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -220,7 +220,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
                 if (commitCount > 20 && commitLimitHit)
                 {
-                    continue;
+                    break;
                 }
 
                 commitMessages


### PR DESCRIPTION
This is needed but a temporary behavior too as we will probably stop listing commits and just diff two.

Resolves https://github.com/dotnet/arcade/issues/11360