### PR TITLE
Revert "Use --config-env to pass in user and pat (#2081)"

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/LocalHelpers.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Microsoft.DotNet.DarcLib.Helpers;
 
@@ -135,10 +134,9 @@ public static class LocalHelpers
         Directory.CreateDirectory(workingDirectory);
 
         ExecuteGitCommand(gitLocation, $"init {repoFolderName}", logger, workingDirectory);
-        string configKey = $"http.{repoUri}.extraheader";
-        string configEnv = ComposeEnvVarArgs(configKey, user, pat);
 
         workingDirectory = Path.Combine(workingDirectory, repoFolderName);
+        repoUri = repoUri.Replace("https://", $"https://{user}:{pat}@");
 
         ExecuteGitCommand(gitLocation, $"remote add {remote} {repoUri}", logger, workingDirectory, secretToMask: pat);
         ExecuteGitCommand(gitLocation, "config core.sparsecheckout true", logger, workingDirectory);
@@ -148,32 +146,10 @@ public static class LocalHelpers
 
         File.WriteAllLines(Path.Combine(workingDirectory, ".git/info/sparse-checkout"), new[] { "eng/", ".config/", $"/{VersionFiles.NugetConfig}", $"/{VersionFiles.GlobalJson}" });
 
-        ExecuteGitCommand(gitLocation, $"-c core.askpass= -c credential.helper= pull --depth=1 {configEnv} {remote} {branch}", logger, workingDirectory, secretToMask: pat);
+        ExecuteGitCommand(gitLocation, $"-c core.askpass= -c credential.helper= pull --depth=1 {remote} {branch}", logger, workingDirectory, secretToMask: pat);
         ExecuteGitCommand(gitLocation, $"checkout {branch}", logger, workingDirectory);
 
         return workingDirectory;
-    }
-
-    private static string ComposeEnvVarArgs(
-        string configKey,
-        string username,
-        string password)
-    {
-        string configValue = $"AUTHORIZATION: {GenerateAuthHeader(username, password)}";
-
-        string envVariableName = $"env_var_{configKey}";
-        Environment.SetEnvironmentVariable(envVariableName, configValue);
-
-        return $"--config-env={configKey}={envVariableName}";
-    }
-
-
-    public static string GenerateAuthHeader(string username, string password)
-    {
-        // use basic auth header with username:password in base64encoding.
-        string authHeader = $"{username ?? string.Empty}:{password ?? string.Empty}";
-        string base64encodedAuthHeader = Convert.ToBase64String(Encoding.UTF8.GetBytes(authHeader));
-        return $"basic {base64encodedAuthHeader}";
     }
 
     /// <summary>


### PR DESCRIPTION
This reverts commit 785cfc67c1c01cc6d465e4824ebf3a64fd75e2b3.

This change is breaking all the git scenarios in the repository, as seen by having every scenario test that uses git fail: https://dev.azure.com/dnceng/internal/_build/results?buildId=2036782&view=logs&j=4d9f00d7-d155-5977-7b70-2e6b79720ff2&t=4efd1961-d068-594b-7567-9ed5686ab047