### PR TITLE
Create a dedicated branch for VMR initialization commits

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
+using Microsoft.Azure.KeyVault.Models;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
@@ -30,7 +32,15 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
 
         {{AUTOMATION_COMMIT_TAG}}
         """;
-    
+
+    // Message used when finalizing the initialization with a merge commit
+    private const string MergeCommitMessage =
+        $$"""
+        Recursive initialization for {name} / {newShaShort}
+
+        {{AUTOMATION_COMMIT_TAG}}
+        """;
+
     private readonly IVmrInfo _vmrInfo;
     private readonly IVmrDependencyTracker _dependencyTracker;
     private readonly IVmrPatchHandler _patchHandler;
@@ -75,6 +85,17 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         {
             throw new EmptySyncException($"Repository {mapping.Name} already exists");
         }
+        
+        string initBranchName = $"init/{mapping.Name}{(targetRevision != null ? $"/{targetRevision}" : string.Empty)}";
+        string currentBranch;
+        using (var repo = new Repository(_vmrInfo.VmrPath))
+        {
+            _logger.LogInformation("Creating a temporary branch {branchName} for initialization commits", initBranchName);
+
+            currentBranch = repo.Head.FriendlyName;
+            Branch branch = repo.Branches.Add(initBranchName, HEAD, allowOverwrite: true);
+            Commands.Checkout(repo, branch);
+        }
 
         var reposToUpdate = new Queue<(SourceMapping mapping, string? targetRevision, string? targetVersion)>();
         reposToUpdate.Enqueue((mapping, targetRevision, targetVersion));
@@ -117,6 +138,25 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
                 }
             }
         }
+
+        string newSha = _dependencyTracker.GetDependencyVersion(mapping)!.Sha;
+
+        using (var repo = new Repository(_vmrInfo.VmrPath))
+        {
+            _logger.LogInformation("Merging {branchName} into {mainBranch}", initBranchName, currentBranch);
+            Commands.Checkout(repo, currentBranch);
+            repo.Merge(repo.Branches[initBranchName], DotnetBotCommitSignature, new MergeOptions
+            {
+                FastForwardStrategy = FastForwardStrategy.NoFastForward,
+                CommitOnSuccess = false,
+            });
+
+            var commitMessage = PrepareCommitMessage(MergeCommitMessage, mapping, oldSha: null, newSha);
+
+            repo.Commit(commitMessage, DotnetBotCommitSignature, DotnetBotCommitSignature);
+        }
+
+        _logger.LogInformation("Recursive initialization for {repo} / {sha} finished", mapping.Name, newSha);
     }
 
     private async Task InitializeRepository(

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -152,4 +152,65 @@ public abstract class VmrManagerBase : IVmrManager
     }
 
     protected static Signature DotnetBotCommitSignature => new(Constants.DarcBotName, Constants.DarcBotEmail, DateTimeOffset.Now);
+
+    /// <summary>
+    /// Helper method that creates a new git branch that we can make changes to.
+    /// After we're done, the branch can be merged into the original branch.
+    /// </summary>
+    protected IWorkBranch CreateWorkBranch(string branchName) => WorkBranch.CreateWorkBranch(_vmrInfo.VmrPath, branchName, _logger);
+
+    protected interface IWorkBranch
+    {
+        void MergeBack(string commitMessage);
+    }
+    
+    /// <summary>
+    /// Helper method that creates a new git branch that we can make changes to.
+    /// After we're done, the branch can be merged into the original branch.
+    /// </summary>
+    private class WorkBranch : IWorkBranch
+    {
+        private readonly string _repoPath;
+        private readonly string _currentBranch;
+        private readonly string _workBranch;
+        private readonly ILogger _logger;
+
+        private WorkBranch(string repoPath, string currentBranch, string workBranch, ILogger logger)
+        {
+            _repoPath = repoPath;
+            _currentBranch = currentBranch;
+            _workBranch = workBranch;
+            _logger = logger;
+        }
+
+        public static WorkBranch CreateWorkBranch(string repoPath, string branchName, ILogger logger)
+        {
+            string originalBranch;
+
+            using (var repo = new Repository(repoPath))
+            {
+                logger.LogInformation("Creating a temporary work branch {branchName}", branchName);
+
+                originalBranch = repo.Head.FriendlyName;
+                Branch branch = repo.Branches.Add(branchName, HEAD, allowOverwrite: true);
+                Commands.Checkout(repo, branch);
+            }
+
+            return new WorkBranch(repoPath, originalBranch, branchName, logger);
+        }
+
+        public void MergeBack(string commitMessage)
+        {
+            using var repo = new Repository(_repoPath);
+            _logger.LogInformation("Merging {branchName} into {mainBranch}", _workBranch, _currentBranch);
+            Commands.Checkout(repo, _currentBranch);
+            repo.Merge(repo.Branches[_workBranch], DotnetBotCommitSignature, new MergeOptions
+            {
+                FastForwardStrategy = FastForwardStrategy.NoFastForward,
+                CommitOnSuccess = false,
+            });
+
+            repo.Commit(commitMessage, DotnetBotCommitSignature, DotnetBotCommitSignature);
+        }
+    }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -165,8 +165,7 @@ public abstract class VmrManagerBase : IVmrManager
     }
     
     /// <summary>
-    /// Helper method that creates a new git branch that we can make changes to.
-    /// After we're done, the branch can be merged into the original branch.
+    /// Helper class that creates a new git branch when initialized and can merge this branch back into the original branch.
     /// </summary>
     private class WorkBranch : IWorkBranch
     {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -281,7 +281,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             targetRevision ?? HEAD);
 
         // When we synchronize in bulk, we do it in a separate branch that we then merge into the main one
-        string syncBranchName = $"sync/{DarcLib.Commit.GetShortSha(GetCurrentVersion(rootMapping))}-{targetRevision}";
+        string syncBranchName = $"sync/{rootMapping.Name}/{DarcLib.Commit.GetShortSha(GetCurrentVersion(rootMapping))}-{targetRevision}";
         string currentBranch;
         using (var repo = new Repository(_vmrInfo.VmrPath))
         {


### PR DESCRIPTION
- Deduplicated code for `VmrUpdater` and `VmrInitializer` and put it in a wrapper class
- I cannot use `IDisposal` for this purpose as I don't want this to trigger when exceptions happen

https://github.com/dotnet/arcade/issues/11530