### PR TITLE
Fix Autoscale out alert 

### DIFF
--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -1664,7 +1664,7 @@
             },
             "reducer": {
               "params": [],
-              "type": "max"
+              "type": "avg"
             },
             "type": "query"
           }
@@ -1782,7 +1782,7 @@
             "dimensionFilters": [
               {
                 "dimension": "cloud/roleName",
-                "filter": "fabric:/Helix/AutoScaleActorService' or cloud/roleName eq 'fabric:/Helix/ProcessAutoScaleService",
+                "filter": "fabric:/Helix/AutoScaleActorService",
                 "operator": "eq"
               }
             ],
@@ -1793,7 +1793,7 @@
             "resourceName": "[parameter(dotnet-eng-appinsights-resourcename)]",
             "timeGrain": "auto",
             "timeGrains": [],
-            "top": "10"
+            "top": "100"
           },
           "azureResourceGraph": {
             "resultFormat": "table"
@@ -1819,7 +1819,7 @@
         {
           "colorMode": "critical",
           "op": "lt",
-          "value": 4,
+          "value": 20,
           "visible": true
         }
       ],

--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -1819,7 +1819,7 @@
         {
           "colorMode": "critical",
           "op": "lt",
-          "value": 1,
+          "value": 10,
           "visible": true
         }
       ],

--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -1819,7 +1819,7 @@
         {
           "colorMode": "critical",
           "op": "lt",
-          "value": 10,
+          "value": 4,
           "visible": true
         }
       ],


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/11521

When the autoscaler is frozen, ProcessAutoscaleService can still trace ~2 traces per minute; this causes the alert to prematurely go green despite still being ongoing

<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

