### PR TITLE
Share OTP code, since it's used in 2 places in helix

### DIFF
--- a/arcade-services.sln
+++ b/arcade-services.sln
@@ -205,6 +205,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.GitHub.Aut
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Darc", "Darc", "{C0B90032-033F-4C3E-809F-BD3339E1E313}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Authentication.Algorithms", "src\Shared\Microsoft.DotNet.Authentication.Algorithms\Microsoft.DotNet.Authentication.Algorithms.csproj", "{98119800-E540-4928-8354-5E21E1384169}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Authentication.Algorithms.Tests", "src\Shared\Microsoft.DotNet.Authentication.Algorithms.Tests\Microsoft.DotNet.Authentication.Algorithms.Tests.csproj", "{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1115,6 +1119,30 @@ Global
 		{907149A6-902B-4BED-956C-6478D58C7578}.Release|x64.Build.0 = Release|Any CPU
 		{907149A6-902B-4BED-956C-6478D58C7578}.Release|x86.ActiveCfg = Release|Any CPU
 		{907149A6-902B-4BED-956C-6478D58C7578}.Release|x86.Build.0 = Release|Any CPU
+		{98119800-E540-4928-8354-5E21E1384169}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98119800-E540-4928-8354-5E21E1384169}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98119800-E540-4928-8354-5E21E1384169}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{98119800-E540-4928-8354-5E21E1384169}.Debug|x64.Build.0 = Debug|Any CPU
+		{98119800-E540-4928-8354-5E21E1384169}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{98119800-E540-4928-8354-5E21E1384169}.Debug|x86.Build.0 = Debug|Any CPU
+		{98119800-E540-4928-8354-5E21E1384169}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98119800-E540-4928-8354-5E21E1384169}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98119800-E540-4928-8354-5E21E1384169}.Release|x64.ActiveCfg = Release|Any CPU
+		{98119800-E540-4928-8354-5E21E1384169}.Release|x64.Build.0 = Release|Any CPU
+		{98119800-E540-4928-8354-5E21E1384169}.Release|x86.ActiveCfg = Release|Any CPU
+		{98119800-E540-4928-8354-5E21E1384169}.Release|x86.Build.0 = Release|Any CPU
+		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5}.Debug|x64.Build.0 = Debug|Any CPU
+		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5}.Debug|x86.Build.0 = Debug|Any CPU
+		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5}.Release|x64.ActiveCfg = Release|Any CPU
+		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5}.Release|x64.Build.0 = Release|Any CPU
+		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5}.Release|x86.ActiveCfg = Release|Any CPU
+		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1182,6 +1210,8 @@ Global
 		{5E7035A0-EF43-428B-8DB7-5322BDEAE85A} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
 		{BB47E23E-7969-478D-A6FF-0A4B4A15A4F7} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
 		{907149A6-902B-4BED-956C-6478D58C7578} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
+		{98119800-E540-4928-8354-5E21E1384169} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
+		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {32B9C883-432E-4FC8-A1BF-090EB033DD5B}

--- a/src/Microsoft.DncEng.SecretManager/Microsoft.DncEng.SecretManager.csproj
+++ b/src/Microsoft.DncEng.SecretManager/Microsoft.DncEng.SecretManager.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" />
     <PackageReference Include="Microsoft.Azure.Management.Storage" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client"/>
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" />
     <PackageReference Include="Mono.Options" />
     <PackageReference Include="WindowsAzure.Storage" />
     <PackageReference Include="YamlDotNet" />
@@ -39,5 +39,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DncEng.Configuration.Extensions\Microsoft.DncEng.Configuration.Extensions.csproj" />
     <ProjectReference Include="..\Shared\Microsoft.DncEng.CommandLineLib\Microsoft.DncEng.CommandLineLib.csproj" />
+    <ProjectReference Include="..\Shared\Microsoft.DotNet.Authentication.Algorithms\Microsoft.DotNet.Authentication.Algorithms.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccountInteractiveSecretType.cs
+++ b/src/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccountInteractiveSecretType.cs
@@ -1,5 +1,6 @@
 using Microsoft.DncEng.CommandLineLib;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Authentication.Algorithms;
 
 namespace Microsoft.DncEng.SecretManager.SecretTypes;
 

--- a/src/Shared/Microsoft.DotNet.Authentication.Algorithms.Tests/Microsoft.DotNet.Authentication.Algorithms.Tests.csproj
+++ b/src/Shared/Microsoft.DotNet.Authentication.Algorithms.Tests/Microsoft.DotNet.Authentication.Algorithms.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.Authentication.Algorithms\Microsoft.DotNet.Authentication.Algorithms.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Shared/Microsoft.DotNet.Authentication.Algorithms.Tests/OneTimePasswordGeneratorTests.cs
+++ b/src/Shared/Microsoft.DotNet.Authentication.Algorithms.Tests/OneTimePasswordGeneratorTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.DotNet.Authentication.Algorithms;
 using NUnit.Framework;
 
 namespace Microsoft.DncEng.SecretManager.Tests;

--- a/src/Shared/Microsoft.DotNet.Authentication.Algorithms/Microsoft.DotNet.Authentication.Algorithms.csproj
+++ b/src/Shared/Microsoft.DotNet.Authentication.Algorithms/Microsoft.DotNet.Authentication.Algorithms.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+</Project>

--- a/src/Shared/Microsoft.DotNet.Authentication.Algorithms/OneTimePasswordGenerator.cs
+++ b/src/Shared/Microsoft.DotNet.Authentication.Algorithms/OneTimePasswordGenerator.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 
-namespace Microsoft.DncEng.SecretManager;
+namespace Microsoft.DotNet.Authentication.Algorithms;
 
 public class OneTimePasswordGenerator
 {
@@ -12,8 +12,9 @@ public class OneTimePasswordGenerator
     {
         _seed = ConvertFromBase32(secretBase32Encoded);
     }
+    
     public string Generate(DateTimeOffset timestamp)
-    {            
+    {
         byte[] timestampBy30sBytes = BitConverter.GetBytes(timestamp.ToUnixTimeSeconds() / 30);
         Array.Reverse((Array)timestampBy30sBytes);
         byte[] hash;

--- a/src/Shared/Microsoft.DotNet.Web.Authentication.Tests/Microsoft.DotNet.Web.Authentication.Tests.csproj
+++ b/src/Shared/Microsoft.DotNet.Web.Authentication.Tests/Microsoft.DotNet.Web.Authentication.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web" ToolsVersion="Current">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <SignAssembly>false</SignAssembly>


### PR DESCRIPTION
This code is used in multiple places, let get it shared without a bunch of dependencies,
so we can use the code in helix too.

https://github.com/dotnet/arcade/issues/11539