### PR TITLE
Add release notes to dotnet/dnceng alerts

### DIFF
--- a/src/DotNet.Status.Web/Controllers/AlertHookController.cs
+++ b/src/DotNet.Status.Web/Controllers/AlertHookController.cs
@@ -181,6 +181,8 @@ public class AlertHookController : ControllerBase
 {string.Format(BodyLabelTextFormat, GetUniqueIdentifier(notification))}
 
 </details>
+
+{(options.NotificationTarget == "@dotnet/dnceng" ? "### Release Note Description" : "")}
 ".Replace("\r\n","\n")
         };
 

--- a/src/DotNet.Status.Web/Controllers/AlertHookController.cs
+++ b/src/DotNet.Status.Web/Controllers/AlertHookController.cs
@@ -182,7 +182,7 @@ public class AlertHookController : ControllerBase
 
 </details>
 
-{(options.NotificationTarget == "@dotnet/dnceng" ? "### Release Note Description" : "")}
+{(options.NotificationTarget == "@dotnet/dnceng" ? "### Release Note Description\nDo not include in release notes. (Note to devs: change this if this alert results in a code change.)" : "")}
 ".Replace("\r\n","\n")
         };
 


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade/issues/11433

Adds a release notes to grafana alerts targeting dotnet/dnceng. 