### PR TITLE
Add the possibility to map any non-`src/` VMR content

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
@@ -63,9 +63,9 @@ public class SourceMappingParser : ISourceMappingParser
             var additionalMappings = new List<(string Source, string? Destination)>();
             foreach (var additionalMapping in settings.AdditionalMappings)
             {
-                if (NormalizePath(additionalMapping.Source) is null || !additionalMapping.Source.StartsWith($"{VmrInfo.SourcesDir}/"))
+                if (additionalMapping.Source is null || NormalizePath(additionalMapping.Source) is null || !additionalMapping.Source.StartsWith($"{VmrInfo.SourcesDir}/"))
                 {
-                    throw new Exception($"Additional mapping for {additionalMapping.Destination} needs to declare the source pointing to src/");
+                    throw new Exception($"Additional mapping for {additionalMapping.Destination} needs to declare the source pointing to {VmrInfo.SourcesDir}/");
                 }
 
                 additionalMappings.Add((additionalMapping.Source, NormalizePath(additionalMapping.Destination)));

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
@@ -60,7 +60,7 @@ public class SourceMappingParser : ISourceMappingParser
 
         if (settings.AdditionalMappings is not null)
         {
-            var paths = new List<(string Source, string? Destination)>();
+            var additionalMappings = new List<(string Source, string? Destination)>();
             foreach (var additionalMapping in settings.AdditionalMappings)
             {
                 if (additionalMapping.Source is null)
@@ -68,10 +68,10 @@ public class SourceMappingParser : ISourceMappingParser
                     throw new Exception($"Invalid additional mapping: {additionalMapping.Source} -> {additionalMapping.Destination}");
                 }
 
-                paths.Add((additionalMapping.Source, NormalizePath(additionalMapping.Destination)));
+                additionalMappings.Add((additionalMapping.Source, NormalizePath(additionalMapping.Destination)));
             }
 
-            _vmrInfo.AdditionalMappings = paths.ToImmutableArray();
+            _vmrInfo.AdditionalMappings = additionalMappings.ToImmutableArray();
         }
 
         var mappings = settings.Mappings

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
@@ -63,9 +63,9 @@ public class SourceMappingParser : ISourceMappingParser
             var additionalMappings = new List<(string Source, string? Destination)>();
             foreach (var additionalMapping in settings.AdditionalMappings)
             {
-                if (additionalMapping.Source is null)
+                if (NormalizePath(additionalMapping.Source) is null || !additionalMapping.Source.StartsWith($"{VmrInfo.SourcesDir}/"))
                 {
-                    throw new Exception($"Invalid additional mapping: {additionalMapping.Source} -> {additionalMapping.Destination}");
+                    throw new Exception($"Additional mapping for {additionalMapping.Destination} needs to declare the source pointing to src/");
                 }
 
                 additionalMappings.Add((additionalMapping.Source, NormalizePath(additionalMapping.Destination)));

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -23,15 +23,18 @@ public interface IVmrInfo
     string VmrPath { get; }
 
     /// <summary>
-    /// Path within the VMR where VMR patches are stored
-    /// (these patches are applied on top of the synchronized content)
+    /// Path within the VMR where VMR patches are stored.
+    /// These patches are applied on top of the synchronized content.
+    /// The Path is UNIX style and relative (e.g. "src/patches").
     /// </summary>
     string? PatchesPath { get; set; }
 
     /// <summary>
     /// Additionally mapped directories that are copied to non-src/ locations within the VMR.
+    /// Paths are UNIX style and relative.
+    /// Example: ("src/installer/eng/common", "eng/common")
     /// </summary>
-    IReadOnlyCollection<(string Source, string Destination)> AdditionalMappings { get; set; }
+    IReadOnlyCollection<(string Source, string? Destination)> AdditionalMappings { get; set; }
 
     /// <summary>
     /// Gets a full path leading to sources belonging to a given repo (mapping)
@@ -64,7 +67,7 @@ public class VmrInfo : IVmrInfo
 
     public string? PatchesPath { get; set; }
 
-    public IReadOnlyCollection<(string Source, string Destination)> AdditionalMappings { get; set; } = Array.Empty<(string Source, string Destination)>();
+    public IReadOnlyCollection<(string Source, string? Destination)> AdditionalMappings { get; set; } = Array.Empty<(string, string?)>();
 
     public VmrInfo(string vmrPath, string tmpPath)
     {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 
@@ -27,9 +29,9 @@ public interface IVmrInfo
     string? PatchesPath { get; set; }
 
     /// <summary>
-    /// Path within the VMR from where the non-src/ files are copied from.
+    /// Additionally mapped directories that are copied to non-src/ locations within the VMR.
     /// </summary>
-    string? ContentPath { get; set; }
+    IReadOnlyCollection<(string Source, string Destination)> AdditionalMappings { get; set; }
 
     /// <summary>
     /// Gets a full path leading to sources belonging to a given repo (mapping)
@@ -60,9 +62,9 @@ public class VmrInfo : IVmrInfo
 
     public string TmpPath { get; }
 
-    public string? ContentPath { get; set; }
-
     public string? PatchesPath { get; set; }
+
+    public IReadOnlyCollection<(string Source, string Destination)> AdditionalMappings { get; set; } = Array.Empty<(string Source, string Destination)>();
 
     public VmrInfo(string vmrPath, string tmpPath)
     {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using LibGit2Sharp;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
@@ -542,7 +541,7 @@ public class VmrPatchHandler : IVmrPatchHandler
 
         var mappingPatchesPath = _fileSystem.PathCombine(
             _vmrInfo.VmrPath,
-            _vmrInfo.PatchesPath.Replace('/', Path.DirectorySeparatorChar),
+            _vmrInfo.PatchesPath.Replace('/', _fileSystem.DirectorySeparatorChar),
             mapping.Name);
 
         if (!_fileSystem.DirectoryExists(mappingPatchesPath))

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -5,10 +5,12 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
@@ -177,12 +179,17 @@ public class VmrPatchHandler : IVmrPatchHandler
 
         // If current mapping hosts VMR's non-src/ content, synchronize it too
         // We only do it when processing the root mapping, not its submodules
-        var sourcesPath = _vmrInfo.GetRepoSourcesPath(mapping);
-        if (relativePath == mapping.Name && (_vmrInfo.ContentPath?.StartsWith(sourcesPath) ?? false))
+        var relativeRepoPath = _vmrInfo.GetRelativeRepoSourcesPath(mapping);
+        int i = 1;
+        foreach (var (source, destination) in _vmrInfo.AdditionalMappings.Where(m => m.Source.StartsWith(relativeRepoPath)))
         {
-            _logger.LogInformation("Mapping {mapping} contains VMR's non-src/ content. Creating patch for it too..", mapping.Name);
+            var relativeClonePath = source.Substring(relativeRepoPath.Length + 1);
 
-            patchName = _fileSystem.PathCombine(destDir, $"root-{Commit.GetShortSha(sha1)}-{Commit.GetShortSha(sha2)}.patch");
+            _logger.LogInformation("Detected 'non-src/' mapped content in {source}. Creating patch..", source);
+
+            patchName = $"{(destination != null ? destination.Replace('/', '_') : "root")}-{Commit.GetShortSha(sha1)}-{Commit.GetShortSha(sha2)}-{i++}.patch";
+            patchName = _fileSystem.PathCombine(destDir, patchName);
+
             args = new List<string>
             {
                 "diff",
@@ -197,8 +204,7 @@ public class VmrPatchHandler : IVmrPatchHandler
             };
 
             // We take the content path from the VMR config and map it onto the cloned repo
-            var contentDir = _vmrInfo.ContentPath.Substring(sourcesPath.Length + 1);
-            contentDir = _fileSystem.PathCombine(repoPath, contentDir);
+            var contentDir = _fileSystem.PathCombine(repoPath, relativeClonePath.Replace('/', _fileSystem.DirectorySeparatorChar));
 
             result = await _processManager.Execute(
                 _processManager.GitExecutable,
@@ -206,7 +212,7 @@ public class VmrPatchHandler : IVmrPatchHandler
                 workingDir: contentDir,
                 cancellationToken: cancellationToken);
 
-            patches.Add(new VmrIngestionPatch(patchName, null));
+            patches.Add(new VmrIngestionPatch(patchName, destination));
         }
 
         if (!submoduleChanges.Any())
@@ -298,6 +304,11 @@ public class VmrPatchHandler : IVmrPatchHandler
         {
             args.Add("--directory");
             args.Add(patch.ApplicationPath);
+
+            if (!_fileSystem.DirectoryExists(patch.ApplicationPath))
+            {
+                _fileSystem.CreateDirectory(patch.ApplicationPath);
+            }
         }
 
         args.Add(patch.Path);
@@ -529,7 +540,11 @@ public class VmrPatchHandler : IVmrPatchHandler
             return Array.Empty<string>();
         }
 
-        var mappingPatchesPath = _fileSystem.PathCombine(_vmrInfo.PatchesPath, mapping.Name);
+        var mappingPatchesPath = _fileSystem.PathCombine(
+            _vmrInfo.VmrPath,
+            _vmrInfo.PatchesPath.Replace('/', Path.DirectorySeparatorChar),
+            mapping.Name);
+
         if (!_fileSystem.DirectoryExists(mappingPatchesPath))
         {
             return Array.Empty<string>();

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -511,7 +511,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         patchesToRestore.AddRange(_patchHandler.GetVmrPatches(updatedMapping).Select(patch => (updatedMapping, patch)));
 
         // If we are not updating the mapping that the VMR patches come from, we're done
-        if (_vmrInfo.PatchesPath == null || !_vmrInfo.PatchesPath.StartsWith(_vmrInfo.GetRepoSourcesPath(updatedMapping)))
+        if (_vmrInfo.PatchesPath == null || !_vmrInfo.PatchesPath.StartsWith(_vmrInfo.GetRelativeRepoSourcesPath(updatedMapping)))
         {
             return patchesToRestore;
         }
@@ -523,9 +523,9 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         {
             var patchedFiles = await _patchHandler.GetPatchedFiles(clonePath, patch.Path, cancellationToken);
             var affectedPatches = patchedFiles
+                .Where(path => path.StartsWith(_vmrInfo.PatchesPath) && path.EndsWith(".patch"))
                 .Select(path => path.Replace('/', _fileSystem.DirectorySeparatorChar))
-                .Select(path => _fileSystem.PathCombine(_vmrInfo.GetRepoSourcesPath(updatedMapping), path))
-                .Where(path => path.StartsWith(_vmrInfo.PatchesPath) && path.EndsWith(".patch"));
+                .Select(path => _fileSystem.PathCombine(_vmrInfo.GetRepoSourcesPath(updatedMapping), path));
 
             foreach (var affectedPatch in affectedPatches)
             {


### PR DESCRIPTION
Since we need to be able to map multiple different paths from within the development repositories into the VMR (and not only to VMR's root), we need to extend the functionality that synchronizes non-`src/` content. Example is the `eng/common` folder from `dotnet/installer`.

Previously, we had 1 path that we synchronized with the root of the VMR:
```json
    "contentPath": "src/installer/src/SourceBuild/tarball/content",
```

Now we can have this:
```json
    "additionalMappings": [
        {
            "source": "src/installer/src/SourceBuild/tarball/content",
            "destination": ""
        },
        {
            "source": "src/installer/eng/common",
            "destination": "eng/common"
        }
    ],
```

Resolves https://github.com/dotnet/arcade/issues/11548