### PR TITLE
Fix URLs in VMR's README's auto-generated list of components

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Models/VirtualMonoRepo/ManifestRecord.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Models/VirtualMonoRepo/ManifestRecord.cs
@@ -16,13 +16,19 @@ public interface ISourceComponent
     // TODO (https://github.com/dotnet/arcade/issues/10549): Add also non-GitHub implementations
     public string GetPublicUrl()
     {
-        var url = RemoteUri + "/commit/" + CommitSha;
-        url = url.Replace("//", "/");
+        var url = RemoteUri;
 
         if (url.EndsWith(".git"))
         {
             url = url[..^4];
         }
+
+        if (!url.EndsWith('/'))
+        {
+            url += '/';
+        }
+
+        url += "commit/" + CommitSha;
 
         return url;
     }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/ReadmeComponentListGenerator.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/ReadmeComponentListGenerator.cs
@@ -97,8 +97,13 @@ public class ReadmeComponentListGenerator : IReadmeComponentListGenerator
     {
         // TODO (https://github.com/dotnet/arcade/issues/10549): Add also non-GitHub implementations
         string[] uriParts = component.RemoteUri.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        string repo = $"{uriParts[^2]}/{uriParts[^1]}";
+        if (repo.EndsWith(".git"))
+        {
+            repo = repo[..^4];
+        }
 
         await writer.WriteLineAsync($"{new string(' ', indentation)}- `{VmrInfo.SourcesDir}/{component.Path}`  ");
-        await writer.WriteLineAsync($"{new string(' ', indentation)}*[{uriParts[^2]}/{uriParts[^1]}@{Commit.GetShortSha(component.CommitSha)}]({component.GetPublicUrl()})*");
+        await writer.WriteLineAsync($"{new string(' ', indentation)}*[{repo}@{Commit.GetShortSha(component.CommitSha)}]({component.GetPublicUrl()})*");
     }
 }


### PR DESCRIPTION
The links in [the list of components of dotnet/dotnet](https://github.com/dotnet/dotnet#detailed-list) are currently all 404, because the code `url.Replace("//", "/")` leads to incorrect single-slashed `http:/github.com` URLs.

Also, the removal of `.git` in URLs wasn't working properly and was missing altogether in repo names.

With this PR, all component links in the README lead to valid pages.

https://github.com/dotnet/arcade/issues/11587