### PR TITLE
Add basic E2E test for the VMR tooling

### DIFF
--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -46,10 +46,10 @@ steps:
     $darc = "$(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe"
 
     # Prepare darc settings
-    $darc authenticate --clear
+    "$darc" authenticate --clear
 
     # Initialize a couple of repos in the VMR
-    $darc vmr initialize `
+    "$darc" vmr initialize `
     --vmr "$vmrDir"                `
     --tmp "$(Agent.TempDirectory)" `
     --azdev-pat "N/A"              `
@@ -59,7 +59,7 @@ steps:
     command-line-api:$firstSha
 
     # Update the repos in the VMR with some new commits
-    $darc vmr update `
+    "$darc" vmr update `
     --vmr "$vmrDir"                `
     --tmp "$(Agent.TempDirectory)" `
     --azdev-pat "N/A"              `

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -43,9 +43,13 @@ steps:
     $response = Invoke-RestMethod -Uri "https://api.github.com/repos/dotnet/command-line-api/commits?per_page=5"
     $firstSha = $response[0].sha
     $secondSha = $response[4].sha
+    $darc = "$(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe"
+
+    # Prepare darc settings
+    $darc authenticate --clear
 
     # Initialize a couple of repos in the VMR
-    $(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe vmr initialize `
+    $darc vmr initialize `
     --vmr "$vmrDir"                `
     --tmp "$(Agent.TempDirectory)" `
     --azdev-pat "N/A"              `
@@ -55,7 +59,7 @@ steps:
     command-line-api:$firstSha
 
     # Update the repos in the VMR with some new commits
-    $(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe vmr update `
+    $darc vmr update `
     --vmr "$vmrDir"                `
     --tmp "$(Agent.TempDirectory)" `
     --azdev-pat "N/A"              `

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -42,7 +42,7 @@ steps:
     # Get SHAs of last few commits to sync between them
     $response = Invoke-RestMethod -Uri "https://api.github.com/repos/dotnet/command-line-api/commits?per_page=5"
     $firstSha = $response[0].sha
-    $secondSha = $response[4].sha
+    $secondSha = $response[-1].sha
 
     # Prepare darc settings
     $(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe authenticate --clear

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -29,6 +29,7 @@ steps:
   condition: succeededOrFailed()
 
 - powershell: |
+    # Prepare an empty VMR
     $vmrDir = "$(Agent.TempDirectory)\vmr"
     New-Item -Path "$vmrDir\src" -ItemType directory
     Copy-Item -Path "$(Build.SourcesDirectory)\src\Microsoft.DotNet.Darc\tests\Microsoft.DotNet.Darc.Tests\inputs\source-mappings.json" -Destination "$vmrDir\src"
@@ -37,10 +38,13 @@ steps:
     git -C "$vmrDir" init --initial-branch main
     git -C "$vmrDir" add -A
     git -C "$vmrDir" commit -m "Initial commit"
+
+    # Get SHAs of last few commits to sync between them
     $response = Invoke-RestMethod -Uri "https://api.github.com/repos/dotnet/command-line-api/commits?per_page=5"
     $firstSha = $response[0].sha
     $secondSha = $response[4].sha
 
+    # Initialize a couple of repos in the VMR
     $(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe vmr initialize `
     --vmr "$vmrDir"                `
     --tmp "$(Agent.TempDirectory)" `
@@ -50,6 +54,7 @@ steps:
     --verbose                      `
     command-line-api:$firstSha
 
+    # Update the repos in the VMR with some new commits
     $(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe vmr update `
     --vmr "$vmrDir"                `
     --tmp "$(Agent.TempDirectory)" `

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -28,6 +28,39 @@ steps:
     NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
   condition: succeededOrFailed()
 
+- powershell: |
+    $vmrDir = "$(Agent.TempDirectory)\vmr"
+    New-Item -Path "$vmrDir\src" -ItemType directory
+    Copy-Item -Path "$(Build.SourcesDirectory)\src\Microsoft.DotNet.Darc\tests\Microsoft.DotNet.Darc.Tests\inputs\source-mappings.json" -Destination "$vmrDir\src"
+    git config --global user.email "dotnet-maestro[bot]@users.noreply.github.com"
+    git config --global user.name "dotnet-maestro[bot]"
+    git -C "$vmrDir" init --initial-branch main
+    git -C "$vmrDir" add -A
+    git -C "$vmrDir" commit -m "Initial commit"
+    $response = Invoke-RestMethod -Uri "https://api.github.com/repos/dotnet/command-line-api/commits?per_page=5"
+    $firstSha = $response[0].sha
+    $secondSha = $response[4].sha
+
+    $(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe vmr initialize `
+    --vmr "$vmrDir"                     `
+    --tmp "$(Agent.TempDirectory)"      `
+    --azdev-pat "$(System.AccessToken)" `
+    --github-pat "N/A"                  `
+    --recursive                         `
+    --verbose                           `
+    command-line-api:$firstSha
+
+    $(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe vmr update `
+    --vmr "$vmrDir"                     `
+    --tmp "$(Agent.TempDirectory)"      `
+    --azdev-pat "$(System.AccessToken)" `
+    --github-pat "N/A"                  `
+    --recursive                         `
+    --verbose                           `
+    command-line-api:$secondSha
+  displayName: Test VMR tooling
+  condition: and(succeeded(), in(variables['Build.Reason'], 'PullRequest'), eq(variables['_BuildConfig'], 'Debug'))
+
 - task: Powershell@2
   inputs: 
     targetType: filePath

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -42,21 +42,21 @@ steps:
     $secondSha = $response[4].sha
 
     $(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe vmr initialize `
-    --vmr "$vmrDir"                     `
-    --tmp "$(Agent.TempDirectory)"      `
-    --azdev-pat "$(System.AccessToken)" `
-    --github-pat "N/A"                  `
-    --recursive                         `
-    --verbose                           `
+    --vmr "$vmrDir"                `
+    --tmp "$(Agent.TempDirectory)" `
+    --azdev-pat "N/A"              `
+    --github-pat "N/A"             `
+    --recursive                    `
+    --verbose                      `
     command-line-api:$firstSha
 
     $(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe vmr update `
-    --vmr "$vmrDir"                     `
-    --tmp "$(Agent.TempDirectory)"      `
-    --azdev-pat "$(System.AccessToken)" `
-    --github-pat "N/A"                  `
-    --recursive                         `
-    --verbose                           `
+    --vmr "$vmrDir"                `
+    --tmp "$(Agent.TempDirectory)" `
+    --azdev-pat "N/A"              `
+    --github-pat "N/A"             `
+    --recursive                    `
+    --verbose                      `
     command-line-api:$secondSha
   displayName: Test VMR tooling
   condition: and(succeeded(), in(variables['Build.Reason'], 'PullRequest'), eq(variables['_BuildConfig'], 'Debug'))

--- a/eng/test.yaml
+++ b/eng/test.yaml
@@ -43,13 +43,12 @@ steps:
     $response = Invoke-RestMethod -Uri "https://api.github.com/repos/dotnet/command-line-api/commits?per_page=5"
     $firstSha = $response[0].sha
     $secondSha = $response[4].sha
-    $darc = "$(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe"
 
     # Prepare darc settings
-    "$darc" authenticate --clear
+    $(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe authenticate --clear
 
     # Initialize a couple of repos in the VMR
-    "$darc" vmr initialize `
+    $(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe vmr initialize `
     --vmr "$vmrDir"                `
     --tmp "$(Agent.TempDirectory)" `
     --azdev-pat "N/A"              `
@@ -59,7 +58,7 @@ steps:
     command-line-api:$firstSha
 
     # Update the repos in the VMR with some new commits
-    "$darc" vmr update `
+    $(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.Darc\Debug\net6.0\publish\Microsoft.DotNet.Darc.exe vmr update `
     --vmr "$vmrDir"                `
     --tmp "$(Agent.TempDirectory)" `
     --azdev-pat "N/A"              `

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/source-mappings.json
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/inputs/source-mappings.json
@@ -1,0 +1,172 @@
+// This files is used for E2E tests of the VMR tooling in arcade-services.
+//
+// This file configures where the VMR synchronizes the sources from.
+// Each development repository has a mapping record which says where the remote repo is,
+// what files are in/excluded from the sync, etc.
+//
+// This file does not contain information about what version of sources is synchronized.
+// Please check the source-manifest.json file for that purpose.
+//
+// More details on this file's mechanics:
+// https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Design-And-Operation.md#repository-source-mappings
+{
+    // Location within the VMR where the source-build patches are stored
+    // These patches are applied on top of the code synchronized into the VMR
+    "patchesPath": "src/installer/src/SourceBuild/tarball/patches",
+
+    // Some files are copied outside of the src/ directory into other locations
+    // When files in the source paths are changed, they are automatically synchronized too
+    "additionalMappings": [
+        {
+            "source": "src/installer/src/SourceBuild/tarball/content",
+            "destination": ""
+        },
+        {
+            "source": "src/installer/eng/common",
+            "destination": "eng/common"
+        }
+    ],
+
+    // These defaults are added to all mappings unless `ignoreDefaults: true` is specified
+    // When no "include" filter is specified, "**/*" is used
+    // The default filters do not apply to submodules
+    // Only filters which start with submodule's path are applied when syncing submodules
+    "defaults": {
+        "defaultRef": "main",
+        "exclude": [
+            "**/*.dll",
+            "**/*.Dll",
+            "**/*.exe",
+            "**/*.pdb",
+            "**/*.mdb",
+            "**/*.zip",
+            "**/*.nupkg"
+        ]
+    },
+
+    // Each of these mappings has a corresponding folder in the src/ directory
+    "mappings": [
+        {
+            "name": "arcade",
+            "defaultRemote": "https://github.com/dotnet/arcade"
+        },
+        {
+            "name": "aspnetcore",
+            "defaultRemote": "https://github.com/dotnet/aspnetcore",
+            "exclude": [
+                "src/submodules/MessagePack-CSharp/**/*.dll",
+                "**/samples/**/jquery-validation-unobtrusive/.bower.json",
+                "**/samples/**/jquery-validation-unobtrusive/*.js"
+            ]
+        },
+        {
+            "name": "command-line-api",
+            "defaultRemote": "https://github.com/dotnet/command-line-api"
+        },
+        {
+            "name": "deployment-tools",
+            "defaultRemote": "https://github.com/dotnet/deployment-tools"
+        },
+        {
+            "name": "diagnostics",
+            "defaultRemote": "https://github.com/dotnet/diagnostics"
+        },
+        {
+            "name": "format",
+            "defaultRemote": "https://github.com/dotnet/format"
+        },
+        {
+            "name": "fsharp",
+            "defaultRemote": "https://github.com/dotnet/fsharp"
+        },
+        {
+            "name": "installer",
+            "defaultRemote": "https://github.com/dotnet/installer",
+            "exclude": [
+                // We don't need the tarball content in the VMR again, it's already copied in the root
+                "src/SourceBuild/tarball/content/**/*"
+            ]
+        },
+        {
+            "name": "linker",
+            "defaultRemote": "https://github.com/dotnet/linker",
+            "exclude": [
+                "external/cecil/**/*.dll",
+                "external/cecil/**/*.exe",
+                "external/cecil/**/*.pdb",
+                "external/cecil/**/*.mdb"
+            ]
+        },
+        {
+            "name": "msbuild",
+            "defaultRemote": "https://github.com/dotnet/msbuild"
+        },
+        {
+            "name": "nuget-client",
+            "defaultRemote": "https://github.com/NuGet/NuGet.Client",
+            "defaultRef": "dev"
+        },
+        {
+            "name": "razor-compiler",
+            "defaultRemote": "https://github.com/dotnet/razor-compiler"
+        },
+        {
+            "name": "roslyn",
+            "defaultRemote": "https://github.com/dotnet/roslyn"
+        },
+        {
+            "name": "roslyn-analyzers",
+            "defaultRemote": "https://github.com/dotnet/roslyn-analyzers"
+        },
+        {
+            "name": "runtime",
+            "defaultRemote": "https://github.com/dotnet/runtime"
+        },
+        {
+            "name": "sdk",
+            "defaultRemote": "https://github.com/dotnet/sdk"
+        },
+        {
+            "name": "source-build-externals",
+            "defaultRemote": "https://github.com/dotnet/source-build-externals",
+            "exclude": [
+                "src/humanizer/samples/**/*.js",
+                "src/application-insights/**/*.exe",
+                "src/application-insights/**/*.dll",
+                "src/application-insights/**/*.zip"
+            ]
+        },
+        {
+            "name": "source-build-reference-packages",
+            "defaultRemote": "https://github.com/dotnet/source-build-reference-packages"
+        },
+        {
+            "name": "sourcelink",
+            "defaultRemote": "https://github.com/dotnet/sourcelink"
+        },
+        {
+            "name": "symreader",
+            "defaultRemote": "https://github.com/dotnet/symreader"
+        },
+        {
+            "name": "templating",
+            "defaultRemote": "https://github.com/dotnet/templating"
+        },
+        {
+            "name": "test-templates",
+            "defaultRemote": "https://github.com/dotnet/test-templates"
+        },
+        {
+            "name": "vstest",
+            "defaultRemote": "https://github.com/microsoft/vstest"
+        },
+        {
+            "name": "xdt",
+            "defaultRemote": "https://github.com/dotnet/xdt"
+        },
+        {
+            "name": "xliff-tasks",
+            "defaultRemote": "https://github.com/dotnet/xliff-tasks"
+        }
+    ]
+}


### PR DESCRIPTION
This PR temporarily adds a build step before the proper E2E tests are ready. This step adds about 8-12 minutes to the build because it needs to clone quite a lot of repositories and I haven't found a way to go around it.
It adds a lot of code coverage though before we add more unit tests and finish the proper E2E tests and we need the coverage at this moment to not break the VMR.

Sample run: https://dev.azure.com/dnceng-public/public/_build/results?buildId=90844&view=logs&j=074323ca-ed16-5d66-87ac-2d9d4a30c602&t=6a6cde9d-c41f-5b7b-7538-ebe626f97918

https://github.com/dotnet/arcade/issues/11618