### PR TITLE
Add publish-using-darc dependency in rollout pipeline

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -50,6 +50,7 @@ stages:
   - build
   - Validate
   - ValidateSecrets
+  - publish_using_darc
   jobs:
   - deployment: approval
     displayName: deployment approval (conditional)


### PR DESCRIPTION
There is a race condition in the production rollout pipeline where if we deploy before the publish using darc stage is complete, the main publishing pipeline could try to use the new version of darc before it is published, which will fail the publish job. This causes confusion for product teams when their jobs start failing. This change adds a dependency to the approval stage to only run after publish using darc completes, since if there is a failure there, we shouldn't approve anyway.

Addresses https://github.com/dotnet/arcade/issues/11575

<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

