### PR TITLE
Fixup conditional GitHub issue check again

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ pr:
 stages:
 - stage: GitHub_Issue_Verification
   displayName: GitHub Issue Verification
-  condition: and(eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.TargetBranch'], 'refs/heads/production'))
+  condition: and(eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.TargetBranch'], 'refs/heads/production'), ne(variables['Build.SourceBranch'], 'refs/heads/production'))
   jobs:
     - job: VerifyGitHubIssue
       displayName: Verify GitHub Issue Link included in all PRs


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade/issues/11433

Had a nightmare last night where I realized that this check existed for the merge of prod back to master specifically.