### PR TITLE
Fix typo: there is no 'x' permission for Azure storage blob SAS Uris

### DIFF
--- a/.vault-config/shared/dotneteng-status-secrets.yaml
+++ b/.vault-config/shared/dotneteng-status-secrets.yaml
@@ -23,7 +23,7 @@ data-protection-key-file-uri:
   type: azure-storage-blob-sas-uri
   parameters:
     connectionString: dotnet-status-storage-account
-    permissions: racwdx
+    permissions: racwd
     container: site
     blob: keys.xml
 


### PR DESCRIPTION
Noted after merging https://github.com/dotnet/arcade/issues/11650 and testing pipelines.

