### PR TITLE
Assign weekly secret job failures to FROps

### DIFF
--- a/src/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/.config/settings.json
@@ -59,25 +59,25 @@
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\arcade-services\\dotnet-arcade-services-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade-first-responder"
+          "IssuesId": "dotnet-arcade-frops"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\arcade\\dotnet-arcade-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade-first-responder"
+          "IssuesId": "dotnet-arcade-frops"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\helix-service\\dotnet-helix-service-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade-first-responder"
+          "IssuesId": "dotnet-arcade-frops"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\helix-machines\\dotnet-helix-machines-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-arcade-first-responder"
+          "IssuesId": "dotnet-arcade-frops"
         },
         {
           "Project": "internal",
@@ -121,6 +121,12 @@
         "Owner": "dotnet",
         "Name": "arcade",
         "Labels": [ "Build Failed", "First Responder" ]
+      },
+      {
+        "Id": "dotnet-arcade-frops",
+        "Owner": "dotnet",
+        "Name": "arcade",
+        "Labels": [ "Build Failed", "FROps" ]
       },
       {
         "Id": "dotnet-aspnetcore-infra",


### PR DESCRIPTION
Originally, these were considered First Responder, but now that we have FROps, these fall more in the domain of that effort. Change the labels that are assigned to these build failures.

<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

https://github.com/dotnet/arcade/issues/11692
