### PR TITLE
Let CG run on all pipelines

### DIFF
--- a/azure-pipeline-codeql.yml
+++ b/azure-pipeline-codeql.yml
@@ -6,9 +6,6 @@ parameters:
   default: true
 
 variables:
-  # CG is handled in the primary CI pipeline
-- name: skipComponentGovernanceDetection
-  value: true
   # Force CodeQL enabled so it may be run on any branch
 - name: Codeql.Enabled
   value: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,8 +6,6 @@ variables:
     value: true
   - name: _DotNetArtifactsCategory
     value: .NETCore
-  - name: skipComponentGovernanceDetection
-    value: true
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: SDL_Settings
 


### PR DESCRIPTION
Previously, Component Governance scans were enabled only on pipelines known to be run regularly and in the "production" configuration. The CG tools have changed how pipelines are tracked, making the selective path less effective.

This change lets CG run on all pipelines. This should be more like what CG tools expect and give a better reporting experience.

Part of [dotnet/arcade#11705](https://github.com/dotnet/arcade/issues/11705)