### PR TITLE
Skip scanning empty VMR patch files

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -368,7 +368,7 @@ public class VmrPatchHandler : IVmrPatchHandler
             return files;
         }
 
-        var result = await _processManager.ExecuteGit(repoPath, new string[] { "apply", "--numstat", "--allow-empty", patchPath }, cancellationToken);
+        var result = await _processManager.ExecuteGit(repoPath, new string[] { "apply", "--numstat", patchPath }, cancellationToken);
         result.ThrowIfFailed($"Failed to enumerate files from a patch at `{patchPath}`");
 
         foreach (var line in result.StandardOutput.Split(Environment.NewLine))

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -361,10 +361,16 @@ public class VmrPatchHandler : IVmrPatchHandler
         string patchPath,
         CancellationToken cancellationToken)
     {
+        var files = new List<string>();
+        if (_fileSystem.GetFileInfo(repoPath).Length == 0)
+        {
+            _logger.LogDebug("Patch {patch} is empty. Skipping file enumeration..", patchPath);
+            return files;
+        }
+
         var result = await _processManager.ExecuteGit(repoPath, new string[] { "apply", "--numstat", "--allow-empty", patchPath }, cancellationToken);
         result.ThrowIfFailed($"Failed to enumerate files from a patch at `{patchPath}`");
 
-        var files = new List<string>();
         foreach (var line in result.StandardOutput.Split(Environment.NewLine))
         {
             var match = GitPatchSummaryLine.Match(line);

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -179,8 +180,11 @@ public class VmrPatchHandlerTests
             .Setup(x => x.FileExists($"{_clonePath}/{patchedFiles[1]}"))
             .Returns(false);
 
+        _fileSystem
+            .SetReturnsDefault(Mock.Of<IFileInfo>(x => x.Length == 1024 && x.Exists));
+
         SetupGitCall(
-            new[] { "apply", "--numstat", "--allow-empty", patch },
+            new[] { "apply", "--numstat", patch },
             new ProcessExecutionResult()
             {
                 ExitCode = 0,


### PR DESCRIPTION
Resolves https://github.com/dotnet/arcade/issues/11716