### PR TITLE
update secret manager in repo to enable automatic PAT rotation features

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "microsoft.dnceng.secretmanager": {
-      "version": "1.1.0-beta.22174.7",
+      "version": "1.1.0-beta.22580.1",
       "commands": [
         "secret-manager"
       ]

--- a/.vault-config/shared/maestro-secrets.yaml
+++ b/.vault-config/shared/maestro-secrets.yaml
@@ -70,4 +70,4 @@ dn-bot-dnceng-packaging-rwm:
       location: helixkv
       name: dn-bot-account-redmond
     organizations: dnceng
-    scopes: packaging_write
+    scopes: packaging_manage


### PR DESCRIPTION
Part of https://github.com/dotnet/arcade/issues/11745

This repo already has the correct format in its manifests for PATs to get auto cycled, but we're using an older version of the tool that doesn't have the feature yet. This updates us to the package released during the latest production deployment. 

