### PR TITLE
Make GitHub client work without a token

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -744,8 +744,16 @@ public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
     /// <returns>New http client</returns
     private HttpClient CreateHttpClient()
     {
-        var client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }) {BaseAddress = new Uri(GitHubApiUri)};
-        client.DefaultRequestHeaders.Add("Authorization", $"Token {_personalAccessToken}");
+        var client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true })
+        {
+            BaseAddress = new Uri(GitHubApiUri)
+        };
+        
+        if (_personalAccessToken != null)
+        {
+            client.DefaultRequestHeaders.Add("Authorization", $"Token {_personalAccessToken}");
+        }
+
         client.DefaultRequestHeaders.Add("User-Agent", _userAgent);
 
         return client;


### PR DESCRIPTION
Technically, we allow `null` token and we also even do it https://github.com/dotnet/arcade-services/blob/91b319ebd690281e46c035306c5145672e44dd26/src/Maestro/Maestro.DataProviders/DarcRemoteFactory.cs#L72

But.. it actually does not work as we get 401 from GH when the token in the header is empty. So let's allow this scenario as the VMR only clones public remotes and doesn't need a token then.

https://github.com/dotnet/arcade/issues/10549