### PR TITLE
Migrate Dotnet.Status.Web to Azure.Security.Keyvault

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,10 +14,12 @@
     <PackageVersion Include="Azure.Core" Version="1.25.0" />
     <PackageVersion Include="Azure.Data.AppConfiguration" Version="1.0.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.2.0" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.3" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.1.0" />
     <PackageVersion Include="Azure.Identity" Version="1.5.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.0.1" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.0.1" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.13.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.4.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.4.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.13.1" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.11.0" />
     <PackageVersion Include="Castle.Core" Version="4.3.0" />
     <PackageVersion Include="CommandLineParser" Version="2.2.1" />

--- a/src/DotNet.Status.Web/.config/settings.Production.json
+++ b/src/DotNet.Status.Web/.config/settings.Production.json
@@ -10,7 +10,7 @@
     "TitlePrefix": "Production - "
   },
   "DataProtection": {
-    "KeyBlobUri": "",
+    "KeyBlobUri": "https://dotnetengstatusprod.blob.core.windows.net/site/keys.xml",
     "DataProtectionKeyUri": "https://dotneteng-status-prod.vault.azure.net/keys/dotnet-status-data-protection/"
   },
   "Grafana": {

--- a/src/DotNet.Status.Web/.config/settings.Production.json
+++ b/src/DotNet.Status.Web/.config/settings.Production.json
@@ -9,6 +9,10 @@
     "EnvironmentLabels": [ "Production" ],
     "TitlePrefix": "Production - "
   },
+  "DataProtection": {
+    "KeyBlobUri": "",
+    "DataProtectionKeyUri": "https://dotneteng-status-prod.vault.azure.net/keys/dotnet-status-data-protection/"
+  },
   "Grafana": {
     "BaseUrl": "https://dotnet-eng-grafana.westus2.cloudapp.azure.com"
   }

--- a/src/DotNet.Status.Web/.config/settings.Staging.json
+++ b/src/DotNet.Status.Web/.config/settings.Staging.json
@@ -8,5 +8,9 @@
     "AlertLabels": [ "First Responder" ],
     "EnvironmentLabels": [ "Staging" ],
     "TitlePrefix": "Staging - "
+  },
+  "DataProtection": {
+    "KeyBlobUri": "https://dotnetengstatusstaging.blob.core.windows.net/site/keys.xml",
+    "DataProtectionKeyUri": "https://dotneteng-status-staging.vault.azure.net/keys/dotnet-status-data-protection/"
   }
 }

--- a/src/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/.config/settings.json
@@ -172,10 +172,6 @@
   "AzureTableTokenStore": {
     "TableUri": "[vault(token-table-sas-uri)]"
   },
-  "DataProtection": {
-    "StorageAccountConnectionString": "[vault(dotnet-status-storage-account)]",
-    "KeyIdentifier": "dotnet-status-data-protection"
-  },
   "Grafana": {
     "BaseUrl": "https://dotnet-eng-grafana-staging.westus2.cloudapp.azure.com",
     "ApiToken": "[vault(grafana-api-token)]",

--- a/src/DotNet.Status.Web/DotNet.Status.Web.csproj
+++ b/src/DotNet.Status.Web/DotNet.Status.Web.csproj
@@ -15,12 +15,13 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.Storage.Queues" />
     <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureStorage" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
     <PackageReference Include="Microsoft.AspNetCore.WebHooks.Receivers.GitHub" />
     <PackageReference Include="Microsoft.AspNetCore.WebHooks.Receivers" />


### PR DESCRIPTION
Part of https://github.com/dotnet/arcade/issues/11852
The changes were extracted from @garath's branch https://github.com/dotnet/arcade-services/compare/main...garath:arcade-services:mistucke/11756-azure-keyvault, for easier validation.
I also enabled Managed Identity authentication on the staging storage account used for the staging DotNet.Status app to validate the Managed Identity changes