### PR TITLE
Use `VmrDependencyUpdate` everywhere

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrDependencyUpdate.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrDependencyUpdate.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+public record VmrDependencyUpdate(
+    SourceMapping Mapping,
+    string RemoteUri,
+    string TargetRevision,
+    string? TargetVersion,
+    SourceMapping? Parent);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrDependencyUpdate.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrDependencyUpdate.cs
@@ -7,6 +7,14 @@ using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
+/// <summary>
+/// Represents related metadata needed to update a repository in the VMR.
+/// </summary>
+/// <param name="Mapping">Source mapping that is being updated</param>
+/// <param name="RemoteUri">Remote URI from which we will pull the new updates</param>
+/// <param name="TargetRevision">Target revision (usually commit SHA but also a branch or a tag) to update to</param>
+/// <param name="TargetVersion">Version of packages built for that given SHA (e.g. 8.0.0-alpha.1.22614.1)</param>
+/// <param name="Parent">Parent dependency in the dependency tree that caused this update,null for root (installer)</param>
 public record VmrDependencyUpdate(
     SourceMapping Mapping,
     string RemoteUri,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -71,14 +71,14 @@ public abstract class VmrManagerBase : IVmrManager
     /// <summary>
     /// Recursively parses Version.Details.xml files of all repositories and returns the list of source build dependencies.
     /// </summary>
-    protected async Task<IEnumerable<DependencyUpdate>> GetAllDependencies(DependencyUpdate root, CancellationToken cancellationToken)
+    protected async Task<IEnumerable<VmrDependencyUpdate>> GetAllDependencies(VmrDependencyUpdate root, CancellationToken cancellationToken)
     {
-        var transitiveDependencies = new Dictionary<SourceMapping, DependencyUpdate>
+        var transitiveDependencies = new Dictionary<SourceMapping, VmrDependencyUpdate>
         {
             { root.Mapping, root },
         };
 
-        var reposToScan = new Queue<DependencyUpdate>();
+        var reposToScan = new Queue<VmrDependencyUpdate>();
         reposToScan.Enqueue(transitiveDependencies.Values.Single());
 
         _logger.LogInformation("Finding transitive dependencies for {mapping}:{revision}..", root.Mapping.Name, root.TargetRevision);
@@ -97,7 +97,7 @@ public abstract class VmrManagerBase : IVmrManager
                         $"No source mapping named '{dependency.SourceBuild.RepoName}' found " +
                         $"for a {VersionFiles.VersionDetailsXml} dependency of {dependency.Name}");
 
-                var update = new DependencyUpdate(
+                var update = new VmrDependencyUpdate(
                     mapping,
                     dependency.RepoUri,
                     dependency.Commit,
@@ -265,11 +265,4 @@ public abstract class VmrManagerBase : IVmrManager
             repo.Commit(commitMessage, DotnetBotCommitSignature, DotnetBotCommitSignature);
         }
     }
-
-    protected record DependencyUpdate(
-        SourceMapping Mapping,
-        string RemoteUri,
-        string TargetRevision,
-        string? TargetVersion,
-        SourceMapping? Parent);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -107,7 +107,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
     {
         var dependencyUpdate = new VmrDependencyUpdate(
             mapping,
-            mapping.DefaultRef,
+            mapping.DefaultRemote,
             targetRevision ?? mapping.DefaultRef,
             targetVersion,
             null);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -323,7 +323,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             if (update.Parent is not null)
             {
                 _logger.LogInformation("Recursively updating {parent}'s dependency {repo} / {from}{arrow}{to}",
-                    update.Parent,
+                    update.Parent.Name,
                     update.Mapping.Name,
                     currentSha,
                     Arrow,


### PR DESCRIPTION
This PR simplifies how we pass around related metadata that we need during VMR sync.
No functional changes but preparing the ground for a follow-up PR.

https://github.com/dotnet/arcade/issues/11912
