### PR TITLE
Add the `darc vmr scan` command

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperation.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
 namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
 internal class ScanOperation : Operation
@@ -21,8 +22,7 @@ internal class ScanOperation : Operation
         var vmrScanner = Provider.GetRequiredService<IVmrScanner>();
         using var listener = CancellationKeyListener.ListenForCancellation(Logger);
 
-        var r = await vmrScanner.ListCloakedFiles(listener.Token);
-        r = r.ToList();
+        await vmrScanner.ListCloakedFiles(listener.Token);
         return 0;
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperation.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.DependencyInjection;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperation.cs
@@ -1,0 +1,27 @@
+using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
+
+internal class ScanOperation : Operation
+{
+    public ScanOperation(ScanCommandLineOptions options) : base(options, options.RegisterServices())
+    {
+    }
+
+    public override async Task<int> ExecuteAsync()
+    {
+        var vmrScanner = Provider.GetRequiredService<IVmrScanner>();
+        await vmrScanner.ScanVmr();
+        return 0;
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperation.cs
@@ -1,13 +1,10 @@
-using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
@@ -18,7 +19,10 @@ internal class ScanOperation : Operation
     public override async Task<int> ExecuteAsync()
     {
         var vmrScanner = Provider.GetRequiredService<IVmrScanner>();
-        await vmrScanner.ScanVmr();
+        using var listener = CancellationKeyListener.ListenForCancellation(Logger);
+
+        var r = await vmrScanner.ListCloakedFiles(listener.Token);
+        r = r.ToList();
         return 0;
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/ScanCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/ScanCommandLineOptions.cs
@@ -6,6 +6,7 @@ using CommandLine;
 using Microsoft.DotNet.Darc.Operations;
 using Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
+#nullable enable
 namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
 [Verb("scan", HelpText = "Scans the VMR, checking if it contains any cloacked files")]

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/ScanCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/ScanCommandLineOptions.cs
@@ -1,17 +1,19 @@
-using CommandLine.Text;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using CommandLine;
 using Microsoft.DotNet.Darc.Operations;
 using Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
-namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo
-{
-    [Verb("scan", HelpText = "Scans the VMR, checking if it contains any cloacked files")]
-    internal class ScanCommandLineOptions : VmrCommandLineOptions
-    {
-        public ScanCommandLineOptions()
-        {
-        }
+namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
-        public override Operation GetOperation() => new ScanOperation(this);
+[Verb("scan", HelpText = "Scans the VMR, checking if it contains any cloacked files")]
+internal class ScanCommandLineOptions : VmrCommandLineOptions
+{
+    public ScanCommandLineOptions()
+    {
     }
+
+    public override Operation GetOperation() => new ScanOperation(this);
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/ScanCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/ScanCommandLineOptions.cs
@@ -1,0 +1,17 @@
+using CommandLine.Text;
+using CommandLine;
+using Microsoft.DotNet.Darc.Operations;
+using Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
+
+namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo
+{
+    [Verb("scan", HelpText = "Scans the VMR, checking if it contains any cloacked files")]
+    internal class ScanCommandLineOptions : VmrCommandLineOptions
+    {
+        public ScanCommandLineOptions()
+        {
+        }
+
+        public override Operation GetOperation() => new ScanOperation(this);
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
@@ -195,6 +195,7 @@ internal static class Program
         typeof(InitializeCommandLineOptions),
         typeof(UpdateCommandLineOptions),
         typeof(GenerateTpnCommandLineOptions),
+        typeof(ScanCommandLineOptions),
     };
 
     private static void InitializeTelemetry()

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IVmrScanner
 {
-    Task ScanVmr();
+    Task<IEnumerable<string>> ListCloakedFiles(CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IVmrScanner

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
@@ -10,5 +10,5 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IVmrScanner
 {
-    Task<IEnumerable<string>> ListCloakedFiles(CancellationToken cancellationToken);
+    Task<List<string>> ListCloakedFiles(CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo
+{
+    public interface IVmrScanner
+    {
+        Task ScanVmr();
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
@@ -1,13 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Threading.Tasks;
 
-namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+public interface IVmrScanner
 {
-    public interface IVmrScanner
-    {
-        Task ScanVmr();
-    }
+    Task ScanVmr();
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -58,7 +58,11 @@ public class VmrInfo : IVmrInfo
     public const string SourceMappingsFileName = "source-mappings.json";
     public const string GitInfoSourcesDir = "prereqs/git-info";
     public const string SourceManifestFileName = "source-manifest.json";
-    
+
+    // These git attributes can override cloaking of files when set it individual repositories
+    public const string KeepAttribute = "vmr-preserve";
+    public const string IgnoreAttribute = "vmr-ignore";
+
     public const string ReadmeFileName = "README.md";
     public const string ReadmeTemplatePath = "eng/bootstrap/README.template.md";
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -23,10 +23,6 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 /// </summary>
 public class VmrPatchHandler : IVmrPatchHandler
 {
-    // These git attributes can override cloaking of files when set it individual repositories
-    private const string KeepAttribute = "vmr-preserve";
-    private const string IgnoreAttribute = "vmr-ignore";
-
     /// <summary>
     /// Matches output of `git apply --numstat` which lists files contained in a patch file.
     /// Example output:
@@ -139,8 +135,8 @@ public class VmrPatchHandler : IVmrPatchHandler
             "--",
         };
 
-        args.AddRange(mapping.Include.Select(p => $":(glob,attr:!{IgnoreAttribute}){p}"));
-        args.AddRange(mapping.Exclude.Select(p => $":(exclude,glob,attr:!{KeepAttribute}){p}"));
+        args.AddRange(mapping.Include.Select(p => $":(glob,attr:!{VmrInfo.IgnoreAttribute}){p}"));
+        args.AddRange(mapping.Exclude.Select(p => $":(exclude,glob,attr:!{VmrInfo.KeepAttribute}){p}"));
 
         // Ignore submodules in the diff, they will be inlined via their own diffs
         if (submoduleChanges.Any())

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -63,6 +63,7 @@ public static class VmrRegistrations
         services.TryAddTransient<IRepositoryCloneManager, RepositoryCloneManager>();
         services.TryAddTransient<IFileSystem, FileSystem>();
         services.TryAddTransient<IGitRepoClonerFactory, GitRepoClonerFactory>();
+        services.TryAddTransient<IVmrScanner, VmrScanner>();
 
         // These initialize the configuration by reading the JSON files in VMR's src/
         services.TryAddSingleton<IReadOnlyCollection<SourceMapping>>(sp =>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -80,6 +80,8 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo
 
         private async Task CreateZeroCommitTag()
         {
+            await DeleteZeroCommitTag();
+
             var args = new[]
             {
                 "hash-object",
@@ -98,11 +100,7 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo
             };
             var res = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args);
 
-            if(res.ExitCode == 128)
-            {
-                await DeleteZeroCommitTag();
-                await CreateZeroCommitTag();
-            }
+            res.ThrowIfFailed($"Error creating {_zeroCommitTag} git tag: {res.StandardError}");
         }
 
         private async Task DeleteZeroCommitTag()

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -1,0 +1,135 @@
+using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo
+{
+    public class VmrScanner : IVmrScanner
+    {
+        private const string _zeroCommitTag = "zeroCommit";
+
+        private readonly IReadOnlyCollection<SourceMapping> _sourceMappings;
+        private readonly IProcessManager _processManager;
+        private readonly IVmrInfo _vmrInfo;
+        private readonly ILogger<VmrScanner> _logger;
+
+        public VmrScanner(
+            IReadOnlyCollection<SourceMapping> sourceMappings,
+            IProcessManager processManager,
+            IVmrInfo vmrInfo,
+            ILogger<VmrScanner> logger)
+        {
+            _sourceMappings = sourceMappings;
+            _processManager = processManager;
+            _vmrInfo = vmrInfo;
+            _logger = logger;
+        }
+
+        public async Task ScanVmr()
+        {
+            await CreateZeroCommitTag();
+
+            foreach (var sourceMapping in _sourceMappings)
+            {
+                await ScanSubRepository(sourceMapping);
+            }
+        }
+
+        private async Task ScanSubRepository(SourceMapping sourceMapping)
+        {
+            _logger.LogInformation("Scanning {repository} repository", sourceMapping.Name);
+            var args = new List<string>
+            {
+                "diff",
+                "--name-only",
+                _zeroCommitTag
+            };
+
+            var baseExcludePath = _vmrInfo.GetRepoSourcesPath(sourceMapping);
+            var preservedFiles = GetVmrPreservedFiles(sourceMapping);
+
+            foreach (var exclude in sourceMapping.Exclude)
+            {
+                args.Add(baseExcludePath / exclude);
+            }
+
+            var ret = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args.ToArray());
+
+            ret.ThrowIfFailed($"Failed to scan the {sourceMapping.Name} repository");
+            var files = ret.StandardOutput
+                .Split("\r\n")
+                .Where(file => file != string.Empty)
+                .Select(file => _vmrInfo.VmrPath / file);
+                
+            foreach (var file in files)
+            {
+                if (preservedFiles.Contains(file))
+                {
+                    continue;
+                }
+                _logger.LogWarning("Found file {file} that should be exluded from the {repository} repository", file.ToString(), sourceMapping.Name);
+            }
+            
+        }
+
+        private async Task CreateZeroCommitTag()
+        {
+            var args = new[]
+            {
+                "hash-object",
+                "-t",
+                "tree",
+                "/dev/null",
+            };
+            var zeroCommitResult = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args);
+            var zeroCommitSha = zeroCommitResult.StandardOutput.TrimEnd('\n', '\r');
+
+            args = new[]
+            {
+                "tag",
+                _zeroCommitTag,
+                zeroCommitSha
+            };
+            var res = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args);
+
+            if(res.ExitCode == 128)
+            {
+                await DeleteZeroCommitTag();
+                await CreateZeroCommitTag();
+            }
+        }
+
+        private async Task DeleteZeroCommitTag()
+        {
+            var args = new[]
+            {
+                "tag",
+                "-d",
+                _zeroCommitTag
+            };
+
+            await _processManager.ExecuteGit(_vmrInfo.VmrPath, args);
+        }
+
+        private HashSet<NativePath> GetVmrPreservedFiles(SourceMapping sourceMapping)
+        {
+            var files = Directory.GetFiles(_vmrInfo.GetRepoSourcesPath(sourceMapping), ".gitattributes", SearchOption.AllDirectories);
+
+            return files.Select(file =>
+                (fileName: file, Attributes: File.ReadAllLines(file)
+                            .Where(line => line.Contains("vmr-preserve"))
+                            .Select(line => line.Split(" ").First())
+                            .ToList()))
+                    .Where(entry => entry.Attributes.Count > 0)
+                    .SelectMany(entry => entry.Attributes
+                        .Select(attribute => new NativePath(Path.Join(Path.GetDirectoryName(entry.fileName), attribute))))
+                    .ToHashSet();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -2,14 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
-using Microsoft.DotNet.DarcLib.Helpers;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.Logging;
+
 
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -75,7 +75,8 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo
                 }
                 _logger.LogWarning("Found file {file} that should be exluded from the {repository} repository", file.ToString(), sourceMapping.Name);
             }
-            
+
+            await DeleteZeroCommitTag();
         }
 
         private async Task CreateZeroCommitTag()

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
@@ -5,130 +9,88 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
-namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+// This class is able to scan the VMR for cloacked files that shouldn't be inside of it
+public class VmrScanner : IVmrScanner
 {
-    public class VmrScanner : IVmrScanner
+    private const string _zeroCommitTag = "zeroCommit";
+
+    private readonly IReadOnlyCollection<SourceMapping> _sourceMappings;
+    private readonly IProcessManager _processManager;
+    private readonly IVmrInfo _vmrInfo;
+    private readonly ILogger<VmrScanner> _logger;
+
+    public VmrScanner(
+        IReadOnlyCollection<SourceMapping> sourceMappings,
+        IProcessManager processManager,
+        IVmrInfo vmrInfo,
+        ILogger<VmrScanner> logger)
     {
-        private const string _zeroCommitTag = "zeroCommit";
+        _sourceMappings = sourceMappings;
+        _processManager = processManager;
+        _vmrInfo = vmrInfo;
+        _logger = logger;
+    }
 
-        private readonly IReadOnlyCollection<SourceMapping> _sourceMappings;
-        private readonly IProcessManager _processManager;
-        private readonly IVmrInfo _vmrInfo;
-        private readonly ILogger<VmrScanner> _logger;
-
-        public VmrScanner(
-            IReadOnlyCollection<SourceMapping> sourceMappings,
-            IProcessManager processManager,
-            IVmrInfo vmrInfo,
-            ILogger<VmrScanner> logger)
+    public async Task ScanVmr()
+    {
+        foreach (var sourceMapping in _sourceMappings)
         {
-            _sourceMappings = sourceMappings;
-            _processManager = processManager;
-            _vmrInfo = vmrInfo;
-            _logger = logger;
-        }
-
-        public async Task ScanVmr()
-        {
-            await CreateZeroCommitTag();
-
-            foreach (var sourceMapping in _sourceMappings)
-            {
-                await ScanSubRepository(sourceMapping);
-            }
-        }
-
-        private async Task ScanSubRepository(SourceMapping sourceMapping)
-        {
-            _logger.LogInformation("Scanning {repository} repository", sourceMapping.Name);
-            var args = new List<string>
-            {
-                "diff",
-                "--name-only",
-                _zeroCommitTag
-            };
-
-            var baseExcludePath = _vmrInfo.GetRepoSourcesPath(sourceMapping);
-            var preservedFiles = GetVmrPreservedFiles(sourceMapping);
-
-            foreach (var exclude in sourceMapping.Exclude)
-            {
-                args.Add(baseExcludePath / exclude);
-            }
-
-            var ret = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args.ToArray());
-
-            ret.ThrowIfFailed($"Failed to scan the {sourceMapping.Name} repository");
-            var files = ret.StandardOutput
-                .Split("\r\n")
-                .Where(file => file != string.Empty)
-                .Select(file => _vmrInfo.VmrPath / file);
-                
-            foreach (var file in files)
-            {
-                if (preservedFiles.Contains(file))
-                {
-                    continue;
-                }
-                _logger.LogWarning("Found file {file} that should be exluded from the {repository} repository", file.ToString(), sourceMapping.Name);
-            }
-
-            await DeleteZeroCommitTag();
-        }
-
-        private async Task CreateZeroCommitTag()
-        {
-            await DeleteZeroCommitTag();
-
-            var args = new[]
-            {
-                "hash-object",
-                "-t",
-                "tree",
-                "/dev/null",
-            };
-            var zeroCommitResult = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args);
-            var zeroCommitSha = zeroCommitResult.StandardOutput.TrimEnd('\n', '\r');
-
-            args = new[]
-            {
-                "tag",
-                _zeroCommitTag,
-                zeroCommitSha
-            };
-            var res = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args);
-
-            res.ThrowIfFailed($"Error creating {_zeroCommitTag} git tag: {res.StandardError}");
-        }
-
-        private async Task DeleteZeroCommitTag()
-        {
-            var args = new[]
-            {
-                "tag",
-                "-d",
-                _zeroCommitTag
-            };
-
-            await _processManager.ExecuteGit(_vmrInfo.VmrPath, args);
-        }
-
-        private HashSet<NativePath> GetVmrPreservedFiles(SourceMapping sourceMapping)
-        {
-            var files = Directory.GetFiles(_vmrInfo.GetRepoSourcesPath(sourceMapping), ".gitattributes", SearchOption.AllDirectories);
-
-            return files.Select(file =>
-                (fileName: file, Attributes: File.ReadAllLines(file)
-                            .Where(line => line.Contains("vmr-preserve"))
-                            .Select(line => line.Split(" ").First())
-                            .ToList()))
-                    .Where(entry => entry.Attributes.Count > 0)
-                    .SelectMany(entry => entry.Attributes
-                        .Select(attribute => new NativePath(Path.Join(Path.GetDirectoryName(entry.fileName), attribute))))
-                    .ToHashSet();
+            await ScanRepository(sourceMapping);
         }
     }
+
+    private async Task ScanRepository(SourceMapping sourceMapping)
+    {
+        _logger.LogInformation("Scanning {repository} repository", sourceMapping.Name);
+        var args = new List<string>
+        {
+            "diff",
+            "--name-only",
+            Constants.EmptyGitObject
+        };
+
+        var baseExcludePath = _vmrInfo.GetRepoSourcesPath(sourceMapping);
+        var preservedFiles = GetVmrPreservedFiles(sourceMapping);
+
+        foreach (var exclude in sourceMapping.Exclude)
+        {
+            args.Add(baseExcludePath / exclude);
+        }
+
+        var ret = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args.ToArray());
+
+        ret.ThrowIfFailed($"Failed to scan the {sourceMapping.Name} repository");
+        var files = ret.StandardOutput
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .Select(file => _vmrInfo.VmrPath / file);
+
+        foreach (var file in files)
+        {
+            if (preservedFiles.Contains(file))
+            {
+                continue;
+            }
+            _logger.LogWarning($"File {file} is cloaked but present in the VMR\", file", file.ToString());
+        }
+    }
+
+    private HashSet<NativePath> GetVmrPreservedFiles(SourceMapping sourceMapping)
+    {
+        var files = Directory.GetFiles(_vmrInfo.GetRepoSourcesPath(sourceMapping), ".gitattributes", SearchOption.AllDirectories);
+
+        return files.Select(file =>
+            (fileName: file, Attributes: File.ReadAllLines(file)
+                        .Where(line => line.Contains("vmr-preserve"))
+                        .Select(line => line.Split(" ").First())
+                        .ToList()))
+                .Where(entry => entry.Attributes.Count > 0)
+                .SelectMany(entry => entry.Attributes
+                    .Select(attribute => new NativePath(Path.Join(Path.GetDirectoryName(entry.fileName), attribute))))
+                .ToHashSet();
+    }
 }
+

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -20,8 +20,6 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 /// </summary>
 public class VmrScanner : IVmrScanner
 {
-    private const string _vmrPreserveAttribute = "vmr-preserve";
-
     private readonly IVmrDependencyTracker _dependencyTracker;
     private readonly IProcessManager _processManager;
     private readonly IVmrInfo _vmrInfo;
@@ -87,6 +85,6 @@ public class VmrScanner : IVmrScanner
         return files;
     }
 
-    private static string ExcludeFile(string file) => $":(attr:!{_vmrPreserveAttribute}){file}";
+    private static string ExcludeFile(string file) => $":(attr:!{VmrInfo.KeepAttribute}){file}";
 }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -12,7 +12,7 @@ using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
 
-
+#nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 /// <summary>
@@ -44,16 +44,16 @@ public class VmrScanner : IVmrScanner
         await _dependencyTracker
             .InitializeSourceMappings(_vmrInfo.VmrPath / VmrInfo.SourcesDir / VmrInfo.SourceMappingsFileName);
 
-        var cloakedFilesList = new List<string>();
+        var cloakedFiles = new List<string>();
 
         foreach (var sourceMapping in _dependencyTracker.Mappings)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            cloakedFilesList.AddRange(await ScanRepository(sourceMapping, cancellationToken));
+            cloakedFiles.AddRange(await ScanRepository(sourceMapping, cancellationToken));
         }
 
-        return cloakedFilesList;
+        return cloakedFiles;
     }
 
     private async Task<string[]> ScanRepository(SourceMapping sourceMapping, CancellationToken cancellationToken)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -14,10 +14,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
-// This class is able to scan the VMR for cloacked files that shouldn't be inside of it
+/// <summary>
+/// This class is able to scan the VMR for cloacked files that shouldn't be inside of it
+/// </summary>
 public class VmrScanner : IVmrScanner
 {
-    private const string _zeroCommitTag = "zeroCommit";
     private const string _vmrPreserveAttribute = "vmr-preserve";
 
     private readonly IReadOnlyCollection<SourceMapping> _sourceMappings;
@@ -66,18 +67,14 @@ public class VmrScanner : IVmrScanner
 
         ret.ThrowIfFailed($"Failed to scan the {sourceMapping.Name} repository");
         var files = ret.StandardOutput
-            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
-            .Select(file => _vmrInfo.VmrPath / file);
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
 
         foreach (var file in files)
         {
-            _logger.LogWarning($"File {file} is cloaked but present in the VMR\", file", file.ToString());
+            _logger.LogWarning($"File {file} is cloaked but present in the VMR", file);
         }
     }
 
-    private string ExcludeFile(string file)
-    {
-        return $":(attr:!{_vmrPreserveAttribute}){file}";
-    }
+    private string ExcludeFile(string file) => $":(attr:!{_vmrPreserveAttribute}){file}";
 }
 

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrScannerTest.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrScannerTest.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
+
+[TestFixture]
+public class VmrScannerTest : VmrTestsBase
+{
+    [Test]
+    public async Task VmrScannerFindsNothingTest()
+    {
+        await InitializeRepoAtLastCommit(Constants.ProductRepoName, ProductRepoPath);
+
+        var list = await CallDarcScan();
+        Assert.AreEqual(0, list.Count);
+    }
+
+    [Test]
+    public async Task VmrScannerVmrPreservedTest()
+    {
+        await InitializeRepoAtLastCommit(Constants.ProductRepoName, ProductRepoPath);
+
+        var newFilePath = VmrPath / "src" / Constants.ProductRepoName / "src";
+        Directory.CreateDirectory(newFilePath);
+        File.WriteAllText(newFilePath / "test.dll", "this is a test file");
+        File.WriteAllText(newFilePath / ".gitattributes", $"*.dll {VmrInfo.KeepAttribute}");
+        await GitOperations.CommitAll(VmrPath, "Commit dll file");
+
+        var list = await CallDarcScan();
+        Assert.AreEqual(0, list.Count);
+    }
+
+    [Test]
+    public async Task VmrScannerFindsFileTest()
+    {
+        await InitializeRepoAtLastCommit(Constants.ProductRepoName, ProductRepoPath);
+
+        var newFilePath = VmrPath / "src" / Constants.ProductRepoName / "src";
+        Directory.CreateDirectory(newFilePath);
+        File.WriteAllText(newFilePath / "test.dll", "this is a test file");
+        await GitOperations.CommitAll(VmrPath, "Commit dll file");
+
+        var list = await CallDarcScan();
+        Assert.AreEqual(1, list.Count);
+    }
+
+    protected override async Task CopyReposForCurrentTest()
+    {
+        await CopyRepoAndCreateVersionDetails(CurrentTestDirectory, Constants.ProductRepoName);
+
+        await GitOperations.CommitAll(ProductRepoPath, "First commit");
+    }
+
+    protected async override Task CopyVmrForCurrentTest()
+    {
+        CopyDirectory(VmrTestsOneTimeSetUp.CommonVmrPath, VmrPath);
+
+        var sourceMappings = new SourceMappingFile()
+        {
+            Mappings = new List<SourceMappingSetting>
+            {
+                new SourceMappingSetting
+                {
+                    Name = Constants.ProductRepoName,
+                    DefaultRemote = ProductRepoPath
+                }
+            }
+        };
+
+        sourceMappings.Defaults.Exclude = new[]
+        {
+            "**/*.dll"
+        };
+
+        await WriteSourceMappingsInVmr(sourceMappings);
+    }
+}
+

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -166,6 +166,12 @@ public abstract class VmrTestsBase
         await vmrUpdater.UpdateRepository(repository, commit, null, false, true, _cancellationToken.Token);
     }
 
+    protected async Task<List<string>> CallDarcScan()
+    {
+        var vmrScanner = _serviceProvider.Value.GetRequiredService<IVmrScanner>();
+        return await vmrScanner.ListCloakedFiles(_cancellationToken.Token);
+    }
+
     protected void CopyDirectory(string source, LocalPath destination)
     {
         if (!Directory.Exists(destination))


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

The PR adds a new command to the vmr: scan. The command scans the VMR, searching for files that shouldn't be there (the ones that are specified in the source-mappings.json as excluded, ignoring the ones permitted by the gitattributes). It does so by creating a git diff between the "zeroCommit" and the current branch HEAD

https://github.com/dotnet/arcade/issues/11985