### PR TITLE
Unify repo update process for `VmrInitializer` and `VmrUpdater`

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -15,12 +15,6 @@ public interface IVmrPatchHandler
 {
     Task ApplyPatch(VmrIngestionPatch patch, CancellationToken cancellationToken);
 
-    Task ApplyPatch(
-        SourceMapping mapping,
-        string patchPath,
-        CancellationToken cancellationToken)
-        => ApplyPatch(new VmrIngestionPatch(patchPath, VmrInfo.RelativeSourcesDir / mapping.Name), cancellationToken);
-
     Task<List<VmrIngestionPatch>> CreatePatches(
         SourceMapping mapping,
         LocalPath repoPath,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -67,7 +67,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
     private readonly IVmrDependencyTracker _dependencyTracker;
     private readonly IRepositoryCloneManager _cloneManager;
     private readonly IVmrPatchHandler _patchHandler;
-    private readonly IReadmeComponentListGenerator _readmeComponentListGenerator;
     private readonly IFileSystem _fileSystem;
     private readonly ILogger<VmrUpdater> _logger;
     private readonly ISourceManifest _sourceManifest;
@@ -85,7 +84,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         ILogger<VmrUpdater> logger,
         ISourceManifest sourceManifest,
         IVmrInfo vmrInfo)
-        : base(vmrInfo, sourceManifest, dependencyTracker, versionDetailsParser, thirdPartyNoticesGenerator, localGitClient, gitFileManagerFactory, fileSystem, logger)
+        : base(vmrInfo, sourceManifest, dependencyTracker, patchHandler, versionDetailsParser, thirdPartyNoticesGenerator, readmeComponentListGenerator, localGitClient, gitFileManagerFactory, fileSystem, logger)
     {
         _logger = logger;
         _sourceManifest = sourceManifest;
@@ -93,7 +92,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         _dependencyTracker = dependencyTracker;
         _cloneManager = cloneManager;
         _patchHandler = patchHandler;
-        _readmeComponentListGenerator = readmeComponentListGenerator;
         _fileSystem = fileSystem;
     }
 
@@ -217,10 +215,10 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
             return await UpdateRepoToRevision(
                 update,
-                currentSha,
                 clonePath,
-                message,
+                currentSha,
                 DotnetBotCommitSignature,
+                message,
                 reapplyVmrPatches,
                 cancellationToken);
         }
@@ -243,10 +241,10 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
             var patches = await UpdateRepoToRevision(
                 update,
-                currentSha,
                 clonePath,
-                message,
+                currentSha,
                 commitToCopy.Author,
+                message,
                 reapplyVmrPatches,
                 cancellationToken);
 
@@ -407,70 +405,13 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
     }
 
     /// <summary>
-    /// Synchronizes given repo in VMR onto given revision.
-    /// </summary>
-    private async Task<IReadOnlyCollection<VmrIngestionPatch>> UpdateRepoToRevision(
-        VmrDependencyUpdate update,
-        string fromRevision,
-        LocalPath clonePath,
-        string commitMessage,
-        Signature author,
-        bool reapplyVmrPatches,
-        CancellationToken cancellationToken)
-    {
-        IReadOnlyCollection<VmrIngestionPatch> patches = await _patchHandler.CreatePatches(
-            update.Mapping,
-            clonePath,
-            fromRevision,
-            update.TargetRevision,
-            _vmrInfo.TmpPath,
-            _vmrInfo.TmpPath,
-            cancellationToken);
-        cancellationToken.ThrowIfCancellationRequested();
-
-        // Get a list of patches that need to be reverted for this update so that repo changes can be applied
-        // This includes all patches that are also modified by the current change
-        // (happens when we update repo from which the VMR patches come)
-        var vmrPatchesToRestore = await RestoreVmrPatchedFiles(update.Mapping, patches, cancellationToken);
-
-        foreach (var patch in patches)
-        {
-            await _patchHandler.ApplyPatch(patch, cancellationToken);
-            cancellationToken.ThrowIfCancellationRequested();
-        }
-
-        _dependencyTracker.UpdateDependencyVersion(update);
-        await _readmeComponentListGenerator.UpdateReadme();
-        
-        Commands.Stage(new Repository(_vmrInfo.VmrPath), new string[]
-        {
-            VmrInfo.ReadmeFileName,
-            VmrInfo.GitInfoSourcesDir,
-            _vmrInfo.GetSourceManifestPath()
-        });
-
-        cancellationToken.ThrowIfCancellationRequested();
-
-        if (reapplyVmrPatches)
-        {
-            await ReapplyVmrPatches(vmrPatchesToRestore.DistinctBy(p => p.Path).ToArray(), cancellationToken);
-        }
-
-        await UpdateThirdPartyNotices(cancellationToken);
-
-        Commit(commitMessage, author);
-
-        return vmrPatchesToRestore;
-    }
-
-    /// <summary>
     /// Detects VMR patches affected by a given set of patches and restores files patched by these
     /// VMR patches into their original state.
     /// Detects whether patched files are coming from a mapped repository or a submodule too.
     /// </summary>
     /// <param name="updatedMapping">Mapping that is currently being updated (so we get its patches)</param>
     /// <param name="patches">Patches with incoming changes to be checked whether they affect some VMR patch</param>
-    private async Task<IReadOnlyCollection<VmrIngestionPatch>> RestoreVmrPatchedFiles(
+    protected override async Task<IReadOnlyCollection<VmrIngestionPatch>> RestoreVmrPatchedFiles(
         SourceMapping updatedMapping,
         IReadOnlyCollection<VmrIngestionPatch> patches,
         CancellationToken cancellationToken)
@@ -629,36 +570,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         }
 
         return patchesToRestore;
-    }
-
-    private async Task ReapplyVmrPatches(
-        IReadOnlyCollection<VmrIngestionPatch> patches,
-        CancellationToken cancellationToken)
-    {
-        if (patches.Count == 0)
-        {
-            return;
-        }
-
-        _logger.LogInformation("Re-applying {count} VMR patch{s}...",
-            patches.Count,
-            patches.Count > 1 ? "es" : string.Empty);
-
-        foreach (var patch in patches)
-        {
-            if (!_fileSystem.FileExists(patch.Path))
-            {
-                // Patch was removed, so it doesn't exist anymore
-                _logger.LogDebug("Not re-applying {patch} as it was removed", patch.Path);
-                continue;
-            }
-
-            // Re-apply VMR patch back
-            await _patchHandler.ApplyPatch(patch, cancellationToken);
-            cancellationToken.ThrowIfCancellationRequested();
-        }
-
-        _logger.LogInformation("VMR patches re-applied back onto the VMR");
     }
 
     private string GetCurrentVersion(SourceMapping mapping)


### PR DESCRIPTION
Repo initialization and update share a common pattern of "update the repo, re-generate readme, re-generate third-party notices, ...". The code is duplicated between `VmrInitializer` and `VmrUpdater` and this PR unifies that.

https://github.com/dotnet/arcade/issues/11914