### PR TITLE
Add support for multiple remotes of temporary clones

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
@@ -13,7 +13,8 @@ public interface ILocalGitRepo : IGitRepo
     /// </summary>
     /// <param name="repoDir">Path to a git repository</param>
     /// <param name="repoUrl">URL of the remote to add</param>
-    void AddRemoteIfMissing(string repoDir, string repoUrl);
+    /// <param name="forceFetch">Fetch changes even when remote exists</param>
+    void AddRemoteIfMissing(string repoDir, string repoUrl, bool forceFetch = false);
 
     /// <summary>
     ///     Checkout the repo to the specified state.

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -69,7 +69,7 @@ public class LocalGitClient : ILocalGitRepo
         string repoDir = LocalHelpers.GetRootDir(_gitExecutable, _logger);
         try
         {
-            using (LibGit2Sharp.Repository localRepo = new LibGit2Sharp.Repository(repoDir))
+            using (Repository localRepo = new Repository(repoDir))
             {
                 foreach (GitFile file in filesToCommit)
                 {
@@ -180,14 +180,14 @@ public class LocalGitClient : ILocalGitRepo
     public void Checkout(string repoDir, string commit, bool force = false)
     {
         _logger.LogDebug($"Checking out {commit}", commit ?? "default commit");
-        LibGit2Sharp.CheckoutOptions checkoutOptions = new LibGit2Sharp.CheckoutOptions
+        CheckoutOptions checkoutOptions = new CheckoutOptions
         {
-            CheckoutModifiers = force ? LibGit2Sharp.CheckoutModifiers.Force : LibGit2Sharp.CheckoutModifiers.None,
+            CheckoutModifiers = force ? CheckoutModifiers.Force : CheckoutModifiers.None,
         };
         try
         {
             _logger.LogDebug($"Reading local repo from {repoDir}");
-            using (LibGit2Sharp.Repository localRepo = new LibGit2Sharp.Repository(repoDir))
+            using (Repository localRepo = new Repository(repoDir))
             {
                 if (commit == null)
                 {
@@ -203,7 +203,7 @@ public class LocalGitClient : ILocalGitRepo
                         CleanRepoAndSubmodules(localRepo, _logger);
                     }
                 }
-                catch (LibGit2Sharp.NotFoundException)
+                catch (NotFoundException)
                 {
                     _logger.LogWarning($"Couldn't find commit {commit} in {repoDir} locally.  Attempting fetch.");
                     try
@@ -214,7 +214,7 @@ public class LocalGitClient : ILocalGitRepo
                             _logger.LogDebug($"Fetching {string.Join(";", refSpecs)} from {r.Url} in {repoDir}");
                             try
                             {
-                                LibGit2Sharp.Commands.Fetch(localRepo, r.Name, refSpecs, new LibGit2Sharp.FetchOptions(), $"Fetching from {r.Url}");
+                                Commands.Fetch(localRepo, r.Name, refSpecs, new FetchOptions(), $"Fetching from {r.Url}");
                             }
                             catch
                             {
@@ -249,20 +249,20 @@ public class LocalGitClient : ILocalGitRepo
         Commands.Stage(repository, pathToStage);
     }
 
-    private static void CleanRepoAndSubmodules(LibGit2Sharp.Repository repo, ILogger log)
+    private static void CleanRepoAndSubmodules(Repository repo, ILogger log)
     {
         using (log.BeginScope($"Beginning clean of {repo.Info.WorkingDirectory} and {repo.Submodules.Count()} submodules"))
         {
             log.LogDebug($"Beginning clean of {repo.Info.WorkingDirectory} and {repo.Submodules.Count()} submodules");
-            LibGit2Sharp.StatusOptions options = new LibGit2Sharp.StatusOptions
+            StatusOptions options = new StatusOptions
             {
                 IncludeUntracked = true,
                 RecurseUntrackedDirs = true,
             };
             int count = 0;
-            foreach (LibGit2Sharp.StatusEntry item in repo.RetrieveStatus(options))
+            foreach (StatusEntry item in repo.RetrieveStatus(options))
             {
-                if (item.State == LibGit2Sharp.FileStatus.NewInWorkdir)
+                if (item.State == FileStatus.NewInWorkdir)
                 {
                     File.Delete(Path.Combine(repo.Info.WorkingDirectory, item.FilePath));
                     ++count;
@@ -270,7 +270,7 @@ public class LocalGitClient : ILocalGitRepo
             }
             log.LogDebug($"Deleted {count} untracked files");
 
-            foreach (LibGit2Sharp.Submodule sub in repo.Submodules)
+            foreach (Submodule sub in repo.Submodules)
             {
                 string normalizedSubPath = sub.Path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
                 string subRepoPath = Path.Combine(repo.Info.WorkingDirectory, normalizedSubPath);
@@ -281,16 +281,16 @@ public class LocalGitClient : ILocalGitRepo
                     // hasn't been initialized yet, can happen when different hashes have new or moved submodules
                     try
                     {
-                        repo.Submodules.Update(sub.Name, new LibGit2Sharp.SubmoduleUpdateOptions { Init = true });
+                        repo.Submodules.Update(sub.Name, new SubmoduleUpdateOptions { Init = true });
                     }
                     catch
                     {
                         log.LogDebug($"Submodule {sub.Name} in {subRepoPath} is already initialized, trying to adopt from super-repo {repo.Info.Path}");
 
                         // superrepo thinks it is initialized, but it's orphaned.  Go back to the master repo to find out where this is supposed to point.
-                        using (LibGit2Sharp.Repository masterRepo = new LibGit2Sharp.Repository(repo.Info.WorkingDirectory))
+                        using (Repository masterRepo = new Repository(repo.Info.WorkingDirectory))
                         {
-                            LibGit2Sharp.Submodule masterSubModule = masterRepo.Submodules.Single(s => s.Name == sub.Name);
+                            Submodule masterSubModule = masterRepo.Submodules.Single(s => s.Name == sub.Name);
                             string masterSubPath = Path.Combine(repo.Info.Path, "modules", masterSubModule.Path);
                             log.LogDebug($"Writing .gitdir redirect {masterSubPath} to {subRepoGitFilePath}");
                             Directory.CreateDirectory(Path.GetDirectoryName(subRepoGitFilePath));
@@ -305,8 +305,8 @@ public class LocalGitClient : ILocalGitRepo
 
                     // The worktree is stored in the .gitdir/config file, so we have to change it
                     // to get it to check out to the correct place.
-                    LibGit2Sharp.ConfigurationEntry<string> oldWorkTree = null;
-                    using (LibGit2Sharp.Repository subRepo = new LibGit2Sharp.Repository(subRepoPath))
+                    ConfigurationEntry<string> oldWorkTree = null;
+                    using (Repository subRepo = new Repository(subRepoPath))
                     {
                         oldWorkTree = subRepo.Config.Get<string>("core.worktree");
                         if (oldWorkTree != null)
@@ -321,10 +321,10 @@ public class LocalGitClient : ILocalGitRepo
                         }
                     }
 
-                    using (LibGit2Sharp.Repository subRepo = new LibGit2Sharp.Repository(subRepoPath))
+                    using (Repository subRepo = new Repository(subRepoPath))
                     {
                         log.LogDebug($"Resetting {sub.Name} to {sub.HeadCommitId.Sha}");
-                        subRepo.Reset(LibGit2Sharp.ResetMode.Hard, subRepo.Commits.QueryBy(new LibGit2Sharp.CommitFilter { IncludeReachableFrom = subRepo.Refs }).Single(c => c.Sha == sub.HeadCommitId.Sha));
+                        subRepo.Reset(ResetMode.Hard, subRepo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = subRepo.Refs }).Single(c => c.Sha == sub.HeadCommitId.Sha));
                         // Now we reset the worktree back so that when we can initialize a Repository
                         // from it, instead of having to figure out which hash of the repo was most recently checked out.
                         if (oldWorkTree != null)
@@ -357,21 +357,37 @@ public class LocalGitClient : ILocalGitRepo
     /// <summary>
     ///     Add a remote to a local repo if does not already exist, and attempt to fetch commits.
     /// </summary>
-    public void AddRemoteIfMissing(string repoDir, string repoUrl)
+    public void AddRemoteIfMissing(string repoDir, string repoUrl, bool forceFetch = false)
     {
-        using LibGit2Sharp.Repository repo = new LibGit2Sharp.Repository(repoDir);
-        if (repo.Network.Remotes.Any(remote => remote.Url.Equals(repoUrl, StringComparison.InvariantCultureIgnoreCase)))
+        using var repo = new Repository(repoDir);
+        var remote = repo.Network.Remotes.FirstOrDefault(r => r.Url.Equals(repoUrl, StringComparison.InvariantCultureIgnoreCase));
+        string remoteName;
+
+        if (remote is not null)
         {
-            return;
+            if (!forceFetch)
+            {
+                return;
+            }
+
+            remoteName = remote.Name;
+        }
+        else
+        {
+            _logger.LogDebug($"Adding {repoUrl} remote to {repoDir}");
+
+            // Remote names don't matter, make sure it's unique
+            remoteName = Guid.NewGuid().ToString();
+            repo.Network.Remotes.Add(remoteName, repoUrl);
         }
 
-        _logger.LogDebug($"Adding {repoUrl} remote to {repoDir}");
-
-        // remote names don't matter, make sure it's unique
-        string remoteName = Guid.NewGuid().ToString();
-        repo.Network.Remotes.Add(remoteName, repoUrl);
         _logger.LogDebug($"Fetching new commits from {repoUrl} into {repoDir}");
-        LibGit2Sharp.Commands.Fetch(repo, remoteName, new[] { $"+refs/heads/*:refs/remotes/{remoteName}/*" }, new LibGit2Sharp.FetchOptions(), $"Fetching {repoUrl} into {repoDir}");
+        Commands.Fetch(
+            repo,
+            remoteName,
+            new[] { $"+refs/heads/*:refs/remotes/{remoteName}/*" },
+            new FetchOptions(),
+            $"Fetching {repoUrl} into {repoDir}");
     }
 
     public List<GitSubmoduleInfo> GetGitSubmodules(string repoDir, string commit)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -30,7 +30,7 @@ public interface IVmrInfo
     string? PatchesPath { get; set; }
 
     /// <summary>
-    /// Path to the source-mapping.json file 
+    /// Path to the source-mappings.json file 
     /// </summary>
     string? SourceMappingsPath { get; set; }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -30,7 +30,7 @@ public interface IVmrInfo
     string? PatchesPath { get; set; }
 
     /// <summary>
-    /// Path to the source-manifest.json file 
+    /// Path to the source-mapping.json file 
     /// </summary>
     string? SourceMappingsPath { get; set; }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -130,7 +130,12 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
     {
         _logger.LogInformation("Initializing {name} at {revision}..", update.Mapping.Name, update.TargetRevision);
 
-        var clonePath = await _cloneManager.PrepareClone(update.RemoteUri, update.TargetRevision, cancellationToken);
+        var clonePath = await _cloneManager.PrepareClone(
+            update.Mapping,
+            new[] { update.RemoteUri },
+            update.TargetRevision,
+            cancellationToken);
+
         cancellationToken.ThrowIfCancellationRequested();
 
         update = update with

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -130,7 +130,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
     {
         _logger.LogInformation("Initializing {name} at {revision}..", update.Mapping.Name, update.TargetRevision);
 
-        var clonePath = await _cloneManager.PrepareClone(
+        var clonePath = _cloneManager.PrepareClone(
             update.Mapping,
             new[] { update.RemoteUri },
             update.TargetRevision,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -421,7 +421,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         CancellationToken cancellationToken)
     {
         var checkoutCommit = change.Before == Constants.EmptyGitObject ? change.After : change.Before;
-        var clonePath = await _cloneManager.PrepareClone(change.Url, checkoutCommit, cancellationToken);   
+        var clonePath = _cloneManager.PrepareClone(change.Url, checkoutCommit, cancellationToken);   
 
         // We are only interested in filters specific to submodule's path
         ImmutableArray<string> GetSubmoduleFilters(IReadOnlyCollection<string> filters)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -114,7 +114,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             && _vmrInfo.SourceMappingsPath.StartsWith(VmrInfo.GetRelativeRepoSourcesPath(mapping)))
         {
             var fileRelativePath = _vmrInfo.SourceMappingsPath.Substring(VmrInfo.GetRelativeRepoSourcesPath(mapping).Length);
-            var clonePath = await _cloneManager.PrepareClone(
+            var clonePath = _cloneManager.PrepareClone(
                 mapping,
                 new[] { mapping.DefaultRemote },
                 targetRevision ?? mapping.DefaultRef, 
@@ -163,7 +163,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             _sourceManifest.Repositories.First(r => r.Path == update.Mapping.Name).RemoteUri,
         };
 
-        LocalPath clonePath = await _cloneManager.PrepareClone(update.Mapping, remotes, update.TargetRevision, cancellationToken);
+        LocalPath clonePath = _cloneManager.PrepareClone(update.Mapping, remotes, update.TargetRevision, cancellationToken);
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -518,7 +518,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 source.RemoteUri,
                 source.CommitSha);
 
-            var clonePath = await _cloneManager.PrepareClone(source.RemoteUri, source.CommitSha, cancellationToken);
+            var clonePath = _cloneManager.PrepareClone(source.RemoteUri, source.CommitSha, cancellationToken);
 
             foreach ((UnixPath relativePath, UnixPath pathInVmr) in group)
             {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -13,7 +13,6 @@ using LibGit2Sharp;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
-using Microsoft.VisualBasic;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
@@ -116,7 +115,8 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         {
             var fileRelativePath = _vmrInfo.SourceMappingsPath.Substring(VmrInfo.GetRelativeRepoSourcesPath(mapping).Length);
             var clonePath = await _cloneManager.PrepareClone(
-                mapping.DefaultRemote, 
+                mapping,
+                new[] { mapping.DefaultRemote },
                 targetRevision ?? mapping.DefaultRef, 
                 cancellationToken);
             
@@ -156,7 +156,14 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         _logger.LogInformation("Synchronizing {name} from {current} to {repo} / {revision}{oneByOne}",
             update.Mapping.Name, currentSha, update.RemoteUri, update.TargetRevision, noSquash ? " one commit at a time" : string.Empty);
 
-        LocalPath clonePath = await _cloneManager.PrepareClone(update.RemoteUri, update.TargetRevision, cancellationToken);
+        // Add remotes for where we synced last from and where we are syncing to (e.g. github.com -> dev.azure.com)
+        var remotes = new[]
+        {
+            update.RemoteUri,
+            _sourceManifest.Repositories.First(r => r.Path == update.Mapping.Name).RemoteUri,
+        };
+
+        LocalPath clonePath = await _cloneManager.PrepareClone(update.Mapping, remotes, update.TargetRevision, cancellationToken);
 
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrMultipleRemotesTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrMultipleRemotesTests.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using NUnit.Framework;
+
+
+namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
+
+public class VmrMultipleRemotesTests : VmrTestsBase
+{
+    private LocalPath FirstDependencyPath => CurrentTestDirectory / (Constants.DependencyRepoName + "1");
+    private LocalPath SecondDependencyPath => CurrentTestDirectory / (Constants.DependencyRepoName + "2");
+
+    [Test]
+    public async Task SynchronizationBetweenDifferentRemotesTest()
+    {
+        var vmrSourcesDir = VmrPath / VmrInfo.SourcesDir;
+        var installerFilePath = vmrSourcesDir / Constants.InstallerRepoName / Constants.GetRepoFileName(Constants.InstallerRepoName);
+        var dependencyFilePath = vmrSourcesDir / Constants.DependencyRepoName / Constants.GetRepoFileName(Constants.DependencyRepoName);
+
+        /* 
+         *  The dependency tree looks like:
+         *  
+         *  installer
+         *    └── dependency
+         *          
+         *  We will have two copies of "dependency" in folders dependency1 and dependency2
+         *  We will synchronize to the first one and then to the second one
+         */
+
+        // Prepare dependencies at paths 1 and 2
+        Directory.Move(DependencyRepoPath, FirstDependencyPath);
+        CopyDirectory(FirstDependencyPath, SecondDependencyPath);
+
+        var versionDetailsPath = InstallerRepoPath / VersionFiles.VersionDetailsXml;
+        var versionDetailsContent = await File.ReadAllTextAsync(versionDetailsPath);
+        versionDetailsContent = versionDetailsContent.Replace(
+            CurrentTestDirectory / Constants.DependencyRepoName,
+            CurrentTestDirectory / Constants.DependencyRepoName + "1");
+        await File.WriteAllTextAsync(versionDetailsPath, versionDetailsContent);
+        await GitOperations.CommitAll(InstallerRepoPath, "Point VersionDetails.xml to first location");
+
+        await InitializeRepoAtLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
+
+        var expectedFilesFromRepos = new List<LocalPath>
+        {
+            installerFilePath,
+            dependencyFilePath,
+        };
+
+        var expectedFiles = GetExpectedFilesInVmr(
+            VmrPath,
+            new[] 
+            { 
+                Constants.InstallerRepoName,
+                Constants.DependencyRepoName, 
+            },
+            expectedFilesFromRepos);
+
+        CheckDirectoryContents(VmrPath, expectedFiles);
+
+        // Prepare a new commit in the second dependency repo
+        await File.WriteAllTextAsync(
+            SecondDependencyPath / Constants.GetRepoFileName(Constants.DependencyRepoName),
+            "New content only in the second folder now");
+        await GitOperations.CommitAll(SecondDependencyPath, "New commit in the second dependency repo");
+
+        // Point installer's VersionDetails.xml to this new repo
+        var oldSha = await GitOperations.GetRepoLastCommit(FirstDependencyPath);
+        var newSha = await GitOperations.GetRepoLastCommit(SecondDependencyPath);
+
+        versionDetailsContent = await File.ReadAllTextAsync(versionDetailsPath);
+        versionDetailsContent = versionDetailsContent.Replace(
+            CurrentTestDirectory / Constants.DependencyRepoName + "1",
+            CurrentTestDirectory / Constants.DependencyRepoName + "2");
+        versionDetailsContent = versionDetailsContent.Replace(oldSha, newSha);
+        await File.WriteAllTextAsync(versionDetailsPath, versionDetailsContent);
+        await GitOperations.CommitAll(InstallerRepoPath, "Point VersionDetails.xml to second location");
+
+        await UpdateRepoToLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
+
+        CheckFileContents(dependencyFilePath, "New content only in the second folder now");
+    }
+
+    protected override async Task CopyReposForCurrentTest()
+    {
+        var dependenciesMap = new Dictionary<string, List<string>>
+        {
+            { Constants.InstallerRepoName, new List<string> { Constants.DependencyRepoName } },
+        };
+
+        await CopyRepoAndCreateVersionDetails(CurrentTestDirectory, Constants.InstallerRepoName, dependenciesMap);
+    }
+
+    protected override async Task CopyVmrForCurrentTest()
+    {
+        CopyDirectory(VmrTestsOneTimeSetUp.CommonVmrPath, VmrPath);
+
+        var sourceMappings = new SourceMappingFile
+        {
+            Mappings = new List<SourceMappingSetting>
+            {
+                new SourceMappingSetting
+                {
+                    Name = Constants.InstallerRepoName,
+                    DefaultRemote = InstallerRepoPath
+                },
+                new SourceMappingSetting
+                {
+                    Name = Constants.DependencyRepoName,
+                    DefaultRemote = FirstDependencyPath
+                }
+            },
+            PatchesPath = "src/installer/patches/"
+        };
+
+        await WriteSourceMappingsInVmr(sourceMappings);
+    }
+}

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -97,7 +96,7 @@ public class VmrPatchHandlerTests
         _cloneManager.Reset();
         _cloneManager
             .Setup(x => x.PrepareClone(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string uri, string _, CancellationToken _) => new UnixPath("/tmp/" + uri.Split("/").Last()));
+            .Returns((string uri, string _, CancellationToken _) => new UnixPath("/tmp/" + uri.Split("/").Last()));
 
         _processManager.Reset();
         _processManager


### PR DESCRIPTION
This makes it possible to synchronize a repo in the VMR from one remote to the other, e.g. a commit that is in public github.com repo onto one that is in the internal AzDO.

Resolves https://github.com/dotnet/arcade/issues/11913

