### PR TITLE
Allow passing additional remotes to cloned repositories

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
@@ -26,7 +26,15 @@ internal class InitializeOperation : VmrOperationBase<IVmrInitializer>
         IVmrInitializer vmrManager,
         string repoName,
         string? targetRevision,
+        IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken)
         =>
-        await vmrManager.InitializeRepository(repoName, targetRevision, null, _options.Recursive, new NativePath(_options.SourceMappings), cancellationToken);
+        await vmrManager.InitializeRepository(
+            repoName,
+            targetRevision,
+            null,
+            _options.Recursive,
+            new NativePath(_options.SourceMappings),
+            additionalRemotes,
+            cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
@@ -24,7 +25,15 @@ internal class UpdateOperation : VmrOperationBase<IVmrUpdater>
         IVmrUpdater vmrManager,
         string repoName,
         string? targetRevision,
+        IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken)
         =>
-        await vmrManager.UpdateRepository(repoName, targetRevision, null, _options.NoSquash, _options.Recursive, cancellationToken);
+        await vmrManager.UpdateRepository(
+            repoName,
+            targetRevision,
+            null,
+            _options.NoSquash,
+            _options.Recursive,
+            additionalRemotes,
+            cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrCommandLineOptions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using CommandLine;
 using Microsoft.DotNet.Darc.Helpers;
@@ -19,6 +20,9 @@ internal abstract class VmrCommandLineOptions : CommandLineOptions
 
     [Option("tmp", Required = false, HelpText = "Temporary path where intermediate files are stored (e.g. cloned repos, patch files); defaults to usual TEMP.")]
     public string TmpPath { get; set; }
+
+    [Option("add-remote", Required = false, HelpText = "Additional remote URIs (can be repeated) to add to a given mapping in the format [mapping name]:[remote URI], e.g. installer:https://github.com/myfork/installer")]
+    public IEnumerable<string> AdditionalRemotes { get; set; }
 
     public IServiceCollection RegisterServices()
     {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -1389,7 +1389,7 @@ public sealed class Remote : IRemote
     public void Clone(string repoUri, string commit, string targetDirectory, bool checkoutSubmodules, string gitDirectory = null)
     {
         CheckForValidGitClient();
-        _gitClient.Clone(repoUri, commit, targetDirectory, checkoutSubmodules, gitDirectory);
+        _gitClient.Clone(repoUri, commit, targetDirectory, checkoutSubmodules ? CheckoutType.CheckoutWithSubmodules : CheckoutType.CheckoutWithoutSubmodules, gitDirectory);
     }
 
     /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -1389,7 +1389,7 @@ public sealed class Remote : IRemote
     public void Clone(string repoUri, string commit, string targetDirectory, bool checkoutSubmodules, string gitDirectory = null)
     {
         CheckForValidGitClient();
-        _gitClient.Clone(repoUri, commit, targetDirectory, checkoutSubmodules ? CheckoutType.CheckoutWithSubmodules : CheckoutType.CheckoutWithoutSubmodules, gitDirectory);
+        _gitClient.Clone(repoUri, commit, targetDirectory, checkoutSubmodules, gitDirectory);
     }
 
     /// <summary>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitRepoCloner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitRepoCloner.cs
@@ -12,13 +12,6 @@ using LibGit2Sharp;
 #nullable enable
 namespace Microsoft.DotNet.DarcLib;
 
-public enum CheckoutType
-{
-    CheckoutWithoutSubmodules,
-    CheckoutWithSubmodules,
-    NoCheckout,
-}
-
 public class GitRepoCloner : IGitRepoCloner
 {
     private readonly ILogger _logger;
@@ -36,9 +29,26 @@ public class GitRepoCloner : IGitRepoCloner
     /// <param name="repoUri">Repository uri to clone</param>
     /// <param name="commit">Branch, commit, or tag to checkout</param>
     /// <param name="targetDirectory">Target directory to clone to</param>
-    /// <param name="checkoutType">Indicates whether working tree and submodules should be checked out</param>
+    /// <param name="checkoutSubmodules">Indicates whether submodules should be checked out as well</param>
     /// <param name="gitDirectory">Location for the .git directory, or null for default</param>
-    public void Clone(string repoUri, string? commit, string targetDirectory, CheckoutType checkoutType, string? gitDirectory)
+    public void Clone(string repoUri, string? commit, string targetDirectory, bool checkoutSubmodules, string? gitDirectory)
+        => Clone(
+            repoUri,
+            commit,
+            targetDirectory,
+            checkoutSubmodules ? CheckoutType.CheckoutWithSubmodules : CheckoutType.CheckoutWithoutSubmodules,
+            gitDirectory);
+
+    /// <summary>
+    ///     Clone a remote git repo without checking out the working tree.
+    /// </summary>
+    /// <param name="repoUri">Repository uri to clone</param>
+    /// <param name="targetDirectory">Target directory to clone to</param>
+    /// <param name="gitDirectory">Location for the .git directory, or null for default</param>
+    public void Clone(string repoUri, string targetDirectory, string? gitDirectory)
+        => Clone(repoUri, null, targetDirectory, CheckoutType.NoCheckout, gitDirectory);
+
+    private void Clone(string repoUri, string? commit, string targetDirectory, CheckoutType checkoutType, string? gitDirectory)
     {
         string dotnetMaestro = "dotnet-maestro"; // lgtm [cs/hardcoded-credentials] Value is correct for this service
         CloneOptions cloneOptions = new()
@@ -183,5 +193,12 @@ public class GitRepoCloner : IGitRepoCloner
                 log.LogDebug($"{sub.Name} doesn't have a .gitdir redirect at {subRepoGitFilePath}, skipping delete");
             }
         }
+    }
+
+    private enum CheckoutType
+    {
+        CheckoutWithoutSubmodules,
+        CheckoutWithSubmodules,
+        NoCheckout,
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitRepoCloner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitRepoCloner.cs
@@ -12,6 +12,13 @@ using LibGit2Sharp;
 #nullable enable
 namespace Microsoft.DotNet.DarcLib;
 
+public enum CheckoutType
+{
+    CheckoutWithoutSubmodules,
+    CheckoutWithSubmodules,
+    NoCheckout,
+}
+
 public class GitRepoCloner : IGitRepoCloner
 {
     private readonly ILogger _logger;
@@ -29,10 +36,9 @@ public class GitRepoCloner : IGitRepoCloner
     /// <param name="repoUri">Repository uri to clone</param>
     /// <param name="commit">Branch, commit, or tag to checkout</param>
     /// <param name="targetDirectory">Target directory to clone to</param>
-    /// <param name="checkoutSubmodules">Indicates whether submodules should be checked out as well</param>
+    /// <param name="checkoutType">Indicates whether working tree and submodules should be checked out</param>
     /// <param name="gitDirectory">Location for the .git directory, or null for default</param>
-    /// <returns></returns>
-    public void Clone(string repoUri, string commit, string targetDirectory, bool checkoutSubmodules, string? gitDirectory)
+    public void Clone(string repoUri, string? commit, string targetDirectory, CheckoutType checkoutType, string? gitDirectory)
     {
         string dotnetMaestro = "dotnet-maestro"; // lgtm [cs/hardcoded-credentials] Value is correct for this service
         CloneOptions cloneOptions = new()
@@ -47,7 +53,9 @@ public class GitRepoCloner : IGitRepoCloner
                     Password = _personalAccessToken
                 },
         };
+        
         _logger.LogInformation("Cloning {repoUri} to {targetDirectory}", repoUri, targetDirectory);
+
         try
         {
             _logger.LogDebug($"Cloning {repoUri} to {targetDirectory}");
@@ -55,6 +63,11 @@ public class GitRepoCloner : IGitRepoCloner
                 repoUri,
                 targetDirectory,
                 cloneOptions);
+
+            if (checkoutType == CheckoutType.NoCheckout)
+            {
+                return;
+            }
 
             CheckoutOptions checkoutOptions = new()
             {
@@ -67,7 +80,7 @@ public class GitRepoCloner : IGitRepoCloner
                 if (commit == null)
                 {
                     commit = localRepo.Head.Reference.TargetIdentifier;
-                    _logger.LogInformation($"Repo {localRepo.Info.WorkingDirectory} has no commit to clone at, assuming it's {commit}");
+                    _logger.LogDebug($"Repo {localRepo.Info.WorkingDirectory} has no commit to clone at, assuming it's {commit}");
                 }
                 _logger.LogDebug($"Attempting to checkout {commit} as commit in {localRepo.Info.WorkingDirectory}");
                 LibGit2SharpHelpers.SafeCheckout(localRepo, commit, checkoutOptions, _logger);
@@ -83,7 +96,7 @@ public class GitRepoCloner : IGitRepoCloner
                 gitDirectory = repoPath;
             }
 
-            if (checkoutSubmodules)
+            if (checkoutType == CheckoutType.CheckoutWithSubmodules)
             {
                 using var localRepo = new Repository(targetDirectory);
                 CheckoutSubmodules(localRepo, cloneOptions, gitDirectory, _logger);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/StringUtils.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/StringUtils.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
+using System.IO.Hashing;
+using System.Text;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.Helpers;
@@ -63,5 +66,14 @@ public class StringUtils
         readable /= 1024;
         // Return formatted number with suffix
         return readable.ToString("0.### ") + suffix;
+    }
+
+    public static string GetXxHash64(string input)
+    {
+        var hasher = new XxHash64(0);
+        byte[] inputBytes = Encoding.ASCII.GetBytes(input);
+        hasher.Append(inputBytes);
+        byte[] hashBytes = hasher.GetCurrentHash();
+        return Convert.ToHexString(hashBytes);
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoCloner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoCloner.cs
@@ -2,17 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 namespace Microsoft.DotNet.DarcLib;
 
 public interface IGitRepoCloner
 {
     /// <summary>
-    ///     Clone a remote repository.
+    ///     Clone a remote git repo.
     /// </summary>
-    /// <param name="repoUri">Repository uri</param>
+    /// <param name="repoUri">Repository uri to clone</param>
     /// <param name="commit">Branch, commit, or tag to checkout</param>
-    /// <param name="targetDirectory">Directory to clone to</param>
-    /// <param name="checkoutSubmodules">Indicates whether submodules should be checked out as well</param>
-    /// <param name="gitDirectory">Location for .git directory, or null for default</param>
-    void Clone(string repoUri, string commit, string targetDirectory, bool checkoutSubmodules, string gitDirectory = null);
+    /// <param name="targetDirectory">Target directory to clone to</param>
+    /// <param name="checkoutType">Indicates whether working tree and submodules should be checked out</param>
+    /// <param name="gitDirectory">Location for the .git directory, or null for default</param>
+    public void Clone(string repoUri, string? commit, string targetDirectory, CheckoutType checkoutType, string? gitDirectory);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoCloner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IGitRepoCloner.cs
@@ -13,7 +13,20 @@ public interface IGitRepoCloner
     /// <param name="repoUri">Repository uri to clone</param>
     /// <param name="commit">Branch, commit, or tag to checkout</param>
     /// <param name="targetDirectory">Target directory to clone to</param>
-    /// <param name="checkoutType">Indicates whether working tree and submodules should be checked out</param>
+    /// <param name="checkoutSubmodules">Indicates whether submodules should be checked out as well</param>
     /// <param name="gitDirectory">Location for the .git directory, or null for default</param>
-    public void Clone(string repoUri, string? commit, string targetDirectory, CheckoutType checkoutType, string? gitDirectory);
+    public void Clone(
+        string repoUri,
+        string? commit,
+        string targetDirectory,
+        bool checkoutSubmodules,
+        string? gitDirectory);
+
+    /// <summary>
+    ///     Clone a remote git repo without checking out the working tree.
+    /// </summary>
+    /// <param name="repoUri">Repository uri to clone</param>
+    /// <param name="targetDirectory">Target directory to clone to</param>
+    /// <param name="gitDirectory">Location for the .git directory, or null for default</param>
+    public void Clone(string repoUri, string targetDirectory, string? gitDirectory);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -376,8 +376,8 @@ public class LocalGitClient : ILocalGitRepo
         {
             _logger.LogDebug($"Adding {repoUrl} remote to {repoDir}");
 
-            // Remote names don't matter, make sure it's unique
-            remoteName = Guid.NewGuid().ToString();
+            // Remote names don't matter much but should be stable
+            remoteName = StringUtils.GetXxHash64(repoUrl);
             repo.Network.Remotes.Add(remoteName, repoUrl);
         }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -42,7 +42,7 @@ public class LocalGitClient : ILocalGitRepo
             }
             else
             {
-                throw new InvalidOperationException($"Neither parent-directory path ('{parentTwoDirectoriesUp}') nor specified file ('{relativeFilePath}') found.");
+                throw new DependencyFileNotFoundException($"Neither parent-directory path ('{parentTwoDirectoriesUp}') nor specified file ('{relativeFilePath}') found.");
             }
         }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.DarcLib.Helpers;
@@ -24,6 +25,7 @@ public interface IVmrInitializer : IVmrManager
         string? targetRevision,
         string? targetVersion,
         bool initializeDependencies,
-        LocalPath sourceMappings,
+        LocalPath sourceMappingsPath,
+        IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,5 +26,6 @@ public interface IVmrUpdater : IVmrManager
         string? targetVersion,
         bool noSquash,
         bool updateDependencies,
+        IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -75,7 +75,7 @@ public class RepositoryCloneManager : IRepositoryCloneManager
         {
             // Path should be returned the same for all invocations
             // We checkout a default ref
-            path = PrepareCloneInternal(remoteUri,mapping.Name, cancellationToken);
+            path = PrepareCloneInternal(remoteUri, mapping.Name, cancellationToken);
         }
 
         _localGitRepo.Checkout(path, checkoutRef);
@@ -112,7 +112,7 @@ public class RepositoryCloneManager : IRepositoryCloneManager
         {
             _logger.LogDebug("Cloning {repo} to {clonePath}", remoteUri, clonePath);
             var repoCloner = _remoteFactory.GetCloner(remoteUri, _logger);
-            repoCloner.Clone(remoteUri, null, clonePath, CheckoutType.NoCheckout, null);
+            repoCloner.Clone(remoteUri, clonePath, null);
         }
         else
         {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -231,7 +231,18 @@ public abstract class VmrManagerBase : IVmrManager
         }
 
         var gitFileManager = _gitFileManagerFactory.Create(remoteRepoUri);
-        return await gitFileManager.ParseVersionDetailsXmlAsync(remoteRepoUri, commitSha, includePinned: true);
+
+        try
+        {
+            return await gitFileManager.ParseVersionDetailsXmlAsync(remoteRepoUri, commitSha, includePinned: true);
+        }
+        catch (DependencyFileNotFoundException e)
+        {
+            _logger.LogInformation("Repository at {remoteUri} does not have {file} file, skipping dependency detection",
+                remoteRepoUri,
+                VersionFiles.VersionDetailsXml);
+            return Array.Empty<DependencyDetail>();
+        }
     }
 
     protected async Task UpdateThirdPartyNotices(CancellationToken cancellationToken)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -238,9 +238,12 @@ public abstract class VmrManagerBase : IVmrManager
         }
         catch (DependencyFileNotFoundException e)
         {
-            _logger.LogInformation("Repository at {remoteUri} does not have {file} file, skipping dependency detection",
+            _logger.LogInformation(
+                $"Repository at {{remoteUri}} does not have {{file}} file, " +
+                $"skipping dependency detection.{Environment.NewLine}{{error}}",
                 remoteRepoUri,
-                VersionFiles.VersionDetailsXml);
+                VersionFiles.VersionDetailsXml,
+                e.Message);
             return Array.Empty<DependencyDetail>();
         }
     }

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrMultipleRemotesTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrMultipleRemotesTests.cs
@@ -11,7 +11,6 @@ using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using NUnit.Framework;
 
-
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
 public class VmrMultipleRemotesTests : VmrTestsBase
@@ -19,26 +18,22 @@ public class VmrMultipleRemotesTests : VmrTestsBase
     private LocalPath FirstDependencyPath => CurrentTestDirectory / (Constants.DependencyRepoName + "1");
     private LocalPath SecondDependencyPath => CurrentTestDirectory / (Constants.DependencyRepoName + "2");
 
+    /// <summary>
+    /// The dependency tree of repos in this test looks like:
+    /// 
+    /// installer
+    ///   └── dependency
+    ///         
+    /// We will have two copies of "dependency" in folders dependency1 and dependency2
+    /// We will synchronize to the first one and then to the second one
+    /// </summary>
+    /// <returns></returns>
     [Test]
     public async Task SynchronizationBetweenDifferentRemotesTest()
     {
         var vmrSourcesDir = VmrPath / VmrInfo.SourcesDir;
         var installerFilePath = vmrSourcesDir / Constants.InstallerRepoName / Constants.GetRepoFileName(Constants.InstallerRepoName);
         var dependencyFilePath = vmrSourcesDir / Constants.DependencyRepoName / Constants.GetRepoFileName(Constants.DependencyRepoName);
-
-        /* 
-         *  The dependency tree looks like:
-         *  
-         *  installer
-         *    └── dependency
-         *          
-         *  We will have two copies of "dependency" in folders dependency1 and dependency2
-         *  We will synchronize to the first one and then to the second one
-         */
-
-        // Prepare dependencies at paths 1 and 2
-        Directory.Move(DependencyRepoPath, FirstDependencyPath);
-        CopyDirectory(FirstDependencyPath, SecondDependencyPath);
 
         var versionDetailsPath = InstallerRepoPath / VersionFiles.VersionDetailsXml;
         var versionDetailsContent = await File.ReadAllTextAsync(versionDetailsPath);
@@ -84,28 +79,25 @@ public class VmrMultipleRemotesTests : VmrTestsBase
         versionDetailsContent = versionDetailsContent.Replace(oldSha, newSha);
         await File.WriteAllTextAsync(versionDetailsPath, versionDetailsContent);
         await GitOperations.CommitAll(InstallerRepoPath, "Point VersionDetails.xml to second location");
-
         await UpdateRepoToLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
 
         CheckFileContents(dependencyFilePath, "New content only in the second folder now");
     }
 
+    /// <summary>
+    /// In this test:
+    ///   - We will have two copies of a repo in folders dependency1 and dependency2
+    ///   - We will create a commit only in the second folder
+    ///   - We will synchronize the VMR using --additional-remote to pull the commits from both folders
+    /// </summary>
+    /// <returns></returns>
     [Test]
     public async Task SynchronizationWithAdditionalRemoteTest()
     {
         var vmrSourcesDir = VmrPath / VmrInfo.SourcesDir;
         var dependencyFilePath = vmrSourcesDir / Constants.DependencyRepoName / Constants.GetRepoFileName(Constants.DependencyRepoName);
 
-        /*        
-         *  We will have two copies of a repo in folders dependency and dependency2
-         *  We will create a commit only in the -local folder
-         *  We will synchronize the VMR using --additional-remote to pull the commits from both folders
-         */
-
-        // Prepare dependencies at paths 1 and 2
-        CopyDirectory(DependencyRepoPath, SecondDependencyPath);
-
-        await InitializeRepoAtLastCommit(Constants.DependencyRepoName, DependencyRepoPath);
+        await InitializeRepoAtLastCommit(Constants.DependencyRepoName, FirstDependencyPath);
 
         var expectedFilesFromRepos = new List<LocalPath>
         {
@@ -122,7 +114,7 @@ public class VmrMultipleRemotesTests : VmrTestsBase
             "New content only in the second folder now");
         await GitOperations.CommitAll(SecondDependencyPath, "New commit in the second dependency repo");
 
-        // Point installer's VersionDetails.xml to this new repo
+        // Get SHA that is only in the second folder which is not in source-mapping.json
         var newSha = await GitOperations.GetRepoLastCommit(SecondDependencyPath);
 
         var additionalRemotes = new[]
@@ -143,6 +135,10 @@ public class VmrMultipleRemotesTests : VmrTestsBase
         };
 
         await CopyRepoAndCreateVersionDetails(CurrentTestDirectory, Constants.InstallerRepoName, dependenciesMap);
+
+        // Prepare dependencies at paths 1 and 2
+        Directory.Move(DependencyRepoPath, FirstDependencyPath);
+        CopyDirectory(FirstDependencyPath, SecondDependencyPath);
     }
 
     protected override async Task CopyVmrForCurrentTest()

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -157,13 +157,18 @@ public abstract class VmrTestsBase
     private async Task CallDarcInitialize(string repository, string commit, LocalPath sourceMappingsPath)
     {
         var vmrInitializer = _serviceProvider.Value.GetRequiredService<IVmrInitializer>();
-        await vmrInitializer.InitializeRepository(repository, commit, null, true, sourceMappingsPath, _cancellationToken.Token);
+        await vmrInitializer.InitializeRepository(repository, commit, null, true, sourceMappingsPath, Array.Empty<AdditionalRemote>(), _cancellationToken.Token);
     }
 
     protected async Task CallDarcUpdate(string repository, string commit)
     {
+        await CallDarcUpdate(repository, commit, Array.Empty<AdditionalRemote>());
+    }
+
+    protected async Task CallDarcUpdate(string repository, string commit, AdditionalRemote[] additionalRemotes)
+    {
         var vmrUpdater = _serviceProvider.Value.GetRequiredService<IVmrUpdater>();
-        await vmrUpdater.UpdateRepository(repository, commit, null, false, true, _cancellationToken.Token);
+        await vmrUpdater.UpdateRepository(repository, commit, null, false, true, additionalRemotes, _cancellationToken.Token);
     }
 
     protected void CopyDirectory(string source, LocalPath destination)

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
@@ -74,7 +74,7 @@ public class RepositoryCloneManagerTests
         path.Should().Be(_clonePath);
 
         _remoteFactory.Verify(x => x.GetCloner(RepoUri, It.IsAny<ILogger>()), Times.Once);
-        _remote.Verify(x => x.Clone(RepoUri, Ref, _clonePath, false, null), Times.Once);
+        _remote.Verify(x => x.Clone(RepoUri, Ref, _clonePath, CheckoutType.NoCheckout, null), Times.Once);
         _localGitRepo.Verify(x => x.Checkout(_clonePath, "main", false), Times.Exactly(2));
     }
 
@@ -91,7 +91,7 @@ public class RepositoryCloneManagerTests
         path.Should().Be(_clonePath);
 
         _remoteFactory.Verify(x => x.GetCloner(RepoUri, It.IsAny<ILogger>()), Times.Never);
-        _remote.Verify(x => x.Clone(RepoUri, Ref, _clonePath, false, null), Times.Never);
+        _remote.Verify(x => x.Clone(RepoUri, Ref, _clonePath, CheckoutType.NoCheckout, null), Times.Never);
         _localGitRepo.Verify(x => x.Checkout(_clonePath, Ref, false), Times.Once);
         _localGitRepo.Verify(x => x.Checkout(_clonePath, "main", false), Times.Once);
     }
@@ -121,7 +121,7 @@ public class RepositoryCloneManagerTests
         path.Should().Be(clonePath);
 
         _remoteFactory.Verify(x => x.GetCloner(mapping.DefaultRemote, It.IsAny<ILogger>()), Times.Once);
-        _remote.Verify(x => x.Clone(mapping.DefaultRemote, "main", clonePath, false, null), Times.Once);
+        _remote.Verify(x => x.Clone(mapping.DefaultRemote, "main", clonePath, CheckoutType.NoCheckout, null), Times.Once);
         _localGitRepo.Verify(x => x.Checkout(clonePath, "main", false), Times.Never);
 
         // A second clone of the same
@@ -129,7 +129,7 @@ public class RepositoryCloneManagerTests
         path = _manager.PrepareClone(mapping, new[] { mapping.DefaultRemote }, Ref, default);
         
         path.Should().Be(clonePath);
-        _remote.Verify(x => x.Clone(mapping.DefaultRemote, Ref, clonePath, false, null), Times.Never);
+        _remote.Verify(x => x.Clone(mapping.DefaultRemote, Ref, clonePath, CheckoutType.NoCheckout, null), Times.Never);
         _localGitRepo.Verify(x => x.Checkout(clonePath, Ref, false), Times.Once);
 
         // A third clone with a new remote
@@ -139,7 +139,7 @@ public class RepositoryCloneManagerTests
         
         path.Should().Be(clonePath);
         _remoteFactory.Verify(x => x.GetCloner(newRemote, It.IsAny<ILogger>()), Times.Never);
-        _remote.Verify(x => x.Clone(RepoUri, Ref, clonePath, false, null), Times.Never);
+        _remote.Verify(x => x.Clone(RepoUri, Ref, clonePath, CheckoutType.NoCheckout, null), Times.Never);
         _localGitRepo.Verify(x => x.AddRemoteIfMissing(clonePath, newRemote, true), Times.Once);
         _localGitRepo.Verify(x => x.Checkout(clonePath, Ref, false), Times.Once);
 
@@ -149,7 +149,7 @@ public class RepositoryCloneManagerTests
         
         path.Should().Be(clonePath);
         _remoteFactory.Verify(x => x.GetCloner(newRemote, It.IsAny<ILogger>()), Times.Never);
-        _remote.Verify(x => x.Clone(RepoUri, Ref + "3", clonePath, false, null), Times.Never);
+        _remote.Verify(x => x.Clone(RepoUri, Ref + "3", clonePath, CheckoutType.NoCheckout, null), Times.Never);
         _localGitRepo.Verify(x => x.AddRemoteIfMissing(clonePath, newRemote, true), Times.Never);
         _localGitRepo.Verify(x => x.Checkout(clonePath, Ref + "3", false), Times.Once);
 
@@ -159,7 +159,7 @@ public class RepositoryCloneManagerTests
 
         path.Should().Be(clonePath);
         _remoteFactory.Verify(x => x.GetCloner(RepoUri, It.IsAny<ILogger>()), Times.Never);
-        _remote.Verify(x => x.Clone(RepoUri, Ref + "4", clonePath, false, null), Times.Never);
+        _remote.Verify(x => x.Clone(RepoUri, Ref + "4", clonePath, CheckoutType.NoCheckout, null), Times.Never);
         _localGitRepo.Verify(x => x.AddRemoteIfMissing(clonePath, RepoUri, true), Times.Never);
         _localGitRepo.Verify(x => x.Checkout(clonePath, Ref + "4", false), Times.Once);
 
@@ -169,7 +169,7 @@ public class RepositoryCloneManagerTests
 
         path.Should().Be(clonePath);
         _remoteFactory.Verify(x => x.GetCloner(newRemote, It.IsAny<ILogger>()), Times.Never);
-        _remote.Verify(x => x.Clone(RepoUri, Ref + "5", clonePath, false, null), Times.Never);
+        _remote.Verify(x => x.Clone(RepoUri, Ref + "5", clonePath, CheckoutType.NoCheckout, null), Times.Never);
         _localGitRepo.Verify(x => x.AddRemoteIfMissing(clonePath, newRemote, true), Times.Never);
         _localGitRepo.Verify(x => x.Checkout(clonePath, Ref + "5", false), Times.Once);
     }


### PR DESCRIPTION
This makes it possible to add a local directory as a remote when creating the clones which means we can make sure the clone has all the commits it needs (e.g. if we clone a fork, we can use the cloned fork to synchronize to it).

Also contains:
- Improvement into the clone manager where we first clone and fetch all remotes before we checkout a SHA
- Does not expect a repo to have `Version.Details.xml` inside no more
- Fixes a bug where we were not passing the `targetVersion`

https://github.com/dotnet/arcade/issues/11386
