### PR TITLE
Fix the `--additional-remotes` argument

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/VmrOperationBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/VmrOperationBase.cs
@@ -47,6 +47,7 @@ internal abstract class VmrOperationBase<TVmrManager> : Operation where TVmrMana
                 : (a, null));
 
         IReadOnlyCollection<AdditionalRemote> additionalRemotes = _options.AdditionalRemotes
+            .Split(',')
             .Select(a => a.Split(':', 2))
             .Select(parts => new AdditionalRemote(parts[0], parts[1]))
             .ToImmutableArray();

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrCommandLineOptions.cs
@@ -21,9 +21,6 @@ internal abstract class VmrCommandLineOptions : CommandLineOptions
     [Option("tmp", Required = false, HelpText = "Temporary path where intermediate files are stored (e.g. cloned repos, patch files); defaults to usual TEMP.")]
     public string TmpPath { get; set; }
 
-    [Option("add-remote", Required = false, HelpText = "Additional remote URIs (can be repeated) to add to a given mapping in the format [mapping name]:[remote URI], e.g. installer:https://github.com/myfork/installer")]
-    public IEnumerable<string> AdditionalRemotes { get; set; }
-
     public IServiceCollection RegisterServices()
     {
         var tmpPath = Path.GetFullPath(TmpPath ?? Path.GetTempPath());

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrSyncCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrSyncCommandLineOptions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,6 +9,11 @@ namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
 internal abstract class VmrSyncCommandLineOptions : VmrCommandLineOptions
 {
+    [Option("additional-remotes", Required = false, Separator = ',', HelpText =
+        "Comma separated list of additional remote URIs to add to mappings in the format [mapping name]:[remote URI]. " +
+        "Example: installer:https://github.com/myfork/installer,sdk:/local/path/to/sdk")]
+    public string AdditionalRemotes { get; set; }
+    
     [Value(0, Required = true, HelpText =
         "Repository names in the form of NAME or NAME:REVISION where REVISION is a commit SHA or other git reference (branch, tag). " +
         "Omitting REVISION will synchronize the repo to current HEAD. Pass 'all' to update all repositories.")]


### PR DESCRIPTION
The original argument was conflicting with the positional one we use for repositories

https://github.com/dotnet/arcade/issues/11386

