### PR TITLE
Target the locally built sdk

### DIFF
--- a/src/Monitoring/Sdk/sdk/Sdk.props
+++ b/src/Monitoring/Sdk/sdk/Sdk.props
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <MicrosoftDotNetMonitoringSdkTasksAssembly>$(MSBuildThisFileDirectory)net6.0/Microsoft.DotNet.Monitoring.Sdk.dll</MicrosoftDotNetMonitoringSdkTasksAssembly>
-    <MicrosoftDotNetMonitoringSdkTasksAssembly Condition="!Exists('$(MicrosoftDotNetMonitoringSdkTasksAssembly)')">$(MSBuildThisFileDirectory)/../tools/net6.0/Microsoft.DotNet.Monitoring.Sdk.dll</MicrosoftDotNetMonitoringSdkTasksAssembly>
+    <MicrosoftDotNetMonitoringSdkTasksAssembly Condition="!Exists('$(MicrosoftDotNetMonitoringSdkTasksAssembly)')">$(MSBuildThisFileDirectory)/../../../../artifacts/bin/Microsoft.DotNet.Monitoring.Sdk/$(Configuration)/net6.0/publish/Microsoft.DotNet.Monitoring.Sdk.dll</MicrosoftDotNetMonitoringSdkTasksAssembly>
     <GrafanaDashboardTag Condition="'$(GrafanaDashboardTag)' == ''">$(MSBuildProjectName)</GrafanaDashboardTag>
   </PropertyGroup>
 


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade/issues/11852#issuecomment-1373875060


We are building and publishing the Sdk project before calling `Monitoring.ArcadeServices.proj`, and in its build directory, it has the `Microsoft.Identity.Client` package, which is the problematic one, at least when I run the command on my machine. I think the problem is that the script is not actually using the locally built Sdk from the previous step, but rather something else: 
https://github.com/dotnet/arcade-services/blob/9c2ae5ed7ed8346952ef49e40d7586faf27f0317/src/Monitoring/Sdk/sdk/Sdk.props#L6-L7
even tho we set it to 
https://github.com/dotnet/arcade-services/blob/9c2ae5ed7ed8346952ef49e40d7586faf27f0317/src/Monitoring/Monitoring.ArcadeServices/Monitoring.ArcadeServices.proj#L6 which is the one built before with `dotnet publish`