### PR TITLE
Support JSON output for `darc get-subscriptions` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ Generated\ Files/
 *.VisualState.xml
 TestResult.xml
 
+# Verify and AppovalTests
+*.received.*
+
 # Build Results of an ATL Project
 [Dd]ebugPS/
 [Rr]eleasePS/
@@ -334,4 +337,3 @@ ASALocalRun/
 
 # angular stuff
 .angulardoc.json
-*.received.*

--- a/.gitignore
+++ b/.gitignore
@@ -334,3 +334,4 @@ ASALocalRun/
 
 # angular stuff
 .angulardoc.json
+*.received.*

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -130,7 +130,7 @@
     <PackageVersion Include="NuGet.Packaging" Version="5.11.3" />
     <PackageVersion Include="NuGet.Protocol" Version="5.11.3" />
     <PackageVersion Include="NuGet.Versioning" Version="5.11.3" />
-    <PackageVersion Include="NUnit" Version="3.12.0" />  
+    <PackageVersion Include="NUnit" Version="3.13.3" />  
     <PackageVersion Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageVersion Include="Octokit" Version="0.49.0" />
     <PackageVersion Include="Quartz" Version="3.0.6" />
@@ -149,6 +149,7 @@
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="4.7.1" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" /> 
+    <PackageVersion Include="Verify.NUnit" Version="19.6" />
     <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageVersion Include="YamlDotNet" Version="9.1.4" />
     <PackageVersion Include="YamlDotNet.Signed" Version="5.3.0" />

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetSubscriptionsOperation.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
@@ -117,7 +116,6 @@ class GetSubscriptionsOperation : Operation
 
     // Based on the current output schema, sort by source repo, target repo, target branch, etc.
     // Concat the input strings as a simple sorting mechanism.
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static IEnumerable<Subscription> Sort(IEnumerable<Subscription> subscriptions)
         => subscriptions.OrderBy(subscription => $"{subscription.SourceRepository}{subscription.Channel}{subscription.TargetRepository}{subscription.TargetBranch}");
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetSubscriptionsOperation.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -12,6 +14,7 @@ using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -24,8 +27,8 @@ class GetSubscriptionsOperation : Operation
 {
     private readonly GetSubscriptionsCommandLineOptions _options;
 
-    public GetSubscriptionsOperation(GetSubscriptionsCommandLineOptions options)
-        : base(options)
+    public GetSubscriptionsOperation(GetSubscriptionsCommandLineOptions options, IServiceCollection? services = null)
+        : base(options, services)
     {
         _options = options;
     }
@@ -34,7 +37,7 @@ class GetSubscriptionsOperation : Operation
     {
         try
         {
-            IRemote remote = RemoteFactory.GetBarOnlyRemote(_options, Logger);
+            IRemote remote = Provider.GetService<IRemote>() ??  RemoteFactory.GetBarOnlyRemote(_options, Logger);
 
             IEnumerable<Subscription> subscriptions = await _options.FilterSubscriptions(remote);
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
@@ -56,7 +56,7 @@ abstract class SubscriptionsCommandLineOptions : CommandLineOptions
     [Option("ids", Separator = ',', HelpText = "Get only subscriptions with these ids.")]
     public IEnumerable<string> SubscriptionIds { get; set; }
 
-    public async Task<IEnumerable<Subscription>> FilterSubscriptions(IRemote remote)
+    public virtual async Task<IEnumerable<Subscription>> FilterSubscriptions(IRemote remote)
     {
         IEnumerable<DefaultChannel> defaultChannels = await remote.GetDefaultChannelsAsync();
         return (await remote.GetSubscriptionsAsync()).Where(subscription =>

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/SubscriptionsCommandLineOptions.cs
@@ -56,7 +56,7 @@ abstract class SubscriptionsCommandLineOptions : CommandLineOptions
     [Option("ids", Separator = ',', HelpText = "Get only subscriptions with these ids.")]
     public IEnumerable<string> SubscriptionIds { get; set; }
 
-    public virtual async Task<IEnumerable<Subscription>> FilterSubscriptions(IRemote remote)
+    public async Task<IEnumerable<Subscription>> FilterSubscriptions(IRemote remote)
     {
         IEnumerable<DefaultChannel> defaultChannels = await remote.GetDefaultChannelsAsync();
         return (await remote.GetSubscriptionsAsync()).Where(subscription =>
@@ -93,14 +93,14 @@ abstract class SubscriptionsCommandLineOptions : CommandLineOptions
     }
 
     public bool SubscriptionIdsParameterMatches(Subscription subscription)
-    {
-        return !SubscriptionIds.Any() || SubscriptionIds.Any(id => id.Equals(subscription.Id.ToString(), StringComparison.OrdinalIgnoreCase));
-    }
+        => SubscriptionIds is null
+        || !SubscriptionIds.Any()
+        || SubscriptionIds.Any(id => id.Equals(subscription.Id.ToString(), StringComparison.OrdinalIgnoreCase));
 
     public bool SubscriptionFrequenciesParameterMatches(Subscription subscription)
-    {
-        return !Frequencies.Any() || Frequencies.Any(frequency => subscription.Policy.UpdateFrequency.ToString().Contains(frequency, StringComparison.OrdinalIgnoreCase));
-    }
+        => Frequencies is null
+        || !Frequencies.Any()
+        || Frequencies.Any(frequency => subscription.Policy.UpdateFrequency.ToString().Contains(frequency, StringComparison.OrdinalIgnoreCase));
 
     public bool SubscriptionDefaultChannelTargetParameterMatches(Subscription subscription, IEnumerable<DefaultChannel> defaultChannels)
     {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.DotNet.Darc.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Helpers/ConsoleOutputIntercepter.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Helpers/ConsoleOutputIntercepter.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.DotNet.Darc.Tests.Helpers;
+
+// Copied from https://www.codeproject.com/articles/501610/getting-console-output-within-a-unit-test
+// Code provided under Code Project Open License 1.02, https://www.codeproject.com/info/cpol10.aspx
+
+public sealed class ConsoleOutputIntercepter : IDisposable
+{
+    private readonly StringWriter _stringWriter;
+    private readonly TextWriter _originalOutput;
+
+    public ConsoleOutputIntercepter()
+    {
+        _stringWriter = new();
+        _originalOutput = Console.Out;
+        Console.SetOut(_stringWriter);
+    }
+
+    public string GetOuput() => _stringWriter.ToString();
+
+    public void Dispose()
+    {
+        Console.SetOut(_originalOutput);
+        _stringWriter.Dispose();
+    }
+}

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" />
+    <PackageReference Include="Verify.NUnit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_json.verified.txt
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_json.verified.txt
@@ -1,0 +1,21 @@
+﻿[
+  {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "channel": {
+      "id": 1,
+      "name": "name",
+      "classification": "classification"
+    },
+    "sourceRepository": "source",
+    "targetRepository": "target",
+    "targetBranch": "test",
+    "policy": {
+      "batchable": false,
+      "updateFrequency": 1,
+      "mergePolicies": []
+    },
+    "lastAppliedBuild": null,
+    "enabled": true,
+    "pullRequestFailureNotificationTags": ""
+  }
+]

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_sorted_text.verified.txt
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_sorted_text.verified.txt
@@ -1,0 +1,14 @@
+﻿source1 (name) ==> 'target1' ('test')
+  - Id: 00000000-0000-0000-0000-000000000000
+  - Update Frequency: EveryDay
+  - Enabled: True
+  - Batchable: False
+  - PR Failure Notification tags: 
+  - Merge Policies: []
+source2 (name) ==> 'target2' ('test')
+  - Id: 00000000-0000-0000-0000-000000000000
+  - Update Frequency: EveryDay
+  - Enabled: True
+  - Batchable: False
+  - PR Failure Notification tags: 
+  - Merge Policies: []

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_text.verified.txt
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_text.verified.txt
@@ -1,0 +1,7 @@
+﻿source (name) ==> 'target' ('test')
+  - Id: 00000000-0000-0000-0000-000000000000
+  - Update Frequency: EveryDay
+  - Enabled: True
+  - Batchable: False
+  - PR Failure Notification tags: 
+  - Merge Policies: []

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.cs
@@ -1,0 +1,191 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.DotNet.Darc.Operations;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.Darc.Tests.Helpers;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Moq;
+using NUnit.Framework;
+using VerifyNUnit;
+
+namespace Microsoft.DotNet.Darc.Tests.Operations;
+
+[TestFixture]
+public class GetSubscriptionsOperationTests
+{
+    private ConsoleOutputIntercepter _consoleOutput;
+
+    [SetUp]
+    public void Setup()
+    {
+        _consoleOutput = new();
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        _consoleOutput.Dispose();
+    }
+
+    [Test]
+    public async Task GetSubscriptionsOperationTests_ExecuteAsync_returns_ErrorCode_for_empty_set()
+    {
+        var optionsMock = new Mock<GetSubscriptionsCommandLineOptions>();
+        optionsMock.Setup(t => t.FilterSubscriptions(It.IsAny<IRemote>()))
+            .Returns(Task.FromResult(new List<Subscription>().AsEnumerable()));
+
+        GetSubscriptionsOperation operation = new(optionsMock.Object);
+
+        int result = await operation.ExecuteAsync();
+
+        result.Should().Be(Constants.ErrorCode);
+
+        var logs = _consoleOutput.GetOuput();
+        logs.Should().Be($"No subscriptions found matching the specified criteria.{Environment.NewLine}");
+    }
+
+    [Test]
+    public async Task GetSubscriptionsOperationTests_ExecuteAsync_returns_ErrorCode_for_AuthenticationException()
+    {
+        var optionsMock = new Mock<GetSubscriptionsCommandLineOptions>();
+        optionsMock.Setup(t => t.FilterSubscriptions(It.IsAny<IRemote>()))
+            .Throws(new AuthenticationException("boo."));
+
+        GetSubscriptionsOperation operation = new(optionsMock.Object);
+
+        int result = await operation.ExecuteAsync();
+
+        result.Should().Be(Constants.ErrorCode);
+
+        var logs = _consoleOutput.GetOuput();
+        logs.Should().Be($"boo.{Environment.NewLine}");
+    }
+
+    [Test]
+    public async Task GetSubscriptionsOperationTests_ExecuteAsync_returns_ErrorCode_for_Exception()
+    {
+        var optionsMock = new Mock<GetSubscriptionsCommandLineOptions>();
+        optionsMock.Setup(t => t.FilterSubscriptions(It.IsAny<IRemote>()))
+            .Throws(new Exception("foo."));
+
+        GetSubscriptionsOperation operation = new(optionsMock.Object);
+
+        int result = await operation.ExecuteAsync();
+
+        result.Should().Be(Constants.ErrorCode);
+
+        var logs = _consoleOutput.GetOuput();
+        // Nothing is written to the console, but to ILogger.Error instead.
+        logs.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GetSubscriptionsOperationTests_ExecuteAsync_returns_text()
+    {
+        List<Subscription> subscriptions = new();
+
+        Subscription subscription = new(Guid.Empty, true, "source", "target", "test", string.Empty)
+        {
+            Channel = new(id: 1, name: "name", classification: "classification"),
+            Policy = new(batchable: false, updateFrequency: UpdateFrequency.EveryDay)
+            {
+                MergePolicies = ImmutableList<MergePolicy>.Empty
+            }
+        };
+
+        subscriptions.Add(subscription);
+
+        var optionsMock = new Mock<GetSubscriptionsCommandLineOptions>();
+        optionsMock.Setup(t => t.FilterSubscriptions(It.IsAny<IRemote>()))
+            .Returns(Task.FromResult(subscriptions.AsEnumerable()));
+
+        GetSubscriptionsOperation operation = new(optionsMock.Object);
+
+        int result = await operation.ExecuteAsync();
+
+        result.Should().Be(Constants.SuccessCode);
+
+        var logs = _consoleOutput.GetOuput();
+        await Verifier.Verify(logs);
+    }
+
+    [Test]
+    public async Task GetSubscriptionsOperationTests_ExecuteAsync_returns_json()
+    {
+        List<Subscription> subscriptions = new();
+
+        Subscription subscription = new(Guid.Empty, true, "source", "target", "test", string.Empty)
+        {
+            Channel = new(id: 1, name: "name", classification: "classification"),
+            Policy = new(batchable: false, updateFrequency: UpdateFrequency.EveryDay)
+            {
+                MergePolicies = ImmutableList<MergePolicy>.Empty
+            }
+        };
+
+        subscriptions.Add(subscription);
+
+        var optionsMock = new Mock<GetSubscriptionsCommandLineOptions>();
+        optionsMock.Setup(t => t.FilterSubscriptions(It.IsAny<IRemote>()))
+            .Returns(Task.FromResult(subscriptions.AsEnumerable()));
+        optionsMock.Object.OutputFormat = DarcOutputType.json;
+
+        GetSubscriptionsOperation operation = new(optionsMock.Object);
+
+        int result = await operation.ExecuteAsync();
+
+        result.Should().Be(Constants.SuccessCode);
+
+        var logs = _consoleOutput.GetOuput();
+        await Verifier.Verify(logs);
+    }
+
+    [Test]
+    public async Task GetSubscriptionsOperationTests_ExecuteAsync_returns_sorted_text()
+    {
+        List<Subscription> subscriptions = new();
+
+        Subscription subscription = new(Guid.Empty, true, "source2", "target2", "test", string.Empty)
+        {
+            Channel = new(id: 1, name: "name", classification: "classification"),
+            Policy = new(batchable: false, updateFrequency: UpdateFrequency.EveryDay)
+            {
+                MergePolicies = ImmutableList<MergePolicy>.Empty
+            }
+        };
+        subscriptions.Add(subscription);
+
+        subscription = new(Guid.Empty, true, "source1", "target1", "test", string.Empty)
+        {
+            Channel = new(id: 1, name: "name", classification: "classification"),
+            Policy = new(batchable: false, updateFrequency: UpdateFrequency.EveryDay)
+            {
+                MergePolicies = ImmutableList<MergePolicy>.Empty
+            }
+        };
+        subscriptions.Add(subscription);
+
+        var optionsMock = new Mock<GetSubscriptionsCommandLineOptions>();
+        optionsMock.Setup(t => t.FilterSubscriptions(It.IsAny<IRemote>()))
+            .Returns(Task.FromResult(subscriptions.AsEnumerable()));
+
+        GetSubscriptionsOperation operation = new(optionsMock.Object);
+
+        int result = await operation.ExecuteAsync();
+
+        result.Should().Be(Constants.SuccessCode);
+
+        var logs = _consoleOutput.GetOuput();
+        await Verifier.Verify(logs);
+    }
+}


### PR DESCRIPTION
The JSON output is helpful for integration scenarios.

Added tests. Please note https://www.nuget.org/packages/Verify.NUnit/ needs to be added to https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-public feed (there's already Verify.XUnit variant).


Closes https://github.com/dotnet/arcade/issues/12442