### PR TITLE
Perform a full fetch before VMR sync

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -1480,7 +1480,7 @@ This pull request has not been merged because Maestro++ is waiting on the follow
     /// </summary>
     /// <param name="repoDir">Ignored</param>
     /// <param name="repoUrl">Ignored</param>
-    public void AddRemoteIfMissing(string repoDir, string repoUrl)
+    public string AddRemoteIfMissing(string repoDir, string repoUrl)
     {
         throw new NotImplementedException("Cannot add a remote to a remote repo.");
     }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -162,9 +162,9 @@ public class Local : ILocal
     /// </summary>
     /// <param name="repoDir">The directory of the local repo</param>
     /// <param name="repoUrl">The remote URL to add</param>
-    public void AddRemoteIfMissing(string repoDir, string repoUrl)
+    public string AddRemoteIfMissing(string repoDir, string repoUrl)
     {
-        _gitClient.AddRemoteIfMissing(repoDir, repoUrl);
+        return _gitClient.AddRemoteIfMissing(repoDir, repoUrl);
     }
 
     private List<GitFile> GetFilesAtRelativeRepoPathAsync(string path)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/ILocalGitRepo.cs
@@ -13,8 +13,9 @@ public interface ILocalGitRepo : IGitRepo
     /// </summary>
     /// <param name="repoDir">Path to a git repository</param>
     /// <param name="repoUrl">URL of the remote to add</param>
-    /// <param name="forceFetch">Fetch changes even when remote exists</param>
-    void AddRemoteIfMissing(string repoDir, string repoUrl, bool forceFetch = false);
+    /// <param name="skipFetch">Skip fetching remote changes</param>
+    /// <returns>Name of the remote</returns>
+    string AddRemoteIfMissing(string repoDir, string repoUrl, bool skipFetch = false);
 
     /// <summary>
     ///     Checkout the repo to the specified state.

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/LocalGitClient.cs
@@ -367,7 +367,7 @@ public class LocalGitClient : ILocalGitRepo
         var remote = repo.Network.Remotes.FirstOrDefault(r => r.Url.Equals(repoUrl, StringComparison.InvariantCultureIgnoreCase));
         string remoteName;
 
-        if (remote is null)
+        if (remote is not null)
         {
             remoteName = remote.Name;
         }
@@ -386,7 +386,7 @@ public class LocalGitClient : ILocalGitRepo
             Commands.Fetch(
                 repo,
                 remoteName,
-                Array.Empty<string>(),
+                new[] { $"+refs/heads/*:refs/remotes/{remoteName}/*" },
                 new FetchOptions(),
                 $"Fetching {repoUrl} into {repoDir}");
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -145,7 +145,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
             .Prepend(update.RemoteUri)
             .ToArray();
 
-        var clonePath = _cloneManager.PrepareClone(
+        var clonePath = await _cloneManager.PrepareClone(
             update.Mapping,
             remotes,
             update.TargetRevision,

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -438,7 +438,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         CancellationToken cancellationToken)
     {
         var checkoutCommit = change.Before == Constants.EmptyGitObject ? change.After : change.Before;
-        var clonePath = _cloneManager.PrepareClone(change.Url, checkoutCommit, cancellationToken);   
+        var clonePath = await _cloneManager.PrepareClone(change.Url, checkoutCommit, cancellationToken);   
 
         // We are only interested in filters specific to submodule's path
         ImmutableArray<string> GetSubmoduleFilters(IReadOnlyCollection<string> filters)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -122,7 +122,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 .Prepend(mapping.DefaultRemote)
                 .ToArray();
 
-            var clonePath = _cloneManager.PrepareClone(
+            var clonePath = await _cloneManager.PrepareClone(
                 mapping,
                 remotes,
                 targetRevision ?? mapping.DefaultRef, 
@@ -173,7 +173,11 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             .Prepend(update.RemoteUri)
             .ToArray();
 
-        LocalPath clonePath = _cloneManager.PrepareClone(update.Mapping, remotes, update.TargetRevision, cancellationToken);
+        LocalPath clonePath = await _cloneManager.PrepareClone(
+            update.Mapping,
+            remotes,
+            update.TargetRevision,
+            cancellationToken);
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -529,7 +533,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 source.RemoteUri,
                 source.CommitSha);
 
-            var clonePath = _cloneManager.PrepareClone(source.RemoteUri, source.CommitSha, cancellationToken);
+            var clonePath = await _cloneManager.PrepareClone(source.RemoteUri, source.CommitSha, cancellationToken);
 
             foreach ((UnixPath relativePath, UnixPath pathInVmr) in group)
             {

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -96,7 +96,7 @@ public class VmrPatchHandlerTests
         _cloneManager.Reset();
         _cloneManager
             .Setup(x => x.PrepareClone(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Returns((string uri, string _, CancellationToken _) => new UnixPath("/tmp/" + uri.Split("/").Last()));
+            .ReturnsAsync((string uri, string _, CancellationToken _) => new UnixPath("/tmp/" + uri.Split("/").Last()));
 
         _processManager.Reset();
         _processManager


### PR DESCRIPTION
It seems like that the fetch provided by `AddRemotesIfMissing` only fetched named refs and not all commits which is what we need for our scenarios in the VMR. This is because AzDO shallow clones only a single commit which is not referenced and we then don't fetch it locally.

https://github.com/dotnet/arcade/issues/11386

