### PR TITLE
Fetch by remote URI not name during VMR sync

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -121,10 +121,10 @@ public class RepositoryCloneManager : IRepositoryCloneManager
         else
         {
             _logger.LogDebug("Clone of {repo} found in {clonePath}", remoteUri, clonePath);
-            var remoteName = _localGitRepo.AddRemoteIfMissing(clonePath, remoteUri, skipFetch: true);
+            _localGitRepo.AddRemoteIfMissing(clonePath, remoteUri, skipFetch: true);
 
             // We need to perform a full fetch and not the one provided by localGitRepo as we want all commits
-            var result = await _processManager.ExecuteGit(clonePath, new[] { "fetch", remoteName }, cancellationToken);
+            var result = await _processManager.ExecuteGit(clonePath, new[] { "fetch", remoteUri }, cancellationToken);
             result.ThrowIfFailed($"Failed to fetch changes from {remoteUri} into {clonePath}");
         }
 

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
@@ -167,7 +167,7 @@ public class RepositoryCloneManagerTests
         _remote.Verify(x => x.Clone(RepoUri, clonePath, null), Times.Never);
         _localGitRepo.Verify(x => x.AddRemoteIfMissing(clonePath, newRemote, true), Times.Once);
         _localGitRepo.Verify(x => x.Checkout(clonePath, Ref, false), Times.Once);
-        _processManager.Verify(x => x.ExecuteGit(clonePath, new[] { "fetch", "new" }, default), Times.Once);
+        _processManager.Verify(x => x.ExecuteGit(clonePath, new[] { "fetch", newRemote }, default), Times.Once);
 
         // Same again, should be cached
         ResetCalls();


### PR DESCRIPTION
Somehow `fetch remoteName` does something else than `fetch remoteUri`

https://github.com/dotnet/arcade/issues/11386

