### PR TITLE
Add baselines for ignored files during VMR scans

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/BinaryFileScanOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/BinaryFileScanOperation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
 internal class BinaryFileScanOperation : ScanOperationBase<VmrBinaryFileScanner>
 {
-    public BinaryFileScanOperation(BinaryFileScanOptions options) : base(options, options.RegisterServices())
+    public BinaryFileScanOperation(BinaryFileScanOptions options) : base(options)
     {
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/BinaryFileScanOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/BinaryFileScanOperation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
 internal class BinaryFileScanOperation : ScanOperationBase<VmrBinaryFileScanner>
 {
-    public BinaryFileScanOperation(VmrScanOptions options) : base(options, options.RegisterServices())
+    public BinaryFileScanOperation(BinaryFileScanOptions options) : base(options, options.RegisterServices())
     {
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/BinaryFileScanOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/BinaryFileScanOperation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
 internal class BinaryFileScanOperation : ScanOperationBase<VmrBinaryFileScanner>
 {
-    public BinaryFileScanOperation(BinaryFileScanOptions options) : base(options, options.RegisterServices())
+    public BinaryFileScanOperation(VmrScanOptions options) : base(options, options.RegisterServices())
     {
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/CloakedFileScanOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/CloakedFileScanOperation.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
 internal class CloakedFileScanOperation : ScanOperationBase<VmrCloakedFileScanner>
 {
-    public CloakedFileScanOperation(CloakedFileScanOptions options) : base(options, options.RegisterServices())
+    public CloakedFileScanOperation(CloakedFileScanOptions options) : base(options)
     {
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/CloakedFileScanOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/CloakedFileScanOperation.cs
@@ -2,19 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
-using Microsoft.Extensions.DependencyInjection;
 
 #nullable enable
 namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
 internal class CloakedFileScanOperation : ScanOperationBase<VmrCloakedFileScanner>
 {
-    public CloakedFileScanOperation(CloakedFileScanOptions options) : base(options, options.RegisterServices())
+    public CloakedFileScanOperation(VmrScanOptions options) : base(options, options.RegisterServices())
     {
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/CloakedFileScanOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/CloakedFileScanOperation.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
 internal class CloakedFileScanOperation : ScanOperationBase<VmrCloakedFileScanner>
 {
-    public CloakedFileScanOperation(VmrScanOptions options) : base(options, options.RegisterServices())
+    public CloakedFileScanOperation(CloakedFileScanOptions options) : base(options, options.RegisterServices())
     {
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperationBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperationBase.cs
@@ -16,7 +16,7 @@ internal abstract class ScanOperationBase<T> : Operation where T : IVmrScanner
 {
     private readonly VmrScanOptions _options;
 
-    public ScanOperationBase(VmrScanOptions options, IServiceCollection services = null) : base(options, services)
+    public ScanOperationBase(VmrScanOptions options) : base(options, options.RegisterServices())
     {
         _options = options;
     }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperationBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperationBase.cs
@@ -26,7 +26,7 @@ internal abstract class ScanOperationBase<T> : Operation where T : IVmrScanner
         var vmrScanner = Provider.GetRequiredService<T>();
         using var listener = CancellationKeyListener.ListenForCancellation(Logger);
 
-        var files = await vmrScanner.ScanVmr(_options.BaselineFilePath, listener.Token);
+        var files = await vmrScanner.ScanVmr(_options.BaselineFilesPath, listener.Token);
 
         foreach (var file in files)
         {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperationBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperationBase.cs
@@ -26,7 +26,7 @@ internal abstract class ScanOperationBase<T> : Operation where T : IVmrScanner
         var vmrScanner = Provider.GetRequiredService<T>();
         using var listener = CancellationKeyListener.ListenForCancellation(Logger);
 
-        var files = await vmrScanner.ScanVmr(_options.BaselineFilesPath, listener.Token);
+        var files = await vmrScanner.ScanVmr(_options.BaselineFilePath, listener.Token);
 
         foreach (var file in files)
         {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperationBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/ScanOperationBase.cs
@@ -2,19 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Linq;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
 internal abstract class ScanOperationBase<T> : Operation where T : IVmrScanner
 {
-    public ScanOperationBase(CommandLineOptions options, IServiceCollection services = null) : base(options, services)
+    private readonly VmrScanOptions _options;
+
+    public ScanOperationBase(VmrScanOptions options, IServiceCollection services = null) : base(options, services)
     {
+        _options = options;
     }
 
     public override async Task<int> ExecuteAsync()
@@ -22,7 +25,7 @@ internal abstract class ScanOperationBase<T> : Operation where T : IVmrScanner
         var vmrScanner = Provider.GetRequiredService<T>();
         using var listener = CancellationKeyListener.ListenForCancellation(Logger);
 
-        await vmrScanner.ScanVmr(listener.Token);
+        await vmrScanner.ScanVmr(_options.BaselineFilePath, listener.Token);
         return 0;
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/BinaryFileScanOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/BinaryFileScanOptions.cs
@@ -10,7 +10,7 @@ using Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
 [Verb("scan-binary-files", HelpText = "Scans the VMR, checking if it contains any binary files")]
-internal class BinaryFileScanOptions : VmrCommandLineOptions
+internal class BinaryFileScanOptions : VmrScanOptions
 {
     public override Operation GetOperation() => new BinaryFileScanOperation(this);
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/CloakedFileScanOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/CloakedFileScanOptions.cs
@@ -10,7 +10,7 @@ using Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
 [Verb("scan-cloaked-files", HelpText = "Scans the VMR, checking if it contains any cloaked files")]
-internal class CloakedFileScanOptions : VmrCommandLineOptions
+internal class CloakedFileScanOptions : VmrScanOptions
 {
     public override Operation GetOperation() => new CloakedFileScanOperation(this);
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrScanOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrScanOptions.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommandLine;
+
+#nullable enable
+namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
+
+internal abstract class VmrScanOptions : VmrCommandLineOptions
+{
+    [Option("baseline-file", Required = true, HelpText = "Path to the VMR baseline file")]
+    public string BaselineFilePath { get; set; } = string.Empty;
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrScanOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrScanOptions.cs
@@ -9,6 +9,6 @@ namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
 internal abstract class VmrScanOptions : VmrCommandLineOptions
 {
-    [Option("baseline-file", Required = true, HelpText = "Path to the file containing a list of the VMR baseline files")]
-    public string BaselineFilesPath { get; set; } = string.Empty;
+    [Option("baseline-file", Required = true, HelpText = "Path to the scan baseline file (list of files ignored by the scan)")]
+    public string BaselineFilePath { get; set; } = null!;
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrScanOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrScanOptions.cs
@@ -9,6 +9,6 @@ namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
 internal abstract class VmrScanOptions : VmrCommandLineOptions
 {
-    [Option("baseline-file", Required = true, HelpText = "Path to the VMR baseline file")]
-    public string BaselineFilePath { get; set; } = string.Empty;
+    [Option("baseline-file", Required = true, HelpText = "Path to the file containing a list of the VMR baseline files")]
+    public string BaselineFilesPath { get; set; } = string.Empty;
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
@@ -11,5 +11,5 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IVmrScanner
 {
-    Task<List<string>> ScanVmr(string baselineFilePath, CancellationToken cancellationToken);
+    Task<List<string>> ScanVmr(string baselineFilesPath, CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
@@ -11,5 +11,5 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IVmrScanner
 {
-    Task<List<string>> ScanVmr(string baselineFilesPath, CancellationToken cancellationToken);
+    Task<List<string>> ScanVmr(string baselineFilePath, CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrScanner.cs
@@ -11,5 +11,5 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IVmrScanner
 {
-    Task<List<string>> ScanVmr(CancellationToken cancellationToken);
+    Task<List<string>> ScanVmr(string baselineFilePath, CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrBinaryFileScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrBinaryFileScanner.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
+using NuGet.Packaging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,16 +29,18 @@ public class VmrBinaryFileScanner : VmrScanner
     {
     }
 
-    protected override async Task<IEnumerable<string>> ScanRepository(SourceMapping sourceMapping, CancellationToken cancellationToken)
+    protected override async Task<IEnumerable<string>> ScanRepository(SourceMapping sourceMapping, string baselineFilesPath, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        var args = new string[]
+        var args = new List<string>
         {
             "diff",
             Constants.EmptyGitObject,
             "--numstat",
             _vmrInfo.GetRepoSourcesPath(sourceMapping)
         };
+
+        args.AddRange(GetBaselineFilesExclusionList(baselineFilesPath));
 
         var ret = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args.ToArray(), cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrBinaryFileScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrBinaryFileScanner.cs
@@ -40,7 +40,7 @@ public class VmrBinaryFileScanner : VmrScanner
             _vmrInfo.GetRepoSourcesPath(sourceMapping)
         };
 
-        args.AddRange(GetBaselineFilesExclusionList(baselineFilesPath));
+        args.AddRange(GetBaselineFiles(baselineFilesPath));
 
         var ret = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args.ToArray(), cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrBinaryFileScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrBinaryFileScanner.cs
@@ -43,7 +43,7 @@ public class VmrBinaryFileScanner : VmrScanner
             _vmrInfo.GetRepoSourcesPath(sourceMapping)
         };
 
-        args.AddRange(await GetBaselineFilesAsync(baselineFilePath));
+        args.AddRange(await GetBaselineFilesAsync(sourceMapping.Name, baselineFilePath));
 
         var ret = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args.ToArray(), cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrBinaryFileScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrBinaryFileScanner.cs
@@ -43,7 +43,7 @@ public class VmrBinaryFileScanner : VmrScanner
             _vmrInfo.GetRepoSourcesPath(sourceMapping)
         };
 
-        args.AddRange(await GetBaselineFilesAsync(sourceMapping.Name, baselineFilePath));
+        args.AddRange(await GetExclusionFilters(sourceMapping.Name, baselineFilePath));
 
         var ret = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args.ToArray(), cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrBinaryFileScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrBinaryFileScanner.cs
@@ -29,7 +29,10 @@ public class VmrBinaryFileScanner : VmrScanner
     {
     }
 
-    protected override async Task<IEnumerable<string>> ScanRepository(SourceMapping sourceMapping, string baselineFilesPath, CancellationToken cancellationToken)
+    protected override async Task<IEnumerable<string>> ScanRepository(
+        SourceMapping sourceMapping,
+        string baselineFilePath, 
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var args = new List<string>
@@ -40,7 +43,7 @@ public class VmrBinaryFileScanner : VmrScanner
             _vmrInfo.GetRepoSourcesPath(sourceMapping)
         };
 
-        args.AddRange(GetBaselineFiles(baselineFilesPath));
+        args.AddRange(await GetBaselineFilesAsync(baselineFilePath));
 
         var ret = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args.ToArray(), cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrCloakedFileScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrCloakedFileScanner.cs
@@ -27,7 +27,10 @@ public class VmrCloakedFileScanner : VmrScanner
     {
     }
 
-    protected override async Task<IEnumerable<string>> ScanRepository(SourceMapping sourceMapping, string baselineFilesPath, CancellationToken cancellationToken)
+    protected override async Task<IEnumerable<string>> ScanRepository(
+        SourceMapping sourceMapping, 
+        string baselineFilePath,
+        CancellationToken cancellationToken)
     {
         var args = new List<string>
         {
@@ -43,7 +46,7 @@ public class VmrCloakedFileScanner : VmrScanner
             args.Add(GetExclusionFilter(baseExcludePath / exclude));
         }
 
-        args.AddRange(GetBaselineFiles(baselineFilesPath));
+        args.AddRange(await GetBaselineFilesAsync(baselineFilePath));
 
         var ret = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args.ToArray(), cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrCloakedFileScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrCloakedFileScanner.cs
@@ -46,7 +46,7 @@ public class VmrCloakedFileScanner : VmrScanner
             args.Add(GetExclusionFilter(baseExcludePath / exclude));
         }
 
-        args.AddRange(await GetBaselineFilesAsync(sourceMapping.Name, baselineFilePath));
+        args.AddRange(await GetExclusionFilters(sourceMapping.Name, baselineFilePath));
 
         var ret = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args.ToArray(), cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrCloakedFileScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrCloakedFileScanner.cs
@@ -43,7 +43,7 @@ public class VmrCloakedFileScanner : VmrScanner
             args.Add(GetExclusionFilter(baseExcludePath / exclude));
         }
 
-        args.AddRange(GetBaselineFilesExclusionList(baselineFilesPath));
+        args.AddRange(GetBaselineFiles(baselineFilesPath));
 
         var ret = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args.ToArray(), cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrCloakedFileScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrCloakedFileScanner.cs
@@ -46,7 +46,7 @@ public class VmrCloakedFileScanner : VmrScanner
             args.Add(GetExclusionFilter(baseExcludePath / exclude));
         }
 
-        args.AddRange(await GetBaselineFilesAsync(baselineFilePath));
+        args.AddRange(await GetBaselineFilesAsync(sourceMapping.Name, baselineFilePath));
 
         var ret = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args.ToArray(), cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrCloakedFileScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrCloakedFileScanner.cs
@@ -7,6 +7,7 @@ using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -26,7 +27,7 @@ public class VmrCloakedFileScanner : VmrScanner
     {
     }
 
-    protected override async Task<IEnumerable<string>> ScanRepository(SourceMapping sourceMapping, CancellationToken cancellationToken)
+    protected override async Task<IEnumerable<string>> ScanRepository(SourceMapping sourceMapping, string baselineFilesPath, CancellationToken cancellationToken)
     {
         var args = new List<string>
         {
@@ -42,6 +43,8 @@ public class VmrCloakedFileScanner : VmrScanner
             args.Add(GetExclusionFilter(baseExcludePath / exclude));
         }
 
+        args.AddRange(GetBaselineFilesExclusionList(baselineFilesPath));
+
         var ret = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args.ToArray(), cancellationToken);
 
         ret.ThrowIfFailed($"Failed to scan the {sourceMapping.Name} repository");
@@ -52,5 +55,4 @@ public class VmrCloakedFileScanner : VmrScanner
 
     protected override string ScanType { get; } = "cloaked";
     private string GetExclusionFilter(string file) => $":(attr:!{VmrInfo.KeepAttribute}){file}";
-
 }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -74,10 +74,11 @@ public abstract class VmrScanner : IVmrScanner
     /// <summary>
     /// Returns a list of files that will be exluded from the scan operation, loaded from the baselineFilesPath
     /// </summary>
-    protected async Task<IEnumerable<string>> GetBaselineFilesAsync(string baselineFilePath)
+    protected async Task<IEnumerable<string>> GetBaselineFilesAsync(string repoName, string baselineFilePath)
     {
         var text = await _fileSystem.ReadAllTextAsync(baselineFilePath);
         return text.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .Where(line => line.StartsWith($"src/{repoName}") || line.StartsWith('*'))
             .Select(line =>
             {
                 // Ignore comments

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -73,7 +73,7 @@ public abstract class VmrScanner : IVmrScanner
     /// <summary>
     /// Returns a list of files that will be exluded from the scan operation, loaded from the baselineFilesPath
     /// </summary>
-    protected async Task<IEnumerable<string>> GetBaselineFilesAsync(string repoName, string baselineFilePath)
+    protected async Task<IEnumerable<string>> GetExclusionFilters(string repoName, string baselineFilePath)
     {
         var text = await _fileSystem.ReadAllTextAsync(baselineFilePath);
         return text.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -70,7 +70,7 @@ public abstract class VmrScanner : IVmrScanner
     /// </summary>
     /// <param name="baselineFilesPath"></param>
     /// <returns></returns>
-    protected IEnumerable<string> GetBaselineFilesExclusionList(string baselineFilesPath)
+    protected IEnumerable<string> GetBaselineFiles(string baselineFilesPath)
     {
         var a =  File.ReadAllLines(baselineFilesPath).Select(line =>
             {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,8 +24,6 @@ public abstract class VmrScanner : IVmrScanner
     protected readonly IVmrInfo _vmrInfo;
     protected readonly ILogger<VmrScanner> _logger;
 
-    
-
     public VmrScanner(
         IVmrDependencyTracker dependencyTracker,
         IProcessManager processManager,
@@ -37,7 +36,7 @@ public abstract class VmrScanner : IVmrScanner
         _logger = logger;
     }
 
-    public async Task<List<string>> ScanVmr(CancellationToken cancellationToken)
+    public async Task<List<string>> ScanVmr(string baselineFilesPath, CancellationToken cancellationToken)
     {
         await _dependencyTracker
             .InitializeSourceMappings(_vmrInfo.VmrPath / VmrInfo.SourcesDir / VmrInfo.SourceMappingsFileName);
@@ -48,7 +47,7 @@ public abstract class VmrScanner : IVmrScanner
 
         foreach (var sourceMapping in _dependencyTracker.Mappings)
         {
-            taskList.Add(ScanRepository(sourceMapping, cancellationToken));
+            taskList.Add(ScanRepository(sourceMapping, baselineFilesPath, cancellationToken));
         }
 
         await Task.WhenAll(taskList);
@@ -68,6 +67,22 @@ public abstract class VmrScanner : IVmrScanner
     }
 
     protected abstract string ScanType { get; }
-    protected abstract Task<IEnumerable<string>> ScanRepository(SourceMapping sourceMapping, CancellationToken cancellationToken);
+    protected abstract Task<IEnumerable<string>> ScanRepository(SourceMapping sourceMapping, string baselineFilesPath, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns a list of files that will be exluded from the scan operation, loaded from the baselineFilesPath
+    /// </summary>
+    /// <param name="baselineFilesPath"></param>
+    /// <returns></returns>
+    protected IEnumerable<string> GetBaselineFilesExclusionList(string baselineFilesPath)
+    {
+        var a =  File.ReadAllLines(baselineFilesPath).Select(line =>
+            {
+                var index = line.IndexOf('#');
+                return index >= 0 ? line.Substring(0, index).TrimEnd() : line;
+            })
+            .Select(filePath => $":(exclude){filePath}");
+        return a;
+    }
 }
 

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrBinaryFileScannerTest.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrBinaryFileScannerTest.cs
@@ -23,13 +23,13 @@ public class VmrBinaryFileScannerTest : VmrTestsBase
     public async Task VmrBinaryFileScannerTests()
     {
         var testFileName = "test.jpg";
-        var baselineFilePath = VmrTestsOneTimeSetUp.TestsDirectory / "baselineFiles.txt";
-        File.Create(baselineFilePath).Close();
+        var baselinesFilePath = VmrTestsOneTimeSetUp.TestsDirectory / "baselineFiles.txt";
+        File.Create(baselinesFilePath).Close();
 
         await InitializeRepoAtLastCommit(Constants.ProductRepoName, ProductRepoPath);
 
         // Test the scanner when there are no cloacked files to be found
-        var list = await CallDarcBinaryFileScan(baselineFilePath);
+        var list = await CallDarcBinaryFileScan(baselinesFilePath);
 
         list.Count().Should().Be(0);
 
@@ -40,16 +40,16 @@ public class VmrBinaryFileScannerTest : VmrTestsBase
         await GitOperations.CommitAll(VmrPath, "Commit dll file");
 
         // Test the scanner when there is a binary file to be found
-        list = await CallDarcBinaryFileScan(baselineFilePath);
+        list = await CallDarcBinaryFileScan(baselinesFilePath);
 
         list.Should().HaveCount(1);
         var path = new NativePath(list.First());
         path.Should().BeEquivalentTo(new NativePath(Path.Join("src", Constants.ProductRepoName, "src", testFileName)));
 
-        File.WriteAllText(baselineFilePath, "*.jpg");
+        File.WriteAllText(baselinesFilePath, "*.jpg");
 
         // Test the scanner when the binary file is a baseline file
-        list = await CallDarcBinaryFileScan(baselineFilePath);
+        list = await CallDarcBinaryFileScan(baselinesFilePath);
 
         list.Count().Should().Be(0);
     }

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrBinaryFileScannerTest.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrBinaryFileScannerTest.cs
@@ -31,7 +31,7 @@ public class VmrBinaryFileScannerTest : VmrTestsBase
         // Test the scanner when there are no cloacked files to be found
         var list = await CallDarcBinaryFileScan(baselinesFilePath);
 
-        list.Count().Should().Be(0);
+        list.Should().BeEmpty();
 
         var newFilePath = VmrPath / "src" / Constants.ProductRepoName / "src";
         Directory.CreateDirectory(newFilePath);
@@ -51,7 +51,7 @@ public class VmrBinaryFileScannerTest : VmrTestsBase
         // Test the scanner when the binary file is a baseline file
         list = await CallDarcBinaryFileScan(baselinesFilePath);
 
-        list.Count().Should().Be(0);
+        list.Should().BeEmpty();
     }
 
     protected override async Task CopyReposForCurrentTest()

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCloakedFileScannerTest.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCloakedFileScannerTest.cs
@@ -25,13 +25,13 @@ public class VmrCloakedFileScannerTest : VmrTestsBase
     public async Task VmrCloakedFileScannerTests()
     {
         var testFileName = "test.dll";
-        var baselineFilePath = VmrTestsOneTimeSetUp.TestsDirectory / "baselineFiles.txt";
-        File.Create(baselineFilePath).Close();
+        var baselinesFilePath = VmrTestsOneTimeSetUp.TestsDirectory / "baselineFiles.txt";
+        File.Create(baselinesFilePath).Close();
 
         await InitializeRepoAtLastCommit(Constants.ProductRepoName, ProductRepoPath);
 
         // Test the scanner when there are no cloaked files to be found
-        var list = await CallDarcCloakedFileScan(baselineFilePath);
+        var list = await CallDarcCloakedFileScan(baselinesFilePath);
 
         list.Count().Should().Be(0);
 
@@ -41,7 +41,7 @@ public class VmrCloakedFileScannerTest : VmrTestsBase
         await GitOperations.CommitAll(VmrPath, "Commit dll file");
 
         // Test the scanner when there is a cloaked file to be found
-        list = await CallDarcCloakedFileScan(baselineFilePath);
+        list = await CallDarcCloakedFileScan(baselinesFilePath);
 
         list.Should().HaveCount(1);
         var path = new NativePath(list.First());
@@ -51,7 +51,7 @@ public class VmrCloakedFileScannerTest : VmrTestsBase
         await GitOperations.CommitAll(VmrPath, "Commit .gitattributes file");
 
         // Test the scanner when the .gitattributes file is preserving the cloaked file
-        list = await CallDarcCloakedFileScan(baselineFilePath);
+        list = await CallDarcCloakedFileScan(baselinesFilePath);
 
         list.Count().Should().Be(0);
     }

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCloakedFileScannerTest.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCloakedFileScannerTest.cs
@@ -25,10 +25,13 @@ public class VmrCloakedFileScannerTest : VmrTestsBase
     public async Task VmrCloakedFileScannerTests()
     {
         var testFileName = "test.dll";
+        var baselineFilePath = VmrTestsOneTimeSetUp.TestsDirectory / "baselineFiles.txt";
+        File.Create(baselineFilePath).Close();
+
         await InitializeRepoAtLastCommit(Constants.ProductRepoName, ProductRepoPath);
 
         // Test the scanner when there are no cloaked files to be found
-        var list = await CallDarcCloakedFileScan();
+        var list = await CallDarcCloakedFileScan(baselineFilePath);
 
         list.Count().Should().Be(0);
 
@@ -38,7 +41,7 @@ public class VmrCloakedFileScannerTest : VmrTestsBase
         await GitOperations.CommitAll(VmrPath, "Commit dll file");
 
         // Test the scanner when there is a cloaked file to be found
-        list = await CallDarcCloakedFileScan();
+        list = await CallDarcCloakedFileScan(baselineFilePath);
 
         list.Should().HaveCount(1);
         var path = new NativePath(list.First());
@@ -48,7 +51,7 @@ public class VmrCloakedFileScannerTest : VmrTestsBase
         await GitOperations.CommitAll(VmrPath, "Commit .gitattributes file");
 
         // Test the scanner when the .gitattributes file is preserving the cloaked file
-        list = await CallDarcCloakedFileScan();
+        list = await CallDarcCloakedFileScan(baselineFilePath);
 
         list.Count().Should().Be(0);
     }

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -171,16 +171,16 @@ public abstract class VmrTestsBase
         await vmrUpdater.UpdateRepository(repository, commit, null, false, true, additionalRemotes, _cancellationToken.Token);
     }
 
-    protected async Task<List<string>> CallDarcCloakedFileScan()
+    protected async Task<List<string>> CallDarcCloakedFileScan(string baselineFilePath)
     {
         var cloakedFileScanner = _serviceProvider.Value.GetRequiredService<VmrCloakedFileScanner>();
-        return await cloakedFileScanner.ScanVmr(_cancellationToken.Token);
+        return await cloakedFileScanner.ScanVmr(baselineFilePath, _cancellationToken.Token);
     }
 
-    protected async Task<List<string>> CallDarcBinaryFileScan()
+    protected async Task<List<string>> CallDarcBinaryFileScan(string baselineFilePath)
     {
         var binaryFileScanner = _serviceProvider.Value.GetRequiredService<VmrBinaryFileScanner>();
-        return await binaryFileScanner.ScanVmr(_cancellationToken.Token);
+        return await binaryFileScanner.ScanVmr(baselineFilePath, _cancellationToken.Token);
     }
 
     protected void CopyDirectory(string source, LocalPath destination)

--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -171,16 +171,16 @@ public abstract class VmrTestsBase
         await vmrUpdater.UpdateRepository(repository, commit, null, false, true, additionalRemotes, _cancellationToken.Token);
     }
 
-    protected async Task<List<string>> CallDarcCloakedFileScan(string baselineFilePath)
+    protected async Task<List<string>> CallDarcCloakedFileScan(string baselinesFilePath)
     {
         var cloakedFileScanner = _serviceProvider.Value.GetRequiredService<VmrCloakedFileScanner>();
-        return await cloakedFileScanner.ScanVmr(baselineFilePath, _cancellationToken.Token);
+        return await cloakedFileScanner.ScanVmr(baselinesFilePath, _cancellationToken.Token);
     }
 
-    protected async Task<List<string>> CallDarcBinaryFileScan(string baselineFilePath)
+    protected async Task<List<string>> CallDarcBinaryFileScan(string baselinesFilePath)
     {
         var binaryFileScanner = _serviceProvider.Value.GetRequiredService<VmrBinaryFileScanner>();
-        return await binaryFileScanner.ScanVmr(baselineFilePath, _cancellationToken.Token);
+        return await binaryFileScanner.ScanVmr(baselinesFilePath, _cancellationToken.Token);
     }
 
     protected void CopyDirectory(string source, LocalPath destination)


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/12238

We want to add baseline files to the VMR. These files won't appear in any of the scans.
For the implementation, we're appending a list of these to the `git diff` command in the following way:
`git diff <some options> :(exclude)<baseline_file>`
With this implementation, we don't have to do any parsing in case we want to use wildcard characters (things like arcade/documentation/*), git takes care of everything.
I tested the change with 39 of these baseline additions, and there was no performance hit. I'm not sure what would happen if we'd eventually have a list of 100+ of these, need to test that