### PR TITLE
Add the `darc vmr get-version` command

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/GetRepoVersionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/VirtualMonoRepo/GetRepoVersionOperation.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+#nullable enable
+namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
+
+internal class GetRepoVersionOperation : Operation
+{
+    private readonly GetRepoVersionCommandLineOptions _options;
+
+    public GetRepoVersionOperation(GetRepoVersionCommandLineOptions options)
+        : base(options, options.RegisterServices())
+    {
+        _options = options;
+    }
+
+    public async override Task<int> ExecuteAsync()
+    {
+        var repositories = _options.Repositories.ToList();
+
+        if (!repositories.Any())
+        {
+            Logger.LogError("Please specify at least one repository to synchronize");
+            return Constants.ErrorCode;
+        }
+
+        var vmrManager = Provider.GetRequiredService<IVmrRepoVersionResolver>();
+
+        foreach (var repo in repositories)
+        {
+            Console.WriteLine(await vmrManager.GetVersion(repo));
+        }
+
+        return 0;
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/GetRepoVersionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/GetRepoVersionCommandLineOptions.cs
@@ -2,19 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
 using CommandLine;
 using Microsoft.DotNet.Darc.Operations;
 using Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 using Microsoft.Extensions.DependencyInjection;
-using System.Collections.Generic;
 
+#nullable enable
 namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
 [Verb("get-version", HelpText = "Gets the current version (a SHA) of a repository in the VMR.")]
 internal class GetRepoVersionCommandLineOptions : VmrCommandLineOptionsBase
 {
     [Value(0, Required = true, HelpText = "Repository names (e.g. runtime) to get the versions for.")]
-    public IEnumerable<string> Repositories { get; set; }
+    public IEnumerable<string> Repositories { get; set; } = Array.Empty<string>();
 
     public override Operation GetOperation() => new GetRepoVersionOperation(this);
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/GetRepoVersionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/GetRepoVersionCommandLineOptions.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommandLine;
+using Microsoft.DotNet.Darc.Operations;
+using Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
+using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
+
+[Verb("get-version", HelpText = "Gets the current version (a SHA) of a repository in the VMR.")]
+internal class GetRepoVersionCommandLineOptions : VmrCommandLineOptionsBase
+{
+    [Value(0, Required = true, HelpText = "Repository names (e.g. runtime) to get the versions for.")]
+    public IEnumerable<string> Repositories { get; set; }
+
+    public override Operation GetOperation() => new GetRepoVersionOperation(this);
+
+    public IServiceCollection RegisterServices() => RegisterServices(tmpPath: null);
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrCommandLineOptions.cs
@@ -2,59 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using CommandLine;
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
-internal abstract class VmrCommandLineOptions : CommandLineOptions
+internal abstract class VmrCommandLineOptions : VmrCommandLineOptionsBase
 {
-    [Option("vmr", Required = true, HelpText = "Path to the VMR; defaults to nearest git root above the current working directory.")]
-    public string VmrPath { get; set; } = Environment.CurrentDirectory;
-
     [Option("tmp", Required = false, HelpText = "Temporary path where intermediate files are stored (e.g. cloned repos, patch files); defaults to usual TEMP.")]
     public string TmpPath { get; set; }
 
-    public IServiceCollection RegisterServices()
-    {
-        var tmpPath = Path.GetFullPath(TmpPath ?? Path.GetTempPath());
-        LocalSettings localDarcSettings = null;
-
-        var gitHubToken = GitHubPat;
-        var azureDevOpsToken = AzureDevOpsPat;
-
-        if (gitHubToken == null || azureDevOpsToken == null)
-        {
-            try
-            {
-                localDarcSettings = LocalSettings.LoadSettingsFile(this);
-            }
-            catch (DarcException)
-            {
-                // The VMR synchronization often works with public repositories where tokens are not required
-            }
-
-            gitHubToken = localDarcSettings?.GitHubToken;
-            azureDevOpsToken = localDarcSettings?.AzureDevOpsToken;
-        }
-
-        var services = new ServiceCollection();
-        services
-            .AddTransient<GitFileManagerFactory>()
-            .AddVmrManagers(
-                sp => sp.GetRequiredService<GitFileManagerFactory>(),
-                GitLocation,
-                VmrPath,
-                tmpPath,
-                gitHubToken,
-                azureDevOpsToken);
-
-        return services;
-    }
+    public IServiceCollection RegisterServices() => RegisterServices(TmpPath);
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrCommandLineOptionsBase.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrCommandLineOptionsBase.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using CommandLine;
+using Microsoft.DotNet.Darc.Helpers;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using Microsoft.Extensions.DependencyInjection;
+
+#nullable enable
+namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
+
+internal abstract class VmrCommandLineOptionsBase : CommandLineOptions
+{
+    [Option("vmr", Required = true, HelpText = "Path to the VMR; defaults to nearest git root above the current working directory.")]
+    public string VmrPath { get; set; } = Environment.CurrentDirectory;
+
+    protected IServiceCollection RegisterServices(string? tmpPath)
+    {
+        tmpPath = Path.GetFullPath(tmpPath ?? Path.GetTempPath());
+        LocalSettings? localDarcSettings = null;
+
+        var gitHubToken = GitHubPat;
+        var azureDevOpsToken = AzureDevOpsPat;
+
+        if (gitHubToken == null || azureDevOpsToken == null)
+        {
+            try
+            {
+                localDarcSettings = LocalSettings.LoadSettingsFile(this);
+            }
+            catch (DarcException)
+            {
+                // The VMR synchronization often works with public repositories where tokens are not required
+            }
+
+            gitHubToken = localDarcSettings?.GitHubToken;
+            azureDevOpsToken = localDarcSettings?.AzureDevOpsToken;
+        }
+
+        var services = new ServiceCollection();
+        services
+            .AddTransient<GitFileManagerFactory>()
+            .AddVmrManagers(
+                sp => sp.GetRequiredService<GitFileManagerFactory>(),
+                GitLocation,
+                VmrPath,
+                tmpPath,
+                gitHubToken,
+                azureDevOpsToken);
+
+        return services;
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrSyncCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrSyncCommandLineOptions.cs
@@ -16,6 +16,6 @@ internal abstract class VmrSyncCommandLineOptions : VmrCommandLineOptions
     
     [Value(0, Required = true, HelpText =
         "Repository names in the form of NAME or NAME:REVISION where REVISION is a commit SHA or other git reference (branch, tag). " +
-        "Omitting REVISION will synchronize the repo to current HEAD. Pass 'all' to update all repositories.")]
+        "Omitting REVISION will synchronize the repo to current HEAD.")]
     public IEnumerable<string> Repositories { get; set; }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
@@ -197,6 +197,7 @@ internal static class Program
         typeof(GenerateTpnCommandLineOptions),
         typeof(CloakedFileScanOptions),
         typeof(BinaryFileScanOptions),
+        typeof(GetRepoVersionCommandLineOptions),
     };
 
     private static void InitializeTelemetry()

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrRepoVersionResolver.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/IVmrRepoVersionResolver.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+public interface IVmrRepoVersionResolver
+{
+    /// <summary>
+    /// Returns a SHA of the commit that the mapped repo is currently at in the VMR.
+    /// </summary>
+    /// <param name="mappingName">Name of a repository mapping</param>
+    Task<string> GetVersion(string mappingName);
+}
+
+internal class VmrRepoVersionResolver : IVmrRepoVersionResolver
+{
+    private readonly IVmrDependencyTracker _dependencyTracker;
+
+    public VmrRepoVersionResolver(IVmrDependencyTracker dependencyTracker)
+    {
+        _dependencyTracker = dependencyTracker;
+    }
+
+    public async Task<string> GetVersion(string mappingName)
+    {
+        await _dependencyTracker.InitializeSourceMappings();
+
+        SourceMapping mapping = _dependencyTracker.Mappings.FirstOrDefault(m => m.Name == mappingName)
+            ?? throw new ArgumentException($"No mapping named {mappingName} found");
+
+        return _dependencyTracker.GetDependencyVersion(mapping)?.Sha
+            ?? throw new Exception($"Mapping {mappingName} has not been initialized yet");
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
@@ -17,7 +16,11 @@ public interface IVmrDependencyTracker
 {
     IReadOnlyCollection<SourceMapping> Mappings { get; }
 
-    Task InitializeSourceMappings(string sourceMappingsPath);
+    /// <summary>
+    /// Loads repository mappings from source-mappings.json
+    /// </summary>
+    /// <param name="sourceMappingsPath">Leave empty for default (src/source-mappings.json)</param>
+    Task InitializeSourceMappings(string? sourceMappingsPath = null);
 
     void UpdateDependencyVersion(VmrDependencyUpdate update);
 
@@ -66,8 +69,9 @@ public class VmrDependencyTracker : IVmrDependencyTracker
     public VmrDependencyVersion? GetDependencyVersion(SourceMapping mapping)
         => _sourceManifest.GetVersion(mapping.Name);
 
-    public async Task InitializeSourceMappings(string sourceMappingsPath)
+    public async Task InitializeSourceMappings(string? sourceMappingsPath = null)
     {
+        sourceMappingsPath ??= _vmrInfo.VmrPath / VmrInfo.SourcesDir / VmrInfo.SourceMappingsFileName;
         _mappings = await _sourceMappingParser.ParseMappings(sourceMappingsPath);
     }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -56,6 +56,7 @@ public static class VmrRegistrations
         services.TryAddTransient<IVmrPatchHandler, VmrPatchHandler>();
         services.TryAddTransient<IVmrUpdater, VmrUpdater>();
         services.TryAddTransient<IVmrInitializer, VmrInitializer>();
+        services.TryAddTransient<IVmrRepoVersionResolver, VmrRepoVersionResolver>();
         services.TryAddSingleton<IVmrDependencyTracker, VmrDependencyTracker>();
         services.TryAddTransient<IThirdPartyNoticesGenerator, ThirdPartyNoticesGenerator>();
         services.TryAddTransient<IReadmeComponentListGenerator, ReadmeComponentListGenerator>();

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -37,8 +37,7 @@ public abstract class VmrScanner : IVmrScanner
 
     public async Task<List<string>> ScanVmr(CancellationToken cancellationToken)
     {
-        await _dependencyTracker
-            .InitializeSourceMappings(_vmrInfo.VmrPath / VmrInfo.SourcesDir / VmrInfo.SourceMappingsFileName);
+        await _dependencyTracker.InitializeSourceMappings();
 
         var taskList = new List<Task<IEnumerable<string>>>();
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -104,8 +104,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken)
     {
-        await _dependencyTracker
-            .InitializeSourceMappings(_vmrInfo.VmrPath / VmrInfo.SourcesDir / VmrInfo.SourceMappingsFileName);
+        await _dependencyTracker.InitializeSourceMappings();
 
         var mapping = _dependencyTracker.Mappings
             .FirstOrDefault(m => m.Name.Equals(mappingName, StringComparison.InvariantCultureIgnoreCase))


### PR DESCRIPTION
Adds a new command that will give you the SHA of a repos you pass in

https://github.com/dotnet/arcade/issues/12258