### PR TITLE
OS agnostic baseline file split

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -89,7 +89,7 @@ public abstract class VmrScanner : IVmrScanner
     protected async Task<IEnumerable<string>> GetExclusionFilters(string? repoName, string baselineFilePath)
     {
         var text = await _fileSystem.ReadAllTextAsync(baselineFilePath);
-        return text.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+        return text.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
             .Where(line => (repoName is null ? false : line.StartsWith($"src/{repoName}")) || line.StartsWith('*'))
             .Select(line =>
             {


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

https://github.com/dotnet/arcade/issues/12339
The slitting of the baseline file should work both on Windows and Unix