### PR TITLE
Add a default HttpClient handler option

### DIFF
--- a/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests.csproj
+++ b/src/Microsoft.DotNet.Darc/tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests.csproj
@@ -47,4 +47,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" />
+  </ItemGroup>
+
 </Project>

--- a/src/Shared/Microsoft.DotNet.Services.Utility/DefaultHttpHandlerConfiguration.cs
+++ b/src/Shared/Microsoft.DotNet.Services.Utility/DefaultHttpHandlerConfiguration.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+
+namespace Microsoft.DotNet.Services.Utility;
+
+internal class DefaultHttpHandlerConfiguration<T> : IHttpMessageHandlerBuilderFilter where T : DelegatingHandler
+{
+    private readonly IServiceProvider _services;
+
+    public DefaultHttpHandlerConfiguration(IServiceProvider services)
+    {
+        _services = services;
+    }
+
+    public Action<HttpMessageHandlerBuilder> Configure(Action<HttpMessageHandlerBuilder> next)
+    {
+        return builder =>
+        {
+            builder.AdditionalHandlers.Add(ActivatorUtilities.CreateInstance<T>(_services));
+            next(builder);
+        };
+    }
+}

--- a/src/Shared/Microsoft.DotNet.Services.Utility/DefaultHttpHandlerConfigurationExtensions.cs
+++ b/src/Shared/Microsoft.DotNet.Services.Utility/DefaultHttpHandlerConfigurationExtensions.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Http;
+using Microsoft.DotNet.Services.Utility;
+using Microsoft.Extensions.Http;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class DefaultHttpHandlerConfigurationExtensions
+{
+    /// <summary>
+    /// Add a handler that will be applied to all HttpClients returned from IHttpClientFactory
+    /// </summary>
+    public static IServiceCollection AddDefaultHttpHandler<T>(this IServiceCollection services) where T : DelegatingHandler
+    {
+        services.AddSingleton<IHttpMessageHandlerBuilderFilter, DefaultHttpHandlerConfiguration<T>>();
+        return services;
+    }
+}

--- a/src/Shared/Microsoft.DotNet.Services.Utility/Microsoft.DotNet.Services.Utility.csproj
+++ b/src/Shared/Microsoft.DotNet.Services.Utility/Microsoft.DotNet.Services.Utility.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="WindowsAzure.Storage" />


### PR DESCRIPTION
Make it easy to add a default handler for all HttpClients (in particular, so we can get retry behavior in some apps)

https://github.com/dotnet/arcade/issues/9875