### PR TITLE
Revert path change from 5b8fe69f

### DIFF
--- a/src/Monitoring/Sdk/sdk/Sdk.props
+++ b/src/Monitoring/Sdk/sdk/Sdk.props
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <MicrosoftDotNetMonitoringSdkTasksAssembly>$(MSBuildThisFileDirectory)net6.0/Microsoft.DotNet.Monitoring.Sdk.dll</MicrosoftDotNetMonitoringSdkTasksAssembly>
-    <MicrosoftDotNetMonitoringSdkTasksAssembly Condition="!Exists('$(MicrosoftDotNetMonitoringSdkTasksAssembly)')">$(MSBuildThisFileDirectory)/../../../../artifacts/bin/Microsoft.DotNet.Monitoring.Sdk/$(Configuration)/net6.0/publish/Microsoft.DotNet.Monitoring.Sdk.dll</MicrosoftDotNetMonitoringSdkTasksAssembly>
+    <MicrosoftDotNetMonitoringSdkTasksAssembly Condition="!Exists('$(MicrosoftDotNetMonitoringSdkTasksAssembly)')">$(MSBuildThisFileDirectory)/../net6.0/Microsoft.DotNet.Monitoring.Sdk.dll</MicrosoftDotNetMonitoringSdkTasksAssembly>
     <GrafanaDashboardTag Condition="'$(GrafanaDashboardTag)' == ''">$(MSBuildProjectName)</GrafanaDashboardTag>
   </PropertyGroup>
 

--- a/src/Monitoring/Sdk/sdk/Sdk.props
+++ b/src/Monitoring/Sdk/sdk/Sdk.props
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <MicrosoftDotNetMonitoringSdkTasksAssembly>$(MSBuildThisFileDirectory)net6.0/Microsoft.DotNet.Monitoring.Sdk.dll</MicrosoftDotNetMonitoringSdkTasksAssembly>
-    <MicrosoftDotNetMonitoringSdkTasksAssembly Condition="!Exists('$(MicrosoftDotNetMonitoringSdkTasksAssembly)')">$(MSBuildThisFileDirectory)/../net6.0/Microsoft.DotNet.Monitoring.Sdk.dll</MicrosoftDotNetMonitoringSdkTasksAssembly>
+    <MicrosoftDotNetMonitoringSdkTasksAssembly Condition="!Exists('$(MicrosoftDotNetMonitoringSdkTasksAssembly)')">$(MSBuildThisFileDirectory)/../tools/net6.0/Microsoft.DotNet.Monitoring.Sdk.dll</MicrosoftDotNetMonitoringSdkTasksAssembly>
     <GrafanaDashboardTag Condition="'$(GrafanaDashboardTag)' == ''">$(MSBuildProjectName)</GrafanaDashboardTag>
   </PropertyGroup>
 


### PR DESCRIPTION
Revert a path change made in 5b8fe69f that breaks consumers of the Monitoring SDK. 

Resolves [dotnet/arcade#12375](https://github.com/dotnet/arcade/issues/12375)