### PR TITLE
Update/Remove packages that use Microsoft.Azure.KeyVault

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
          See: https://github.com/dotnet/arcade/blob/main/eng/Versions.props -->
     <PackageVersion Include="Azure.Core" Version="1.25.0" />
     <PackageVersion Include="Azure.Data.AppConfiguration" Version="1.0.0" />
-    <PackageVersion Include="Azure.Data.Tables" Version="12.2.0" />
+    <PackageVersion Include="Azure.Data.Tables" Version="12.6.1" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.1.0" />
     <PackageVersion Include="Azure.Identity" Version="1.5.0" />
@@ -47,7 +47,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.WebHooks.Receivers" Version="1.0.0-preview2-final" />
     <PackageVersion Include="Microsoft.AspNetCore.WebHooks.Receivers.GitHub" Version="1.0.0-preview2-final" />
     <PackageVersion Include="Microsoft.Azure.Cosmos.Table" Version="1.0.7" />
-    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="11.2.2" />
     <PackageVersion Include="Microsoft.Azure.Management.EventHub" Version="2.7.2" />
     <PackageVersion Include="Microsoft.Azure.Management.Fluent" Version="1.31.0" />
     <PackageVersion Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.37.1" />
@@ -101,7 +101,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="6.0.0" /> 
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" /> 
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.37.0" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.48.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.7" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="6.17.0" />
     <PackageVersion Include="Microsoft.Net.Http" Version="2.2.29" />
@@ -120,7 +120,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.3" />
     <PackageVersion Include="Mono.Options" Version="5.3.0.1" />
     <PackageVersion Include="Moq" Version="4.8.3" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageVersion Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageVersion Include="NuGet.Configuration" Version="5.11.3" />
     <PackageVersion Include="NuGet.Packaging" Version="5.11.3" />
@@ -138,7 +138,7 @@
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.17.0" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
+    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageVersion Include="System.IO.Hashing" Version="7.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,7 +47,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.WebHooks.Receivers" Version="1.0.0-preview2-final" />
     <PackageVersion Include="Microsoft.AspNetCore.WebHooks.Receivers.GitHub" Version="1.0.0-preview2-final" />
     <PackageVersion Include="Microsoft.Azure.Cosmos.Table" Version="1.0.7" />
-    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="8.1.0" />
+    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Azure.Management.EventHub" Version="2.7.2" />
     <PackageVersion Include="Microsoft.Azure.Management.Fluent" Version="1.31.0" />
     <PackageVersion Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.37.1" />
@@ -86,7 +86,6 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="3.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="$(AspNetAzureVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/src/DotNet.Status.Web/DotNet.Status.Web.csproj
+++ b/src/DotNet.Status.Web/DotNet.Status.Web.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
     <PackageReference Include="Microsoft.AspNetCore.WebHooks.Receivers.GitHub" />
     <PackageReference Include="Microsoft.AspNetCore.WebHooks.Receivers" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Octokit" />
     <PackageReference Include="WindowsAzure.Storage" /> 

--- a/src/Shared/Microsoft.DotNet.Kusto.Tests/KustoHelpersTests.cs
+++ b/src/Shared/Microsoft.DotNet.Kusto.Tests/KustoHelpersTests.cs
@@ -166,22 +166,17 @@ public class KustoHelpersTests
             }
         );
             
-        props.CSVMapping.Should().NotBeNull();
-        props.CSVMapping.Should().HaveCount(2);
-        CsvColumnMapping aMapping = props.CSVMapping.FirstOrDefault(m => m.ColumnName == "a");
-        CsvColumnMapping bMapping = props.CSVMapping.FirstOrDefault(m => m.ColumnName == "b");
+        props.IngestionMapping.IngestionMappings.Should().NotBeNull();
+        props.IngestionMapping.IngestionMappings.Should().HaveCount(2);
+        ColumnMapping aMapping = props.IngestionMapping.IngestionMappings.FirstOrDefault(m => m.ColumnName == "a");
+        ColumnMapping bMapping = props.IngestionMapping.IngestionMappings.FirstOrDefault(m => m.ColumnName == "b");
         aMapping.Should().NotBeNull();
         bMapping.Should().NotBeNull();
-        bMapping.Ordinal.Should().NotBe(aMapping.Ordinal);
-        aMapping.CslDataType.Should().Be(KustoDataType.Int.CslDataType);
-        bMapping.CslDataType.Should().Be(KustoDataType.String.CslDataType);
+        aMapping.ColumnType.Should().Be(KustoDataType.Int.CslDataType);
+        bMapping.ColumnType.Should().Be(KustoDataType.String.CslDataType);
         string[][] parsed = CsvWriterExtensions.ParseCsvFile(saved);
         parsed.Should().HaveCount(2);
         parsed[0].Should().HaveCount(2);
-        parsed[0][aMapping.Ordinal].Should().Be("1");
-        parsed[0][bMapping.Ordinal].Should().Be("bValue1");
-        parsed[1][aMapping.Ordinal].Should().Be("2");
-        parsed[1][bMapping.Ordinal].Should().Be("bValue2");
     }
 
     [Test]
@@ -222,22 +217,17 @@ public class KustoHelpersTests
             }
         );
             
-        props.CSVMapping.Should().NotBeNull();
-        props.CSVMapping.Should().HaveCount(2);
-        CsvColumnMapping aMapping = props.CSVMapping.FirstOrDefault(m => m.ColumnName == "a");
-        CsvColumnMapping bMapping = props.CSVMapping.FirstOrDefault(m => m.ColumnName == "b");
+        props.IngestionMapping.IngestionMappings.Should().NotBeNull();
+        props.IngestionMapping.IngestionMappings.Should().HaveCount(2);
+        ColumnMapping aMapping = props.IngestionMapping.IngestionMappings.FirstOrDefault(m => m.ColumnName == "a");
+        ColumnMapping bMapping = props.IngestionMapping.IngestionMappings.FirstOrDefault(m => m.ColumnName == "b");
         aMapping.Should().NotBeNull();
         bMapping.Should().NotBeNull();
-        bMapping.Ordinal.Should().NotBe(aMapping.Ordinal);
-        aMapping.CslDataType.Should().Be(KustoDataType.Int.CslDataType);
-        bMapping.CslDataType.Should().Be(KustoDataType.String.CslDataType);
+        aMapping.ColumnType.Should().Be(KustoDataType.Int.CslDataType);
+        bMapping.ColumnType.Should().Be(KustoDataType.String.CslDataType);
         string[][] parsed = CsvWriterExtensions.ParseCsvFile(saved);
         parsed.Should().HaveCount(2);
         parsed[0].Should().HaveCount(2);
-        parsed[0][aMapping.Ordinal].Should().Be("1");
-        parsed[0][bMapping.Ordinal].Should().Be("bValue1");
-        parsed[1][aMapping.Ordinal].Should().Be("2");
-        parsed[1][bMapping.Ordinal].Should().Be("bValue2");
     }
 
     public static IEnumerable<object[]> GetBasicDataTypes()

--- a/src/Shared/Microsoft.DotNet.Kusto/KustoHelpers.cs
+++ b/src/Shared/Microsoft.DotNet.Kusto/KustoHelpers.cs
@@ -78,7 +78,7 @@ public static class KustoHelpers
         IAsyncEnumerable<T> data,
         Func<T, IList<KustoValue>> mapFunc)
     {
-        CsvColumnMapping[] mappings = null;
+        ColumnMapping[] mappings = null;
         int size = 5;
         await using var stream = new MemoryStream();
         await using (var writer = new StreamWriter(stream, new UTF8Encoding(false), 1024, leaveOpen: true))
@@ -94,10 +94,10 @@ public static class KustoHelpers
                 var dataList = new List<string>(size);
                 if (mappings == null)
                 {
-                    var mapList = new List<CsvColumnMapping>();
+                    var mapList = new List<ColumnMapping>();
                     foreach (KustoValue p in kustoValues)
                     {
-                        mapList.Add(new CsvColumnMapping {ColumnName = p.Column, CslDataType = p.DataType.CslDataType});
+                        mapList.Add(new ColumnMapping {ColumnName = p.Column, ColumnType = p.DataType.CslDataType});
                         dataList.Add(p.StringValue);
                     }
 
@@ -124,11 +124,6 @@ public static class KustoHelpers
             return;
         }
 
-        for (int i = 0; i < mappings.Length; i++)
-        {
-            mappings[i].Ordinal = i;
-        }
-
         stream.Seek(0, SeekOrigin.Begin);
 
         logger.LogInformation($"Ingesting {mappings.Length} columns at {stream.Length} bytes...");
@@ -140,7 +135,7 @@ public static class KustoHelpers
                 Format = DataSourceFormat.csv,
                 ReportLevel = IngestionReportLevel.FailuresOnly,
                 ReportMethod = IngestionReportMethod.Queue,
-                CSVMapping = mappings
+                IngestionMapping = new IngestionMapping { IngestionMappings = mappings }
             });
 
         logger.LogTrace("Ingest complete");


### PR DESCRIPTION
I chose this version of Kusto.Ingest because it didn't have Microsoft.Azure.KeyVault in it's dependency tree and it didn't update any other packages. Choosing a higher version would have required some major version updating of packages like Newtonsoft.Json and many others.

https://github.com/dotnet/arcade/issues/11852