### PR TITLE
Fix parsing of the additional-remotes argument

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrSyncCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/VirtualMonoRepo/VmrSyncCommandLineOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
 internal abstract class VmrSyncCommandLineOptions : VmrCommandLineOptions
 {
-    [Option("additional-remotes", Required = false, Separator = ',', HelpText =
+    [Option("additional-remotes", Required = false, HelpText =
         "Comma separated list of additional remote URIs to add to mappings in the format [mapping name]:[remote URI]. " +
         "Example: installer:https://github.com/myfork/installer,sdk:/local/path/to/sdk")]
     public string AdditionalRemotes { get; set; }


### PR DESCRIPTION
Seems like the `commandline` library doesn't work when using the separator so we do it ourselves.

https://github.com/dotnet/arcade/issues/11539