### PR TITLE
Lower the severity of missing next-rotation-on tag log record.

### DIFF
--- a/src/Microsoft.DncEng.SecretManager/StorageTypes/AzureKeyVault.cs
+++ b/src/Microsoft.DncEng.SecretManager/StorageTypes/AzureKeyVault.cs
@@ -67,7 +67,7 @@ public class AzureKeyVault : StorageLocationType<AzureKeyVaultParameters>
         if (!tags.TryGetValue(_nextRotationOnTag, out var nextRotationOnString) ||
             !DateTimeOffset.TryParse(nextRotationOnString, out var nextRotationOn))
         {
-            _console.LogError($"Key Vault Secret '{name}' is missing {_nextRotationOnTag} tag, using the end of time as value. Please force a rotation or manually set this value.");
+            _console.LogWarning($"Key Vault Secret '{name}' is missing {_nextRotationOnTag} tag, using the end of time as value. Please force a rotation or manually set this value.");
             nextRotationOn = DateTimeOffset.MaxValue;
         }
 


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
In the https://github.com/dotnet/arcade-services/commit/d24bed6ebc3c9a4e4cc7c9635baa194f235391f3 commit we introduced an error log record about missing `next-rotation-on` tag for secrets. It blocks the weekly pipeline, cause we have 130 secrets without `next-rotation-on` tag, and in order to unblock release - we decided to lower the severity to warning.

https://github.com/dotnet/arcade/issues/12363