### PR TITLE
Gather linker packages

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GatherDropOperation.cs
@@ -351,6 +351,7 @@ internal class GatherDropOperation : Operation
         { $"{githubRepoPrefix}dotnet/emsdk", (coreRepoCategory, "emsdk") },
         { $"{githubRepoPrefix}dotnet/sdk", (coreRepoCategory, "sdk") },
         { $"{githubRepoPrefix}dotnet/roslyn-analyzers", (coreRepoCategory, "roslyn-analyzers") },
+        { $"{githubRepoPrefix}dotnet/linker", (coreRepoCategory, "linker") },
         // Internal
         { $"{azdoRepoPrefix}dotnet-corefx", (coreRepoCategory, "corefx") },
         { $"{azdoRepoPrefix}dotnet-coreclr", (coreRepoCategory, "coreclr") },
@@ -361,6 +362,7 @@ internal class GatherDropOperation : Operation
         { $"{azdoRepoPrefix}dotnet-emsdk", (coreRepoCategory, "emsdk") },
         { $"{azdoRepoPrefix}dotnet-sdk", (coreRepoCategory, "sdk") },
         { $"{azdoRepoPrefix}dotnet-roslyn-analyzers", (coreRepoCategory, "roslyn-analyzers") },
+        { $"{azdoRepoPrefix}dotnet-linker", (coreRepoCategory, "linker") },
 
         // ASPNET
 


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

Ensures that the linker packages get put into the package layout for nuget publishing.

@asvyat @rbhanda @tkapin @premun 

This is an area where we need to improve. Gather-drop today has to populate at least 2 (maybe 3) locations with the same files. The release automation understands this legacy "publish_files" location for the purposes of determining what to push to nuget.org and storage accounts and whatever. This is largely legacy of when we populated this stuff on vsufile.

This is confusing and inefficient and whenever we have changes in what repos push packages, we have to go and change things in multiple places. This cruft is expensive to maintain. Ideally we would:
- Remove the dependency on publish_files in the release pipeline. The release pipeline should just drive off staging locations.
- Remove darc's population of publish_files.

https://github.com/dotnet/arcade/issues/12783