### PR TITLE
Increase SHA length for Maestro comparison links

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
@@ -186,11 +186,14 @@ public class PullRequestDescriptionBuilder
             throw new ArgumentNullException(nameof(to));
         }
 
+        string fromSha = from.Length > 7 ? from.Substring(0, 7) : from;
+        string toSha = to.Length > 7 ? to.Substring(0, 7) : to;
+
         if (repoURI.Contains("github.com"))
         {
-            return $"{repoURI}/compare/{from}...{to}";
+            return $"{repoURI}/compare/{fromSha}...{toSha}";
         }
-        return $"{repoURI}/branches?baseVersion=GC{from}&targetVersion=GC{to}&_a=files";
+        return $"{repoURI}/branches?baseVersion=GC{fromSha}&targetVersion=GC{toSha}&_a=files";
     }
 
     public override string ToString()

--- a/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
@@ -186,14 +186,11 @@ public class PullRequestDescriptionBuilder
             throw new ArgumentNullException(nameof(to));
         }
 
-        string fromSha = from.Length > 7 ? from.Substring(0, 7) : from;
-        string toSha = to.Length > 7 ? to.Substring(0, 7) : to;
-
         if (repoURI.Contains("github.com"))
         {
-            return $"{repoURI}/compare/{fromSha}...{toSha}";
+            return $"{repoURI}/compare/{from}...{to}";
         }
-        return $"{repoURI}/branches?baseVersion=GC{fromSha}&targetVersion=GC{toSha}&_a=files";
+        return $"{repoURI}/branches?baseVersion=GC{from}&targetVersion=GC{to}&_a=files";
     }
 
     public override string ToString()

--- a/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
@@ -27,6 +27,8 @@ public class PullRequestDescriptionBuilder
 
     private readonly StringBuilder _description;
 
+    private const int _comparisonShaLength = 10;
+
     private int _startingReferenceId;
 
     /// <summary>
@@ -186,8 +188,8 @@ public class PullRequestDescriptionBuilder
             throw new ArgumentNullException(nameof(to));
         }
 
-        string fromSha = from.Length > 7 ? from.Substring(0, 7) : from;
-        string toSha = to.Length > 7 ? to.Substring(0, 7) : to;
+        string fromSha = from.Length > _comparisonShaLength ? from.Substring(0, _comparisonShaLength) : from;
+        string toSha = to.Length > _comparisonShaLength ? to.Substring(0, _comparisonShaLength) : to;
 
         if (repoURI.Contains("github.com"))
         {


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/12793

I think there used to be a 4000 character limit for GitHub descriptions/comments. Looks like that limit is 65536 characters now (based on https://github.com/orgs/community/discussions/27190), so having the full SHAs in our PRs shouldn't be an issue