### PR TITLE
Only log errors if secrets in the manifest are missing the NextRotationOn tag

### DIFF
--- a/src/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
@@ -86,12 +86,10 @@ public class SynchronizeCommand : Command
             {
                 _console.WriteLine($"Synchronizing secret {name}, type {secret.Type}");
 
-                if (existingSecrets.TryGetValue(name, out var existingSecret))
+                if (existingSecrets.TryGetValue(name, out var existingSecret)
+                    && !existingSecret.Tags.ContainsKey(AzureKeyVault.NextRotationOnTag))
                 {
-                    if (!existingSecret.Tags.ContainsKey(AzureKeyVault.NextRotationOnTag))
-                    {
-                        _console.LogError($"Key Vault Secret '{name}' is missing {AzureKeyVault.NextRotationOnTag} tag, using the end of time as value. Please force a rotation or manually set this value.");
-                    }
+                    _console.LogError($"Key Vault Secret '{name}' is missing {AzureKeyVault.NextRotationOnTag} tag, using the end of time as value. Please force a rotation or manually set this value.");
                 }
 
                 List<string> names = secretType.GetCompositeSecretSuffixes().Select(suffix => name + suffix).ToList();

--- a/src/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
+++ b/src/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
@@ -86,9 +86,12 @@ public class SynchronizeCommand : Command
             {
                 _console.WriteLine($"Synchronizing secret {name}, type {secret.Type}");
 
-                if (!existingSecrets[name].Tags.ContainsKey(AzureKeyVault.NextRotationOnTag))
+                if (existingSecrets.TryGetValue(name, out var existingSecret))
                 {
-                    _console.LogError($"Key Vault Secret '{name}' is missing {AzureKeyVault.NextRotationOnTag} tag, using the end of time as value. Please force a rotation or manually set this value.");
+                    if (!existingSecret.Tags.ContainsKey(AzureKeyVault.NextRotationOnTag))
+                    {
+                        _console.LogError($"Key Vault Secret '{name}' is missing {AzureKeyVault.NextRotationOnTag} tag, using the end of time as value. Please force a rotation or manually set this value.");
+                    }
                 }
 
                 List<string> names = secretType.GetCompositeSecretSuffixes().Select(suffix => name + suffix).ToList();

--- a/src/Microsoft.DncEng.SecretManager/SecretProperties.cs
+++ b/src/Microsoft.DncEng.SecretManager/SecretProperties.cs
@@ -5,15 +5,13 @@ namespace Microsoft.DncEng.SecretManager;
 
 public class SecretProperties
 {
-    public SecretProperties(string name, DateTimeOffset expiresOn, DateTimeOffset nextRotationOn, IImmutableDictionary<string, string> tags)
+    public SecretProperties(string name, DateTimeOffset expiresOn, IImmutableDictionary<string, string> tags)
     {
         Name = name;
         ExpiresOn = expiresOn;
-        NextRotationOn = nextRotationOn;
         Tags = tags;
     }
 
-    public DateTimeOffset NextRotationOn { get; }
     public DateTimeOffset ExpiresOn { get; }
     public IImmutableDictionary<string, string> Tags { get; }
     public string Name { get; }

--- a/src/Microsoft.DncEng.SecretManager/StorageTypes/AzureKeyVault.cs
+++ b/src/Microsoft.DncEng.SecretManager/StorageTypes/AzureKeyVault.cs
@@ -21,7 +21,7 @@ public class AzureKeyVaultParameters
 [Name("azure-key-vault")]
 public class AzureKeyVault : StorageLocationType<AzureKeyVaultParameters>
 {
-    public static readonly string NextRotationOnTag = "next-rotation-on";
+    public const string NextRotationOnTag = "next-rotation-on";
     private readonly TokenCredentialProvider _tokenCredentialProvider;
     private readonly IConsole _console;
 

--- a/src/Microsoft.DncEng.SecretManager/StorageTypes/AzureKeyVault.cs
+++ b/src/Microsoft.DncEng.SecretManager/StorageTypes/AzureKeyVault.cs
@@ -21,7 +21,7 @@ public class AzureKeyVaultParameters
 [Name("azure-key-vault")]
 public class AzureKeyVault : StorageLocationType<AzureKeyVaultParameters>
 {
-    private static readonly string _nextRotationOnTag = "next-rotation-on";
+    public static readonly string NextRotationOnTag = "next-rotation-on";
     private readonly TokenCredentialProvider _tokenCredentialProvider;
     private readonly IConsole _console;
 
@@ -54,9 +54,8 @@ public class AzureKeyVault : StorageLocationType<AzureKeyVaultParameters>
         var secrets = new List<SecretProperties>();
         await foreach (var secret in client.GetPropertiesOfSecretsAsync())
         {
-            DateTimeOffset nextRotationOn = GetNextRotationOn(secret.Name, secret.Tags);
             ImmutableDictionary<string, string> tags = GetTags(secret);
-            secrets.Add(new SecretProperties(secret.Name, secret.ExpiresOn ?? DateTimeOffset.MaxValue, nextRotationOn, tags));
+            secrets.Add(new SecretProperties(secret.Name, secret.ExpiresOn ?? DateTimeOffset.MaxValue, tags));
         }
 
         return secrets;
@@ -64,10 +63,10 @@ public class AzureKeyVault : StorageLocationType<AzureKeyVaultParameters>
 
     private DateTimeOffset GetNextRotationOn(string name, IDictionary<string, string> tags)
     {
-        if (!tags.TryGetValue(_nextRotationOnTag, out var nextRotationOnString) ||
+        if (!tags.TryGetValue(NextRotationOnTag, out var nextRotationOnString) ||
             !DateTimeOffset.TryParse(nextRotationOnString, out var nextRotationOn))
         {
-            _console.LogError($"Key Vault Secret '{name}' is missing {_nextRotationOnTag} tag, using the end of time as value. Please force a rotation or manually set this value.");
+            _console.LogError($"Key Vault Secret '{name}' is missing {NextRotationOnTag} tag, using the end of time as value. Please force a rotation or manually set this value.");
             nextRotationOn = DateTimeOffset.MaxValue;
         }
 
@@ -96,7 +95,6 @@ public class AzureKeyVault : StorageLocationType<AzureKeyVaultParameters>
     private static ImmutableDictionary<string, string> GetTags(global::Azure.Security.KeyVault.Secrets.SecretProperties properties)
     {
         ImmutableDictionary<string, string> tags = properties.Tags
-            .Where(p => p.Key != _nextRotationOnTag)
             .Where(p => p.Key != "Md5")
             .ToImmutableDictionary();
         return tags;
@@ -111,7 +109,7 @@ public class AzureKeyVault : StorageLocationType<AzureKeyVaultParameters>
         {
             properties.Tags[k] = v;
         }
-        properties.Tags[_nextRotationOnTag] = value.NextRotationOn.ToString("O");
+        properties.Tags[NextRotationOnTag] = value.NextRotationOn.ToString("O");
         properties.Tags["ChangedBy"] = "secret-manager.exe";
         // Tags to appease the old secret management system
         properties.Tags["Owner"] = "secret-manager.exe";


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

https://github.com/dotnet/arcade/issues/12792

The NextRotationOn property is already in the Tags, we don't need to have a separate Property just for it, since it's used only in one place