### PR TITLE
Enable generation of account SAS uris

### DIFF
--- a/src/Microsoft.DncEng.SecretManager.ScenarioTests/StorageTests.cs
+++ b/src/Microsoft.DncEng.SecretManager.ScenarioTests/StorageTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DncEng.SecretManager.Tests
         const string TableSasNamePrefix = "azure-storage-table-sas-uri";
         const string ContainerSasUriNamePrefix = "azure-storage-container-sas-uri";
         const string ContainerSasTokenNamePrefix = "azure-storage-container-sas-token";
+        const string StorageSasUriTokenNamePrefix = "azure-storage-account-sas-uri";
         const string KeyNamePrefix = "azure-storage-key";
         const string AccountKeyPrefix = "AccountKey=";
 
@@ -76,6 +77,14 @@ secrets:
     parameters:
       ConnectionString: {ConnectionStringNamePrefix}{{0}}
       Container: test
+      Permissions: l
+  {StorageSasUriTokenNamePrefix}{{0}}:
+    type: azure-storage-account-sas-uri
+    owner: scenarioTests
+    description: storage account sas URI
+    parameters:
+      ConnectionString: {ConnectionStringNamePrefix}{{0}}
+      Service: blob
       Permissions: l";
 
 
@@ -89,6 +98,7 @@ secrets:
             string tableSasSecretName = TableSasNamePrefix + nameSuffix;
             string containerSasUriSecretName = ContainerSasUriNamePrefix + nameSuffix;
             string containerSasTokenSecretName = ContainerSasTokenNamePrefix + nameSuffix;
+            string storageSasUriTokenSecretName = StorageSasUriTokenNamePrefix + nameSuffix;
             string manifest = string.Format(Manifest, nameSuffix);
 
             await ExecuteSynchronizeCommand(manifest);
@@ -111,6 +121,8 @@ secrets:
             AssertValidSasUri(containerSasUriSecret.Value.Value);
             Response<KeyVaultSecret> containerSasTokenSecret = await client.GetSecretAsync(containerSasTokenSecretName);
             AssertValidSas(containerSasTokenSecret.Value.Value);
+            Response<KeyVaultSecret> storageSasUriTokenSecret = await client.GetSecretAsync(storageSasUriTokenSecretName);
+            AssertValidSas(storageSasUriTokenSecret.Value.Value);
         }
 
         [Test]
@@ -123,6 +135,7 @@ secrets:
             string tableSasSecretName = TableSasNamePrefix + nameSuffix;
             string containerSasUriSecretName = ContainerSasUriNamePrefix + nameSuffix;
             string containerSasTokenSecretName = ContainerSasTokenNamePrefix + nameSuffix;
+            string storageSasUriTokenSecretName = StorageSasUriTokenNamePrefix + nameSuffix;
             string manifest = string.Format(Manifest, nameSuffix);
 
             SecretClient client = GetSecretClient();
@@ -139,6 +152,8 @@ secrets:
             await UpdateNextRotationTagIntoFuture(client, containerSasUriSecret.Value);
             Response<KeyVaultSecret> containerSasTokenSecret = await client.SetSecretAsync(containerSasTokenSecretName, "TEST");
             await UpdateNextRotationTagIntoFuture(client, containerSasTokenSecret.Value);
+            Response<KeyVaultSecret> storageSasUriTokenSecret = await client.SetSecretAsync(storageSasUriTokenSecretName, "TEST");
+            await UpdateNextRotationTagIntoFuture(client, storageSasUriTokenSecret.Value);
 
 
             HashSet<string> accessKeys = await GetAccessKeys();
@@ -168,6 +183,8 @@ secrets:
             AssertValidSasUri(containerSasUriSecret.Value.Value);
             containerSasTokenSecret = await client.GetSecretAsync(containerSasTokenSecretName);
             AssertValidSas(containerSasTokenSecret.Value.Value);
+            storageSasUriTokenSecret = await client.GetSecretAsync(storageSasUriTokenSecretName);
+            AssertValidSas(storageSasUriTokenSecret.Value.Value);
         }
 
         [OneTimeTearDown]

--- a/src/Microsoft.DncEng.SecretManager/SecretTypes/AzureStorageAccountSasUri.cs
+++ b/src/Microsoft.DncEng.SecretManager/SecretTypes/AzureStorageAccountSasUri.cs
@@ -5,8 +5,8 @@ using Microsoft.DncEng.CommandLineLib;
 
 namespace Microsoft.DncEng.SecretManager.SecretTypes;
 
-[Name("azure-storage-account-sas-token")]
-public class AzureStorageAccountSas : SecretType<AzureStorageAccountSas.Parameters>
+[Name("azure-storage-account-sas-uri")]
+public class AzureStorageAccountSasUri : SecretType<AzureStorageAccountSasUri.Parameters>
 {
     public class Parameters
     {
@@ -17,7 +17,7 @@ public class AzureStorageAccountSas : SecretType<AzureStorageAccountSas.Paramete
 
     private readonly ISystemClock _clock;
 
-    public AzureStorageAccountSas(ISystemClock clock)
+    public AzureStorageAccountSasUri(ISystemClock clock)
     {
         _clock = clock;
     }
@@ -29,7 +29,9 @@ public class AzureStorageAccountSas : SecretType<AzureStorageAccountSas.Paramete
 
         string connectionString = await context.GetSecretValue(parameters.ConnectionString);
         (string accountUri, string sas) = StorageUtils.GenerateBlobAccountSas(connectionString, parameters.Permissions, parameters.Service, expiresOn);
+        string uriWithSas = accountUri + sas;
 
-        return new SecretData(sas, expiresOn, nextRotationOn);
+        return new SecretData(uriWithSas, expiresOn, nextRotationOn);
     }
 }
+

--- a/src/Microsoft.DncEng.SecretManager/StorageUtils.cs
+++ b/src/Microsoft.DncEng.SecretManager/StorageUtils.cs
@@ -72,7 +72,7 @@ public static class StorageUtils
         return accessAccountPermissions;
     }
 
-    public static string GenerateBlobAccountSas(string connectionString, string permissions, string service, DateTimeOffset expiryTime)
+    public static (string accountUri, string sas) GenerateBlobAccountSas(string connectionString, string permissions, string service, DateTimeOffset expiryTime)
     {
         CloudStorageAccount account = CloudStorageAccount.Parse(connectionString);
         SharedAccessAccountServices serviceList = default(SharedAccessAccountServices);
@@ -106,7 +106,7 @@ public static class StorageUtils
             ResourceTypes = SharedAccessAccountResourceTypes.Service | SharedAccessAccountResourceTypes.Container | SharedAccessAccountResourceTypes.Object,
             Protocols = SharedAccessProtocol.HttpsOnly,
         });
-        return sas;
+        return (account.BlobStorageUri.PrimaryUri.AbsoluteUri, sas);
     }
 
     public static (string containerUri,string sas) GenerateBlobContainerSas(string connectionString, string containerName, string permissions, DateTimeOffset expiryTime)


### PR DESCRIPTION
Staging publishing needs to use an account SAS. Currently, publishing supports SAS uris (not just suffixes). Support generation of these.

https://github.com/dotnet/arcade/issues/13041

