### PR TITLE
Migrate TestAppFactory to Microsoft.DotNet.Internal.Testing.Utility

### DIFF
--- a/src/DotNet.Status.Web.Tests/AnnotationsControllerTests.cs
+++ b/src/DotNet.Status.Web.Tests/AnnotationsControllerTests.cs
@@ -3,6 +3,7 @@ using DotNet.Status.Web.Options;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.DotNet.Internal.Testing.Utility;
 using Microsoft.DotNet.Web.Authentication.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -118,7 +119,7 @@ public class AnnotationsControllerTests
 
         public TestData()
         {
-            var factory = new TestAppFactory();
+            var factory = new TestAppFactory<EmptyTestStartup>();
 
             factory.ConfigureServices(services =>
             {

--- a/src/DotNet.Status.Web.Tests/AnnotationsControllerTests.cs
+++ b/src/DotNet.Status.Web.Tests/AnnotationsControllerTests.cs
@@ -115,7 +115,7 @@ public class AnnotationsControllerTests
 
         public TestData()
         {
-            var factory = new TestAppFactory<EmptyTestStartup>();
+            var factory = new TestAppFactory<DotNetStatusEmptyTestStartup>();
 
             factory.ConfigureServices(services =>
             {

--- a/src/DotNet.Status.Web.Tests/AnnotationsControllerTests.cs
+++ b/src/DotNet.Status.Web.Tests/AnnotationsControllerTests.cs
@@ -2,16 +2,12 @@ using DotNet.Status.Web.Controllers;
 using DotNet.Status.Web.Options;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.DotNet.Internal.Testing.Utility;
-using Microsoft.DotNet.Web.Authentication.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace DotNet.Status.Web.Tests;

--- a/src/DotNet.Status.Web.Tests/DotNet.Status.Web.Tests.csproj
+++ b/src/DotNet.Status.Web.Tests/DotNet.Status.Web.Tests.csproj
@@ -43,6 +43,5 @@
     <ProjectReference Include="..\Shared\Microsoft.DotNet.Internal.Testing.DependencyInjection.Abstractions\Microsoft.DotNet.Internal.Testing.DependencyInjection.Abstractions.csproj" />
     <ProjectReference Include="..\Shared\Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen\Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Shared\Microsoft.DotNet.Internal.Testing.Utility\Microsoft.DotNet.Internal.Testing.Utility.csproj" />
-    <ProjectReference Include="..\Shared\Microsoft.DotNet.Web.Authentication.Tests\Microsoft.DotNet.Web.Authentication.Tests.csproj" />
   </ItemGroup>
 </Project>

--- a/src/DotNet.Status.Web.Tests/DotNetStatusEmptyTestStartup.cs
+++ b/src/DotNet.Status.Web.Tests/DotNetStatusEmptyTestStartup.cs
@@ -1,0 +1,5 @@
+namespace DotNet.Status.Web.Tests;
+
+public class DotNetStatusEmptyTestStartup
+{
+}

--- a/src/DotNet.Status.Web.Tests/EmptyTestStartup.cs
+++ b/src/DotNet.Status.Web.Tests/EmptyTestStartup.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotNet.Status.Web.Tests;
+
+public class EmptyTestStartup
+{
+}

--- a/src/DotNet.Status.Web.Tests/EmptyTestStartup.cs
+++ b/src/DotNet.Status.Web.Tests/EmptyTestStartup.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace DotNet.Status.Web.Tests;
 
 public class EmptyTestStartup

--- a/src/DotNet.Status.Web.Tests/EmptyTestStartup.cs
+++ b/src/DotNet.Status.Web.Tests/EmptyTestStartup.cs
@@ -1,5 +1,0 @@
-namespace DotNet.Status.Web.Tests;
-
-public class EmptyTestStartup
-{
-}

--- a/src/DotNet.Status.Web.Tests/GitHubHookControllerTests.cs
+++ b/src/DotNet.Status.Web.Tests/GitHubHookControllerTests.cs
@@ -900,7 +900,7 @@ public class GitHubHookControllerTests
     public TestData SetupTestData(bool expectNotification)
     {
         var mockClientFactory = new MockHttpClientFactory();
-        var factory = new TestAppFactory();
+        var factory = new TestAppFactory<EmptyTestStartup>();
         factory.ConfigureServices(services =>
         {
             services.AddControllers()
@@ -957,7 +957,7 @@ public class GitHubHookControllerTests
 
     public class TestData : IDisposable
     {
-        public TestData(HttpClient client, TestAppFactory factory, MockHttpClientFactory mockClientFactory)
+        public TestData(HttpClient client, TestAppFactory<EmptyTestStartup> factory, MockHttpClientFactory mockClientFactory)
         {
             Client = client;
             Factory = factory;
@@ -965,7 +965,7 @@ public class GitHubHookControllerTests
         }
 
         public HttpClient Client { get; }
-        public TestAppFactory Factory { get; }
+        public TestAppFactory<EmptyTestStartup> Factory { get; }
         public MockHttpClientFactory MockClientFactory { get; }
 
         public void VerifyAll()

--- a/src/DotNet.Status.Web.Tests/GitHubHookControllerTests.cs
+++ b/src/DotNet.Status.Web.Tests/GitHubHookControllerTests.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading.Tasks;
 using DotNet.Status.Web.Controllers;
 using DotNet.Status.Web.Models;
-using DotNet.Status.Web.Options;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -17,10 +16,8 @@ using Microsoft.AspNetCore.WebHooks.Filters;
 using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.DotNet.Internal.AzureDevOps;
 using Microsoft.DotNet.Internal.DependencyInjection;
-using Microsoft.DotNet.Internal.Testing.DependencyInjection.Abstractions;
 using Microsoft.DotNet.Internal.Testing.Utility;
 using Microsoft.DotNet.Services.Utility;
-using Microsoft.DotNet.Web.Authentication.Tests;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -900,7 +897,7 @@ public class GitHubHookControllerTests
     public TestData SetupTestData(bool expectNotification)
     {
         var mockClientFactory = new MockHttpClientFactory();
-        var factory = new TestAppFactory<EmptyTestStartup>();
+        var factory = new TestAppFactory<DotNetStatusEmptyTestStartup>();
         factory.ConfigureServices(services =>
         {
             services.AddControllers()
@@ -957,7 +954,7 @@ public class GitHubHookControllerTests
 
     public class TestData : IDisposable
     {
-        public TestData(HttpClient client, TestAppFactory<EmptyTestStartup> factory, MockHttpClientFactory mockClientFactory)
+        public TestData(HttpClient client, TestAppFactory<DotNetStatusEmptyTestStartup> factory, MockHttpClientFactory mockClientFactory)
         {
             Client = client;
             Factory = factory;
@@ -965,7 +962,7 @@ public class GitHubHookControllerTests
         }
 
         public HttpClient Client { get; }
-        public TestAppFactory<EmptyTestStartup> Factory { get; }
+        public TestAppFactory<DotNetStatusEmptyTestStartup> Factory { get; }
         public MockHttpClientFactory MockClientFactory { get; }
 
         public void VerifyAll()

--- a/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/Microsoft.DotNet.Internal.Testing.Utility.csproj
+++ b/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/Microsoft.DotNet.Internal.Testing.Utility.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="NUnit" />

--- a/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/TestAppFactory.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/TestAppFactory.cs
@@ -1,11 +1,11 @@
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Internal.Testing.Utility;
 

--- a/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/TestAppFactory.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/TestAppFactory.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Internal.Testing.Utility;
 
-public class TestAppFactory<TEmptyTestStartup> : WebApplicationFactory<TEmptyTestStartup> where TEmptyTestStartup : class
+public class TestAppFactory<TTestStartup> : WebApplicationFactory<TTestStartup> where TTestStartup : class
 {
     private readonly string _rootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
     private Action<IServiceCollection> _configureServices;
@@ -27,7 +27,7 @@ public class TestAppFactory<TEmptyTestStartup> : WebApplicationFactory<TEmptyTes
 
     protected override IWebHostBuilder CreateWebHostBuilder()
     {
-        return WebHost.CreateDefaultBuilder<TEmptyTestStartup>(Array.Empty<string>());
+        return WebHost.CreateDefaultBuilder<TTestStartup>(Array.Empty<string>());
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/TestAppFactory.cs
+++ b/src/Shared/Microsoft.DotNet.Internal.Testing.Utility/TestAppFactory.cs
@@ -1,16 +1,15 @@
-using System;
-using System.IO;
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.DotNet.Internal.Testing.Utility;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.IO;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.DotNet.Web.Authentication.Tests;
+namespace Microsoft.DotNet.Internal.Testing.Utility;
 
-public class TestAppFactory : WebApplicationFactory<EmptyTestStartup>
+public class TestAppFactory<TEmptyTestStartup> : WebApplicationFactory<TEmptyTestStartup> where TEmptyTestStartup : class
 {
     private readonly string _rootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
     private Action<IServiceCollection> _configureServices;
@@ -28,7 +27,7 @@ public class TestAppFactory : WebApplicationFactory<EmptyTestStartup>
 
     protected override IWebHostBuilder CreateWebHostBuilder()
     {
-        return WebHost.CreateDefaultBuilder<EmptyTestStartup>(Array.Empty<string>());
+        return WebHost.CreateDefaultBuilder<TEmptyTestStartup>(Array.Empty<string>());
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/src/Shared/Microsoft.DotNet.Web.Authentication.Tests/DefaultAuthorizeActionModelConventionTests.cs
+++ b/src/Shared/Microsoft.DotNet.Web.Authentication.Tests/DefaultAuthorizeActionModelConventionTests.cs
@@ -158,7 +158,7 @@ public class DefaultAuthorizeActionModelConventionTests
 
     private HttpClient CreateHttpClient(string user = null, string role = null)
     {
-        var factory = new TestAppFactory();
+        var factory = new TestAppFactory<EmptyTestStartup>();
         factory.ConfigureServices(services =>
             {
                 services.AddControllers(o =>

--- a/src/Shared/Microsoft.DotNet.Web.Authentication.Tests/Microsoft.DotNet.Web.Authentication.Tests.csproj
+++ b/src/Shared/Microsoft.DotNet.Web.Authentication.Tests/Microsoft.DotNet.Web.Authentication.Tests.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Internal.Testing.Utility\Microsoft.DotNet.Internal.Testing.Utility.csproj" />

--- a/src/Shared/Microsoft.DotNet.Web.Authentication.Tests/PersonalAccessTokenAuthenticationTests.cs
+++ b/src/Shared/Microsoft.DotNet.Web.Authentication.Tests/PersonalAccessTokenAuthenticationTests.cs
@@ -189,7 +189,7 @@ public class PersonalAccessTokenAuthenticationTests
     [Test]
     public async Task PasswordFromWrongSizeFails()
     {
-        using HttpClient client = CreateClient(out TestAppFactory factory);
+        using HttpClient client = CreateClient(out TestAppFactory<EmptyTestStartup> factory);
 
         var pat = factory.Services.GetRequiredService<PersonalAccessTokenAuthenticationHandler<TestUser>>();
         string token = PersonalAccessTokenUtilities.EncodeToken(42, GetPasswordBytesForToken(42, 10));
@@ -256,7 +256,7 @@ public class PersonalAccessTokenAuthenticationTests
     }
 
     private HttpClient CreateClient(
-        out TestAppFactory factory,
+        out TestAppFactory<EmptyTestStartup> factory,
         int passwordSize = 17,
         string schemeName = null,
         Func<PersonalAccessTokenValidatePrincipalContext<TestUser>, Task> validatedPrincipal = null)
@@ -305,7 +305,7 @@ public class PersonalAccessTokenAuthenticationTests
         }
 
         var localClock = new TestClock();
-        factory = new TestAppFactory();
+        factory = new TestAppFactory<EmptyTestStartup>();
         factory.ConfigureServices(services =>
         {
             services.AddSingleton<ISystemClock>(localClock);


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/12952

The `EmptyTestStartup` class has to be in a project with an entry point. Since the `Testing.Utility` project is a library, it doesn't fulfill this requirement, so we have to create it in every Test project that wants to use `TestAppFactory`