### PR TITLE
Specify building architecture

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,7 +159,6 @@ stages:
         - script: eng\common\cibuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
-            -platform x64
             $(_InternalBuildArgs)
             $(_ProductionArgs)
             /p:Test=false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,6 +159,7 @@ stages:
         - script: eng\common\cibuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
+            -platform x64
             $(_InternalBuildArgs)
             $(_ProductionArgs)
             /p:Test=false

--- a/src/Maestro/CoreHealthMonitor.Tests/CoreHealthMonitor.Tests.csproj
+++ b/src/Maestro/CoreHealthMonitor.Tests/CoreHealthMonitor.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

Attempts to fix: https://github.com/dotnet/arcade/issues/12985 by building for x64 instead of `Any CPU`