### PR TITLE
Suppress credscan false-positives in readme

### DIFF
--- a/CredScanSuppressions.json
+++ b/CredScanSuppressions.json
@@ -4,6 +4,10 @@
       {
         "placeholder": "  hasWebHookSecret: boolean",
         "_justification": "The word secret is not a secret"
+      },
+      {
+        "hash": "0wmzz0zI9MmVLebdqWxSIJ9uxLJ13oIQKoWkEWrmViw=",
+        "_justification": "SecretReference is the name of a Type. It is not a secret."
       }
     ]
 }


### PR DESCRIPTION
Fixes [dotnet/arcade#12993](https://github.com/dotnet/arcade/issues/12993) by adding the hash, as detected and calculated by credscan, to the local suppressions configuration file.