### PR TITLE
Change Log Scraping regex for Microsoft Hosted Agents

### DIFF
--- a/arcade-services.sln
+++ b/arcade-services.sln
@@ -211,7 +211,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Authentica
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests", "src\Microsoft.DotNet.Darc\tests\Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests\Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests.csproj", "{8B2E07FA-ED55-40B4-8D3B-F73B4BD641F8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Maestro.MergePolicyEvaluation", "src\Maestro\Maestro.MergePolicyEvaluation\Maestro.MergePolicyEvaluation.csproj", "{D16DB73B-4EDF-4E61-9392-238CF3800DE2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Maestro.MergePolicyEvaluation", "src\Maestro\Maestro.MergePolicyEvaluation\Maestro.MergePolicyEvaluation.csproj", "{D16DB73B-4EDF-4E61-9392-238CF3800DE2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureDevOpsClient.Tests", "src\Telemetry\AzureDevOpsClient.Tests\AzureDevOpsClient.Tests.csproj", "{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1171,6 +1173,18 @@ Global
 		{D16DB73B-4EDF-4E61-9392-238CF3800DE2}.Release|x64.Build.0 = Release|Any CPU
 		{D16DB73B-4EDF-4E61-9392-238CF3800DE2}.Release|x86.ActiveCfg = Release|Any CPU
 		{D16DB73B-4EDF-4E61-9392-238CF3800DE2}.Release|x86.Build.0 = Release|Any CPU
+		{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}.Debug|x64.Build.0 = Debug|Any CPU
+		{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}.Debug|x86.Build.0 = Debug|Any CPU
+		{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}.Release|x64.ActiveCfg = Release|Any CPU
+		{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}.Release|x64.Build.0 = Release|Any CPU
+		{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}.Release|x86.ActiveCfg = Release|Any CPU
+		{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1242,6 +1256,7 @@ Global
 		{8A8A95E8-C834-4771-9FF8-82A65F5E2BE5} = {FB572E03-6F42-4262-ABB6-9D481E3647D6}
 		{8B2E07FA-ED55-40B4-8D3B-F73B4BD641F8} = {C0B90032-033F-4C3E-809F-BD3339E1E313}
 		{D16DB73B-4EDF-4E61-9392-238CF3800DE2} = {AE791E26-78E1-4936-BCF4-1BF5152CBBD6}
+		{6CAC1E0D-C81E-4A97-A836-2FEB697C424D} = {0D9FE592-7EB7-4CEE-95E8-3379B98041C6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {32B9C883-432E-4FC8-A1BF-090EB033DD5B}

--- a/src/DotNet.Status.Web.Tests/AzurePipelinesControllerTests.cs
+++ b/src/DotNet.Status.Web.Tests/AzurePipelinesControllerTests.cs
@@ -539,7 +539,7 @@ public partial class AzurePipelinesControllerTests
                 .Setup(
                     m => m.GetBuildChangesAsync(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>())
                 )
-                .Returns(Task.FromResult(((BuildChange[]? changes, int? truncatedChangeCount)?)(new BuildChange[0], 0)));
+                .Returns(Task.FromResult(((BuildChange[] changes, int? truncatedChangeCount)?)(new BuildChange[0], 0)));
             mockAzureDevOpsClient
                 .Setup(m => m.GetTimelineAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new Timeline()));

--- a/src/DotNet.Status.Web.Tests/AzurePipelinesControllerTests.cs
+++ b/src/DotNet.Status.Web.Tests/AzurePipelinesControllerTests.cs
@@ -535,12 +535,11 @@ public partial class AzurePipelinesControllerTests
                     )
                     .Returns(Task.FromResult(build));
             }
-
             mockAzureDevOpsClient
                 .Setup(
                     m => m.GetBuildChangesAsync(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>())
                 )
-                .Returns(Task.FromResult((new BuildChange[0], 0)));
+                .Returns(Task.FromResult(((BuildChange[]? changes, int? truncatedChangeCount)?)(new BuildChange[0], 0)));
             mockAzureDevOpsClient
                 .Setup(m => m.GetTimelineAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new Timeline()));

--- a/src/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
+++ b/src/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
@@ -301,9 +301,9 @@ public class AzurePipelinesController : ControllerBase
 
     private async Task<string> BuildChangesMessage(IAzureDevOpsClient client, Build build)
     {
-        (BuildChange[] changes, int truncatedChangeCount) = await client.GetBuildChangesAsync(build.Project.Name, build.Id, CancellationToken.None);
+        var buildChanges = await client.GetBuildChangesAsync(build.Project.Name, build.Id, CancellationToken.None);
         StringBuilder b = new StringBuilder();
-        foreach (BuildChange change in changes.OrEmpty())
+        foreach (BuildChange change in buildChanges.Value.changes)
         {
             string url = change.DisplayUri;
 
@@ -336,10 +336,10 @@ public class AzurePipelinesController : ControllerBase
             b.AppendLine(change.Message);
         }
 
-        if (truncatedChangeCount > 0)
+        if (buildChanges.Value.truncatedChangeCount > 0)
         {
             b.Append("- ... and ");
-            b.Append(truncatedChangeCount);
+            b.Append(buildChanges.Value.truncatedChangeCount);
             b.AppendLine(" more ...");
         }
 

--- a/src/Telemetry/AzureDevOpsClient.Tests/AzureDevOpsClient.Tests.csproj
+++ b/src/Telemetry/AzureDevOpsClient.Tests/AzureDevOpsClient.Tests.csproj
@@ -3,11 +3,12 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Shared\Microsoft.DotNet.Internal.Testing.Utility\Microsoft.DotNet.Internal.Testing.Utility.csproj" />
     <ProjectReference Include="..\AzureDevOpsClient\AzureDevOpsClient.csproj" />
+    <ProjectReference Include="..\..\Shared\Microsoft.DotNet.Internal.Testing.Utility\Microsoft.DotNet.Internal.Testing.Utility.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Telemetry/AzureDevOpsClient.Tests/AzureDevOpsClient.Tests.csproj
+++ b/src/Telemetry/AzureDevOpsClient.Tests/AzureDevOpsClient.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Shared\Microsoft.DotNet.Internal.Testing.Utility\Microsoft.DotNet.Internal.Testing.Utility.csproj" />
+    <ProjectReference Include="..\AzureDevOpsClient\AzureDevOpsClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Telemetry/AzureDevOpsClient.Tests/TryGetImageNameTests.cs
+++ b/src/Telemetry/AzureDevOpsClient.Tests/TryGetImageNameTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using Microsoft.DotNet.Internal.Testing.Utility;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Internal.AzureDevOps.Tests;
+
+[TestFixture]
+public class TryGetImageNameTests
+{
+    public static string EmptyUrl = "https://www.fakeurl.test/";
+
+    private ILogger<AzureDevOpsClient> _logger = LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<AzureDevOpsClient>();
+
+    [Test]
+    public async Task AzureDevOpsClientShouldReturnImageName()
+    {
+        var mockHttpClientFactory = new MockHttpClientFactory();
+        var response = """
+            a
+            b
+            b
+            c
+            """;
+        var regexes = new Regex[]
+        {
+            new Regex("([ab])"),
+            new Regex("([ab])"),
+            new Regex("(c)")
+        };
+        mockHttpClientFactory.AddCannedResponse(EmptyUrl, response);
+        var client = new AzureDevOpsClient(new AzureDevOpsClientOptions(), _logger, mockHttpClientFactory);
+
+        var result = await client.TryGetImageName(EmptyUrl, regexes, CancellationToken.None);
+
+        result.Should().Be("c");
+    }
+
+    [Test]
+    public async Task AzureDevOpsClientShouldNotReturnImageName()
+    {
+        var mockHttpClientFactory = new MockHttpClientFactory();
+        var response = """
+            a
+            b
+            b
+            b
+            c
+            """;
+        var regexes = new Regex[]
+        {
+            new Regex("([ab])"),
+            new Regex("([ab])"),
+            new Regex("(c)")
+        };
+        mockHttpClientFactory.AddCannedResponse(EmptyUrl, response);
+        var client = new AzureDevOpsClient(new AzureDevOpsClientOptions(), _logger, mockHttpClientFactory);
+
+        var result = await client.TryGetImageName(EmptyUrl, regexes, CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+}

--- a/src/Telemetry/AzureDevOpsClient.Tests/TryGetImageNameTests.cs
+++ b/src/Telemetry/AzureDevOpsClient.Tests/TryGetImageNameTests.cs
@@ -31,7 +31,7 @@ public class TryGetImageNameTests
         var client = new AzureDevOpsClient(new AzureDevOpsClientOptions(), _logger, mockHttpClientFactory);
         var regexes = regexStrings.Select(regex => new Regex(regex)).ToList();
 
-        var result = await client.TryGetImageName(EmptyUrl, regexes, CancellationToken.None);
+        var result = await client.GetImageName(EmptyUrl, regexes, CancellationToken.None);
 
         result.Should().Be(expectedResult);
     }

--- a/src/Telemetry/AzureDevOpsClient.Tests/TryGetImageNameTests.cs
+++ b/src/Telemetry/AzureDevOpsClient.Tests/TryGetImageNameTests.cs
@@ -31,7 +31,7 @@ public class TryGetImageNameTests
         var client = new AzureDevOpsClient(new AzureDevOpsClientOptions(), _logger, mockHttpClientFactory);
         var regexes = regexStrings.Select(regex => new Regex(regex)).ToList();
 
-        var result = await client.GetImageName(EmptyUrl, regexes, CancellationToken.None);
+        var result = await client.MatchLogLineSequence(EmptyUrl, regexes, CancellationToken.None);
 
         result.Should().Be(expectedResult);
     }

--- a/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
+++ b/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
@@ -173,7 +173,7 @@ public sealed class AzureDevOpsClient : IAzureDevOpsClient
         using StreamReader reader = new StreamReader(logStream);
         int regexIndex = 0;
         string line;
-        while ((line = reader.ReadLine()) != null)
+        while ((line = await reader.ReadLineAsync()) != null)
         {
             if (TryMatchRegex(line, regexes[regexIndex], out string imageName))
             {

--- a/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
+++ b/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
@@ -163,8 +163,8 @@ public sealed class AzureDevOpsClient : IAzureDevOpsClient
     }
 
     /// <summary>
-    /// The method reads the logs as a stream, line by line and tries to match the regexes in order. 
-    /// If the regexes are matched in order, the last match is returned.
+    /// The method reads the logs as a stream, line by line and tries to match the regexes in order, one regex per line. 
+    /// If the consecutive regexes match the lines, the last match is returned.
     /// </summary>
     public async Task<string?> TryGetImageName(
         string logUri,
@@ -200,7 +200,7 @@ public sealed class AzureDevOpsClient : IAzureDevOpsClient
             }
             else if (regexIndex > 0)
             {
-                // Add the line that we missed on to the cache, it might fit the 
+                // Add the line that we missed on to the cache, it might fit the regex sequence when we go over the cache
                 lineCache.Enqueue(line);
                 regexIndex = 0;
 
@@ -208,7 +208,7 @@ public sealed class AzureDevOpsClient : IAzureDevOpsClient
                 while (lineCache.Count > 0)
                 {
                     var cachedLine = lineCache.Dequeue();
-                    if (TryMatchRegex(cachedLine, regexes[regexIndex], out result))
+                    if (TryMatchRegex(cachedLine, regexes[regexIndex], out _))
                     {
                         regexIndex++;
                     }

--- a/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
+++ b/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
@@ -167,14 +167,17 @@ public sealed class AzureDevOpsClient : IAzureDevOpsClient
         using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         using Stream logStream = await response.Content.ReadAsStreamAsync(cancellationToken);
         using StreamReader reader = new StreamReader(logStream);
-        string line;
-        while ((line = reader.ReadLine()) != null)
+        // The OneES regex needs two lines to correctly find the match
+        string firstLine = reader.ReadLine();
+        string secondLine;
+        while ((secondLine = reader.ReadLine()) != null)
         {
-            var imageName = findImageName(line);
+            var imageName = findImageName($"{firstLine}{Environment.NewLine}{secondLine}");
             if (imageName != null)
             {
                 return imageName;
             }
+            firstLine = secondLine;
         }
 
         return null;

--- a/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
+++ b/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
@@ -184,9 +184,15 @@ public sealed class AzureDevOpsClient : IAzureDevOpsClient
                     return imageName;
                 }
             }
-            else
+            else if (regexIndex > 0)
             {
                 regexIndex = 0;
+
+                // We need to check if the line we failed on matches the first regex in the list so we don't skip it
+                if (TryMatchRegex(line, regexes[regexIndex], out imageName))
+                {
+                    regexIndex++;
+                }
             }
         }
 

--- a/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
+++ b/src/Telemetry/AzureDevOpsClient/AzureDevOpsClient.cs
@@ -167,9 +167,9 @@ public sealed class AzureDevOpsClient : IAzureDevOpsClient
     /// The method reads the logs as a stream, line by line and tries to match the regexes in order, one regex per line. 
     /// If the consecutive regexes match the lines, the last match is returned.
     /// </summary>
-    public async Task<string?> GetImageName(
+    public async Task<string?> MatchLogLineSequence(
         string logUri,
-        List<Regex> regexes,
+        IReadOnlyList<Regex> regexes,
         CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, logUri);

--- a/src/Telemetry/AzureDevOpsClient/IAzureDevOpsClient.cs
+++ b/src/Telemetry/AzureDevOpsClient/IAzureDevOpsClient.cs
@@ -24,6 +24,6 @@ public interface IAzureDevOpsClient
     public Task<Timeline?> GetTimelineAsync(string project, int buildId, string timelineId, CancellationToken cancellationToken);
     public Task<BuildChangeDetail?> GetChangeDetails(string changeUrl, CancellationToken cancellationToken = default);
     public Task<WorkItem?> CreateRcaWorkItem(string project, string title, CancellationToken cancellationToken = default);
-    public Task<string?> GetImageName(string logUri, List<Regex> regexes, CancellationToken cancellationToken = default);
+    public Task<string?> MatchLogLineSequence(string logUri, IReadOnlyList<Regex> regexes, CancellationToken cancellationToken = default);
     public Task<string?> GetProjectNameAsync(string id);
 }

--- a/src/Telemetry/AzureDevOpsClient/IAzureDevOpsClient.cs
+++ b/src/Telemetry/AzureDevOpsClient/IAzureDevOpsClient.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Text.RegularExpressions;
@@ -23,6 +24,6 @@ public interface IAzureDevOpsClient
     public Task<Timeline?> GetTimelineAsync(string project, int buildId, string timelineId, CancellationToken cancellationToken);
     public Task<BuildChangeDetail?> GetChangeDetails(string changeUrl, CancellationToken cancellationToken = default);
     public Task<WorkItem?> CreateRcaWorkItem(string project, string title, CancellationToken cancellationToken = default);
-    public Task<string?> TryGetImageName(string logUri, Regex[] regexes, CancellationToken cancellationToken = default);
+    public Task<string?> TryGetImageName(string logUri, List<Regex> regexes, CancellationToken cancellationToken = default);
     public Task<string?> GetProjectNameAsync(string id);
 }

--- a/src/Telemetry/AzureDevOpsClient/IAzureDevOpsClient.cs
+++ b/src/Telemetry/AzureDevOpsClient/IAzureDevOpsClient.cs
@@ -10,18 +10,19 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace Microsoft.DotNet.Internal.AzureDevOps;
 
 public interface IAzureDevOpsClient
 {
     public Task<Build[]> ListBuilds(string project, CancellationToken cancellationToken, DateTimeOffset? minTime = default, int? limit = default);
-    public Task<AzureDevOpsProject[]> ListProjectsAsync(CancellationToken cancellationToken = default);
-    public Task<Build> GetBuildAsync(string project, long buildId, CancellationToken cancellationToken = default);
-    public Task<(BuildChange[] changes, int truncatedChangeCount)> GetBuildChangesAsync(string project, long buildId, CancellationToken cancellationToken = default);
-    public Task<Timeline> GetTimelineAsync(string project, int buildId, CancellationToken cancellationToken);
-    public Task<Timeline> GetTimelineAsync(string project, int buildId, string timelineId, CancellationToken cancellationToken);
-    public Task<BuildChangeDetail> GetChangeDetails(string changeUrl, CancellationToken cancellationToken = default);
-    public Task<WorkItem> CreateRcaWorkItem(string project, string title, CancellationToken cancellationToken = default);
-    public Task<string> TryGetImageName(string logUri, Regex[] regexes, CancellationToken cancellationToken = default);
-    public Task<string> GetProjectNameAsync(string id);
+    public Task<AzureDevOpsProject[]?> ListProjectsAsync(CancellationToken cancellationToken = default);
+    public Task<Build?> GetBuildAsync(string project, long buildId, CancellationToken cancellationToken = default);
+    public Task<(BuildChange[]? changes, int? truncatedChangeCount)?> GetBuildChangesAsync(string project, long buildId, CancellationToken cancellationToken = default);
+    public Task<Timeline?> GetTimelineAsync(string project, int buildId, CancellationToken cancellationToken);
+    public Task<Timeline?> GetTimelineAsync(string project, int buildId, string timelineId, CancellationToken cancellationToken);
+    public Task<BuildChangeDetail?> GetChangeDetails(string changeUrl, CancellationToken cancellationToken = default);
+    public Task<WorkItem?> CreateRcaWorkItem(string project, string title, CancellationToken cancellationToken = default);
+    public Task<string?> TryGetImageName(string logUri, Regex[] regexes, CancellationToken cancellationToken = default);
+    public Task<string?> GetProjectNameAsync(string id);
 }

--- a/src/Telemetry/AzureDevOpsClient/IAzureDevOpsClient.cs
+++ b/src/Telemetry/AzureDevOpsClient/IAzureDevOpsClient.cs
@@ -22,6 +22,6 @@ public interface IAzureDevOpsClient
     public Task<Timeline> GetTimelineAsync(string project, int buildId, string timelineId, CancellationToken cancellationToken);
     public Task<BuildChangeDetail> GetChangeDetails(string changeUrl, CancellationToken cancellationToken = default);
     public Task<WorkItem> CreateRcaWorkItem(string project, string title, CancellationToken cancellationToken = default);
-    public Task<string> TryGetImageName(string logUri, Func<string, string> findImageName, CancellationToken cancellationToken = default);
+    public Task<string> TryGetImageName(string logUri, Regex[] regexes, CancellationToken cancellationToken = default);
     public Task<string> GetProjectNameAsync(string id);
 }

--- a/src/Telemetry/AzureDevOpsClient/IAzureDevOpsClient.cs
+++ b/src/Telemetry/AzureDevOpsClient/IAzureDevOpsClient.cs
@@ -24,6 +24,6 @@ public interface IAzureDevOpsClient
     public Task<Timeline?> GetTimelineAsync(string project, int buildId, string timelineId, CancellationToken cancellationToken);
     public Task<BuildChangeDetail?> GetChangeDetails(string changeUrl, CancellationToken cancellationToken = default);
     public Task<WorkItem?> CreateRcaWorkItem(string project, string title, CancellationToken cancellationToken = default);
-    public Task<string?> TryGetImageName(string logUri, List<Regex> regexes, CancellationToken cancellationToken = default);
+    public Task<string?> GetImageName(string logUri, List<Regex> regexes, CancellationToken cancellationToken = default);
     public Task<string?> GetProjectNameAsync(string id);
 }

--- a/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
@@ -383,7 +383,6 @@ public sealed class AzureDevOpsTimeline : IServiceImplementation
             {
                 var childTask = GetDockerImageName(project, record, throttleSemaphore, cancellationToken);
                 taskList.Add(childTask);
-                continue;
             }
         }
 

--- a/src/Telemetry/AzureDevOpsTimeline/BuildLogScraper.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/BuildLogScraper.cs
@@ -17,13 +17,15 @@ public class BuildLogScraper : IBuildLogScraper
 
     // Example: Image: windows-latest
     private static readonly Regex _azurePipelinesRegex = new Regex(@"Image: (\S+)");
+    // OneES logs need to to match both regexes in order to correctly extract the image name
     // Example: 2023-04-04T15:46:13.8907100Z SKU: Standard_D4a_v4
     //          2023-04-04T15:46:13.8907217Z Image: windows.vs2019.amd64
     // or       2023-04-04T15:10:06.5649938Z SKU: Standard_D4a_v4
     //          2023-04-04T15:10:06.5650033Z Image: 1es-windows-2022
-    private static readonly Regex _oneESRegex = new Regex(@"SKU:.+\n.+Image: (\S+)");
+    private static readonly Regex _oneESSkuRegex = new Regex("SKU:.+");
+    private static readonly Regex _oneESImageRegex = new Regex(@"Image: (\S+)");
     // Example: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343
-    private static readonly Regex _dockerImageRegex = new Regex(@"mcr.microsoft.com\/dotnet-buildtools\/prereqs:\S+");
+    private static readonly Regex _dockerImageRegex = new Regex(@"(mcr.microsoft.com\/dotnet-buildtools\/prereqs:\S+)");
 
     public BuildLogScraper(ILogger<BuildLogScraper> logger, IClientFactory<IAzureDevOpsClient> azureDevOpsClientFactory)
     {
@@ -32,19 +34,19 @@ public class BuildLogScraper : IBuildLogScraper
     }
 
     public Task<string> ExtractMicrosoftHostedPoolImageNameAsync(AzureDevOpsProject project, string logUri, CancellationToken cancellationToken)
-        => ExtractImageNameAsync(project, logUri, ExtractMicrosoftHostedImageName, cancellationToken);
+        => ExtractImageNameAsync(project, logUri, new[] { _azurePipelinesRegex }, cancellationToken);
 
     public Task<string> ExtractOneESHostedPoolImageNameAsync(AzureDevOpsProject project, string logUri, CancellationToken cancellationToken)
-        => ExtractImageNameAsync(project, logUri, ExtractOneESHostedImageName, cancellationToken);
+        => ExtractImageNameAsync(project, logUri, new[] { _oneESSkuRegex, _oneESImageRegex }, cancellationToken);
 
     public Task<string> ExtractDockerImageNameAsync(AzureDevOpsProject project, string logUri, CancellationToken cancellationToken)
-        => ExtractImageNameAsync(project, logUri, TryExtractDockerImageName, cancellationToken);
+        => ExtractImageNameAsync(project, logUri, new[] { _dockerImageRegex }, cancellationToken);
 
-    private async Task<string> ExtractImageNameAsync(AzureDevOpsProject project, string logUri, Func<string, string> regexFunction, CancellationToken cancellationToken)
+    private async Task<string> ExtractImageNameAsync(AzureDevOpsProject project, string logUri, Regex[] regexes, CancellationToken cancellationToken)
     {
         using var clientRef = _azureDevOpsClientFactory.GetClient(project.Organization);
         var client = clientRef.Value;
-        var imageName = await client.TryGetImageName(logUri, regexFunction, cancellationToken);
+        var imageName = await client.TryGetImageName(logUri, regexes, cancellationToken);
 
         if (imageName == null)
         {
@@ -53,38 +55,5 @@ public class BuildLogScraper : IBuildLogScraper
         }
             
         return imageName;
-    }
-
-    private string ExtractOneESHostedImageName(string line)
-    {
-        var match = _oneESRegex.Match(line);
-        if (match.Success)
-        {
-            return match.Groups[1].Value;
-        }
-
-        return null;
-    }
-
-    private string ExtractMicrosoftHostedImageName(string line)
-    {
-        var match = _azurePipelinesRegex.Match(line);
-        if (match.Success)
-        {
-            return match.Groups[1].Value;
-        }
-
-        return null;
-    }
-
-    private string TryExtractDockerImageName(string line)
-    {
-        var match = _dockerImageRegex.Match(line);
-        if (match.Success)
-        {
-            return match.Value;
-        }
-
-        return null;
     }
 }

--- a/src/Telemetry/AzureDevOpsTimeline/BuildLogScraper.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/BuildLogScraper.cs
@@ -16,7 +16,7 @@ public class BuildLogScraper : IBuildLogScraper
     private readonly IClientFactory<IAzureDevOpsClient> _azureDevOpsClientFactory;
 
     // Example: Environment: windows-latest
-    private static readonly Regex _azurePipelinesRegex = new Regex(@"Environment: (\S+)");
+    private static readonly Regex _azurePipelinesRegex = new Regex(@"Image: (\S+)");
     // Example: Image: build.ubuntu.1804.amd64
     private static readonly Regex _oneESRegex = new Regex(@"Image: (\S+)");
     // Example: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343

--- a/src/Telemetry/AzureDevOpsTimeline/BuildLogScraper.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/BuildLogScraper.cs
@@ -47,7 +47,7 @@ public class BuildLogScraper : IBuildLogScraper
     {
         using var clientRef = _azureDevOpsClientFactory.GetClient(project.Organization);
         var client = clientRef.Value;
-        var imageName = await client.TryGetImageName(logUri, regexes, cancellationToken);
+        var imageName = await client.GetImageName(logUri, regexes, cancellationToken);
 
         if (imageName == null)
         {

--- a/src/Telemetry/AzureDevOpsTimeline/BuildLogScraper.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/BuildLogScraper.cs
@@ -47,7 +47,7 @@ public class BuildLogScraper : IBuildLogScraper
     {
         using var clientRef = _azureDevOpsClientFactory.GetClient(project.Organization);
         var client = clientRef.Value;
-        var imageName = await client.GetImageName(logUri, regexes, cancellationToken);
+        var imageName = await client.MatchLogLineSequence(logUri, regexes, cancellationToken);
 
         if (imageName == null)
         {

--- a/src/Telemetry/AzureDevOpsTimeline/BuildLogScraper.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/BuildLogScraper.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Internal.DependencyInjection;
+using System.Collections.Generic;
 
 namespace Microsoft.DotNet.AzureDevOpsTimeline;
 
@@ -34,15 +35,15 @@ public class BuildLogScraper : IBuildLogScraper
     }
 
     public Task<string> ExtractMicrosoftHostedPoolImageNameAsync(AzureDevOpsProject project, string logUri, CancellationToken cancellationToken)
-        => ExtractImageNameAsync(project, logUri, new[] { _azurePipelinesRegex }, cancellationToken);
+        => ExtractImageNameAsync(project, logUri, new List<Regex>() { _azurePipelinesRegex }, cancellationToken);
 
     public Task<string> ExtractOneESHostedPoolImageNameAsync(AzureDevOpsProject project, string logUri, CancellationToken cancellationToken)
-        => ExtractImageNameAsync(project, logUri, new[] { _oneESSkuRegex, _oneESImageRegex }, cancellationToken);
+        => ExtractImageNameAsync(project, logUri, new List<Regex>() { _oneESSkuRegex, _oneESImageRegex }, cancellationToken);
 
     public Task<string> ExtractDockerImageNameAsync(AzureDevOpsProject project, string logUri, CancellationToken cancellationToken)
-        => ExtractImageNameAsync(project, logUri, new[] { _dockerImageRegex }, cancellationToken);
+        => ExtractImageNameAsync(project, logUri, new List<Regex>() { _dockerImageRegex }, cancellationToken);
 
-    private async Task<string> ExtractImageNameAsync(AzureDevOpsProject project, string logUri, Regex[] regexes, CancellationToken cancellationToken)
+    private async Task<string> ExtractImageNameAsync(AzureDevOpsProject project, string logUri, List<Regex> regexes, CancellationToken cancellationToken)
     {
         using var clientRef = _azureDevOpsClientFactory.GetClient(project.Organization);
         var client = clientRef.Value;

--- a/src/Telemetry/AzureDevOpsTimeline/BuildLogScraper.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/BuildLogScraper.cs
@@ -15,10 +15,13 @@ public class BuildLogScraper : IBuildLogScraper
     private readonly ILogger<BuildLogScraper> _logger;
     private readonly IClientFactory<IAzureDevOpsClient> _azureDevOpsClientFactory;
 
-    // Example: Environment: windows-latest
+    // Example: Image: windows-latest
     private static readonly Regex _azurePipelinesRegex = new Regex(@"Image: (\S+)");
-    // Example: Image: build.ubuntu.1804.amd64
-    private static readonly Regex _oneESRegex = new Regex(@"Image: (\S+)");
+    // Example: 2023-04-04T15:46:13.8907100Z SKU: Standard_D4a_v4
+    //          2023-04-04T15:46:13.8907217Z Image: windows.vs2019.amd64
+    // or       2023-04-04T15:10:06.5649938Z SKU: Standard_D4a_v4
+    //          2023-04-04T15:10:06.5650033Z Image: 1es-windows-2022
+    private static readonly Regex _oneESRegex = new Regex(@"SKU:.+\n.+Image: (\S+)");
     // Example: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343
     private static readonly Regex _dockerImageRegex = new Regex(@"mcr.microsoft.com\/dotnet-buildtools\/prereqs:\S+");
 

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/BuildLogScraperTests.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/BuildLogScraperTests.cs
@@ -90,6 +90,20 @@ public partial class BuildLogScraperTests
     }
 
     [Test]
+    public async Task BuildLogScraperShouldExtractMmsOneESHostedPoolImageName()
+    {
+        await using TestData testData = await TestData.Default
+            .WithMockRequest((MockAzureClient.MmsOneESLogUrl, MockAzureClient.MmsOneESLog))
+            .BuildAsync();
+
+        var imageName = await testData.Controller.ExtractOneESHostedPoolImageNameAsync(
+                       _project,
+                        MockAzureClient.MmsOneESLogUrl,
+                        CancellationToken.None);
+        Assert.AreEqual(MockAzureClient.MmsOneESImageName, imageName);
+    }
+
+    [Test]
     public async Task BuildLogScraperShouldExtractDockerImageName()
     {
         await using TestData testData = await TestData.Default

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockAzureClient.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockAzureClient.cs
@@ -132,7 +132,7 @@ public class MockAzureClient : IAzureDevOpsClient
         throw new NotImplementedException();
     }
 
-    public Task<string> TryGetImageName(string logUri, Func<string, string> findImageName, CancellationToken cancellationToken)
+    public Task<string> TryGetImageName(string logUri, Regex[] regexes, CancellationToken cancellationToken)
     {
         return Task.FromResult(_urlDictionary.GetOrDefault(logUri, ""));
     }

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockAzureClient.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockAzureClient.cs
@@ -4,17 +4,14 @@
 
 using Kusto.Cloud.Platform.Utils;
 using Microsoft.DotNet.Internal.AzureDevOps;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net.Http;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace Microsoft.DotNet.AzureDevOpsTimeline.Tests;
 
 /// <summary>
@@ -64,12 +61,12 @@ public class MockAzureClient : IAzureDevOpsClient
         2022-08-04T08:00:55.8024527Z 54355103c1c9: Pulling fs layer
     """;
 
-    private readonly IDictionary<string, string> _urlDictionary;
+    private readonly IDictionary<string, string?> _urlDictionary;
 
     public MockAzureClient()
     {
         Builds = new Dictionary<Build, List<Timeline>>();
-        _urlDictionary = new Dictionary<string, string>()
+        _urlDictionary = new Dictionary<string, string?>()
         {
             { OneESLogUrl, OneESImageName },
             { MicrosoftHostedAgentLogUrl, MicrosoftHostedAgentImageName},
@@ -80,7 +77,7 @@ public class MockAzureClient : IAzureDevOpsClient
     public MockAzureClient(Dictionary<Build, List<Timeline>> builds)
     {
         Builds = builds;
-        _urlDictionary = new Dictionary<string, string>()
+        _urlDictionary = new Dictionary<string, string?>()
         {
             { OneESLogUrl, OneESImageName },
             { MicrosoftHostedAgentLogUrl, MicrosoftHostedAgentImageName},
@@ -93,51 +90,51 @@ public class MockAzureClient : IAzureDevOpsClient
         return Task.FromResult(Builds.Keys.ToArray());
     }
 
-    public Task<Timeline> GetTimelineAsync(string project, int buildId, CancellationToken cancellationToken)
+    public Task<Timeline?> GetTimelineAsync(string project, int buildId, CancellationToken cancellationToken)
     {
         return Task.FromResult(Builds
             .Single(build => build.Key.Id == buildId && build.Key.Project.Name == project)
-            .Value.OrderByDescending(timeline => timeline.LastChangedOn).First());
+            .Value.OrderByDescending(timeline => timeline.LastChangedOn).FirstOrDefault());
     }
 
-    public Task<Timeline> GetTimelineAsync(string project, int buildId, string timelineId, CancellationToken cancellationToken)
+    public Task<Timeline?> GetTimelineAsync(string project, int buildId, string timelineId, CancellationToken cancellationToken)
     {
         return Task.FromResult(Builds
             .Single(build => build.Key.Id == buildId && build.Key.Project.Name == project)
-            .Value.Single(timeline => timeline.Id == timelineId));
+            .Value.SingleOrDefault(timeline => timeline.Id == timelineId));
     }
 
-    public Task<Build> GetBuildAsync(string project, long buildId, CancellationToken cancellationToken = default)
+    public Task<Build?> GetBuildAsync(string project, long buildId, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public Task<(BuildChange[] changes, int truncatedChangeCount)> GetBuildChangesAsync(string project, long buildId, CancellationToken cancellationToken = default)
+    public Task<(BuildChange[]? changes, int? truncatedChangeCount)?> GetBuildChangesAsync(string project, long buildId, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public Task<BuildChangeDetail> GetChangeDetails(string changeUrl, CancellationToken cancellationToken = default)
+    public Task<BuildChangeDetail?> GetChangeDetails(string changeUrl, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public Task<Internal.AzureDevOps.AzureDevOpsProject[]> ListProjectsAsync(CancellationToken cancellationToken = default)
+    public Task<Internal.AzureDevOps.AzureDevOpsProject[]?> ListProjectsAsync(CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public Task<WorkItem> CreateRcaWorkItem(string project, string title, CancellationToken cancellationToken)
+    public Task<WorkItem?> CreateRcaWorkItem(string project, string title, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }
 
-    public Task<string> TryGetImageName(string logUri, Regex[] regexes, CancellationToken cancellationToken)
+    public Task<string?> TryGetImageName(string logUri, Regex[] regexes, CancellationToken cancellationToken)
     {
-        return Task.FromResult(_urlDictionary.GetOrDefault(logUri, ""));
+        return Task.FromResult(_urlDictionary.GetOrDefault(logUri, null));
     }
 
-    public Task<string> GetProjectNameAsync(string id)
+    public Task<string?> GetProjectNameAsync(string id)
     {
         throw new NotImplementedException();
     }

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockAzureClient.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockAzureClient.cs
@@ -129,7 +129,7 @@ public class MockAzureClient : IAzureDevOpsClient
         throw new NotImplementedException();
     }
 
-    public Task<string?> TryGetImageName(string logUri, List<Regex> regexes, CancellationToken cancellationToken)
+    public Task<string?> GetImageName(string logUri, List<Regex> regexes, CancellationToken cancellationToken)
     {
         return Task.FromResult(_urlDictionary.GetOrDefault(logUri, null));
     }

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockAzureClient.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockAzureClient.cs
@@ -129,7 +129,7 @@ public class MockAzureClient : IAzureDevOpsClient
         throw new NotImplementedException();
     }
 
-    public Task<string?> GetImageName(string logUri, List<Regex> regexes, CancellationToken cancellationToken)
+    public Task<string?> MatchLogLineSequence(string logUri, IReadOnlyList<Regex> regexes, CancellationToken cancellationToken)
     {
         return Task.FromResult(_urlDictionary.GetOrDefault(logUri, null));
     }

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockAzureClient.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockAzureClient.cs
@@ -26,23 +26,43 @@ public class MockAzureClient : IAzureDevOpsClient
 
     public static string OneESImageName = "Build.Ubuntu.1804.Amd64";
     public static string MicrosoftHostedAgentImageName = "windows-2019";
+    public static string MmsOneESImageName = "1es-windows-2019";
     public static string OneESLogUrl = $"https://www.fakeurl.test/{OneESImageName}";
     public static string MicrosoftHostedAgentLogUrl = $"https://www.fakeurl.test/{MicrosoftHostedAgentImageName}";
-    public static string OneESLog = @$"SKU: Standard_D4_v3
-Image: {OneESImageName}
-Image Version: 2022.0219.013407";
-    public static string MicrosoftHostedLog = @$"SKU: Standard_D4_v3
-Environment: {MicrosoftHostedAgentImageName}
-Version: 20220223.1";
+    public static string MmsOneESLogUrl = $"https://www.fakeurl.test/{MmsOneESImageName}";
+    public static string OneESLog = $"""
+        2023-04-05T10:02:04.2858589Z ##[group]1ES Hosted Pool
+        2023-04-05T10:02:04.2858784Z SKU: Standard_D4a_v4
+        2023-04-05T10:02:04.2858877Z Image: {OneESImageName}
+        """;
+    public static string MicrosoftHostedLog = $"""
+        2023-04-05T08:34:15.6959600Z ##[group]Runner Image
+        2023-04-05T08:34:15.6959721Z Image: {MicrosoftHostedAgentImageName}
+        2023-04-05T08:34:15.6959819Z Version: 20230402.1
+        """;
+    public static string MmsOneESLog = $"""
+        2023-04-04T15:10:06.5649001Z ##[group]Runner Image
+        2023-04-04T15:10:06.5649079Z Image: {MicrosoftHostedAgentImageName}
+        2023-04-04T15:10:06.5649151Z Version: 20230326.1
+        2023-04-04T15:10:06.5649290Z Included Software: https://github.com/actions/runner-images/blob/win22/20230326.1/images/win/Windows2022-Readme.md
+        2023-04-04T15:10:06.5649490Z Image Release: https://github.com/actions/runner-images/releases/tag/win22%2F20230326.1
+        2023-04-04T15:10:06.5649608Z ##[endgroup]
+        2023-04-04T15:10:06.5649673Z ##[group]1ES Hosted Pool
+        2023-04-04T15:10:06.5649938Z SKU: Standard_D4a_v4
+        2023-04-04T15:10:06.5650033Z Image: {MmsOneESImageName}
+        2023-04-04T15:10:06.5650108Z Image Version: 60.0.0
+    """;
     public static string DockerImageName = "mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-mlnet-8bba86b-20190314145033";
     public static string DockerLogUrl = $"https://www.fakeurl.test/{DockerImageName}";
-    public static string DockerLog = $@"2022-08-04T08:00:55.3397230Z Docker client API version: '1.41'
-2022-08-04T08:00:55.3410985Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter 'label=82ff57'
-2022-08-04T08:00:55.3863389Z ##[command]/usr/bin/docker network prune --force --filter 'label=82ff57'
-2022-08-04T08:00:55.4450968Z ##[command]/usr/bin/docker pull mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-mlnet-8bba86b-20190314145033
-2022-08-04T08:00:55.8023661Z centos-7-mlnet-8bba86b-20190314145033: Pulling from dotnet-buildtools/prereqs
-2022-08-04T08:00:55.8024272Z a02a4930cb5d: Pulling fs layer
-2022-08-04T08:00:55.8024527Z 54355103c1c9: Pulling fs layer";
+    public static string DockerLog = $"""
+        2022-08-04T08:00:55.3397230Z Docker client API version: '1.41'
+        2022-08-04T08:00:55.3410985Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter 'label=82ff57'
+        2022-08-04T08:00:55.3863389Z ##[command]/usr/bin/docker network prune --force --filter 'label=82ff57'
+        2022-08-04T08:00:55.4450968Z ##[command]/usr/bin/docker pull {DockerImageName}
+        2022-08-04T08:00:55.8023661Z centos-7-mlnet-8bba86b-20190314145033: Pulling from dotnet-buildtools/prereqs
+        2022-08-04T08:00:55.8024272Z a02a4930cb5d: Pulling fs layer
+        2022-08-04T08:00:55.8024527Z 54355103c1c9: Pulling fs layer
+    """;
 
     private readonly IDictionary<string, string> _urlDictionary;
 

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockAzureClient.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockAzureClient.cs
@@ -129,7 +129,7 @@ public class MockAzureClient : IAzureDevOpsClient
         throw new NotImplementedException();
     }
 
-    public Task<string?> TryGetImageName(string logUri, Regex[] regexes, CancellationToken cancellationToken)
+    public Task<string?> TryGetImageName(string logUri, List<Regex> regexes, CancellationToken cancellationToken)
     {
         return Task.FromResult(_urlDictionary.GetOrDefault(logUri, null));
     }

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockTimeoutAzureClient.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockTimeoutAzureClient.cs
@@ -67,7 +67,7 @@ public class MockTimeoutAzureClient : IAzureDevOpsClient
         throw new NotImplementedException();
     }
 
-    public async Task<string?> TryGetImageName(string logUri, List<Regex> regexes, CancellationToken cancellationToken)
+    public async Task<string?> GetImageName(string logUri, List<Regex> regexes, CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, logUri);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockTimeoutAzureClient.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockTimeoutAzureClient.cs
@@ -67,7 +67,7 @@ public class MockTimeoutAzureClient : IAzureDevOpsClient
         throw new NotImplementedException();
     }
 
-    public async Task<string?> TryGetImageName(string logUri, Regex[] regexes, CancellationToken cancellationToken)
+    public async Task<string?> TryGetImageName(string logUri, List<Regex> regexes, CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, logUri);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockTimeoutAzureClient.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockTimeoutAzureClient.cs
@@ -69,7 +69,7 @@ public class MockTimeoutAzureClient : IAzureDevOpsClient
         throw new NotImplementedException();
     }
 
-    public async Task<string> TryGetImageName(string logUri, Func<string, string> findImageName, CancellationToken cancellationToken)
+    public async Task<string> TryGetImageName(string logUri, Regex[] regexes, CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, logUri);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockTimeoutAzureClient.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockTimeoutAzureClient.cs
@@ -1,16 +1,14 @@
 using Microsoft.DotNet.Internal.AzureDevOps;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace Microsoft.DotNet.AzureDevOpsTimeline.Tests;
 
 public class MockTimeoutAzureClient : IAzureDevOpsClient
@@ -25,38 +23,38 @@ public class MockTimeoutAzureClient : IAzureDevOpsClient
         _httpClient = new HttpClient(httpMessageHandler); // lgtm [cs/httpclient-checkcertrevlist-disabled] Used only for unit testing
     }
 
-    public Task<WorkItem> CreateRcaWorkItem(string project, string title, CancellationToken cancellationToken = default)
+    public Task<WorkItem?> CreateRcaWorkItem(string project, string title, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public Task<Build> GetBuildAsync(string project, long buildId, CancellationToken cancellationToken = default)
+    public Task<Build?> GetBuildAsync(string project, long buildId, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public Task<(BuildChange[] changes, int truncatedChangeCount)> GetBuildChangesAsync(string project, long buildId, CancellationToken cancellationToken = default)
+    public Task<(BuildChange[]? changes, int? truncatedChangeCount)?> GetBuildChangesAsync(string project, long buildId, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public Task<BuildChangeDetail> GetChangeDetails(string changeUrl, CancellationToken cancellationToken = default)
+    public Task<BuildChangeDetail?> GetChangeDetails(string changeUrl, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public Task<Timeline> GetTimelineAsync(string project, int buildId, CancellationToken cancellationToken)
+    public Task<Timeline?> GetTimelineAsync(string project, int buildId, CancellationToken cancellationToken)
     {
         return Task.FromResult(Builds
             .Single(build => build.Key.Id == buildId && build.Key.Project.Name == project)
-            .Value.OrderByDescending(timeline => timeline.LastChangedOn).First());
+            .Value.OrderByDescending(timeline => timeline.LastChangedOn).FirstOrDefault());
     }
 
-    public Task<Timeline> GetTimelineAsync(string project, int buildId, string timelineId, CancellationToken cancellationToken)
+    public Task<Timeline?> GetTimelineAsync(string project, int buildId, string timelineId, CancellationToken cancellationToken)
     {
         return Task.FromResult(Builds
             .Single(build => build.Key.Id == buildId && build.Key.Project.Name == project)
-            .Value.Single(timeline => timeline.Id == timelineId));
+            .Value.SingleOrDefault(timeline => timeline.Id == timelineId));
     }
 
     public Task<Build[]> ListBuilds(string project, CancellationToken cancellationToken, DateTimeOffset? minTime = null, int? limit = null)
@@ -64,12 +62,12 @@ public class MockTimeoutAzureClient : IAzureDevOpsClient
         return Task.FromResult(Builds.Keys.ToArray());
     }
 
-    public Task<Internal.AzureDevOps.AzureDevOpsProject[]> ListProjectsAsync(CancellationToken cancellationToken = default)
+    public Task<Internal.AzureDevOps.AzureDevOpsProject[]?> ListProjectsAsync(CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public async Task<string> TryGetImageName(string logUri, Regex[] regexes, CancellationToken cancellationToken)
+    public async Task<string?> TryGetImageName(string logUri, Regex[] regexes, CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, logUri);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
@@ -81,7 +79,7 @@ public class MockTimeoutAzureClient : IAzureDevOpsClient
         return await response.Content.ReadAsStringAsync();
     }
 
-    public Task<string> GetProjectNameAsync(string id)
+    public Task<string?> GetProjectNameAsync(string id)
     {
         throw new NotImplementedException();
     }

--- a/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockTimeoutAzureClient.cs
+++ b/src/Telemetry/Microsoft.DotNet.AzureDevOpsTimelineTests/MockTimeoutAzureClient.cs
@@ -67,7 +67,7 @@ public class MockTimeoutAzureClient : IAzureDevOpsClient
         throw new NotImplementedException();
     }
 
-    public async Task<string?> GetImageName(string logUri, List<Regex> regexes, CancellationToken cancellationToken)
+    public async Task<string?> MatchLogLineSequence(string logUri, IReadOnlyList<Regex> regexes, CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, logUri);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade/issues/12997

The log structure changed a while ago, examples of the new logs:
- https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_apis/build/builds/2150258/logs/4
- https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_apis/build/builds/2150217/logs/1074

To avoid a thing like this happening, we could set up a grafana dashboard where we query the percentage rate of 1ES and MicrosoftHosted records with an ImageName, and fire an alert if the percentage is too low