### PR TITLE
Add new PATs for azure devops timeline processing

### DIFF
--- a/.vault-config/maestrolocal.yaml
+++ b/.vault-config/maestrolocal.yaml
@@ -81,3 +81,23 @@ secrets:
         name: dn-bot-account-redmond
       organizations: dnceng
       scopes: packaging_manage
+
+  dn-bot-dnceng-build-r:
+    type: azure-devops-access-token
+    parameters:
+      domainAccountName: dn-bot
+      domainAccountSecret:
+        location: helixkv
+        name: dn-bot-account-redmond
+      organizations: dnceng
+      scopes: build
+      
+  dn-bot-dnceng-public-build-r:
+    type: azure-devops-access-token
+    parameters:
+      domainAccountName: dn-bot
+      domainAccountSecret:
+        location: helixkv
+        name: dn-bot-account-redmond
+      organizations: dnceng-public
+      scopes: build

--- a/.vault-config/shared/maestro-secrets.yaml
+++ b/.vault-config/shared/maestro-secrets.yaml
@@ -71,3 +71,23 @@ dn-bot-dnceng-packaging-rwm:
       name: dn-bot-account-redmond
     organizations: dnceng
     scopes: packaging_manage
+
+dn-bot-dnceng-build-r:
+  type: azure-devops-access-token
+  parameters:
+    domainAccountName: dn-bot
+    domainAccountSecret:
+      location: helixkv
+      name: dn-bot-account-redmond
+    organizations: dnceng
+    scopes: build
+    
+dn-bot-dnceng-public-build-r:
+  type: azure-devops-access-token
+  parameters:
+    domainAccountName: dn-bot
+    domainAccountSecret:
+      location: helixkv
+      name: dn-bot-account-redmond
+    organizations: dnceng-public
+    scopes: build

--- a/src/Telemetry/AzureDevOpsTimeline/.config/settings.json
+++ b/src/Telemetry/AzureDevOpsTimeline/.config/settings.json
@@ -28,12 +28,12 @@
   "AzureDevOpsSettings": {
     "dnceng": {
       "Organization": "dnceng",
-      "AccessToken": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
+      "AccessToken": "[vault(dn-bot-dnceng-build-r)]",
       "MaxParallelRequests": 4
     },
     "dnceng-public": {
       "Organization": "dnceng-public",
-      "AccessToken": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
+      "AccessToken": "[vault(dn-bot-dnceng-public-build-r]",
       "MaxParallelRequests": 4
     }
   }


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/13039

Uses PATs with much narrower scope for the Azure DevOps timeline processing, also stops reusing the same PAT for both dnceng* organizations.