### PR TITLE
Split up the queries to get target subscriptions and to fill out thei…

### DIFF
--- a/src/Maestro/DependencyUpdater/DependencyUpdater.cs
+++ b/src/Maestro/DependencyUpdater/DependencyUpdater.cs
@@ -230,6 +230,12 @@ public sealed class DependencyUpdater : IServiceImplementation, IDependencyUpdat
                     .ThenInclude(bc => bc.Build)
                     .FirstOrDefaultAsync(cancellationToken);
 
+                if (subscriptionWithBuilds == null)
+                {
+                    Logger.LogWarning("Subscription {subscriptionId} was not found in the BAR. Not applying updates", subscription.Id.ToString());
+                    continue;
+                }
+
                 Build latestBuildInTargetChannel = subscriptionWithBuilds.Channel.BuildChannels.Select(bc => bc.Build)
                     .Where(b => (subscription.SourceRepository == b.GitHubRepository || subscription.SourceRepository == b.AzureDevOpsRepository))
                     .OrderByDescending(b => b.DateProduced)

--- a/src/Maestro/DependencyUpdater/DependencyUpdater.cs
+++ b/src/Maestro/DependencyUpdater/DependencyUpdater.cs
@@ -217,32 +217,36 @@ public sealed class DependencyUpdater : IServiceImplementation, IDependencyUpdat
         {
             var enabledSubscriptionsWithTargetFrequency = (await Context.Subscriptions
                     .Where(s => s.Enabled)
-                    .Include(s => s.Channel)
-                    .ThenInclude(c => c.BuildChannels)
-                    .ThenInclude(bc => bc.Build)
-                    .ToListAsync())
-                .Where(s => s.PolicyObject.UpdateFrequency == targetUpdateFrequency);
+                    .ToListAsync(cancellationToken))
+                    .Where(s => s.PolicyObject.UpdateFrequency == targetUpdateFrequency);
 
             int subscriptionsUpdated = 0;
             foreach (var subscription in enabledSubscriptionsWithTargetFrequency)
             {
-                Build latestBuildInTargetChannel = subscription.Channel.BuildChannels.Select(bc => bc.Build)
+                Subscription subscriptionWithBuilds = await Context.Subscriptions
+                    .Where(s => s.Id == subscription.Id)
+                    .Include(s => s.Channel)
+                    .ThenInclude(c => c.BuildChannels)
+                    .ThenInclude(bc => bc.Build)
+                    .FirstOrDefaultAsync(cancellationToken);
+
+                Build latestBuildInTargetChannel = subscriptionWithBuilds.Channel.BuildChannels.Select(bc => bc.Build)
                     .Where(b => (subscription.SourceRepository == b.GitHubRepository || subscription.SourceRepository == b.AzureDevOpsRepository))
                     .OrderByDescending(b => b.DateProduced)
                     .FirstOrDefault();
 
                 bool isThereAnUnappliedBuildInTargetChannel = latestBuildInTargetChannel != null &&
-                                                              (subscription.LastAppliedBuild == null || subscription.LastAppliedBuildId != latestBuildInTargetChannel.Id);
+                    (subscription.LastAppliedBuild == null || subscription.LastAppliedBuildId != latestBuildInTargetChannel.Id);
 
                 if (isThereAnUnappliedBuildInTargetChannel)
                 {
-                    Logger.LogInformation($"Will update {subscription.Id} to build {latestBuildInTargetChannel.Id}");
+                    Logger.LogInformation("Will update {subscriptionId} to build {latestBuildInTargetChannelId}", subscription.Id, latestBuildInTargetChannel.Id);
                     await UpdateSubscriptionAsync(subscription.Id, latestBuildInTargetChannel.Id);
                     subscriptionsUpdated++;
                 }
             }
 
-            Logger.LogInformation($"Updated '{subscriptionsUpdated}' subscriptions");
+            Logger.LogInformation("Updated '{SubscriptionsUpdated}' '{targetUpdateFrequency}' subscriptions", subscriptionsUpdated, targetUpdateFrequency.ToString());
         }
     }
 


### PR DESCRIPTION
…r builds and channels during frequency based dependency updates.

https://github.com/dotnet/arcade/issues/13096

There is an alternative where we could map the JSON policy blob to an object so that EFCore knew how to deal with it, but:

1. We'd need to move to EF7 (https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-7.0/whatsnew#json-columns)
2. I still kind of like this approach better?