### PR TITLE
Bump Azure.Data.Tables

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,9 +11,9 @@
     <!-- Note: These libraries can be loaded by Arcade SDK clients, which may already have a
          newer copy of this package loaded. When updating one, be aware of the other to prevent runtime issues
          See: https://github.com/dotnet/arcade/blob/main/eng/Versions.props -->
-    <PackageVersion Include="Azure.Core" Version="1.25.0" />
+    <PackageVersion Include="Azure.Core" Version="1.31.0" />
     <PackageVersion Include="Azure.Data.AppConfiguration" Version="1.0.0" />
-    <PackageVersion Include="Azure.Data.Tables" Version="12.6.1" />
+    <PackageVersion Include="Azure.Data.Tables" Version="12.8.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.1.0" />
     <PackageVersion Include="Azure.Identity" Version="1.5.0" />

--- a/arcade-services.sln
+++ b/arcade-services.sln
@@ -62,8 +62,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		CodeCoverage.runsettings = CodeCoverage.runsettings
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
-		eng\Packages.props = eng\Packages.props
 		eng\Versions.props = eng\Versions.props
 	EndProjectSection
 EndProject
@@ -213,7 +213,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Darc.Virtu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Maestro.MergePolicyEvaluation", "src\Maestro\Maestro.MergePolicyEvaluation\Maestro.MergePolicyEvaluation.csproj", "{D16DB73B-4EDF-4E61-9392-238CF3800DE2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureDevOpsClient.Tests", "src\Telemetry\AzureDevOpsClient.Tests\AzureDevOpsClient.Tests.csproj", "{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureDevOpsClient.Tests", "src\Telemetry\AzureDevOpsClient.Tests\AzureDevOpsClient.Tests.csproj", "{6CAC1E0D-C81E-4A97-A836-2FEB697C424D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Resolves [dotnet/arcade#13187](https://github.com/dotnet/arcade/issues/13187).

Bump `Azure.Data.Tables` and its dependency `Azure.Core`.