### PR TITLE
Change dotneteng-status to use zipDeploy

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -208,7 +208,7 @@ stages:
         SlotName: staging
         Package: $(Pipeline.Workspace)/DotNetStatus/DotNetStatus.zip
         enableCustomDeployment: true
-        DeploymentType: webDeploy
+        DeploymentType: zipDeploy
         RemoveAdditionalFilesFlag: true
 
   - job: deployRolloutScorer


### PR DESCRIPTION
Part of [dotnet/arcade#13312](https://github.com/dotnet/arcade/issues/13312).

Deployments of dotneteng-status are broken. I think this will fix them. Unfortunately, I can't truly test it until it is merged into main (because no deployments happen with PR builds). 

This change only effects the deployment of dotneteng-status.