### PR TITLE
Update .NET SDK to 6.0.410

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "6.0.406",
+    "version": "6.0.410",
     "rollForward": "minor"
   },
   "tools": {
-    "dotnet": "6.0.406",
+    "dotnet": "6.0.410",
     "runtimes": {
       "dotnet": [
         "3.1.32",


### PR DESCRIPTION
New component governance alerts require us to bump .NET to fix them as problems come from NuGet bundled inside of them

[#2675](https://github.com/dotnet/arcade-services/issues/2675)