### PR TITLE
Improve `main`/`production` pipeline run time, clean up YAML

### DIFF
--- a/azure-pipeline-weekly.yml
+++ b/azure-pipeline-weekly.yml
@@ -12,26 +12,4 @@ schedules:
   always: true
 
 stages:
-  - stage: SynchronizeSecrets
-    displayName: Synchronize Secrets
-    jobs:
-    - job: Synchronize
-      displayName: Synchronize Secrets
-      pool:
-        name: NetCore1ESPool-Internal-NoMSI
-        demands: ImageOverride -equals 1es-windows-2022
-      steps:
-      - powershell: |
-          . .\eng\common\tools.ps1
-          InitializeDotNetCli -install $true
-          .\.dotnet\dotnet tool restore
-        displayName: Install Secret Manager
-
-      - task: AzureCLI@2
-        displayName: Synchronize Secrets
-        inputs:
-          azureSubscription: DotNet Eng Services Secret Manager
-          scriptType: ps
-          scriptLocation: inlineScript
-          inlineScript: |
-            Get-ChildItem .vault-config/*.yaml |% { .\.dotnet\dotnet secret-manager synchronize $_ }
+- template: templates/stages/secret-validation.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -238,18 +238,18 @@ stages:
         -TsaPublish $True
         -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/PoliCheckExclusions.xml")'
 
-# - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production'))}}:
-- template: eng\deploy.yaml
-  parameters:
-    ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/production') }}:
-      DeploymentEnvironment: Staging
-      MaestroTestEndpoint: https://maestro-int.westus2.cloudapp.azure.com
-      PublishProfile: Int
-      Subscription: NetHelixStaging
-      VariableGroup: MaestroInt KeyVault
-    ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/production') }}:
-      DeploymentEnvironment: Production
-      MaestroTestEndpoint: https://maestro-prod.westus2.cloudapp.azure.com
-      PublishProfile: Prod
-      Subscription: NetHelix
-      VariableGroup: MaestroProd KeyVault
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production'))}}:
+  - template: eng\deploy.yaml
+    parameters:
+      ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/production') }}:
+        DeploymentEnvironment: Staging
+        MaestroTestEndpoint: https://maestro-int.westus2.cloudapp.azure.com
+        PublishProfile: Int
+        Subscription: NetHelixStaging
+        VariableGroup: MaestroInt KeyVault
+      ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/production') }}:
+        DeploymentEnvironment: Production
+        MaestroTestEndpoint: https://maestro-prod.westus2.cloudapp.azure.com
+        PublishProfile: Prod
+        Subscription: NetHelix
+        VariableGroup: MaestroProd KeyVault

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,6 +105,11 @@ stages:
         - checkout: self
           clean: true
 
+        - task: UseDotNet@2
+          displayName: Install .NET Version 3.1
+          inputs:
+            version: 3.1.x
+
         - powershell: eng\set-version-parameters.ps1
           displayName: Calculate release version variables
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -208,7 +208,7 @@ stages:
             artifact: Maestro.ScenarioTests
             displayName: Publish Maestro Scenario Tests
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.SourceBranch'], 'refs/heads/production')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
       enableSymbolValidation: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,10 +105,20 @@ stages:
         - checkout: self
           clean: true
 
-        - task: UseDotNet@2
-          displayName: Install .NET Version 3.1
+        - task: NodeTool@0
           inputs:
-            version: 3.1.x
+            versionSpec: 12.x
+
+        - task: NuGetToolInstaller@0
+          inputs:
+            versionSpec: 6.1.x
+
+        - task: NuGetCommand@2
+          displayName: Restore Packages
+          inputs:
+            command: restore
+            solution: "**/*.sln"
+            feedstoUse: config
 
         - powershell: eng\set-version-parameters.ps1
           displayName: Calculate release version variables
@@ -225,17 +235,13 @@ stages:
     parameters:
       ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/production') }}:
         DeploymentEnvironment: Staging
-        MaestroPublishEndpoint: https://maestro-prod.westus2.cloudapp.azure.com
         MaestroTestEndpoint: https://maestro-int.westus2.cloudapp.azure.com
         PublishProfile: Int
-        ServiceFabricConnection: Maestro-Int
         Subscription: NetHelixStaging
         VariableGroup: MaestroInt KeyVault
       ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/production') }}:
         DeploymentEnvironment: Production
-        MaestroPublishEndpoint: https://maestro-prod.westus2.cloudapp.azure.com
         MaestroTestEndpoint: https://maestro-prod.westus2.cloudapp.azure.com
         PublishProfile: Prod
-        ServiceFabricConnection: Maestro-Prod
         Subscription: NetHelix
         VariableGroup: MaestroProd KeyVault

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,14 +25,14 @@ stages:
   displayName: GitHub Issue Verification
   condition: and(eq(variables['Build.Reason'], 'PullRequest'), notIn(variables['System.PullRequest.TargetBranch'], 'refs/heads/production', 'production'), notIn(variables['System.PullRequest.SourceBranch'], 'refs/heads/production', 'production'))
   jobs:
-    - job: VerifyGitHubIssue
-      displayName: Verify GitHub Issue Link included in all PRs
-      pool: 
-        vmImage: 'windows-latest'
-      steps:
-        - checkout: self
-        - powershell: eng/enforce-issue.ps1 -PullRequestNumber $(System.PullRequest.PullRequestNumber)
-          displayName: Enforce GitHub issue link presence
+  - job: VerifyGitHubIssue
+    displayName: Verify GitHub Issue Link included in all PRs
+    pool:
+      vmImage: windows-latest
+    steps:
+    - checkout: self
+    - powershell: eng/enforce-issue.ps1 -PullRequestNumber $(System.PullRequest.PullRequestNumber)
+      displayName: Enforce GitHub issue link presence
 
 - stage: build
   dependsOn: []
@@ -106,10 +106,12 @@ stages:
           clean: true
 
         - task: NodeTool@0
+          displayName: Install node.js
           inputs:
             versionSpec: 12.x
 
         - task: NuGetToolInstaller@0
+          displayName: Install NuGet
           inputs:
             versionSpec: 6.1.x
 
@@ -121,7 +123,7 @@ stages:
             feedstoUse: config
 
         - powershell: eng\set-version-parameters.ps1
-          displayName: Calculate release version variables
+          displayName: Calculate Release Versions
 
         - powershell: |
             [xml]$manifest = Get-Content src\Maestro\MaestroApplication\ApplicationPackageRoot\ApplicationManifest.xml
@@ -129,7 +131,7 @@ stages:
             $manifest.SelectSingleNode("/*[local-name()='ApplicationManifest']/*[local-name()='Principals']").RemoveAll()
             $manifest.Save("src\Maestro\MaestroApplication\ApplicationPackageRoot\ApplicationManifest.xml")
             git diff
-          displayName: Remove Service Fabric RunAsPolicy from MaestroApplication
+          displayName: Remove RunAsPolicy From MaestroApplication
 
         - script: eng\common\cibuild.cmd
             -configuration $(_BuildConfig)
@@ -143,6 +145,7 @@ stages:
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
 
           - task: ComponentGovernanceComponentDetection@0
+            displayName: Component Governance Detection
             inputs:
               # `.packages` directory is used by some tools running during build.
               # By default ComponentDetection scans this directory and sometimes reports
@@ -159,6 +162,7 @@ stages:
 
           ## Prepare service fabric artifact
           - task: ServiceFabricUpdateManifests@2
+            displayName: Update Service Fabric manifests
             inputs:
               applicationPackagePath: $(Build.ArtifactStagingDirectory)\ServiceFabric\MaestroApplication\applicationpackage
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,18 +21,18 @@ pr:
 - production
 
 stages:
-- stage: GitHub_Issue_Verification
-  displayName: GitHub Issue Verification
-  condition: and(eq(variables['Build.Reason'], 'PullRequest'), notIn(variables['System.PullRequest.TargetBranch'], 'refs/heads/production', 'production'), notIn(variables['System.PullRequest.SourceBranch'], 'refs/heads/production', 'production'))
-  jobs:
-  - job: VerifyGitHubIssue
-    displayName: Verify GitHub Issue Link included in all PRs
-    pool:
-      vmImage: windows-latest
-    steps:
-    - checkout: self
-    - powershell: eng/enforce-issue.ps1 -PullRequestNumber $(System.PullRequest.PullRequestNumber)
-      displayName: Enforce GitHub issue link presence
+- ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), notIn(variables['System.PullRequest.TargetBranch'], 'refs/heads/production', 'production'), notIn(variables['System.PullRequest.SourceBranch'], 'refs/heads/production', 'production')) }}:
+  - stage: GitHub_Issue_Verification
+    displayName: GitHub Issue Verification
+    jobs:
+    - job: VerifyGitHubIssue
+      displayName: Verify GitHub Issue Link included in all PRs
+      pool:
+        vmImage: windows-latest
+      steps:
+      - checkout: self
+      - powershell: eng/enforce-issue.ps1 -PullRequestNumber $(System.PullRequest.PullRequestNumber)
+        displayName: Enforce GitHub issue link presence
 
 - stage: build
   dependsOn: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,10 +44,14 @@ stages:
   jobs:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
+      ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+        enablePublishBuildArtifacts: true
+        enablePublishBuildAssets: true
+      ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+        enablePublishBuildArtifacts: false
+        enablePublishBuildAssets: false
       enableMicrobuild: false
-      enablePublishBuildArtifacts: true
       enablePublishTestResults: false
-      enablePublishBuildAssets: true
       enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
       enableTelemetry: true
       helixRepo: dotnet/arcade-services

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -234,18 +234,18 @@ stages:
         -TsaPublish $True
         -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/PoliCheckExclusions.xml")'
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production'))}}:
-  - template: eng\deploy.yaml
-    parameters:
-      ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/production') }}:
-        DeploymentEnvironment: Staging
-        MaestroTestEndpoint: https://maestro-int.westus2.cloudapp.azure.com
-        PublishProfile: Int
-        Subscription: NetHelixStaging
-        VariableGroup: MaestroInt KeyVault
-      ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/production') }}:
-        DeploymentEnvironment: Production
-        MaestroTestEndpoint: https://maestro-prod.westus2.cloudapp.azure.com
-        PublishProfile: Prod
-        Subscription: NetHelix
-        VariableGroup: MaestroProd KeyVault
+# - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production'))}}:
+- template: eng\deploy.yaml
+  parameters:
+    ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/production') }}:
+      DeploymentEnvironment: Staging
+      MaestroTestEndpoint: https://maestro-int.westus2.cloudapp.azure.com
+      PublishProfile: Int
+      Subscription: NetHelixStaging
+      VariableGroup: MaestroInt KeyVault
+    ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/production') }}:
+      DeploymentEnvironment: Production
+      MaestroTestEndpoint: https://maestro-prod.westus2.cloudapp.azure.com
+      PublishProfile: Prod
+      Subscription: NetHelix
+      VariableGroup: MaestroProd KeyVault

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,10 @@ pr:
 - main
 - production
 
+pool:
+  name: NetCore1ESPool-Internal-NoMSI
+  demands: ImageOverride -equals 1es-windows-2019
+
 stages:
 - ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), notIn(variables['System.PullRequest.TargetBranch'], 'refs/heads/production', 'production'), notIn(variables['System.PullRequest.SourceBranch'], 'refs/heads/production', 'production')) }}:
   - stage: GitHub_Issue_Verification

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,13 +1,13 @@
 variables:
-  # Cannot use key:value syntax in root defined variables
-  - name: _TeamName
-    value: DotNetCore
-  - name: _PublishUsingPipelines
-    value: true
-  - name: _DotNetArtifactsCategory
-    value: .NETCore
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: SDL_Settings
+# Cannot use key:value syntax in root defined variables
+- name: _TeamName
+  value: DotNetCore
+- name: _PublishUsingPipelines
+  value: true
+- name: _DotNetArtifactsCategory
+  value: .NETCore
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - group: SDL_Settings
 
 # CI and PR triggers
 trigger:
@@ -55,7 +55,7 @@ stages:
             name: NetCore1ESPool-Internal
             demands: ImageOverride -equals 1es-windows-2019
           ${{ if eq(variables['System.TeamProject'], 'public')}}:
-            name: NetCore-Public          
+            name: NetCore-Public
             demands: ImageOverride -equals 1es-windows-2019-open
 
         variables:
@@ -105,31 +105,6 @@ stages:
         - checkout: self
           clean: true
 
-        - task: UseDotNet@2
-          displayName: Install Correct .NET Version
-          inputs:
-            useGlobalJson: true
-
-        - task: UseDotNet@2
-          displayName: Install .NET Version 3.1
-          inputs:
-            version: 3.1.x
-
-        - task: NuGetToolInstaller@0
-          inputs:
-            versionSpec: 6.1.x
-
-        - task: NodeTool@0
-          inputs:
-            versionSpec: 12.x
-
-        - task: NuGetCommand@2
-          displayName: Restore Packages
-          inputs:
-            command: restore
-            solution: "**/*.sln"
-            feedstoUse: config
-
         - powershell: eng\set-version-parameters.ps1
           displayName: Calculate release version variables
 
@@ -149,17 +124,6 @@ stages:
             /p:Test=false
             /P:Sign=false
           name: Build
-          displayName: Build / Publish
-          condition: succeeded()
-        
-        - powershell: |
-            dotnet tool restore
-            $manifestArgs = @()
-            Get-ChildItem .vault-config/*.yaml |% {
-              $manifestArgs += @("-m", $_.FullName)
-            }
-            dotnet secret-manager validate-all -b src @manifestArgs
-          displayName: Verify Secret Usages
 
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
 
@@ -171,7 +135,7 @@ stages:
               # We can ignore this directory because actual vulnerabilities
               # that we are interested in will be found by the tool
               # when scanning .csproj and package.json files.
-              ignoreDirectories: '.packages'
+              ignoreDirectories: .packages
 
         - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
           - template: /eng/test.yaml
@@ -229,7 +193,7 @@ stages:
             artifact: Maestro.ScenarioTests
             displayName: Publish Maestro Scenario Tests
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.SourceBranch'], 'refs/heads/production')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
       enableSymbolValidation: true
@@ -250,6 +214,7 @@ stages:
         -TsaCodebaseName "Arcade-Services"
         -TsaPublish $True
         -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/PoliCheckExclusions.xml")'
+
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production'))}}:
   - template: eng\deploy.yaml
     parameters:

--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -15,38 +15,14 @@ parameters:
   # dotnet-build-bot-dotnet-eng-status-token
 
 stages:
-- stage: ValidateSecrets
-  dependsOn:
-  - build
-  jobs:
-  - job: ValidateSecrets
-    pool: 
-      name: NetCore1ESPool-Internal-NoMSI
-      demands: ImageOverride -equals 1es-windows-2019
-    steps:
-    - task: UseDotNet@2
-      displayName: Install Correct .NET Version
-      inputs:
-        useGlobalJson: true
-
-    - script: dotnet tool restore
-      displayName: Install Secret Manager
-
-    - task: AzureCLI@2
-      inputs:
-        azureSubscription: DotNet Eng Services Secret Manager
-        scriptType: ps
-        scriptLocation: inlineScript
-        inlineScript: |
-          Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize --verify-only $_}
+- template: templates/stages/secret-validation.yml
+  parameters:
+    verifyOnly: true
 
 - stage: approval
   pool: server
   dependsOn:
   - build
-  - Validate
-  - ValidateSecrets
-  - publish_using_darc
   jobs:
   - deployment: approval
     displayName: deployment approval (conditional)
@@ -59,7 +35,6 @@ stages:
     demands: ImageOverride -equals 1es-windows-2019
   dependsOn:
   - build
-  - Validate
   - approval
   variables:
   - group: ${{ parameters.VariableGroup }}

--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -34,9 +34,6 @@ stages:
 
 - stage: deploy
   displayName: Deploy
-  pool:
-    name: NetCore1ESPool-Internal-NoMSI
-    demands: ImageOverride -equals 1es-windows-2019
   dependsOn:
   - build
   - approval
@@ -52,7 +49,7 @@ stages:
       artifact: Maestro.Data
 
     - task: UseDotNet@2
-      displayName: Install Correct .NET Version
+      displayName: Install .NET
       inputs:
         useGlobalJson: true
 
@@ -82,12 +79,9 @@ stages:
       condition: always()
 
   - job: deployMaestro
-    displayName: Deploy maestro service fabric application
+    displayName: Deploy Maestro
     dependsOn:
     - updateDatabase
-    pool:
-      name: NetCore1ESPool-Internal-NoMSI
-      demands: ImageOverride -equals 1es-windows-2019
     steps:
     - download: current
       artifact: MaestroApplication
@@ -114,9 +108,6 @@ stages:
 
 - stage: validateDeployment
   displayName: Validate deployment
-  pool:
-    name: NetCore1ESPool-Internal
-    demands: ImageOverride -equals 1es-windows-2019
   dependsOn:
   - deploy
   variables:
@@ -140,7 +131,7 @@ stages:
         versionSpec: 5.3.x
 
     - task: UseDotNet@2
-      displayName: Install Correct .NET Version
+      displayName: Install .NET
       inputs:
         useGlobalJson: true
 

--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -1,11 +1,15 @@
 parameters:
-  Subscription: ''
-  ServiceFabricConnection: ''
-  PublishProfile: ''
-  DeploymentEnvironment: ''
-  VariableGroup: ''
-  MaestroPublishEndpoint: ''
-  MaestroTestEndpoint: ''
+- name: Subscription
+  type: string
+- name: PublishProfile
+  type: string
+  values: [ 'Int', 'Prod' ]
+- name: DeploymentEnvironment
+  type: string
+- name: VariableGroup
+  type: string
+- name: MaestroTestEndpoint
+  type: string
 
   # --- Secret Variable group requirements ---
   # build-asset-registry-admin-connection-string
@@ -38,8 +42,6 @@ stages:
   - approval
   variables:
   - group: ${{ parameters.VariableGroup }}
-  - name: PublishProfile
-    value: ${{ parameters.PublishProfile }}
   jobs:
   - job: updateDatabase
     displayName: Update BuildAssetRegistry database
@@ -107,7 +109,7 @@ stages:
           }
           eng/deployment/deploy.ps1 -obj $env:BUILD_ARTIFACTSTAGINGDIRECTORY -appPackagePath $env:ApplicationPackage -publishProfile $env:PublishProfilePath -autoRollBack $autoRollBack -location westus2
       env:
-        PublishProfilePath: $(Pipeline.Workspace)/MaestroApplication/projectartifacts/PublishProfiles/$(PublishProfile).xml
+        PublishProfilePath: $(Pipeline.Workspace)/MaestroApplication/projectartifacts/PublishProfiles/${{ parameters.PublishProfile }}.xml
         ApplicationPackage: $(Pipeline.Workspace)/MaestroApplication/applicationpackage
 
 - stage: validateDeployment
@@ -121,8 +123,7 @@ stages:
   - group: ${{ parameters.VariableGroup }}
   # Secret-Manager-Scenario-Tests provides: secret-manager-scenario-tests-client-secret
   - group: Secret-Manager-Scenario-Tests
-  - name: MaestroTestEndpoint
-    value: ${{ parameters.MaestroTestEndpoint }}
+
   jobs:
   - job: scenario
     displayName: Scenario tests
@@ -151,7 +152,7 @@ stages:
           Maestro.ScenarioTests.dll
         searchFolder: $(Pipeline.Workspace)/Maestro.ScenarioTests
       env:
-        MAESTRO_BASEURI: $(MaestroTestEndpoint)
+        MAESTRO_BASEURI: ${{ parameters.MaestroTestEndpoint }}
         MAESTRO_TOKEN: $(scenario-test-maestro-token)
         GITHUB_TOKEN: $(maestro-scenario-test-github-token)
         AZDO_TOKEN: $(dn-bot-dnceng-build-rw-code-rw-release-rw)
@@ -162,7 +163,7 @@ stages:
         nuget sources add -Name "dotnet-core" -Source "https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json"
       displayName: Add nuget Sources
     - powershell: |
-        $versionEndpoint = "$(MaestroTestEndpoint)/api/assets/darc-version?api-version=2019-01-16"
+        $versionEndpoint = "${{ parameters.MaestroTestEndpoint }}/api/assets/darc-version?api-version=2019-01-16"
         $latestDarcVersion = $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
         Write-Host "##vso[task.setvariable variable=darcVersion]$latestDarcVersion"
         Write-Host "Using Darc version $latestDarcVersion to run the tests"

--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -118,7 +118,7 @@ stages:
   jobs:
   - job: scenario
     displayName: Scenario tests
-    timeoutInMinutes: 90
+    timeoutInMinutes: 120
     steps:
     - download: current
       artifact: PackageArtifacts

--- a/eng/templates/stages/secret-validation.yml
+++ b/eng/templates/stages/secret-validation.yml
@@ -1,0 +1,38 @@
+parameters:
+- name: verifyOnly
+  type: boolean
+  default: false
+
+stages:
+- stage: SynchronizeSecrets
+  displayName: Synchronize Secrets
+  jobs:
+  - job: Synchronize
+    displayName: Synchronize Secrets
+    pool:
+      name: NetCore1ESPool-Internal-NoMSI
+      demands: ImageOverride -equals 1es-windows-2022
+
+    variables:
+    - ${{ if parameters.verifyOnly }}:
+      - name: secretManagerArgs
+        value: --verify-only
+    - ${{ else }}:
+      - name: secretManagerArgs
+        value: ''
+
+    steps:
+    - powershell: |
+        . .\eng\common\tools.ps1
+        InitializeDotNetCli -install $true
+        .\.dotnet\dotnet tool restore
+      displayName: Install Secret Manager
+
+    - task: AzureCLI@2
+      displayName: Synchronize Secrets
+      inputs:
+        azureSubscription: DotNet Eng Services Secret Manager
+        scriptType: ps
+        scriptLocation: inlineScript
+        inlineScript: |
+          Get-ChildItem .vault-config/*.yaml |% { .\.dotnet\dotnet secret-manager synchronize $(secretManagerArgs) $_ }


### PR DESCRIPTION
- The `production` build no longer publishes packages → speed-up of 60-90 minutes + we no longer publish old code with new version
- The `main` build no longer waits for package publishing as it's not really required → speed-up of 60 minutes for `main` builds
- Secret verification no longer happens twice (in `Build` and in its own stage)
- Removed unused code such as unused YAML parameters or variables
- Removed unnecessary steps such as .NET restore when it's done as part of Arcade build anyway
- Simplified YAML in many places
- GitHub verification stage is now omitted properly
- YAML de-duplication of secret rotation, pool configuration and more
- E2E test time limit increased from 90 to 120 minutes as it sometimes times out

The new rollout pipeline looks like this:
![image](https://github.com/dotnet/arcade-services/assets/7013027/9f696464-c573-41aa-86aa-05f2bae378f3)

Sample rollout build (that targets staging env):
https://dev.azure.com/dnceng/internal/_build/results?buildId=2207136&view=results

https://github.com/dotnet/arcade-services/issues/2698