### PR TITLE
Re-use local build cache between dependency look-ups

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Actions/Remote.cs
@@ -1486,9 +1486,10 @@ public sealed class Remote : IRemote
     /// <returns>Async task</returns>
     public async Task AddAssetLocationToDependenciesAsync(IEnumerable<DependencyDetail> dependencies)
     {
+        var buildCache = new Dictionary<int, Build>();
+
         foreach (var dependency in dependencies)
         {
-            Dictionary<int, Build> buildCache = new Dictionary<int, Build>();
             IEnumerable<Asset> matchingAssets = await GetAssetsAsync(dependency.Name, dependency.Version);
             List<Asset> matchingAssetsFromSameSha = new List<Asset>();
 


### PR DESCRIPTION
I took a sample problematic scenario from `dotnet/sdk` which takes a bit over 6 minutes to complete:
```
darc update-dependencies --channel ".NET Eng - Latest"
```

I noticed we burn a lot of time querying builds while the cache that we use is too local.
I don't want to make the cache even more long-lived as I don't understand the life-cycle of the `Remote` class within Maestro so it would be too risky to store builds indefinitely.
However, even this change in this PR showed 5x speed-up to about 1 minute 15 seconds.

https://github.com/dotnet/arcade-services/issues/2681