### PR TITLE
Allow scoping `get-asset` search by BAR ID

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetAssetOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetAssetOperation.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations;
@@ -48,17 +49,29 @@ internal class GetAssetOperation : Operation
             List<Asset> matchingAssets =
                 (await remote.GetAssetsAsync(name: _options.Name, version: _options.Version, buildId: _options.Build)).ToList();
 
-            string queryDescriptionString =
-                $"name '{_options.Name}'" +
-                $"{(!string.IsNullOrEmpty(_options.Version) ? $" and version '{_options.Version}'" : string.Empty)}" +
-                $"{(targetChannel != null ? $" on channel '{targetChannel.Name}'" : string.Empty)}" +
-                $"{(_options.Build != null ? $" from build '{_options.Build}'" : string.Empty)}" +
-                $" in the last {_options.MaxAgeInDays} days";
+            var queryDescription = new StringBuilder($"name '{_options.Name}'");
+
+            if (!string.IsNullOrEmpty(_options.Version))
+            {
+                queryDescription.Append($" and version '{_options.Version}'");
+            }
+
+            if (targetChannel != null)
+            {
+                queryDescription.Append($" on channel '{targetChannel.Name}'");
+            }
+
+            if (_options.Build != null)
+            {
+                queryDescription.Append($" from build '{_options.Build}'");
+            }
+
+            queryDescription.Append($" in the last {_options.MaxAgeInDays} days");
 
             // Only print the lookup string if the output type is text.
             if (_options.OutputFormat == DarcOutputType.text)
             {
-                Console.WriteLine($"Looking up assets with {queryDescriptionString}");
+                Console.WriteLine($"Looking up assets with {queryDescription}");
             }
 
             // Walk the assets and look up the corresponding builds, potentially filtering based on channel
@@ -91,7 +104,7 @@ internal class GetAssetOperation : Operation
 
             if (!matchingAssetsAfterDate.Any())
             {
-                Console.WriteLine($"No assets found with {queryDescriptionString}");
+                Console.WriteLine($"No assets found with {queryDescription}");
                 int remaining = matchingAssets.Count - checkedAssets;
                 if (remaining > 0)
                 {

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetAssetOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetAssetOperation.cs
@@ -46,11 +46,14 @@ internal class GetAssetOperation : Operation
 
             // Starting with the remote, get information on the asset name + version
             List<Asset> matchingAssets =
-                (await remote.GetAssetsAsync(name: _options.Name, version: _options.Version)).ToList();
+                (await remote.GetAssetsAsync(name: _options.Name, version: _options.Version, buildId: _options.Build)).ToList();
 
             string queryDescriptionString =
-                $"name '{_options.Name}'{(!string.IsNullOrEmpty(_options.Version) ? $" and version '{_options.Version}'" : "")}" +
-                $"{(targetChannel != null ? $" on channel '{targetChannel.Name}'" : "")} in the last {_options.MaxAgeInDays} days";
+                $"name '{_options.Name}'" +
+                $"{(!string.IsNullOrEmpty(_options.Version) ? $" and version '{_options.Version}'" : string.Empty)}" +
+                $"{(targetChannel != null ? $" on channel '{targetChannel.Name}'" : string.Empty)}" +
+                $"{(_options.Build != null ? $" from build '{_options.Build}'" : string.Empty)}" +
+                $" in the last {_options.MaxAgeInDays} days";
 
             // Only print the lookup string if the output type is text.
             if (_options.OutputFormat == DarcOutputType.text)

--- a/src/Microsoft.DotNet.Darc/Darc/Options/GetAssetCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/GetAssetCommandLineOptions.cs
@@ -3,8 +3,6 @@
 
 using CommandLine;
 using Microsoft.DotNet.Darc.Operations;
-using Microsoft.DotNet.DarcLib;
-using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Darc.Options;
 
@@ -19,6 +17,9 @@ internal class GetAssetCommandLineOptions : CommandLineOptions
 
     [Option("channel", HelpText = "Look up the asset produced from builds applied to this channel.")]
     public string Channel { get; set; }
+
+    [Option("build", HelpText = "If specified, scopes the search to a specific BAR build ID")]
+    public int? Build { get; set; }
 
     [Option("max-age", Default = 30, HelpText = "Show builds with a max age of this many days.")]
     public int MaxAgeInDays { get; set; }

--- a/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
@@ -471,7 +471,11 @@ public interface IRemote
     /// <param name="buildId">ID of build producing the asset</param>
     /// <param name="nonShipping">Only non-shipping</param>
     /// <returns>List of assets.</returns>
-    Task<IEnumerable<Asset>> GetAssetsAsync(string name = null, string version = null, int? buildId = null, bool? nonShipping = null);
+    Task<IEnumerable<Asset>> GetAssetsAsync(
+        string name = null,
+        string version = null,
+        int? buildId = null,
+        bool? nonShipping = null);
 
     /// <summary>
     ///     Update a list of dependencies with asset locations.


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/2600

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements
### Release Note Description
Added the possibility of filtering build assets by BAR build ID in `darc get-asset`