### PR TITLE
Allow specifying release notes in PR descriptions directly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ stages:
         vmImage: windows-latest
       steps:
       - checkout: self
-      - powershell: eng/enforce-issue.ps1 -PullRequestNumber $(System.PullRequest.PullRequestNumber) -RepositoryName dotnet/arcade-services
+      - powershell: eng/enforce-issue.ps1 -PullRequestNumber $(System.PullRequest.PullRequestNumber) -RepositoryName $(Build.Repository.Name)
         displayName: Enforce GitHub issue link presence
 
 - stage: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ stages:
         vmImage: windows-latest
       steps:
       - checkout: self
-      - powershell: eng/enforce-issue.ps1 -PullRequestNumber $(System.PullRequest.PullRequestNumber)
+      - powershell: eng/enforce-issue.ps1 -PullRequestNumber $(System.PullRequest.PullRequestNumber) -RepositoryName arcade-services
         displayName: Enforce GitHub issue link presence
 
 - stage: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ stages:
         vmImage: windows-latest
       steps:
       - checkout: self
-      - powershell: eng/enforce-issue.ps1 -PullRequestNumber $(System.PullRequest.PullRequestNumber) -RepositoryName arcade-services
+      - powershell: eng/enforce-issue.ps1 -PullRequestNumber $(System.PullRequest.PullRequestNumber) -RepositoryName dotnet/arcade-services
         displayName: Enforce GitHub issue link presence
 
 - stage: build

--- a/eng/enforce-issue.ps1
+++ b/eng/enforce-issue.ps1
@@ -11,9 +11,9 @@ function HasReleaseNotes($description) {
 }
 
 $prDetail = Invoke-WebRequest `
-	-UseBasicParsing `
-	-Uri "https://api.github.com/repos/$RepositoryName/pulls/$PullRequestNumber" `
-| ConvertFrom-Json
+		-UseBasicParsing `
+		-Uri "https://api.github.com/repos/$RepositoryName/pulls/$PullRequestNumber" `
+	| ConvertFrom-Json
 
 if ($prDetail.draft) {
 	Write-Host "Draft PR does not have to have GitHub issue specified. Check passed."
@@ -28,16 +28,17 @@ elseif ($prDetail.title -match "\[automated\]") {
 	exit 0
 }
 
-if (HasReleaseNotes $prDetail.body) {
-	Write-Host "PR has release notes in the description. Check passed."
-	exit 0
-}
-
 $hasIssue = $prDetail.body -Match "github\.com/dotnet/(.+)/issues/(\d+)"
 if (-not $hasIssue) {
 	Write-Host "##vso[task.LogIssue type=error;]Link to the corresponding GitHub issue is missing in the PR description. Check failed."
 	exit 1
 }
+
+if (HasReleaseNotes $prDetail.body) {
+	Write-Host "PR has release notes in the description. Check passed."
+	exit 0
+}
+
 
 try {
 	$issueDetail = Invoke-WebRequest `


### PR DESCRIPTION
Associated GitHub issue is still required in the description, just the release notes can be in the PR.

### Release Note Category
- [ ] Feature changes/additions
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements
### Release Note Description
Allow specifying release notes in PR description directly

Resolves https://github.com/dotnet/arcade-services/issues/2727

