### PR TITLE
Bump LibGit2Sharp to 0.27.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="FluentAssertions.Json" Version="5.5.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
-    <PackageVersion Include="LibGit2Sharp" Version="0.27.0-preview-0175" />
+    <PackageVersion Include="LibGit2Sharp" Version="0.27.2" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
     <PackageVersion Include="Microsoft.AspNetCore.ApiPagination" Version="$(MicrosoftAspNetCoreApiPaginationVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.ApiVersioning" Version="$(MicrosoftAspNetCoreApiVersioningVersion)" />


### PR DESCRIPTION
This version doesn't depend on libopenssl1.1 which is not part of new Linux distros (e.g. Ubuntu 22.04). This makes it possible to run darc in many new versions of distributions which we actually need.

- https://github.com/libgit2/libgit2sharp/pull/1714#issuecomment-533828707

### Release Note Category
- [ ] Feature changes/additions
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements ### Release Note Description
Updated LibGit2Sharp to `0.27.2`

https://github.com/dotnet/source-build/issues/1868
