### PR TITLE
Split patches into smaller when over 1GB

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/FileSystem.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/FileSystem.cs
@@ -25,6 +25,8 @@ public class FileSystem : IFileSystem
 
     public string[] GetFiles(string path) => Directory.GetFiles(path);
 
+    public string[] GetDirectories(string path) => Directory.GetDirectories(path);
+
     public string? GetFileName(string? path) => Path.GetFileName(path);
 
     public string PathCombine(string path1, string path2) => Path.Combine(path1, path2);

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IFileSystem.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IFileSystem.cs
@@ -23,6 +23,8 @@ public interface IFileSystem
 
     string[] GetFiles(string path);
 
+    public string[] GetDirectories(string path);
+
     string? GetFileName(string? path);
 
     string? GetDirectoryName(string? path);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -90,7 +90,8 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
             throw new EmptySyncException($"Repository {mapping.Name} already exists");
         }
 
-        var workBranch = CreateWorkBranch($"init/{mapping.Name}{(targetRevision != null ? $"/{targetRevision}" : string.Empty)}");
+        // var workBranch = CreateWorkBranch($"init/{mapping.Name}{(targetRevision != null ? $"/{targetRevision}" : string.Empty)}"); TODO
+        var workBranch = CreateWorkBranch($"init/{mapping.Name}{(targetRevision != null ? $"/{Guid.NewGuid()}" : string.Empty)}");
 
         var rootUpdate = new VmrDependencyUpdate(
             mapping,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -90,8 +90,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
             throw new EmptySyncException($"Repository {mapping.Name} already exists");
         }
 
-        // var workBranch = CreateWorkBranch($"init/{mapping.Name}{(targetRevision != null ? $"/{targetRevision}" : string.Empty)}"); TODO
-        var workBranch = CreateWorkBranch($"init/{mapping.Name}{(targetRevision != null ? $"/{Guid.NewGuid()}" : string.Empty)}");
+        var workBranch = CreateWorkBranch($"init/{mapping.Name}{(targetRevision != null ? $"/{targetRevision}" : string.Empty)}");
 
         var rootUpdate = new VmrDependencyUpdate(
             mapping,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -414,7 +414,7 @@ public class VmrPatchHandler : IVmrPatchHandler
                 sha2,
                 ".",
                 filters,
-                relativePatch,
+                true,
                 workingDir / dirName,
                 applicationPath == null ? new UnixPath(dirName) : applicationPath / dirName,
                 cancellationToken));
@@ -433,7 +433,7 @@ public class VmrPatchHandler : IVmrPatchHandler
                 fileName,
                 // Ignore all files except the one we're currently processing
                 filters?.Except(new[] { ":(glob,attr:!vmr-ignore)**/*" }).ToArray(),
-                relativePatch,
+                true,
                 workingDir,
                 applicationPath,
                 cancellationToken));

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -23,6 +23,9 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 /// </summary>
 public class VmrPatchHandler : IVmrPatchHandler
 {
+    // New git versions have a limit on the size of a patch file that can be applied (1GB)
+    private const uint MaxPatchSize = 1_000_000_000;
+
     /// <summary>
     /// Matches output of `git apply --numstat` which lists files contained in a patch file.
     /// Example output:
@@ -103,10 +106,6 @@ public class VmrPatchHandler : IVmrPatchHandler
         }
 
         var patchName = destDir / $"{mapping.Name}-{Commit.GetShortSha(sha1)}-{Commit.GetShortSha(sha2)}.patch";
-        var patches = new List<VmrIngestionPatch>
-        {
-            new(patchName, VmrInfo.RelativeSourcesDir / relativePath)
-        };
 
         List<SubmoduleChange> submoduleChanges = GetSubmoduleChanges(repoPath, sha1, sha2);
 
@@ -124,52 +123,27 @@ public class VmrPatchHandler : IVmrPatchHandler
             };
         }
 
-        var args = new List<string>
-        {
-            "diff",
-            "--patch",
-            "--binary", // Include binary contents as base64
-            "--output", // Store the diff in a .patch file
-            patchName,
-            $"{sha1}..{sha2}",
-            "--",
-        };
-
-        args.AddRange(mapping.Include.Select(p => $":(glob,attr:!{VmrInfo.IgnoreAttribute}){p}"));
-        args.AddRange(mapping.Exclude.Select(p => $":(exclude,glob,attr:!{VmrInfo.KeepAttribute}){p}"));
+        var filters = new List<string>();
+        filters.AddRange(mapping.Include.Select(p => $":(glob,attr:!{VmrInfo.IgnoreAttribute}){p}"));
+        filters.AddRange(mapping.Exclude.Select(p => $":(exclude,glob,attr:!{VmrInfo.KeepAttribute}){p}"));
 
         // Ignore submodules in the diff, they will be inlined via their own diffs
         if (submoduleChanges.Any())
         {
-            args.AddRange(submoduleChanges.Select(c => $":(exclude){c.Path}").Distinct());
+            filters.AddRange(submoduleChanges.Select(c => $":(exclude){c.Path}").Distinct());
         }
 
-        // Other git commands are executed from whichever folder and use `-C [path to repo]` 
-        // However, here we must execute in repo's dir because attribute filters work against the working tree
-        // We also need to do call this from the repo root and not from repo/.git
-        var result = await _processManager.ExecuteGit(
-            repoPath,
-            args,
-            cancellationToken: cancellationToken);
-
-        result.ThrowIfFailed($"Failed to create an initial diff for {mapping.Name}");
-
-        _logger.LogDebug("{output}", result.ToString());
-
-        var countArgs = new[]
-        {
-            "rev-list",
-            "--count",
-            $"{sha1}..{sha2}",
-        };
-
-        var distance = (await _processManager.ExecuteGit(repoPath, countArgs, cancellationToken)).StandardOutput.Trim();
-
-        _logger.LogInformation("Diff created at {path} - {distance} commit{s}, {size}",
+        var patches = new List<VmrIngestionPatch>();
+        patches.AddRange(await CreatePatchesSafely(
             patchName,
-            distance == "0" ? "?" : distance,
-            distance == "1" ? string.Empty : "s",
-            StringUtils.GetHumanReadableFileSize(patchName));
+            sha1,
+            sha2,
+            path: null,
+            filters,
+            relativePatch: false,
+            repoPath,
+            VmrInfo.RelativeSourcesDir / relativePath,
+            cancellationToken));
 
         // If current mapping hosts VMR's non-src/ content, synchronize it too
         // We only do it when processing the root mapping, not its submodules
@@ -206,26 +180,16 @@ public class VmrPatchHandler : IVmrPatchHandler
                 continue;
             }
 
-            args = new List<string>
-            {
-                "diff",
-                "--patch",
-                "--relative", // Relative paths so that we can apply the patch on VMR's root dir
-                "--binary", // Include binary contents as base64
-                "--output", // Store the diff in a .patch file
+            patches.AddRange(await CreatePatchesSafely(
                 patchName,
-                $"{sha1}..{sha2}",
-                "--",
+                sha1,
+                sha2,
                 path, // Apply for a given file or directory (we will call this from the content dir)
-            };
-
-            result = await _processManager.Execute(
-                _processManager.GitExecutable,
-                args,
-                workingDir: contentDir,
-                cancellationToken: cancellationToken);
-
-            patches.Add(new VmrIngestionPatch(patchName, destination));
+                filters: null,
+                relativePatch: true, // Relative paths so that we can apply the patch on VMR's root dir
+                contentDir,
+                destination != null ? new UnixPath(destination) : null,
+                cancellationToken));
         }
 
         if (!submoduleChanges.Any())
@@ -361,6 +325,127 @@ public class VmrPatchHandler : IVmrPatchHandler
         }
 
         return files;
+    }
+
+    /// <summary>
+    /// Creates patches and if any is > 1GB, splits it into smaller ones.
+    /// </summary>
+    private async Task<List<VmrIngestionPatch>> CreatePatchesSafely(
+        string patchName,
+        string sha1,
+        string sha2,
+        string? path,
+        IReadOnlyCollection<string>? filters,
+        bool relativePatch,
+        LocalPath workingDir,
+        UnixPath? applicationPath,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogError($"Starting patches for {workingDir}\\{path}"); // TODO: Remove
+
+        var args = new List<string>
+        {
+            "diff",
+            "--patch",
+            "--binary", // Include binary contents as base64
+            "--output", // Store the diff in a .patch file
+            patchName,
+        };
+
+        if (relativePatch)
+        {
+            args.Add("--relative");
+        }
+
+        args.Add($"{sha1}..{sha2}");
+        args.Add("--");
+
+        if (path != null)
+        {
+            args.Add(path);
+        }
+
+        if (filters?.Count > 0)
+        {
+            args.AddRange(filters);
+        }
+
+        // TODO: Remove if
+        if (patchName != "D:\\tmp\\llvm-project-4b825dc-0dc0f72.patch")
+        {
+            var result = await _processManager.Execute(
+                _processManager.GitExecutable,
+                args,
+                workingDir: workingDir,
+                cancellationToken: cancellationToken);
+
+            result.ThrowIfFailed($"Failed to create a patch {patchName}");
+        }
+
+        var patches = new List<VmrIngestionPatch>();
+
+        if (_fileSystem.GetFileInfo(patchName).Length < MaxPatchSize)
+        {
+            patches.Add(new VmrIngestionPatch(patchName, applicationPath?.Path));
+            return patches;
+        }
+
+        _logger.LogWarning("Patch {name} targeting {path} is too large (>1GB). Repo will be split into smaller patches." +
+            "Please note that there might be mismatches in non-global cloaking rules.", patchName, applicationPath);
+
+        // If the patch is more than 1GB, new must start over and break it down into smaller patches
+        var files = _fileSystem.GetFiles(workingDir);
+        var directories = _fileSystem.GetDirectories(workingDir);
+
+        if (files.Length == 1 && directories.Length == 0)
+        {
+            throw new Exception($"File {files[0]} is too big to be ingested into VMR - git has a patch size limit of 1GB. " +
+                "Please add the file into the VMR manually.");
+        }
+
+        // Add a patch for each directory
+        for (var i = 0; i < directories.Length; i++)
+        {
+            var dirName = directories[i].Substring(workingDir.Length + 1);
+            if (Path.GetFileName(dirName) == ".git")
+            {
+                continue;
+            }
+
+            var newPatchname = $"{patchName}.{i + 1}";
+
+            patches.AddRange(await CreatePatchesSafely(
+                newPatchname,
+                sha1,
+                sha2,
+                ".",
+                filters,
+                relativePatch,
+                workingDir / dirName,
+                applicationPath == null ? new UnixPath(dirName) : applicationPath / dirName,
+                cancellationToken));
+        }
+
+        // Add a patch for each file
+        for (var i = 0; i < files.Length; i++)
+        {
+            var fileName = files[i].Substring(workingDir.Length + 1);
+            var newPatchname = $"{patchName}.{i + directories.Length + 1}";
+
+            patches.AddRange(await CreatePatchesSafely(
+                newPatchname,
+                sha1,
+                sha2,
+                fileName,
+                // Ignore all files except the one we're currently processing
+                filters?.Except(new[] { ":(glob,attr:!vmr-ignore)**/*" }).ToArray(),
+                relativePatch,
+                workingDir,
+                applicationPath,
+                cancellationToken));
+        }
+
+        return patches;
     }
 
     /// <summary>

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -341,8 +341,6 @@ public class VmrPatchHandler : IVmrPatchHandler
         UnixPath? applicationPath,
         CancellationToken cancellationToken)
     {
-        _logger.LogError($"Starting patches for {workingDir}\\{path}"); // TODO: Remove
-
         var args = new List<string>
         {
             "diff",
@@ -370,17 +368,13 @@ public class VmrPatchHandler : IVmrPatchHandler
             args.AddRange(filters);
         }
 
-        // TODO: Remove if
-        if (patchName != "D:\\tmp\\llvm-project-4b825dc-0dc0f72.patch")
-        {
-            var result = await _processManager.Execute(
-                _processManager.GitExecutable,
-                args,
-                workingDir: workingDir,
-                cancellationToken: cancellationToken);
+        var result = await _processManager.Execute(
+            _processManager.GitExecutable,
+            args,
+            workingDir: workingDir,
+            cancellationToken: cancellationToken);
 
-            result.ThrowIfFailed($"Failed to create a patch {patchName}");
-        }
+        result.ThrowIfFailed($"Failed to create a patch {patchName}");
 
         var patches = new List<VmrIngestionPatch>();
 

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -26,6 +26,7 @@ public class VmrPatchHandlerTests
     private const string SubmoduleSha2 = "bd5b76f98468017131aabe68f47d758f08b1c5ab";
 
     private static readonly UnixPath SRC = new("src");
+    private static readonly UnixPath RepoVmrPath = SRC / IndividualRepoName;
 
     private readonly GitSubmoduleInfo _submoduleInfo = new(
         "external-1",
@@ -137,7 +138,7 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesTest()
     {
         // Setup
-        var patch = new VmrIngestionPatch($"{_patchDir}/test-repo.patch", SRC / IndividualRepoName);
+        var patch = new VmrIngestionPatch($"{_patchDir}/test-repo.patch", RepoVmrPath);
         _fileSystem.SetReturnsDefault(Mock.Of<IFileInfo>(x => x.Exists == true && x.Length == 1243));
 
         // Act
@@ -150,14 +151,14 @@ public class VmrPatchHandlerTests
             "--cached",
             "--ignore-space-change",
             "--directory",
-            SRC / IndividualRepoName,
+            RepoVmrPath,
             patch.Path,
         });
         
         VerifyGitCall(new string[]
         {
             "checkout",
-            SRC / IndividualRepoName,
+            RepoVmrPath,
         });
     }
 
@@ -192,7 +193,7 @@ public class VmrPatchHandlerTests
         _dependencyTracker.Verify(x => x.UpdateSubmodules(new List<SubmoduleRecord>()));
 
         patches.Should().ContainSingle();
-        patches.Single().Should().Be(new VmrIngestionPatch(expectedPatchName, SRC / IndividualRepoName));
+        patches.Single().Should().Be(new VmrIngestionPatch(expectedPatchName, RepoVmrPath));
     }
 
     [Test]
@@ -298,7 +299,7 @@ public class VmrPatchHandlerTests
         _dependencyTracker.Verify(x => x.UpdateSubmodules(new List<SubmoduleRecord>()));
 
         patches.Should().Equal(
-            new VmrIngestionPatch(expectedPatchName1, SRC / IndividualRepoName),
+            new VmrIngestionPatch(expectedPatchName1, RepoVmrPath),
             new VmrIngestionPatch(expectedPatchName2, (string?)null),
             new VmrIngestionPatch(expectedPatchName3, "eng/common"));
     }
@@ -343,7 +344,7 @@ public class VmrPatchHandlerTests
             .Verify(x => x.PrepareClone(_submoduleInfo.Url, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
 
         patches.Should().ContainSingle();
-        patches.Single().Should().Be(new VmrIngestionPatch(expectedPatchName, SRC / IndividualRepoName));
+        patches.Single().Should().Be(new VmrIngestionPatch(expectedPatchName, RepoVmrPath));
 
         _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(1));
 
@@ -427,8 +428,8 @@ public class VmrPatchHandlerTests
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
-            new VmrIngestionPatch(expectedPatchName, SRC / IndividualRepoName),
-            new VmrIngestionPatch(expectedSubmodulePatchName, SRC / IndividualRepoName / _submoduleInfo.Path),
+            new VmrIngestionPatch(expectedPatchName, RepoVmrPath),
+            new VmrIngestionPatch(expectedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path),
         });
     }
 
@@ -544,9 +545,9 @@ public class VmrPatchHandlerTests
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
-            new VmrIngestionPatch(expectedPatchName, SRC / IndividualRepoName),
-            new VmrIngestionPatch(expectedSubmodulePatchName, SRC / IndividualRepoName / _submoduleInfo.Path),
-            new VmrIngestionPatch(expectedNestedSubmodulePatchName, SRC / IndividualRepoName / _submoduleInfo.Path / nestedSubmoduleInfo.Path),
+            new VmrIngestionPatch(expectedPatchName, RepoVmrPath),
+            new VmrIngestionPatch(expectedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path),
+            new VmrIngestionPatch(expectedNestedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path / nestedSubmoduleInfo.Path),
         });
     }
 
@@ -622,8 +623,8 @@ public class VmrPatchHandlerTests
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
-            new VmrIngestionPatch(expectedPatchName, SRC / IndividualRepoName),
-            new VmrIngestionPatch(expectedSubmodulePatchName, SRC / IndividualRepoName / _submoduleInfo.Path),
+            new VmrIngestionPatch(expectedPatchName, RepoVmrPath),
+            new VmrIngestionPatch(expectedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path),
         });
     }
 
@@ -698,8 +699,8 @@ public class VmrPatchHandlerTests
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
-            new VmrIngestionPatch(expectedPatchName, SRC / IndividualRepoName),
-            new VmrIngestionPatch(expectedSubmodulePatchName, SRC / IndividualRepoName / _submoduleInfo.Path),
+            new VmrIngestionPatch(expectedPatchName, RepoVmrPath),
+            new VmrIngestionPatch(expectedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path),
         });
     }
 
@@ -797,9 +798,9 @@ public class VmrPatchHandlerTests
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
-            new VmrIngestionPatch(expectedPatchName, SRC / IndividualRepoName),
-            new VmrIngestionPatch(expectedSubmodulePatchName1, SRC / IndividualRepoName / _submoduleInfo.Path),
-            new VmrIngestionPatch(expectedSubmodulePatchName2, SRC / IndividualRepoName / _submoduleInfo.Path),
+            new VmrIngestionPatch(expectedPatchName, RepoVmrPath),
+            new VmrIngestionPatch(expectedSubmodulePatchName1, RepoVmrPath / _submoduleInfo.Path),
+            new VmrIngestionPatch(expectedSubmodulePatchName2, RepoVmrPath / _submoduleInfo.Path),
         });
     }
 
@@ -824,7 +825,7 @@ public class VmrPatchHandlerTests
             _fileSystem.Object,
             new NullLogger<VmrPatchHandler>());
 
-        var patch = new VmrIngestionPatch($"{_patchDir}/test-repo.patch", SRC / IndividualRepoName);
+        var patch = new VmrIngestionPatch($"{_patchDir}/test-repo.patch", RepoVmrPath);
         _fileSystem.SetReturnsDefault(Mock.Of<IFileInfo>(x => x.Exists == true && x.Length == 1243));
 
         // Act
@@ -837,7 +838,7 @@ public class VmrPatchHandlerTests
             "--cached",
             "--ignore-space-change",
             "--directory",
-            SRC / IndividualRepoName,
+            RepoVmrPath,
             patch.Path,
         },
         _vmrPath + "/");
@@ -845,7 +846,7 @@ public class VmrPatchHandlerTests
         VerifyGitCall(new string[]
         {
             "checkout",
-            SRC / IndividualRepoName,
+            RepoVmrPath,
         },
         _vmrPath + "/");
     }
@@ -927,9 +928,9 @@ public class VmrPatchHandlerTests
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
-            new VmrIngestionPatch(expectedPatchName + ".2", SRC / IndividualRepoName),
-            new VmrIngestionPatch(expectedPatchName + ".1.1", SRC / IndividualRepoName / "large-dir-1/large-dir-2"),
-            new VmrIngestionPatch(expectedPatchName + ".1.2", SRC / IndividualRepoName / "large-dir-1/small-dir"),
+            new VmrIngestionPatch(expectedPatchName + ".2", RepoVmrPath),
+            new VmrIngestionPatch(expectedPatchName + ".1.1", RepoVmrPath / "large-dir-1" / "large-dir-2"),
+            new VmrIngestionPatch(expectedPatchName + ".1.2", RepoVmrPath / "large-dir-1" / "small-dir"),
         });
     }
 

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -107,6 +107,7 @@ public class VmrPatchHandlerTests
         }));
 
         _fileSystem.Reset();
+        _fileSystem.SetReturnsDefault(Mock.Of<IFileInfo>(x => x.Exists && x.Length == 895));
         _fileSystem
             .SetupGet(x => x.DirectorySeparatorChar)
             .Returns('/');
@@ -178,9 +179,10 @@ public class VmrPatchHandlerTests
 
         // Verify
         _processManager
-            .Verify(x => x.ExecuteGit(
-                _clonePath,
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                _clonePath,
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -241,9 +243,10 @@ public class VmrPatchHandlerTests
 
         // Verify
         _processManager
-            .Verify(x => x.ExecuteGit(
-                _clonePath,
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                _clonePath,
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -251,18 +254,17 @@ public class VmrPatchHandlerTests
         {
             "diff",
             "--patch",
-            "--relative",
             "--binary",
             "--output",
             expectedPatchName2,
+            "--relative",
             $"{Sha1}..{Sha2}",
             "--",
             "."
         };
 
         _processManager
-            .Verify(x => x.Execute(
-                "git",
+            .Verify(x => x.Execute("git",
                 expectedArgs,
                 It.IsAny<TimeSpan?>(),
                 $"{_clonePath}/SourceBuild/tarball/content",
@@ -273,18 +275,17 @@ public class VmrPatchHandlerTests
         {
             "diff",
             "--patch",
-            "--relative",
             "--binary",
             "--output",
             expectedPatchName3,
+            "--relative",
             $"{Sha1}..{Sha2}",
             "--",
             "."
         };
 
         _processManager
-            .Verify(x => x.Execute(
-                "git",
+            .Verify(x => x.Execute("git",
                 expectedArgs,
                 It.IsAny<TimeSpan?>(),
                 $"{_clonePath}/eng/common",
@@ -329,9 +330,10 @@ public class VmrPatchHandlerTests
 
         // Verify
         _processManager
-            .Verify(x => x.ExecuteGit(
-                _clonePath,
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                _clonePath,
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -382,9 +384,10 @@ public class VmrPatchHandlerTests
             expectedPatchName, Sha1, Sha2, new[] { _submoduleInfo.Path });
 
         _processManager
-            .Verify(x => x.ExecuteGit(
-                _clonePath,
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                _clonePath,
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -396,9 +399,10 @@ public class VmrPatchHandlerTests
             .Append(":(exclude,glob,attr:!vmr-preserve)LICENSE.md");
 
         _processManager
-            .Verify(x => x.ExecuteGit(
-                "/tmp/external-1",
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                "/tmp/external-1",
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -470,9 +474,10 @@ public class VmrPatchHandlerTests
             expectedPatchName, Sha1, Sha2, new[] { _submoduleInfo.Path });
 
         _processManager
-            .Verify(x => x.ExecuteGit(
-                _clonePath,
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                _clonePath,
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -485,9 +490,10 @@ public class VmrPatchHandlerTests
             .Append(":(exclude)external-2");
 
         _processManager
-            .Verify(x => x.ExecuteGit(
-                "/tmp/external-1",
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                "/tmp/external-1",
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -501,9 +507,10 @@ public class VmrPatchHandlerTests
             .Append(":(glob,attr:!vmr-ignore)**/*");
 
         _processManager
-            .Verify(x => x.ExecuteGit(
-                "/tmp/external-2",
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                "/tmp/external-2",
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -572,9 +579,10 @@ public class VmrPatchHandlerTests
             expectedPatchName, Sha1, Sha2, new[] { _submoduleInfo.Path });
 
         _processManager
-            .Verify(x => x.ExecuteGit(
-                _clonePath,
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                _clonePath,
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -586,9 +594,10 @@ public class VmrPatchHandlerTests
             .Append(":(exclude,glob,attr:!vmr-preserve)LICENSE.md");
 
         _processManager
-            .Verify(x => x.ExecuteGit(
-                "/tmp/external-1",
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                "/tmp/external-1",
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -646,9 +655,10 @@ public class VmrPatchHandlerTests
             expectedPatchName, Sha1, Sha2, new[] { _submoduleInfo.Path });
 
         _processManager
-            .Verify(x => x.ExecuteGit(
-                _clonePath,
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                _clonePath,
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -660,9 +670,10 @@ public class VmrPatchHandlerTests
             .Append(":(exclude,glob,attr:!vmr-preserve)LICENSE.md");
 
         _processManager
-            .Verify(x => x.ExecuteGit(
-                "/tmp/external-1",
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                "/tmp/external-1",
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -721,9 +732,10 @@ public class VmrPatchHandlerTests
             expectedPatchName, Sha1, Sha2, new[] { _submoduleInfo.Path });
 
         _processManager
-            .Verify(x => x.ExecuteGit(
-                _clonePath,
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                _clonePath,
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -735,9 +747,10 @@ public class VmrPatchHandlerTests
             .Append(":(exclude,glob,attr:!vmr-preserve)LICENSE.md");
 
         _processManager
-            .Verify(x => x.ExecuteGit(
-                "/tmp/external-1",
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                "/tmp/external-1",
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -748,9 +761,10 @@ public class VmrPatchHandlerTests
             .Append(":(exclude,glob,attr:!vmr-preserve)LICENSE.md");
 
         _processManager
-            .Verify(x => x.ExecuteGit(
-                "/tmp/external-2",
+            .Verify(x => x.Execute("git",
                 expectedArgs,
+                It.IsAny<TimeSpan?>(),
+                "/tmp/external-2",
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
@@ -832,13 +846,6 @@ public class VmrPatchHandlerTests
             $"src/{IndividualRepoName}",
         },
         _vmrPath + "/");
-    }
-
-    private void SetupGitCall(string[] expectedArguments, ProcessExecutionResult result, string repoDir)
-    {
-        _processManager
-            .Setup(x => x.ExecuteGit(repoDir, expectedArguments, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(result);
     }
 
     private void VerifyGitCall(IEnumerable<string> expectedArguments, Times? times = null) => VerifyGitCall(expectedArguments, _vmrPath.Path, times);

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -942,9 +942,9 @@ public class VmrPatchHandlerTests
             .Setup(x => x.GetFileInfo(expectedPatchName))
             .Returns(Mock.Of<IFileInfo>(x => x.Length == 1_500_000_000));
 
-        // Patch for large-dir-1
+        // Patch for big-file
         _fileSystem
-            .Setup(x => x.GetFileInfo(_clonePath / "big-file"))
+            .Setup(x => x.GetFileInfo(expectedPatchName + ".2"))
             .Returns(Mock.Of<IFileInfo>(x => x.Length == 1_500_000_000));
 
         _fileSystem
@@ -953,7 +953,7 @@ public class VmrPatchHandlerTests
 
         _fileSystem
             .Setup(x => x.GetFiles(_clonePath))
-            .Returns(new string[] { _clonePath / "big-file" });
+            .Returns(new string[] { _clonePath / "small-file", _clonePath / "big-file" });
 
         // Act
         var action = async () => await _patchHandler.CreatePatches(
@@ -966,7 +966,7 @@ public class VmrPatchHandlerTests
             CancellationToken.None);
 
         // Verify
-        await action.Should().ThrowAsync<Exception>().WithMessage($"File {_clonePath / "big-file"} is too big to be ingested into VMR*");
+        await action.Should().ThrowAsync<Exception>().WithMessage($"File {_clonePath / "big-file"} is too big (>1GB) to be ingested into VMR*");
     }
 
     private void VerifyGitCall(IEnumerable<string> expectedArguments, Times? times = null) => VerifyGitCall(expectedArguments, _vmrPath.Path, times);


### PR DESCRIPTION
Recursively splits patches larger than 1GB and creates patches for their child folders

Resolves https://github.com/dotnet/arcade-services/issues/2710

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements
### Release Note Description
Add support for VMR synchronization of repos >1GB
