### PR TITLE
Disallow duplicate assets when merging manifests

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -549,7 +549,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
             }
 
             // Error out for any duplicated packages based on the top level properties of the package.
-            var distinctPackages = manifest.Packages.Distinct(new PackageIdComparer());
+            var distinctPackages = manifest.Packages.DistinctBy(p => p.Id);
             if (distinctPackages.Count() < manifest.Packages.Count())
             {
                 var dupes = manifest.Packages.GroupBy(x => new { x.Id, x.Version })
@@ -567,7 +567,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
             }
 
             // Error out for any duplicated blob based on the top level properties of the blob.
-            var distinctBlobs = manifest.Blobs.Distinct(new BlobIdComparer());
+            var distinctBlobs = manifest.Blobs.DistinctBy(b => b.Id);
             if (distinctBlobs.Count() < manifest.Blobs.Count())
             {
                 var dupes = manifest.Blobs.GroupBy(x => new { x.Id })
@@ -812,23 +812,5 @@ namespace Microsoft.DotNet.Maestro.Tasks
             Log.LogMessage(MessageImportance.High,
                         $"##vso[artifact.upload containerfolder=BlobArtifacts;artifactname=BlobArtifacts]{mergedManifestPath}");
         }
-    }
-
-    /// <summary>
-    /// Comparer used to Distinct packages.
-    /// </summary>
-    class PackageIdComparer : IEqualityComparer<Package>
-    {
-        public bool Equals(Package x, Package y) => x.Id.Equals(y.Id, StringComparison.OrdinalIgnoreCase);
-        public int GetHashCode(Package obj) => obj.Id.GetHashCode();
-    }
-
-    /// <summary>
-    /// Comparer used to Distinct blobs.
-    /// </summary>
-    class BlobIdComparer : IEqualityComparer<Blob>
-    {
-        public bool Equals(Blob x, Blob y) => x.Id.Equals(y.Id, StringComparison.OrdinalIgnoreCase);
-        public int GetHashCode(Blob obj) => throw new NotImplementedException();
     }
 }

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -549,7 +549,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
             }
 
             // Error out for any duplicated packages based on the top level properties of the package.
-            var distinctPackages = manifest.Packages.Distinct();
+            var distinctPackages = manifest.Packages.Distinct(new PackageIdComparer());
             if (distinctPackages.Count() < manifest.Packages.Count())
             {
                 var dupes = manifest.Packages.GroupBy(x => new { x.Id, x.Version })
@@ -567,7 +567,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
             }
 
             // Error out for any duplicated blob based on the top level properties of the blob.
-            var distinctBlobs = manifest.Blobs.Distinct();
+            var distinctBlobs = manifest.Blobs.Distinct(new BlobIdComparer());
             if (distinctBlobs.Count() < manifest.Blobs.Count())
             {
                 var dupes = manifest.Blobs.GroupBy(x => new { x.Id })
@@ -812,5 +812,23 @@ namespace Microsoft.DotNet.Maestro.Tasks
             Log.LogMessage(MessageImportance.High,
                         $"##vso[artifact.upload containerfolder=BlobArtifacts;artifactname=BlobArtifacts]{mergedManifestPath}");
         }
+    }
+
+    /// <summary>
+    /// Comparer used to Distinct packages.
+    /// </summary>
+    class PackageIdComparer : IEqualityComparer<Package>
+    {
+        public bool Equals(Package x, Package y) => x.Id.Equals(y.Id, StringComparison.OrdinalIgnoreCase);
+        public int GetHashCode([DisallowNull] Package obj) => obj.Id.GetHashCode();
+    }
+
+    /// <summary>
+    /// Comparer used to Distinct blobs.
+    /// </summary>
+    class BlobIdComparer : IEqualityComparer<Blob>
+    {
+        public bool Equals(Blob x, Blob y) => x.Id.Equals(y.Id, StringComparison.OrdinalIgnoreCase);
+        public int GetHashCode([DisallowNull] Blob obj) => throw new NotImplementedException();
     }
 }

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -820,7 +820,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
     class PackageIdComparer : IEqualityComparer<Package>
     {
         public bool Equals(Package x, Package y) => x.Id.Equals(y.Id, StringComparison.OrdinalIgnoreCase);
-        public int GetHashCode([DisallowNull] Package obj) => obj.Id.GetHashCode();
+        public int GetHashCode(Package obj) => obj.Id.GetHashCode();
     }
 
     /// <summary>
@@ -829,6 +829,6 @@ namespace Microsoft.DotNet.Maestro.Tasks
     class BlobIdComparer : IEqualityComparer<Blob>
     {
         public bool Equals(Blob x, Blob y) => x.Id.Equals(y.Id, StringComparison.OrdinalIgnoreCase);
-        public int GetHashCode([DisallowNull] Blob obj) => throw new NotImplementedException();
+        public int GetHashCode(Blob obj) => throw new NotImplementedException();
     }
 }

--- a/test/Microsoft.DotNet.Maestro.Tasks.Tests/MergedManifestTests.cs
+++ b/test/Microsoft.DotNet.Maestro.Tasks.Tests/MergedManifestTests.cs
@@ -27,35 +27,36 @@ internal class MergedManifestTests
         public const string BlobId = "BlobId";
         public const string version = "version";
 
-        Package package1 = new Package()
+        readonly Package package1 = new Package()
         {
             Id = PackageId,
             Version = version,
             NonShipping = true,
         };
 
-        Package package2 = new Package()
+        readonly Package package2 = new Package()
         {
             Id = "123",
             Version = "version1",
             NonShipping = false
         };
 
-        private Blob blob1 = new Blob()
+        readonly Blob blob1 = new Blob()
         {
             Id = BlobId,
             Category = "None",
             NonShipping = true
         };
 
-        private Blob blob2 = new Blob()
+        readonly Blob blob2 = new Blob()
         {
             Id = "1",
             Category = "Other",
             NonShipping = false
         };
 
-        Manifest manifest1 = new Manifest() {
+        Manifest Manifest1() => new Manifest()
+        {
             AzureDevOpsBranch = AzureDevOpsBranch1,
             AzureDevOpsAccount = AzureDevOpsAccount1,
             AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1,
@@ -67,7 +68,8 @@ internal class MergedManifestTests
             Blobs = new List<Blob>()
         };
 
-        Manifest manifest2 = new Manifest() {
+        Manifest Manifest2() => new Manifest()
+        {
             AzureDevOpsAccount = "devdiv",
             AzureDevOpsBranch = "refs/heads/test",
             AzureDevOpsBuildDefinitionId = 9,
@@ -79,7 +81,7 @@ internal class MergedManifestTests
             Blobs = new List<Blob>()
         };
 
-        Manifest manifest3 = new Manifest()
+        Manifest Manifest3() => new Manifest()
         {
             AzureDevOpsBranch = AzureDevOpsBranch1,
             AzureDevOpsAccount = AzureDevOpsAccount1,
@@ -92,7 +94,7 @@ internal class MergedManifestTests
             Blobs = new List<Blob>()
         };
 
-        Manifest manifest4 = new Manifest()
+        Manifest Manifest4() => new Manifest()
         {
             AzureDevOpsBranch = AzureDevOpsBranch1,
             AzureDevOpsAccount = AzureDevOpsAccount1,
@@ -105,7 +107,7 @@ internal class MergedManifestTests
             Blobs = new List<Blob>()
         };
 
-        Manifest manifest = new Manifest()
+        Manifest OutputManifest() => new Manifest()
         {
             AzureDevOpsBranch = AzureDevOpsBranch1,
             AzureDevOpsAccount = AzureDevOpsAccount1,
@@ -121,60 +123,71 @@ internal class MergedManifestTests
         [SetUp]
         public void SetupMergeBuildManifestsTests()
         {
-            pushMetadata = new PushMetadataToBuildAssetRegistry();
+            var buildEngine = new Mocks.MockBuildEngine();
+            pushMetadata = new PushMetadataToBuildAssetRegistry()
+            {
+                BuildEngine = buildEngine,
+            };
         }
 
         [Test]
         public void ErrorWhenManifestDoesNotMatch()
         {
-            List<Manifest> manifests = new List<Manifest>() { manifest1, manifest2 };
+            List<Manifest> manifests = new List<Manifest>() { Manifest1(), Manifest2() };
 
             Action act = () => pushMetadata.MergeManifests(manifests);
             act.Should().Throw<Exception>().WithMessage("Can't merge if one or more manifests have different branch, build number, commit, or repository values.");
-
         }
 
         [Test]
         public void TwoCompatibleManifest()
         {
+            var manifest1 = Manifest1();
+            var manifest3 = Manifest3();
             manifest1.Packages = new List<Package>() { package1 };
             manifest3.Packages = new List<Package>() { package2 };
             manifest1.Blobs = new List<Blob>() { blob1 };
             manifest3.Blobs = new List<Blob>() { blob2 };
 
-            manifest.Packages = new List<Package>() { package1, package2 };
-            manifest.Blobs = new List<Blob>() { blob1, blob2 };
+            var outputManifest = OutputManifest();
+
+            outputManifest.Packages = new List<Package>() { package1, package2 };
+            outputManifest.Blobs = new List<Blob>() { blob1, blob2 };
             List<Manifest> manifests = new List<Manifest>() { manifest1, manifest3 };
             Manifest expectedManifest =  pushMetadata.MergeManifests(manifests);
-            expectedManifest.Should().BeEquivalentTo(manifest);
+            expectedManifest.Should().BeEquivalentTo(outputManifest);
         }
 
         [Test]
         public void ThreeCompatibleBuildData()
         {
+            var manifest1 = Manifest1();
+            var manifest3 = Manifest3();
+            var manifest4 = Manifest4();
 
             manifest1.Packages.Add(package1);
             manifest3.Packages.Add(package2);
             manifest4.Blobs.Add(blob1);
             manifest3.Blobs.Add(blob2);
 
-            manifest.Packages.Add(package1);
-            manifest.Packages.Add(package2);
-            manifest.Blobs.Add(blob1);
-            manifest.Blobs.Add(blob2);
+            var outputManifest = OutputManifest();
+
+            outputManifest.Packages.Add(package1);
+            outputManifest.Packages.Add(package2);
+            outputManifest.Blobs.Add(blob1);
+            outputManifest.Blobs.Add(blob2);
 
             List<Manifest> manifests = new List<Manifest>() { manifest1, manifest3, manifest4 };
             Manifest expectedManifest = pushMetadata.MergeManifests(manifests);
-            expectedManifest.Should().BeEquivalentTo(manifest);
+            expectedManifest.Should().BeEquivalentTo(outputManifest);
         }
 
         [Test]
         public void ManifestWithPartiallyEmptyAssets()
         {
-            List<Manifest> manifests = new List<Manifest>() { manifest1, manifest3 };
+            List<Manifest> manifests = new List<Manifest>() { Manifest1(), Manifest3() };
             Manifest expectedManifest = pushMetadata.MergeManifests(manifests);
-            expectedManifest.Should().BeEquivalentTo(manifest);
-
+            expectedManifest.Should().BeEquivalentTo(OutputManifest());
         }
 
         [TestCase("https://github.com/dotnet/trusted-packages", "trusted/packages")]
@@ -195,23 +208,31 @@ internal class MergedManifestTests
         [Test]
         public void MergingShouldNotAllowDuplicatedPackages()
         {
+            var manifest1 = Manifest1();
+            var manifest3 = Manifest3();
+
             manifest1.Packages = new List<Package>() { package1 };
             manifest3.Packages = new List<Package>() { package1 };
 
             List<Manifest> manifests = new List<Manifest>() { manifest1, manifest3 };
             Action act = () => pushMetadata.MergeManifests(manifests);
             act.Should().Throw<Exception>().WithMessage("Duplicate package entries are not allowed for publishing to BAR, as this can cause race conditions and unexpected behavior");
+            pushMetadata.Log.HasLoggedErrors.Should().BeTrue();
         }
 
         [Test]
         public void MergingShouldNotAllowDuplicatedBlobs()
         {
+            var manifest1 = Manifest1();
+            var manifest3 = Manifest3();
+
             manifest1.Blobs = new List<Blob>() { blob1 };
             manifest3.Blobs = new List<Blob>() { blob1 };
 
             List<Manifest> manifests = new List<Manifest>() { manifest1, manifest3 };
             Action act = () => pushMetadata.MergeManifests(manifests);
             act.Should().Throw<Exception>().WithMessage("Duplicate blob entries are not allowed for publishing to BAR, as this can cause race conditions and unexpected behavior");
+            pushMetadata.Log.HasLoggedErrors.Should().BeTrue();
         }
     }
 }

--- a/test/Microsoft.DotNet.Maestro.Tasks.Tests/Mocks/MockBuildEngine.cs
+++ b/test/Microsoft.DotNet.Maestro.Tasks.Tests/Mocks/MockBuildEngine.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Maestro.Tasks.Tests.Mocks;
+
+public class MockBuildEngine : IBuildEngine
+{
+    public bool ContinueOnError => throw new NotImplementedException();
+
+    public int LineNumberOfTaskNode => 0;
+
+    public int ColumnNumberOfTaskNode => 0;
+
+    public string ProjectFileOfTaskNode => "Fake File";
+
+    public List<CustomBuildEventArgs> CustomBuildEvents = new List<CustomBuildEventArgs>();
+    public List<BuildErrorEventArgs> BuildErrorEvents = new List<BuildErrorEventArgs>();
+    public List<BuildMessageEventArgs> BuildMessageEvents = new List<BuildMessageEventArgs>();
+    public List<BuildWarningEventArgs> BuildWarningEvents = new List<BuildWarningEventArgs>();
+
+    public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void LogCustomEvent(CustomBuildEventArgs e)
+    {
+        CustomBuildEvents.Add(e);
+    }
+
+    public void LogErrorEvent(BuildErrorEventArgs e)
+    {
+        BuildErrorEvents.Add(e);
+    }
+
+    public void LogMessageEvent(BuildMessageEventArgs e)
+    {
+        BuildMessageEvents.Add(e);
+    }
+
+    public void LogWarningEvent(BuildWarningEventArgs e)
+    {
+        BuildWarningEvents.Add(e);
+    }
+}


### PR DESCRIPTION
When merging manifests, we were distincting the assets and erroring if there are dupes. This should have been done using an equality comparer that compares based on Id alone. Fix this, and add appropriate testing.

Resolves: https://github.com/dotnet/arcade-services/issues/2762

<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

