### PR TITLE
Add drop metrics generation switch for investigations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -109,6 +109,7 @@
     <PackageVersion Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageVersion Include="Octokit" Version="0.49.0" />
     <PackageVersion Include="ServiceFabricMocks" Version="$(ServiceFabricMocksVersion)" />
+    <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="System.Drawing.Common" Version="6.0.0" />
     <PackageVersion Include="System.IO.Hashing" Version="7.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />

--- a/src/Microsoft.DotNet.Darc/Darc/Microsoft.DotNet.Darc.csproj
+++ b/src/Microsoft.DotNet.Darc/Darc/Microsoft.DotNet.Darc.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="SharpZipLib" />
     <PackageReference Include="YamlDotNet.Signed" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Darc/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/GatherDropCommandLineOptions.cs
@@ -84,6 +84,12 @@ internal class GatherDropCommandLineOptions : CommandLineOptions
     [Option("asset-filter", HelpText = "Only download assets matching the given regex filter")]
     public string AssetFilter { get; set; }
 
+    [Option("accounting", HelpText = "Generate information in the manifest about the artifact size.")]
+    public bool Accounting { get; set; }
+
+    [Option("delete-after-accounting", HelpText = "Delete an asset after accounting for it.")]
+    public bool DeleteAfterAccounting { get; set; }
+
     public override Operation GetOperation()
     {
         return new GatherDropOperation(this);

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DownloadedAsset.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DownloadedAsset.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using Microsoft.DotNet.Maestro.Client.Models;
 
 namespace Microsoft.DotNet.DarcLib.Models.Darc;
@@ -18,7 +19,7 @@ public class DownloadedAsset
     /// <summary>
     /// Target location where the asset was downloaded to for the release style layout
     /// </summary>
-    public string ReleaseLayoutTargetLocation { get; set; }
+    public string SeparatedLayoutTargetLocation { get; set; }
     /// <summary>
     /// Target location where the asset was downloaded to for the unified-style (sans repo/build #) layout
     /// </summary>
@@ -26,9 +27,17 @@ public class DownloadedAsset
     /// <summary>
     /// True if the asset download was successful. If false, Asset is the only valid property
     /// </summary>
+    public string ReleasePackageLayoutTargetLocation { get; set; }
     public bool Successful { get; set; }
     /// <summary>
     /// Location type of the asset that actually got downloaded.
     /// </summary>
     public LocationType LocationType { get; set; }
+    /// <summary>
+    /// Size of the artifact in bytes
+    /// </summary>
+    public long SizeInBytes { get; set; }
+    public string FileHash { get; set; }
+
+    public List<DownloadedSubAsset> SubAssets { get; set; } = new List<DownloadedSubAsset>();
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DownloadedBuild.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DownloadedBuild.cs
@@ -16,10 +16,6 @@ public class DownloadedBuild
     /// </summary>
     public IEnumerable<DownloadedAsset> ExtraDownloadedAssets { get; set; }
     /// <summary>
-    ///     Root output directory for this build.
-    /// </summary>
-    public string ReleaseLayoutOutputDirectory { get; set; }
-    /// <summary>
     ///     True if the output has any shipping assets.
     /// </summary>
     public bool AnyShippingAssets { get; set; }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DownloadedSubAsset.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DownloadedSubAsset.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.DarcLib.Models.Darc;
+public class DownloadedSubAsset
+{
+    public string RelativePath { get; set; }
+    public string FileHash { get; set; }
+    public long SizeInBytes { get; set; }
+}

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DropSizeReport.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DropSizeReport.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.DarcLib.Models.Darc;
+public class DropSizeReport
+{
+    public long DownloadSize { get; set; }
+    public long SizeOnDisk { get; set; }
+    public long SizeOfDuplicatedFilesBeforeUnpack { get; set; }
+    public long SizeOfDuplicatedFilesAfterUnpack { get; set; }
+    public List<DuplicatedAsset> DuplicatedAssets { get; set; } = new List<DuplicatedAsset>();
+}

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DuplicatedAsset.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DuplicatedAsset.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.DarcLib.Models.Darc;
+public class DuplicatedAsset
+{
+    public long OriginalSize { get; set; }
+    public long TotalSize { get; set; }
+    public int TotalCopies { get; set; } = 0;
+    public List<(string location, string optionalSubAssetPath)> Locations { get; set; } = new List<(string location, string optionalSubAssetPath)>();
+}

--- a/test/Microsoft.DotNet.DarcLib.Tests/Helpers/DarcManifestHelperTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Helpers/DarcManifestHelperTests.cs
@@ -26,11 +26,11 @@ public class DarcManifestHelperTests
         JObject testManifest;
         if (includeExtraAssets)
         {
-            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), GetSomeExtraDownloadedAssets(), FakeOutputPath, false);
+            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), GetSomeExtraDownloadedAssets(), null, FakeOutputPath, false);
         }
         else
         {
-            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), FakeOutputPath, false);
+            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), null, FakeOutputPath, false);
         }
 
         var builds = testManifest["builds"].ToList();
@@ -80,11 +80,11 @@ public class DarcManifestHelperTests
         JObject testManifest;
         if (includeExtraAssets)
         {
-            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), GetSomeExtraDownloadedAssets(), FakeOutputPath, true);
+            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), GetSomeExtraDownloadedAssets(), null, FakeOutputPath, true);
         }
         else
         {
-            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), FakeOutputPath, true);
+            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), null, FakeOutputPath, true);
         }
 
         var builds = testManifest["builds"].ToList();
@@ -176,7 +176,7 @@ public class DarcManifestHelperTests
     public void NoDownloadedBuildsProvided()
     {
         List<DownloadedBuild> downloadedBuilds = new List<DownloadedBuild>();
-        JObject emptyManifest = ManifestHelper.GenerateDarcAssetJsonManifest(downloadedBuilds, FakeOutputPath, false);
+        JObject emptyManifest = ManifestHelper.GenerateDarcAssetJsonManifest(downloadedBuilds, null, FakeOutputPath, false);
         var builds = emptyManifest["builds"].ToList();
         builds.Count.Should().Be(0);
         emptyManifest["outputPath"].Value<string>().Should().Be(FakeOutputPath);
@@ -189,7 +189,7 @@ public class DarcManifestHelperTests
         {
             Asset = new Asset(123, 456, false, "FakeExtraAssetOne", "1.0.0", null),
             LocationType = LocationType.Container,
-            ReleaseLayoutTargetLocation = @"F:\A\KE\Path\FakeExtraAssetOne.blob",
+            SeparatedLayoutTargetLocation = @"F:\A\KE\Path\FakeExtraAssetOne.blob",
             UnifiedLayoutTargetLocation = @"F:\A\K\E\OtherPath\FakeExtraAssetOne.blob",
             SourceLocation = "https://fakeplace.blob.core.windows.net/dotnet/assets/fake-blob-one.zip"
         });
@@ -197,7 +197,7 @@ public class DarcManifestHelperTests
         {
             Asset = new Asset(789, 101, true, "FakeExtraAssetTwo", "1.2.0", null),
             LocationType = LocationType.Container,
-            ReleaseLayoutTargetLocation = @"F:\A\KE\Path\FakeExtraAssetTwo.blob",
+            SeparatedLayoutTargetLocation = @"F:\A\KE\Path\FakeExtraAssetTwo.blob",
             UnifiedLayoutTargetLocation = @"F:\A\K\E\OtherPath\FakeExtraAssetTwo.blob",
             SourceLocation = "https://fakeplace.blob.core.windows.net/dotnet/assets/fake-blob-two.zip"
         });
@@ -218,7 +218,6 @@ public class DarcManifestHelperTests
         {
             var buildToAdd = new DownloadedBuild()
             {
-                ReleaseLayoutOutputDirectory = @"F:\A",
                 AnyShippingAssets = true,
                 Build = new Build(i, DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(i)), i, true, true, "fakehash",
                     ImmutableList<Channel>.Empty.AddRange(channels),
@@ -237,7 +236,7 @@ public class DarcManifestHelperTests
                     {
                         Asset = new Asset(i, i + 10000, i % 2 == 0, $"DownloadedAsset{i}", $"{i}.0.0", ImmutableList<AssetLocation>.Empty),
                         SourceLocation = "https://github.com/dotnet/fakerepository",
-                        ReleaseLayoutTargetLocation = @$"F:\A\K\E\Path\SomeAsset.{i}.zip",
+                        SeparatedLayoutTargetLocation = @$"F:\A\K\E\Path\SomeAsset.{i}.zip",
                         UnifiedLayoutTargetLocation = @$"F:\A\KE\Other\Path\SomeAsset.{i}.zip",
                     }
                 },


### PR DESCRIPTION
Adds a feature switch "--accounting" to gather-drop. This generates a set of info about the file hashes of downloaded assets, as well as files inside zips, nupkgs, and .tar.gz files. This data is used after the download to generate additional info in the manifest about the total drop size, duplicate files found, etc. This is good for investigations but I don't think it will be enabled by default. It increases the size of the manifest by about 100x and increases the download time a bit due to the unpack cost.

Also rename the release target location to "Separated" to avoid confusion with the release nupkg dir.

https://github.com/dotnet/arcade-services/issues/2778