### PR TITLE
Make Maestro.Tasks packable again

### DIFF
--- a/eng/BuildTask.targets
+++ b/eng/BuildTask.targets
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <!-- Build Tasks should not include any dependencies -->
     <SuppressDependenciesWhenPacking Condition="'$(SuppressDependenciesWhenPacking)' == ''">true</SuppressDependenciesWhenPacking>
   </PropertyGroup>

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/Microsoft.DotNet.Maestro.Tasks.csproj
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/Microsoft.DotNet.Maestro.Tasks.csproj
@@ -10,6 +10,7 @@
     <!-- Build Tasks should not include any dependencies -->
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <LangVersion>8.0</LangVersion>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/Microsoft.DotNet.Maestro.Tasks.csproj
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/Microsoft.DotNet.Maestro.Tasks.csproj
@@ -10,7 +10,6 @@
     <!-- Build Tasks should not include any dependencies -->
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <LangVersion>8.0</LangVersion>
-    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The resolution of https://github.com/dotnet/arcade-services/issues/2296 made the Maestro tasks package non-packable. This tasks package should either live in arcade-services or arcade (it has lived both places), but it's heavily tied into arcade infra and also heavily uses DarcLib functionality. It didn't move to dnceng or dnceng-shared, and so should be re-enabled.

Resolved https://github.com/dotnet/arcade-services/issues/2805
