### PR TITLE
Improve rollout checklist, hide rollback by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/rollout-issue.md
+++ b/.github/ISSUE_TEMPLATE/rollout-issue.md
@@ -27,9 +27,9 @@ This issue tracks the `arcade-services` repository rollout. On top of the [Rollo
 - [ ] In case there is a problem with the CI build, notify the [Rollout channel](https://teams.microsoft.com/l/channel/19%3a72e283b51f9e4567ba24a35328562df4%40thread.skype/Rollout?groupId=147df318-61de-4f04-8f7b-ecd328c256bb&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47)
 - [ ] Link the rollout PR to the [Rollout PRs](#rollout-prs) section of this issue
 - [ ] Double-check that the release notes contain all information
-- [ ] Merge the already prepared rollout PR
+- [ ] Merge the already prepared rollout PR (⚠️ **DO NOT SQUASH**)
 - [ ] Link the rollout build to the [Rollout build](#rollout-build) section of this issue
-- [ ] Verify that Maestro opened a production => main PR in `arcade-services` with the rollout merge commit ([example](https://github.com/dotnet/arcade-services/pull/2741)). The commit in question should be empty. Do not merge the PR yet
+- [ ] Verify that Maestro opened a production => main PR in `arcade-services` with the rollout merge commit ([example](https://github.com/dotnet/arcade-services/pull/2741)). There should be no changes in the PR to any files. **Do not merge the PR yet**.
 - [ ] Ensure the build is green and stops at the "Approval" phase
 
 ## Rollout day (Wednesday)
@@ -39,10 +39,12 @@ This issue tracks the `arcade-services` repository rollout. On top of the [Rollo
 - [ ] Keep track of any issues encountered during the rollout either directly in this issue, or in a dedicated issue linked to this issue
 - [ ] Update the rollout stats in the [Stats](#stats) section below. The statistics will be available in Kusto a few minutes after the build was finished
 - [ ] Notify the [Rollout channel](https://teams.microsoft.com/l/channel/19%3a72e283b51f9e4567ba24a35328562df4%40thread.skype/Rollout?groupId=147df318-61de-4f04-8f7b-ecd328c256bb&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47)
-- [ ] Merge the production => main Maestro PR in `arcade-services`
+- [ ] Merge the production => main Maestro PR in `arcade-services` (⚠️ **DO NOT SQUASH**)
 - [ ] Move rolled-out issues in the `Rollout` column of the [Product Construction](https://github.com/orgs/dotnet/projects/276) board into `Done`. Add a link in to this rollout issue in the comments before closing them ([example](https://github.com/dotnet/arcade-services/issues/2681#issuecomment-1632288755))
 - [ ] Close this issue with closing comment describing a high-level summary of issues encountered during the rollout
+- In case of rollback, uncomment the *Rollback* section below and follow the steps there
 
+<!-- UNCOMMENT HERE IN CASE OF A ROLLBACK
 ## Rollback
 
 In case the services don't work as expected after the rollout, it's necessary to roll back.
@@ -54,12 +56,15 @@ In case the services don't work as expected after the rollout, it's necessary to
 - [ ] Announce successful rollout on the [Rollout channel](https://teams.microsoft.com/l/channel/19%3a72e283b51f9e4567ba24a35328562df4%40thread.skype/Rollout?groupId=147df318-61de-4f04-8f7b-ecd328c256bb&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47)
 - [ ] Notify the partners that the rollback has been finished (as reply on the original email)
 
+### Rollback PRs
+- `<TO BE FILLED (IF APPICABLE)>`
+-->
+
 # Rollout data
 
 ## Rollout PRs
 
 * The main PR: `<TO BE FILLED>`
-* Rollback PRs: `<TO BE FILLED (IF APPICABLE) OR DELETED>`
 
 ## Rollout build
 


### PR DESCRIPTION
- Adds notes about making sure we're not squash committing
- Hides the rollback section unless it's needed to keep the issue more clean

https://github.com/dotnet/arcade-services/issues/2826

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements
### Release Note Description
Improved instructions in the rollout checklist

