### PR TITLE
Fix darc vmr command argument parsing regression

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Program.cs
@@ -37,7 +37,7 @@ internal static class Program
             options = GetOptions();
         }
 
-        return Parser.Default.ParseArguments(args, GetOptions())
+        return Parser.Default.ParseArguments(args, options)
                 .MapResult(
                     (CommandLineOptions opts) => RunOperation(opts),
                     (errs => 1));


### PR DESCRIPTION
Introduced in https://github.com/dotnet/arcade-services/pull/2809

https://github.com/dotnet/arcade-services/issues/2433

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Fixed darc vmr command argument parsing regression