### PR TITLE
Fix VMR scan rule parsing for non-`src/` content

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using LibGit2Sharp;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
Non-src content rules were ignored (e.g. `eng/common/..`)

Resolves issue when ignoring an `.lss` file https://github.com/dotnet/source-build/issues/3589

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Fixed VMR scan rules parsing for non-src content