### PR TITLE
Maestro++: Ensure that InProgress pull requests remain backward compatible with newer version of Maestro.

### DIFF
--- a/src/Maestro/Maestro.Contracts/CoherencyErrorDetails.cs
+++ b/src/Maestro/Maestro.Contracts/CoherencyErrorDetails.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 

--- a/src/Maestro/Maestro.Contracts/CoherencyErrorDetails.cs
+++ b/src/Maestro/Maestro.Contracts/CoherencyErrorDetails.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Maestro.Contracts;
+
+[DataContract]
+public class CoherencyErrorDetails
+{
+    [DataMember]
+    public string Error { get; set; }
+
+    [DataMember]
+    public IEnumerable<string> PotentialSolutions { get; set; }
+}

--- a/src/Maestro/Maestro.Contracts/IPullRequest.cs
+++ b/src/Maestro/Maestro.Contracts/IPullRequest.cs
@@ -12,7 +12,7 @@ public interface IPullRequest
     /// <summary>
     /// Indicates whether the last coherency update is successful.
     /// </summary>
-    bool CoherencyCheckSuccessful { get; set; }
+    bool? CoherencyCheckSuccessful { get; set; }
 
     /// <summary>
     /// In case of coherency algorithm failure,

--- a/src/Maestro/Maestro.Contracts/IPullRequest.cs
+++ b/src/Maestro/Maestro.Contracts/IPullRequest.cs
@@ -9,5 +9,16 @@ public interface IPullRequest
 {
     string Url { get; set; }
 
+    /// <summary>
+    /// Indicates whether the last coherency update is successful.
+    /// </summary>
+    bool CoherencyCheckSuccessful { get; set; }
+
+    /// <summary>
+    /// In case of coherency algorithm failure,
+    /// provides a list of dependencies that caused the failure.
+    /// </summary>
+    List<CoherencyErrorDetails> CoherencyErrors { get; set; }
+
     List<DependencyUpdateSummary> RequiredUpdates { get; set; }
 }

--- a/src/Maestro/Maestro.MergePolicies/MergePolicyServiceCollectionExtensions.cs
+++ b/src/Maestro/Maestro.MergePolicies/MergePolicyServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ public static class MergePolicyServiceCollectionExtensions
         services.AddTransient<IMergePolicyBuilder, NoRequestedChangesMergePolicyBuilder>();
         services.AddTransient<IMergePolicyBuilder, DontAutomergeDowngradesMergePolicyBuilder>();
         services.AddTransient<IMergePolicyBuilder, StandardMergePolicyBuilder>();
+        services.AddTransient<IMergePolicyBuilder, ValidateCoherencyMergePolicyBuilder>();
         return services;
     }
 }

--- a/src/Maestro/Maestro.MergePolicies/StandardMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/StandardMergePolicy.cs
@@ -67,6 +67,7 @@ public class StandardMergePolicyBuilder : IMergePolicyBuilder
         policies.AddRange(await new AllChecksSuccessfulMergePolicyBuilder().BuildMergePoliciesAsync(standardProperties, pr));
         policies.AddRange(await new NoRequestedChangesMergePolicyBuilder().BuildMergePoliciesAsync(standardProperties, pr));
         policies.AddRange(await new DontAutomergeDowngradesMergePolicyBuilder().BuildMergePoliciesAsync(standardProperties, pr));
+        policies.AddRange(await new ValidateCoherencyMergePolicyBuilder().BuildMergePoliciesAsync(standardProperties, pr));
         return policies;
     }
 }

--- a/src/Maestro/Maestro.MergePolicies/ValidateCoherencyMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/ValidateCoherencyMergePolicy.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Maestro.Contracts;
+using Maestro.MergePolicyEvaluation;
+using Microsoft.DotNet.DarcLib;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Maestro.MergePolicies;
+
+public class ValidateCoherencyMergePolicy : MergePolicy
+{
+    public override string DisplayName => "Validate coherency";
+
+    public override Task<MergePolicyEvaluationResult> EvaluateAsync(IPullRequest pr, IRemote darc)
+    {
+        if (pr.CoherencyCheckSuccessful)
+            return Task.FromResult(Succeed("Coherency check successful."));
+
+        StringBuilder description = new StringBuilder("Coherency update failed for the following dependencies:");
+        foreach (CoherencyErrorDetails error in pr.CoherencyErrors)
+        {
+            description.Append("\n * ").Append(error.Error);
+
+            if (error.PotentialSolutions.Count() > 0)
+            {
+                description.Append("\n    PotentialSolutions:");
+                foreach (string solution in error.PotentialSolutions)
+                {
+                    description.Append("\n     * ").Append(solution);
+                }
+            }
+        }
+        description
+            .Append("\n\nThe documentation can be found at this location: ")
+            .Append("https://github.com/dotnet/arcade/blob/main/Documentation/Darc.md#coherent-parent-dependencies");
+
+        return Task.FromResult(Fail("Coherency check failed.", description.ToString()));
+    }
+}
+
+public class ValidateCoherencyMergePolicyBuilder : IMergePolicyBuilder
+{
+    public string Name => MergePolicyConstants.ValidateCoherencyMergePolicyName;
+
+    public Task<IReadOnlyList<IMergePolicy>> BuildMergePoliciesAsync(MergePolicyProperties properties, IPullRequest pr)
+    {
+        IReadOnlyList<IMergePolicy> policies = new List<IMergePolicy> { new ValidateCoherencyMergePolicy() };
+        return Task.FromResult(policies);
+    }
+}

--- a/src/Maestro/Maestro.MergePolicies/ValidateCoherencyMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/ValidateCoherencyMergePolicy.cs
@@ -18,11 +18,11 @@ public class ValidateCoherencyMergePolicy : MergePolicy
 
     public override Task<MergePolicyEvaluationResult> EvaluateAsync(IPullRequest pr, IRemote darc)
     {
-        if (pr.CoherencyCheckSuccessful)
+        if (pr.CoherencyCheckSuccessful.GetValueOrDefault(true))
             return Task.FromResult(Succeed("Coherency check successful."));
 
         StringBuilder description = new StringBuilder("Coherency update failed for the following dependencies:");
-        foreach (CoherencyErrorDetails error in pr.CoherencyErrors)
+        foreach (CoherencyErrorDetails error in pr.CoherencyErrors ?? Enumerable.Empty<CoherencyErrorDetails>())
         {
             description.Append("\n * ").Append(error.Error);
 

--- a/src/Maestro/Maestro.MergePolicyEvaluation/MergePolicyConstants.cs
+++ b/src/Maestro/Maestro.MergePolicyEvaluation/MergePolicyConstants.cs
@@ -9,6 +9,7 @@ public class MergePolicyConstants
     public const string StandardMergePolicyName = "Standard";
     public const string NoRequestedChangesMergePolicyName = "NoRequestedChanges";
     public const string DontAutomergeDowngradesPolicyName = "DontAutomergeDowngrades";
+    public const string ValidateCoherencyMergePolicyName = "ValidateCoherency";
 
     public const string IgnoreChecksMergePolicyPropertyName = "ignoreChecks";
 

--- a/src/Maestro/SubscriptionActorService/InProgressPullRequest.cs
+++ b/src/Maestro/SubscriptionActorService/InProgressPullRequest.cs
@@ -15,7 +15,7 @@ public class InProgressPullRequest : IPullRequest
     public string Url { get; set; }
 
     [DataMember]
-    public bool CoherencyCheckSuccessful { get; set; }
+    public bool? CoherencyCheckSuccessful { get; set; }
 
     [DataMember]
     public List<CoherencyErrorDetails> CoherencyErrors { get; set; }

--- a/src/Maestro/SubscriptionActorService/InProgressPullRequest.cs
+++ b/src/Maestro/SubscriptionActorService/InProgressPullRequest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Maestro.Contracts;
-using Microsoft.DotNet.DarcLib;
 
 namespace SubscriptionActorService;
 
@@ -14,6 +13,12 @@ public class InProgressPullRequest : IPullRequest
 {
     [DataMember]
     public string Url { get; set; }
+
+    [DataMember]
+    public bool CoherencyCheckSuccessful { get; set; }
+
+    [DataMember]
+    public List<CoherencyErrorDetails> CoherencyErrors { get; set; }
 
     [DataMember]
     public MergePolicyCheckResult MergePolicyResult { get; set; }

--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -14,7 +14,6 @@ using Maestro.Data;
 using Maestro.Data.Models;
 using Maestro.MergePolicyEvaluation;
 using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
 using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
 using Microsoft.Extensions.Logging;
@@ -741,10 +740,10 @@ namespace SubscriptionActorService
             (string targetRepository, string targetBranch) = await GetTargetAsync();
             IRemote darcRemote = await DarcRemoteFactory.GetRemoteAsync(targetRepository, Logger);
 
-            List<(UpdateAssetsParameters update, List<DependencyUpdate> deps)> requiredUpdates =
+            TargetRepoDependencyUpdate repoDependencyUpdate =
                 await GetRequiredUpdates(updates, DarcRemoteFactory, targetRepository, targetBranch);
 
-            if (requiredUpdates.Count < 1)
+            if (repoDependencyUpdate.CoherencyCheckSuccessful && repoDependencyUpdate.RequiredUpdates.Count() < 1)
             {
                 return null;
             }
@@ -754,13 +753,17 @@ namespace SubscriptionActorService
 
             try
             {
-                string description = await CalculatePRDescriptionAndCommitUpdatesAsync(requiredUpdates, null, DarcRemoteFactory, targetRepository, newBranchName);
+                string description = await CalculatePRDescriptionAndCommitUpdatesAsync(
+                    repoDependencyUpdate.RequiredUpdates,
+                    null,
+                    DarcRemoteFactory,
+                    targetRepository,
+                    newBranchName);
 
-                var inProgressPr = new InProgressPullRequest
-                {
+                var inProgressPr = new InProgressPullRequest {
                     // Calculate the subscriptions contained within the
                     // update. Coherency updates do not have subscription info.
-                    ContainedSubscriptions = requiredUpdates
+                    ContainedSubscriptions = repoDependencyUpdate.RequiredUpdates
                             .Where(u => !u.update.IsCoherencyUpdate)
                             .Select(
                             u => new SubscriptionPullRequestUpdate
@@ -770,7 +773,7 @@ namespace SubscriptionActorService
                             })
                         .ToList(),
 
-                    RequiredUpdates = requiredUpdates
+                    RequiredUpdates = repoDependencyUpdate.RequiredUpdates
                             .SelectMany(update => update.deps)
                             .Select(du => new DependencyUpdateSummary
                             {
@@ -778,7 +781,10 @@ namespace SubscriptionActorService
                                 FromVersion = du.From.Version,
                                 ToVersion = du.To.Version
                             })
-                            .ToList()
+                            .ToList(),
+
+                    CoherencyCheckSuccessful = repoDependencyUpdate.CoherencyCheckSuccessful,
+                    CoherencyErrors = repoDependencyUpdate.CoherencyErrors
                 };
 
                 string prUrl = await darcRemote.CreatePullRequestAsync(
@@ -833,7 +839,7 @@ namespace SubscriptionActorService
         }
 
         /// <summary>
-        /// Commit a dependency update to a target branch  and calculate the PR description
+        /// Commit a dependency update to a target branch and calculate the PR description
         /// </summary>
         /// <param name="requiredUpdates">Version updates to apply</param>
         /// <param name="description">
@@ -899,6 +905,15 @@ namespace SubscriptionActorService
                     coherencyUpdate.deps.Select(du => du.To).ToList(), message.ToString());
             }
 
+            // If the coherency algorithm failed and there are no non-coherency updates and
+            // we crate an empty commit that describes an issue.
+            if (requiredUpdates.Count == 0)
+            {
+                string message = "Failed to perform coherency update for one or more dependencies.";
+                await remote.CommitUpdatesAsync(targetRepository, newBranchName, remoteFactory, new List<DependencyDetail>(), message);
+                return $"Coherency update: {message} Please review the GitHub checks or run `darc update-dependencies --coherency-only` locally against {newBranchName} for more information.";
+            }
+
             return pullRequestDescriptionBuilder.ToString();
         }
 
@@ -959,15 +974,17 @@ namespace SubscriptionActorService
             (string targetRepository, string targetBranch) = await GetTargetAsync();
             IRemote darcRemote = await DarcRemoteFactory.GetRemoteAsync(targetRepository, Logger);
 
-            List<(UpdateAssetsParameters update, List<DependencyUpdate> deps)> requiredUpdates =
+            TargetRepoDependencyUpdate targetRepositoryUpdates =
                 await GetRequiredUpdates(updates, DarcRemoteFactory, targetRepository, targetBranch);
 
-            if (requiredUpdates.Count < 1)
+            if (targetRepositoryUpdates.CoherencyCheckSuccessful && targetRepositoryUpdates.RequiredUpdates.Count() < 1)
             {
                 return;
             }
 
-            pr.RequiredUpdates = MergeExistingWithIncomingUpdates(pr.RequiredUpdates, requiredUpdates);
+            pr.RequiredUpdates = MergeExistingWithIncomingUpdates(pr.RequiredUpdates, targetRepositoryUpdates.RequiredUpdates);
+            pr.CoherencyCheckSuccessful = targetRepositoryUpdates.CoherencyCheckSuccessful;
+            pr.CoherencyErrors = targetRepositoryUpdates.CoherencyErrors;
 
             PullRequest pullRequest = await darcRemote.GetPullRequestAsync(pr.Url);
             string headBranch = pullRequest.HeadBranch;
@@ -978,14 +995,14 @@ namespace SubscriptionActorService
             // Replace all existing updates for the subscription id with the new update.
             // This avoids a potential issue where we may update the last applied build id
             // on the subscription to an older build id.
-            foreach ((UpdateAssetsParameters update, List<DependencyUpdate> deps) update in requiredUpdates)
+            foreach ((UpdateAssetsParameters update, List<DependencyUpdate> deps) update in targetRepositoryUpdates.RequiredUpdates)
             {
                 pr.ContainedSubscriptions.RemoveAll(s => s.SubscriptionId == update.update.SubscriptionId);
             }
 
             // Mark all previous dependency updates that are being updated as Updated. All new dependencies should not be
             // marked as update as they are new. Any dependency not being updated should not be marked as failed.
-            // At this point, pr.ContainedSubscriptions only containes the subscriptions that were not updated,
+            // At this point, pr.ContainedSubscriptions only contains the subscriptions that were not updated,
             // so everything that is in the previous list but not in the current list were updated.
             await AddDependencyFlowEventsAsync(
                 previousSubscriptions.Except(pr.ContainedSubscriptions),
@@ -994,7 +1011,7 @@ namespace SubscriptionActorService
                 pr.MergePolicyResult,
                 pr.Url);
 
-            pr.ContainedSubscriptions.AddRange(requiredUpdates
+            pr.ContainedSubscriptions.AddRange(targetRepositoryUpdates.RequiredUpdates
                 .Where(u => !u.update.IsCoherencyUpdate)
                 .Select(
                     u => new SubscriptionPullRequestUpdate
@@ -1004,7 +1021,7 @@ namespace SubscriptionActorService
                     }));
 
             // Mark any new dependency updates as Created. Any subscriptions that are in pr.ContainedSubscriptions
-            // but were not in the previous list of subscripitons are new
+            // but were not in the previous list of subscriptions are new
             await AddDependencyFlowEventsAsync(
                 pr.ContainedSubscriptions.Except(previousSubscriptions),
                 DependencyFlowEventType.Created,
@@ -1012,7 +1029,12 @@ namespace SubscriptionActorService
                 MergePolicyCheckResult.PendingPolicies,
                 pr.Url);
 
-            pullRequest.Description = await CalculatePRDescriptionAndCommitUpdatesAsync(requiredUpdates, pullRequest.Description, DarcRemoteFactory, targetRepository, headBranch);
+            pullRequest.Description = await CalculatePRDescriptionAndCommitUpdatesAsync(
+                targetRepositoryUpdates.RequiredUpdates,
+                pullRequest.Description,
+                DarcRemoteFactory,
+                targetRepository,
+                headBranch);
             pullRequest.Title = await ComputePullRequestTitleAsync(pr, targetBranch);
             await darcRemote.UpdatePullRequestAsync(pr.Url, pullRequest);
 
@@ -1027,7 +1049,7 @@ namespace SubscriptionActorService
 
 
         /// <summary>
-        /// Merges the list of existing updates in a PR with a list of incoming udpates
+        /// Merges the list of existing updates in a PR with a list of incoming updates
         /// </summary>
         /// <param name="existingUpdates">pr object to update</param>
         /// <param name="incomingUpdates">list of new incoming updates</param>
@@ -1065,6 +1087,13 @@ namespace SubscriptionActorService
             return mergedUpdates;
         }
 
+        private class TargetRepoDependencyUpdate
+        {
+            public bool CoherencyCheckSuccessful { get; set; } = true;
+            public List<CoherencyErrorDetails> CoherencyErrors { get; set; }
+            public List<(UpdateAssetsParameters update, List<DependencyUpdate> deps)> RequiredUpdates { get; set; } = new();
+        }
+
         /// <summary>
         /// Given a set of input updates from builds, determine what updates
         /// are required in the target repository.
@@ -1079,7 +1108,7 @@ namespace SubscriptionActorService
         ///     updates required based on the input updates.  The second pass uses the repo state + the
         ///     updates from the first pass to determine what else needs to change based on the coherency metadata.
         /// </remarks>
-        private async Task<List<(UpdateAssetsParameters update, List<DependencyUpdate> deps)>> GetRequiredUpdates(
+        private async Task<TargetRepoDependencyUpdate> GetRequiredUpdates(
             List<UpdateAssetsParameters> updates,
             IRemoteFactory remoteFactory,
             string targetRepository,
@@ -1089,7 +1118,8 @@ namespace SubscriptionActorService
             // Get a remote factory for the target repo
             IRemote darc = await remoteFactory.GetRemoteAsync(targetRepository, Logger);
 
-            var requiredUpdates = new List<(UpdateAssetsParameters update, List<DependencyUpdate> deps)>();
+            TargetRepoDependencyUpdate repoDependencyUpdate = new();
+
             // Existing details 
             List<DependencyDetail> existingDependencies = (await darc.GetDependenciesAsync(targetRepository, branch)).ToList();
 
@@ -1130,31 +1160,26 @@ namespace SubscriptionActorService
                     existingDependencies.Remove(dependencyUpdate.From);
                     existingDependencies.Add(dependencyUpdate.To);
                 }
-                requiredUpdates.Add((update, dependenciesToUpdate));
+                repoDependencyUpdate.RequiredUpdates.Add((update, dependenciesToUpdate));
             }
 
             // Once we have applied all of non coherent updates, then we need to run a coherency check on the dependencies.
-            // First, we'll try it with strict mode; failing that an attempt with legacy mode.
             List<DependencyUpdate> coherencyUpdates = new List<DependencyUpdate>();
-            bool strictCheckFailed = false;
             try
             {
                 Logger.LogInformation($"Running a coherency check on the existing dependencies for branch {branch} of repo {targetRepository}");
                 coherencyUpdates = await darc.GetRequiredCoherencyUpdatesAsync(existingDependencies, remoteFactory, CoherencyMode.Strict);
             }
-            catch (DarcCoherencyException)
+            catch (DarcCoherencyException e)
             {
-                Logger.LogInformation("Failed attempting strict coherency update on branch '{strictCoherencyFailedBranch}' of repo '{strictCoherencyFailedRepo}'.  Will now retry in Legacy mode.",
+                Logger.LogInformation("Failed attempting strict coherency update on branch '{strictCoherencyFailedBranch}' of repo '{strictCoherencyFailedRepo}'.",
                      branch, targetRepository);
-                strictCheckFailed = true;
-            }
-            if (strictCheckFailed)
-            {
-                coherencyUpdates = await darc.GetRequiredCoherencyUpdatesAsync(existingDependencies, remoteFactory, CoherencyMode.Legacy);
-                // If the above call didn't throw, that means legacy worked while strict did not.
-                // Send a special trace that can be easily queried later from App Insights, to gauge when everything can handle Strict mode.
-                Logger.LogInformation("Strict coherency update failed, but Legacy update worked for branch '{strictCoherencyFailedBranch}' of repo '{strictCoherencyFailedRepo}'.",
-                     branch, targetRepository);
+                repoDependencyUpdate.CoherencyCheckSuccessful = false;
+                repoDependencyUpdate.CoherencyErrors = e.Errors.Select(e => new CoherencyErrorDetails
+                {
+                    Error = e.Error,
+                    PotentialSolutions = e.PotentialSolutions
+                }).ToList();
             }
 
             if (coherencyUpdates.Any())
@@ -1165,11 +1190,11 @@ namespace SubscriptionActorService
                 {
                     IsCoherencyUpdate = true
                 };
-                requiredUpdates.Add((coherencyUpdateParameters, coherencyUpdates.ToList()));
+                repoDependencyUpdate.RequiredUpdates.Add((coherencyUpdateParameters, coherencyUpdates.ToList()));
             }
 
             Logger.LogInformation("Finished getting Required Updates from {branch} to {targetRepository}", branch, targetRepository);
-            return requiredUpdates;
+            return repoDependencyUpdate;
         }
 
         private async Task<RepositoryBranchUpdate> GetRepositoryBranchUpdate()

--- a/src/Microsoft.DotNet.Darc/Darc/Constants.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Constants.cs
@@ -31,7 +31,7 @@ public class Constants
 
     /// <summary>
     /// This maybe should be implemented in the API in the future, help info for the available merge policies.  For now,
-    /// this is just generic help for availabel merge policies
+    /// this is just generic help for available merge policies
     /// </summary>
     public static readonly List<string> AvailableMergePolicyYamlHelp = new List<string>
     {
@@ -50,6 +50,7 @@ public class Constants
         $"- {MergePolicyConstants.AllCheckSuccessfulMergePolicyName} with the 'WIP' and 'license/cla' checks ignored.",
         $"- {MergePolicyConstants.NoRequestedChangesMergePolicyName}",
         $"- {MergePolicyConstants.DontAutomergeDowngradesPolicyName}",
+        $"- {MergePolicyConstants.ValidateCoherencyMergePolicyName}",
         "The standard Azure DevOps merge policy is:",
         $"- {MergePolicyConstants.AllCheckSuccessfulMergePolicyName} with the 'Comment requirements', 'Minimum number of reviewers', 'Required reviewers',",
         "  and 'Work item linking' checks ignored.",
@@ -76,5 +77,10 @@ public class Constants
         $"{MergePolicyConstants.DontAutomergeDowngradesPolicyName} - If any version change is a downgrade, it will not be merged.",
         "YAML format:",
         $"- Name: {MergePolicyConstants.DontAutomergeDowngradesPolicyName}",
+        "",
+        $"{MergePolicyConstants.ValidateCoherencyMergePolicyName} - If coherency check failed for the PR, it will not be merged.",
+        "YAML format:",
+        $"- Name: {MergePolicyConstants.ValidateCoherencyMergePolicyName}",
+
     };
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
@@ -87,6 +87,15 @@ class AddSubscriptionOperation : Operation
                 });
         }
 
+        if (_options.ValidateCoherencyCheckMergePolicy)
+        {
+            mergePolicies.Add(
+                new MergePolicy {
+                    Name = MergePolicyConstants.ValidateCoherencyMergePolicyName,
+                    Properties = ImmutableDictionary.Create<string, JToken>()
+                });
+        }
+
         if (_options.Batchable && mergePolicies.Count > 0)
         {
             Console.WriteLine("Batchable subscriptions cannot be combined with merge policies. " +

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
@@ -9,7 +9,6 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
-using Microsoft.TeamFoundation.Common;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Darc/Darc/Options/AddSubscriptionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/AddSubscriptionCommandLineOptions.cs
@@ -60,6 +60,9 @@ class AddSubscriptionCommandLineOptions : CommandLineOptions
     [Option("failure-notification-tags", HelpText = "Semicolon-delineated list of GitHub tags (GitHub login or GitHub team) to notify in the case of non-batched subscription pull-request policy failure.  Users must be publicly a member of the Microsoft org.", Default = "")]
     public string PullRequestFailureNotificationTags { get; set; }
 
+    [Option("validate-coherency", HelpText="PR is not merged if the coherency algorithm failed.")]
+    public bool ValidateCoherencyCheckMergePolicy { get; set; }
+
     public override Operation GetOperation()
     {
         return new AddSubscriptionOperation(this);

--- a/src/Microsoft.DotNet.Darc/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Actions/Remote.cs
@@ -470,12 +470,12 @@ public sealed class Remote : IRemote
     ///     - You need to traverse all nodes in the graph
     ///     - If there is incremental servicing in some places, it's possible for dependencies to get
     ///       unintentionally downgraded (see https://github.com/dotnet/arcade/issues/5195).
-    ///       
+    ///
     ///     Fundamentally, strict coherency does the same thing as regular coherency, but with a limited
     ///     search space and no build information required. In the case where dependency A has CPD B....
     ///     - The version search is only one level deep.
     ///     - B's repo+sha must contain dependency A in its version.details.xml file.
-    ///     
+    ///
     ///     Because B's repo+sha may only have one version of A, this eliminates the need for any kind of version
     ///     check and vastly simplifies the algorithm. The downside is that more repos must bubble up dependencies,
     ///     but this is fairly minimal and generally covered by the need to have dependencies explicit in the
@@ -576,7 +576,7 @@ public sealed class Remote : IRemote
                             Error = $"{parentCoherentDependency.RepoUri} @ {parentCoherentDependency.Commit} does not contain dependency {dependencyToUpdate.Name}",
                             PotentialSolutions = new List<string> {
                                 $"Add the dependency to {parentCoherentDependency.RepoUri}.",
-                                $"Pin the dependenency.",
+                                $"Pin the dependency.",
                                 "Remove the CoherentParentDependency attribute."
                             }
                         });

--- a/src/Microsoft.DotNet.Darc/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/RemoteRepoBase.cs
@@ -104,7 +104,7 @@ public class RemoteRepoBase : GitRepoCloner
                 await _processManager.ExecuteGit(clonedRepo, new[] { "add", filePath });
             }
 
-            await _processManager.ExecuteGit(clonedRepo, new[] { "commit", "-m", commitMessage });
+            await _processManager.ExecuteGit(clonedRepo, new[] { "commit", "--allow-empty", "-m", commitMessage });
             await _processManager.ExecuteGit(clonedRepo, new[] { "-c", "core.askpass=", "-c", "credential.helper=", "push", remote, branch });
         }
         catch (Exception exc)

--- a/test/Maestro.ScenarioTests/EndToEndFlowLogic.cs
+++ b/test/Maestro.ScenarioTests/EndToEndFlowLogic.cs
@@ -91,23 +91,58 @@ namespace Maestro.ScenarioTests
             }
         }
 
-        public async Task NonBatchedGitHubFlowTestBase(string targetBranch, string channelName, IImmutableList<AssetData> source1Assets, List<DependencyDetail> expectedDependencies,
-            bool allChecks = false, bool isCoherencyTest = false, IImmutableList<AssetData> childSourceAssets = null, IImmutableList<AssetData> childSourceBuildAssets = null)
+        public async Task NonBatchedGitHubFlowTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets,
+            List<DependencyDetail> expectedDependencies, bool allChecks = false)
         {
             string targetRepoName = TestRepository.TestRepo2Name;
             string sourceRepoName = TestRepository.TestRepo1Name;
-            string childRepoName = TestRepository.TestRepo1Name;
 
-            if (isCoherencyTest)
+            string testChannelName = channelName;
+            string sourceRepoUri = GetRepoUrl(sourceRepoName);
+            string targetRepoUri = GetRepoUrl(targetRepoName);
+
+            TestContext.WriteLine($"Creating test channel {testChannelName}");
+            await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
+
+            await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionForEndToEndTests(
+                testChannelName, sourceRepoName, targetRepoName, targetBranch, allChecks, false);
+
+            TestContext.WriteLine("Set up build for intake into target repository");
+            Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, sourceBuildNumber, sourceAssets);
+            await AddBuildToChannelAsync(build.Id, testChannelName);
+
+            TestContext.WriteLine("Cloning target repo to prepare the target branch");
+            TemporaryDirectory reposFolder = await CloneRepositoryAsync(targetRepoName);
+
+            using (ChangeDirectory(reposFolder.Directory))
             {
-                if (childSourceAssets == null || childSourceBuildAssets == null)
+                await using (await CheckoutBranchAsync(targetBranch))
                 {
-                    throw new MaestroTestException("Child source and build assets must be provided for coherency tests.");
-                }
+                    TestContext.WriteLine("Adding dependencies to target repo");
+                    await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
 
-                sourceRepoName = TestRepository.TestRepo2Name;
-                targetRepoName = TestRepository.TestRepo3Name;
+                    TestContext.WriteLine("Pushing branch to remote");
+                    await GitCommitAsync("Add dependencies");
+
+                    await using (await PushGitBranchAsync("origin", targetBranch))
+                    {
+                        TestContext.WriteLine("Trigger the dependency update");
+                        await TriggerSubscriptionAsync(subscription1Id.Value);
+
+                        TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
+
+                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: true, isUpdated: false);
+                    }
+                }
             }
+        }
+
+        public async Task NonBatchedGitHubFlowCoherencyTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets,
+            IImmutableList<AssetData> childSourceAssets, List<DependencyDetail> expectedDependencies, string coherentParent, bool allChecks)
+        {
+            string targetRepoName = TestRepository.TestRepo3Name;
+            string sourceRepoName = TestRepository.TestRepo2Name;
+            string childRepoName = TestRepository.TestRepo1Name;
 
             string testChannelName = channelName;
             string sourceRepoUri = GetRepoUrl(sourceRepoName);
@@ -121,15 +156,12 @@ namespace Maestro.ScenarioTests
                 testChannelName, sourceRepoName, targetRepoName, targetBranch, allChecks, false);
 
             TestContext.WriteLine("Set up build for intake into target repository");
-            Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, sourceBuildNumber, source1Assets);
+            Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, sourceBuildNumber, sourceAssets);
             await AddBuildToChannelAsync(build.Id, testChannelName);
 
-            if (isCoherencyTest)
-            {
-                Build build2 = await CreateBuildAsync(childSourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo2Commit,
-                    source2BuildNumber, childSourceBuildAssets);
-                await AddBuildToChannelAsync(build2.Id, testChannelName);
-            }
+            Build build2 = await CreateBuildAsync(childSourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo2Commit,
+                source2BuildNumber, childSourceAssets);
+            await AddBuildToChannelAsync(build2.Id, testChannelName);
 
             TestContext.WriteLine("Cloning target repo to prepare the target branch");
             TemporaryDirectory reposFolder = await CloneRepositoryAsync(targetRepoName);
@@ -138,36 +170,100 @@ namespace Maestro.ScenarioTests
             {
                 await using (await CheckoutBranchAsync(targetBranch))
                 {
-
                     TestContext.WriteLine("Adding dependencies to target repo");
-                    await AddDependenciesToLocalRepo(reposFolder.Directory, source1Assets.ToList(), sourceRepoUri);
+                    await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
 
-                    if (isCoherencyTest)
-                    {
-                        await AddDependenciesToLocalRepo(reposFolder.Directory, childSourceAssets.ToList(), childSourceRepoUri, "Foo");
-                    }
+                    await AddDependenciesToLocalRepo(reposFolder.Directory, childSourceAssets.ToList(), childSourceRepoUri, coherentParent);
 
                     TestContext.WriteLine("Pushing branch to remote");
                     await GitCommitAsync("Add dependencies");
 
-                    await using (await PushGitBranchAsync("origin", targetBranch))
-                    {
-
+                    await using (await PushGitBranchAsync("origin", targetBranch)) {
                         TestContext.WriteLine("Trigger the dependency update");
                         await TriggerSubscriptionAsync(subscription1Id.Value);
 
                         TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
 
-                        if (allChecks)
-                        {
-                            await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: true, isUpdated: false);
-                            return;
-                        }
+                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: allChecks, isUpdated: false);
+                    }
+                }
+            }
+        }
 
-                        if (isCoherencyTest)
+        public async Task NonBatchedGitHubFlowCoherencyOnlyTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets,
+            IImmutableList<AssetData> childSourceAssets, List<DependencyDetail> expectedNonCoherencyDependencies,
+            List<DependencyDetail> expectedCoherencyDependencies, string coherentParent)
+        {
+            string targetRepoName = TestRepository.TestRepo3Name;
+            string sourceRepoName = TestRepository.TestRepo2Name;
+            string childRepoName = TestRepository.TestRepo1Name;
+
+            string testChannelName = channelName;
+            string sourceRepoUri = GetRepoUrl(sourceRepoName);
+            string targetRepoUri = GetRepoUrl(targetRepoName);
+            string childSourceRepoUri = GetRepoUrl(childRepoName);
+
+            TestContext.WriteLine($"Creating test channel {testChannelName}");
+            await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
+
+            await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionAsync(
+                testChannelName,
+                sourceRepoName,
+                targetRepoName,
+                targetBranch,
+                UpdateFrequency.None.ToString(),
+                "maestro-auth-test",
+                additionalOptions: new List<string> { "--validate-coherency" },
+                trigger: true,
+                sourceIsAzDo: false,
+                targetIsAzDo: false);
+
+            TestContext.WriteLine("Set up build for intake into target repository");
+            Build build1 = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit,
+                sourceBuildNumber, sourceAssets);
+            await AddBuildToChannelAsync(build1.Id, testChannelName);
+
+            Build build2 = await CreateBuildAsync(childSourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo2Commit,
+                source2BuildNumber, childSourceAssets);
+            await AddBuildToChannelAsync(build2.Id, testChannelName);
+
+            TestContext.WriteLine("Cloning target repo to prepare the target branch");
+            TemporaryDirectory reposFolder = await CloneRepositoryAsync(targetRepoName);
+
+            using (ChangeDirectory(reposFolder.Directory))
+            {
+                await using (await CheckoutBranchAsync(targetBranch))
+                {
+                    TestContext.WriteLine("Adding dependencies to target repo");
+                    await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
+
+                    TestContext.WriteLine("Pushing branch to remote");
+                    await GitCommitAsync("Add dependencies 1");
+
+                    await using (await PushGitBranchAsync("origin", targetBranch))
+                    {
+                        TestContext.WriteLine("Trigger the dependency update");
+                        await TriggerSubscriptionAsync(subscription1Id.Value);
+
+                        TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
+
+                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedNonCoherencyDependencies, reposFolder.Directory, isCompleted: true, isUpdated: false);
+
+                        await RunGitAsync("checkout", targetBranch);
+                        await RunGitAsync("pull", "origin", targetBranch);
+
+                        await AddDependenciesToLocalRepo(reposFolder.Directory, childSourceAssets.ToList(), childSourceRepoUri, coherentParent);
+                        await GitCommitAsync("Add dependencies 2");
+
+                        await using (await PushGitBranchAsync("origin", targetBranch))
                         {
-                            await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: false, isUpdated: false);
-                            return;
+                            TestContext.WriteLine("Trigger the dependency update");
+                            await TriggerSubscriptionAsync(subscription1Id.Value);
+
+                            TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
+
+                            string expectedPRTitle = $"[{targetBranch}] Update dependencies to ensure coherency";
+                            await CheckGitHubPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedCoherencyDependencies, reposFolder.Directory, isCompleted: false, isUpdated: false);
                         }
                     }
                 }
@@ -175,7 +271,7 @@ namespace Maestro.ScenarioTests
         }
 
         public async Task NonBatchedUpdatingGitHubFlowTestBase(string targetBranch, string channelName, IImmutableList<AssetData> source1Assets, IImmutableList<AssetData> source1AssetsUpdated,
-            List<DependencyDetail> expectedDependencies, List<DependencyDetail> expectedUpdatedDependencies)
+            List<DependencyDetail> expectedDependencies, List<DependencyDetail> expectedUpdatedDependencies, bool allChecks = false)
         {
             string targetRepoName = TestRepository.TestRepo2Name;
             string sourceRepoName = TestRepository.TestRepo1Name;
@@ -189,7 +285,7 @@ namespace Maestro.ScenarioTests
             await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
 
             await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionForEndToEndTests(
-                testChannelName, sourceRepoName, targetRepoName, targetBranch, false, false);
+                testChannelName, sourceRepoName, targetRepoName, targetBranch, allChecks, false);
 
             TestContext.WriteLine("Set up build for intake into target repository");
             Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, sourceBuildNumber, source1Assets);
@@ -215,7 +311,7 @@ namespace Maestro.ScenarioTests
                         await TriggerSubscriptionAsync(subscription1Id.Value);
 
                         TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
-                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, false);
+                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, allChecks);
 
                         TestContext.WriteLine("Set up another build for intake into target repository");
                         Build build2 = await CreateBuildAsync(sourceRepoUri, sourceBranch, TestRepository.CoherencyTestRepo2Commit, source2BuildNumber, source1AssetsUpdated);
@@ -224,7 +320,7 @@ namespace Maestro.ScenarioTests
                         await TriggerSubscriptionAsync(subscription1Id.Value);
 
                         TestContext.WriteLine($"Waiting for PR to be updated in {targetRepoUri}");
-                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedUpdatedDependencies, reposFolder.Directory, false, true);
+                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedUpdatedDependencies, reposFolder.Directory, allChecks, true);
 
                         // Then remove the second build from the channel, trigger the sub again, and it should revert back to the original dependency set
                         TestContext.Write("Remove the build from the channel and verify that the original dependencies are restored");
@@ -235,7 +331,7 @@ namespace Maestro.ScenarioTests
 
                         TestContext.WriteLine($"Waiting for PR to be updated in {targetRepoUri}");
 
-                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, false, true);
+                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, allChecks, true);
                     }
                 }
             }
@@ -307,7 +403,7 @@ namespace Maestro.ScenarioTests
         }
 
         public async Task NonBatchedAzDoFlowTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets,
-    List<DependencyDetail> expectedDependencies, bool allChecks = false, bool isFeedTest = false, string[] expectedFeeds = null, string[] notExpectedFeeds = null)
+            List<DependencyDetail> expectedDependencies, bool allChecks = false, bool isFeedTest = false, string[] expectedFeeds = null, string[] notExpectedFeeds = null)
         {
             string targetRepoName = TestRepository.TestRepo2Name;
             string sourceRepoName = TestRepository.TestRepo1Name;
@@ -374,7 +470,7 @@ namespace Maestro.ScenarioTests
                     targetBranch,
                     UpdateFrequency.None.ToString(),
                     "maestro-auth-test",
-                    additionalOptions: new List<string> { "--all-checks-passed", "--ignore-checks", "license/cla" },
+                    additionalOptions: new List<string> { "--all-checks-passed", "--validate-coherency", "--ignore-checks", "license/cla" },
                     trigger: true,
                     sourceIsAzDo: isAzDoTest,
                     targetIsAzDo: isAzDoTest);

--- a/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
+++ b/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
@@ -314,7 +314,6 @@ namespace Maestro.ScenarioTests
                 string expectedDependenciesString = DependencyCollectionStringBuilder.GetString(expectedDependencies);
 
                 Assert.AreEqual(expectedDependenciesString, actualDependencies, $"Expected: {expectedDependenciesString} \r\n Actual: {actualDependencies}");
-
             }
         }
 

--- a/test/Maestro.ScenarioTests/ObjectHelpers/SubscriptionBuilder.cs
+++ b/test/Maestro.ScenarioTests/ObjectHelpers/SubscriptionBuilder.cs
@@ -62,6 +62,15 @@ namespace Maestro.ScenarioTests.ObjectHelpers
                     });
             }
 
+            if (mergePolicyNames.Contains(MergePolicyConstants.ValidateCoherencyMergePolicyName))
+            {
+                mergePolicies.Add(
+                    new MergePolicy {
+                        Name = MergePolicyConstants.ValidateCoherencyMergePolicyName,
+                        Properties = ImmutableDictionary.Create<string, JToken>()
+                    });
+            }
+
             expectedSubscription.Policy.MergePolicies = mergePolicies.ToImmutableList<MergePolicy>();
             return expectedSubscription;
         }

--- a/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
@@ -54,6 +54,14 @@ namespace Maestro.ScenarioTests
         }
 
         [Test]
+        public async Task Darc_GitHubFlow_AutoMerge_GithubChecks_ValidateCoherencyCheck() {
+            string testChannelName = GetTestChannelName();
+            var targetBranch = GetTargetBranch();
+
+            await AutoMergeFlowTestBase(targetRepo, sourceRepo, targetBranch, testChannelName, new List<string> { "--validate-coherency" });
+        }
+
+        [Test]
         public async Task Darc_GitHubFlow_AutoMerge_GithubChecks_Standard()
         {
             string testChannelName = GetTestChannelName();


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade-services/issues/2687

This PR includes:
* The original "Remove the fallback to the legacy coherency algorithm." commit https://github.com/dotnet/arcade-services/commit/4b3f187465f0f760efe54ac26dd034977a7b961b which was rollback by https://github.com/dotnet/arcade-services/commit/ce6c541aa3d221c0d47093973461b59e7f39c88e
* New commit "Maestro++: Ensure that InProgress pull requests remain backward compatible with newer version of Maestro." which solves the problem described below.

Please pay attention to the second commit, but feel free to do a full review.

## The problem:
I extended the [InProgressPullRequest](https://github.com/dotnet/arcade-services/blob/main/src/Maestro/SubscriptionActorService/InProgressPullRequest.cs) serializable data type with two members, one of these members is a Boolean flag named `CoherencyCheckSuccessful`. Maestro++ utilizes the ActorStateManager to store information about InProgress pull requests; however, due to backward compatibility issue it was not able to properly deserialize the InProgressPullRequest structure. The CoherencyCheckSuccessful flag was set to its default Boolean value of false, and the second member was set to null.
To maintain backward compatibility, I changed the Boolean type to `Nullable<Boolean>`.
The proper solution would be to introduce versioning in InProgressPullRequest and implement conversion between different versions, but this is a consideration for the future.

## Symptoms:
We observed a spike of exceptions with `method like 'Maestro.MergePolicies.ValidateCoherencyMergePolicy.EvaluateAsync'`
```Kusto
exceptions
| where timestamp >= make_datetime(2023, 06, 22) and timestamp <= make_datetime(2023, 06, 24)
| summarize count() by bin(timestamp, 15m), method
| render timechart
```

And duplicated coherency and non-coherency updates created:
* https://github.com/dotnet/sdk/pull/33487
* https://github.com/dotnet/sdk/pull/33492

```Kusto
exceptions
| where timestamp >= make_datetime(2023, 06, 22) and timestamp <= make_datetime(2023, 06, 24)
  and customDimensions["url"] like '33487'
| order by timestamp

// Unexpected error processing action: Object reference not set to an instance of an object.","{OriginalFormat}":"Synchronizing Pull Request: '{url}'
```

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Remove the fallback to the legacy coherency algorithm.