### PR TITLE
Stop using `Microsoft.Azure.Services.AppAuthentication`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,38 +19,37 @@
     <PackageVersion Include="CommandLineParser" Version="2.2.1" />
     <PackageVersion Include="CoreHealthMonitor" Version="$(CoreHealthMonitorVersion)" />
     <PackageVersion Include="EntityFrameworkCore.Triggers" Version="1.1.1" />
+    <PackageVersion Include="FluentAssertions.Json" Version="5.5.0" />
     <PackageVersion Include="FluentAssertions" Version="6.11.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="8.6.2" />
-    <PackageVersion Include="FluentAssertions.Json" Version="5.5.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
     <PackageVersion Include="LibGit2Sharp" Version="0.27.2" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageVersion Include="Microsoft.AspNetCore.ApiPagination" Version="$(MicrosoftAspNetCoreApiPaginationVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.ApiVersioning" Version="$(MicrosoftAspNetCoreApiVersioningVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.ApiVersioning.Analyzers" Version="$(MicrosoftAspNetCoreApiVersioningAnalyzersVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.ApiVersioning.Swashbuckle" Version="$(MicrosoftAspNetCoreApiVersioningSwashbuckleVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.ApiVersioning" Version="$(MicrosoftAspNetCoreApiVersioningVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(AspNetCoreVersion)" />
     <!-- Force version 2.0.2 to avoid unsafe versions -->
     <PackageVersion Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.WebHooks.Receivers" Version="1.0.0-preview2-final" />
     <PackageVersion Include="Microsoft.AspNetCore.WebHooks.Receivers.GitHub" Version="1.0.0-preview2-final" />
-    <PackageVersion Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
-    <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebHooks.Receivers" Version="1.0.0-preview2-final" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.3.2" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.3.2" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.3.2" />
+    <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.1.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.1.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="4.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.1.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.1.0" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="17.4.1" />
@@ -60,12 +59,12 @@
     <PackageVersion Include="Microsoft.DncEng.Configuration.Extensions" Version="$(MicrosoftDncEngConfigurationExtensionsVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Authentication.Algorithms" Version="$(MicrosoftDotNetAuthenticationAlgorithmsVersion)" />
     <PackageVersion Include="Microsoft.DotNet.GitHub.Authentication" Version="$(MicrosoftDotNetGitHubAuthenticationVersion)" />
-    <PackageVersion Include="Microsoft.DotNet.Internal.DependencyInjection" Version="$(MicrosoftDotNetInternalDependencyInjectionVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Internal.DependencyInjection.Testing" Version="$(MicrosoftDotNetInternalDependencyInjectionTestingVersion)" />
+    <PackageVersion Include="Microsoft.DotNet.Internal.DependencyInjection" Version="$(MicrosoftDotNetInternalDependencyInjectionVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Internal.Health" Version="$(MicrosoftDotNetInternalHealthVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Internal.Logging" Version="$(MicrosoftDotNetInternalLoggingVersion)" />
-    <PackageVersion Include="Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen" Version="$(MicrosoftDotNetInternalTestingDependencyInjectionCodeGenVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Internal.Testing.DependencyInjection.Abstractions" Version="$(MicrosoftDotNetInternalTestingDependencyInjectionAbstractionsVersion)" />
+    <PackageVersion Include="Microsoft.DotNet.Internal.Testing.DependencyInjectionCodeGen" Version="$(MicrosoftDotNetInternalTestingDependencyInjectionCodeGenVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Internal.Testing.Utility" Version="$(MicrosoftDotNetInternalTestingUtilityVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Kusto" Version="$(MicrosoftDotNetKustoVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Metrics" Version="$(MicrosoftDotNetMetricsVersion)" />
@@ -74,29 +73,30 @@
     <PackageVersion Include="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="$(MicrosoftDotNetSwaggerGeneratorMSBuildVersion)" />
     <PackageVersion Include="Microsoft.DotNet.VersionTools" Version="$(MicrosoftDotNetVersionToolsVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Web.Authentication" Version="$(MicrosoftDotNetWebAuthenticationVersion)" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(AspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="3.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.ServiceFabric" Version="8.2.1571" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.55.0" />
     <PackageVersion Include="Microsoft.ServiceFabric.Actors" Version="5.2.1571" />
     <PackageVersion Include="Microsoft.ServiceFabric.AspNetCore.HttpSys" Version="5.2.1571" />
     <PackageVersion Include="Microsoft.ServiceFabric.Data" Version="5.2.1571" />
-    <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="5.2.1571" />
     <PackageVersion Include="Microsoft.ServiceFabric.Services.Remoting" Version="5.2.1571" />
+    <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="5.2.1571" />
+    <PackageVersion Include="Microsoft.ServiceFabric" Version="8.2.1571" />
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="19.224.0-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.14" />
@@ -113,12 +113,12 @@
     <PackageVersion Include="System.IO.Hashing" Version="7.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="7.0.0" />
-    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
-    <PackageVersion Include="Verify.NUnit" Version="19.6" />
     <!-- Pin of a transitive dependency. Can be removed after we migrate to net7.0+
          https://dnceng.visualstudio.com/internal/_workitems/edit/5117 -->
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="7.0.0" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="7.0.0" />
+    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
+    <PackageVersion Include="Verify.NUnit" Version="19.6" />
     <PackageVersion Include="YamlDotNet" Version="9.1.4" />
     <PackageVersion Include="YamlDotNet.Signed" Version="5.3.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -90,7 +90,6 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.55.0" />
     <PackageVersion Include="Microsoft.ServiceFabric.Actors" Version="5.2.1571" />
     <PackageVersion Include="Microsoft.ServiceFabric.AspNetCore.HttpSys" Version="5.2.1571" />
     <PackageVersion Include="Microsoft.ServiceFabric.Data" Version="5.2.1571" />

--- a/src/Microsoft.DotNet.Darc/DarcLib/Microsoft.DotNet.DarcLib.csproj
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Microsoft.DotNet.DarcLib.csproj
@@ -10,21 +10,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
+    <PackageReference Include="LibGit2Sharp" />
     <PackageReference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.DotNet.Internal.Logging" />
+    <PackageReference Include="Microsoft.DotNet.Services.Utility" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="Octokit" />
     <PackageReference Include="System.IO.Hashing" />
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="System.Net.Http" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
-    <PackageReference Include="Microsoft.DotNet.Internal.Logging" />
-    <PackageReference Include="Microsoft.DotNet.Services.Utility" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Darc/DarcLib/Microsoft.DotNet.DarcLib.csproj
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Microsoft.DotNet.DarcLib.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="Octokit" />


### PR DESCRIPTION
This PR removes `Microsoft.Azure.Services.AppAuthentication` as it's no longer needed after https://github.com/dotnet/dnceng-shared/commit/da9b63e8cee2228dc0b333e0ff4c721cc7cb490f was made.

The rest of the changes is sorting the packages alphabetically.

CG build break: https://github.com/dotnet/arcade-services/issues/2855

CG alert: https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-arcade-services/alert/8147817?typeId=6567134

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Stop using `Microsoft.Azure.Services.AppAuthentication`