### PR TITLE
Remove the Legacy coherency algorithm from Darc

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -1168,7 +1168,7 @@ namespace SubscriptionActorService
             try
             {
                 Logger.LogInformation($"Running a coherency check on the existing dependencies for branch {branch} of repo {targetRepository}");
-                coherencyUpdates = await darc.GetRequiredCoherencyUpdatesAsync(existingDependencies, remoteFactory, CoherencyMode.Strict);
+                coherencyUpdates = await darc.GetRequiredCoherencyUpdatesAsync(existingDependencies, remoteFactory);
             }
             catch (DarcCoherencyException e)
             {

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
@@ -34,6 +34,12 @@ class UpdateDependenciesOperation : Operation
     /// <returns>Process exit code.</returns>
     public override async Task<int> ExecuteAsync()
     {
+        if (_options.LegacyCoherency)
+        {
+            Logger.LogError("The `legacy-coherency` option is no longer available. Darc supports `Strict` coherency algorithm only.");
+            return Constants.ErrorCode;
+        }
+
         try
         {
             DarcSettings darcSettings = darcSettings = LocalSettings.GetDarcSettings(_options, Logger);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
@@ -34,12 +34,6 @@ class UpdateDependenciesOperation : Operation
     /// <returns>Process exit code.</returns>
     public override async Task<int> ExecuteAsync()
     {
-        if (_options.LegacyCoherency)
-        {
-            Logger.LogError("The `legacy-coherency` option is no longer available. Darc supports `Strict` coherency algorithm only.");
-            return Constants.ErrorCode;
-        }
-
         try
         {
             DarcSettings darcSettings = darcSettings = LocalSettings.GetDarcSettings(_options, Logger);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
@@ -297,46 +297,15 @@ class UpdateDependenciesOperation : Operation
     {
         Console.WriteLine("Checking for coherency updates...");
 
-        CoherencyMode coherencyMode = CoherencyMode.Strict;
-        if (_options.LegacyCoherency)
-        {
-            coherencyMode = CoherencyMode.Legacy;
-        }
-        else
-        {
-            Console.WriteLine("Using 'Strict' coherency mode. If this fails, a second attempt utilizing 'Legacy' Coherency mode will be made.");
-        }
-
         List<DependencyUpdate> coherencyUpdates = null;
-        bool updateSucceeded = false;
         try
         {
             // Now run a coherency update based on the current set of dependencies updated from the previous pass.
-            coherencyUpdates = await barOnlyRemote.GetRequiredCoherencyUpdatesAsync(currentDependencies, remoteFactory, coherencyMode);
-            updateSucceeded = true;
+            coherencyUpdates = await barOnlyRemote.GetRequiredCoherencyUpdatesAsync(currentDependencies, remoteFactory);
         }
         catch (DarcCoherencyException e)
         {
             PrettyPrintCoherencyErrors(e);
-        }
-
-        if (coherencyMode == CoherencyMode.Strict && !updateSucceeded)
-        {
-            Console.WriteLine("Attempting fallback to Legacy coherency");
-            try
-            {
-                // Now run a coherency update based on the current set of dependencies updated from the previous pass.
-                coherencyUpdates = await barOnlyRemote.GetRequiredCoherencyUpdatesAsync(currentDependencies, remoteFactory, CoherencyMode.Legacy);
-                Console.WriteLine("... Legacy-mode fallback worked");
-                updateSucceeded = true;
-            }
-            catch (DarcCoherencyException e)
-            {
-                PrettyPrintCoherencyErrors(e);
-            }
-        }
-        if (!updateSucceeded)
-        {
             return Constants.ErrorCode;
         }
 

--- a/src/Microsoft.DotNet.Darc/Darc/Options/UpdateDependenciesCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/UpdateDependenciesCommandLineOptions.cs
@@ -37,6 +37,9 @@ class UpdateDependenciesCommandLineOptions : CommandLineOptions
     [Option("coherency-only", HelpText = "Only do coherency updates.")]
     public bool CoherencyOnly { get; set; }
 
+    [Option("legacy-coherency", HelpText = "Use 'legacy' coherency mode (default is 'strict')", Hidden = true)]
+    public bool LegacyCoherency { get; set; }
+
     public override Operation GetOperation()
     {
         return new UpdateDependenciesOperation(this);

--- a/src/Microsoft.DotNet.Darc/Darc/Options/UpdateDependenciesCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/UpdateDependenciesCommandLineOptions.cs
@@ -37,9 +37,6 @@ class UpdateDependenciesCommandLineOptions : CommandLineOptions
     [Option("coherency-only", HelpText = "Only do coherency updates.")]
     public bool CoherencyOnly { get; set; }
 
-    [Option("legacy-coherency", HelpText = "Use 'legacy' coherency mode (default is 'strict')", Hidden = true)]
-    public bool LegacyCoherency { get; set; }
-
     public override Operation GetOperation()
     {
         return new UpdateDependenciesOperation(this);

--- a/src/Microsoft.DotNet.Darc/Darc/Options/UpdateDependenciesCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/UpdateDependenciesCommandLineOptions.cs
@@ -37,9 +37,6 @@ class UpdateDependenciesCommandLineOptions : CommandLineOptions
     [Option("coherency-only", HelpText = "Only do coherency updates.")]
     public bool CoherencyOnly { get; set; }
 
-    [Option("legacy-coherency", HelpText = "Use 'legacy' coherency mode (default is 'strict')")]
-    public bool LegacyCoherency { get; set; }
-
     public override Operation GetOperation()
     {
         return new UpdateDependenciesOperation(this);

--- a/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
@@ -291,8 +291,7 @@ public interface IRemote
     /// <returns>List of dependency updates.</returns>
     Task<List<DependencyUpdate>> GetRequiredCoherencyUpdatesAsync(
         IEnumerable<DependencyDetail> dependencies,
-        IRemoteFactory remoteFactory,
-        CoherencyMode coherencyMode);
+        IRemoteFactory remoteFactory);
 
     /// <summary>
     ///     Given a current set of dependencies, determine what non-coherency updates

--- a/test/SubscriptionActorService.Tests/PullRequestActorTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestActorTests.cs
@@ -93,7 +93,7 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
         return base.BeforeExecute(context);
     }
 
-    private void ThenGetRequiredUpdatesShouldHaveBeenCalled(Build withBuild, CoherencyMode withCoherencyMode)
+    private void ThenGetRequiredUpdatesShouldHaveBeenCalled(Build withBuild)
     {
         var assets = new List<IEnumerable<AssetData>>();
         var dependencies = new List<IEnumerable<DependencyDetail>>();
@@ -102,7 +102,7 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
         DarcRemotes[TargetRepo]
             .Verify(r => r.GetDependenciesAsync(TargetRepo, TargetBranch, null, false));
         DarcRemotes[TargetRepo]
-            .Verify(r => r.GetRequiredCoherencyUpdatesAsync(Capture.In(dependencies), RemoteFactory.Object, withCoherencyMode));
+            .Verify(r => r.GetRequiredCoherencyUpdatesAsync(Capture.In(dependencies), RemoteFactory.Object));
         assets.Should()
             .BeEquivalentTo(
                 new List<List<AssetData>>
@@ -261,9 +261,9 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
             .Setup(
                 r => r.GetRequiredCoherencyUpdatesAsync(
                     It.IsAny<IEnumerable<DependencyDetail>>(),
-                    It.IsAny<IRemoteFactory>(), It.IsAny<CoherencyMode>()))
+                    It.IsAny<IRemoteFactory>()))
             .ReturnsAsync(
-                (IEnumerable<DependencyDetail> dependencies, IRemoteFactory factory, CoherencyMode coherencyMode) =>
+                (IEnumerable<DependencyDetail> dependencies, IRemoteFactory factory) =>
                 {
                     return new List<DependencyUpdate>();
                 });
@@ -275,9 +275,9 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
             .Setup(
                 r => r.GetRequiredCoherencyUpdatesAsync(
                     It.IsAny<IEnumerable<DependencyDetail>>(),
-                    It.IsAny<IRemoteFactory>(), CoherencyMode.Strict))
+                    It.IsAny<IRemoteFactory>()))
             .ReturnsAsync(
-                (IEnumerable<DependencyDetail> dependencies, IRemoteFactory factory, CoherencyMode coherencyMode) =>
+                (IEnumerable<DependencyDetail> dependencies, IRemoteFactory factory) =>
                 {
                     CoherencyError fakeCoherencyError = new CoherencyError()
                     {
@@ -568,7 +568,7 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
                 await WhenProcessPendingUpdatesAsyncIsCalled();
                 ThenUpdateReminderIsRemoved();
                 AndPendingUpdateIsRemoved();
-                ThenGetRequiredUpdatesShouldHaveBeenCalled(b, CoherencyMode.Strict);
+                ThenGetRequiredUpdatesShouldHaveBeenCalled(b);
                 AndCommitUpdatesShouldHaveBeenCalled(b);
                 AndUpdatePullRequestShouldHaveBeenCalled();
                 AndShouldHavePullRequestCheckReminder();
@@ -621,7 +621,7 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
 
             await WhenUpdateAssetsAsyncIsCalled(b);
 
-            ThenGetRequiredUpdatesShouldHaveBeenCalled(b, CoherencyMode.Strict);
+            ThenGetRequiredUpdatesShouldHaveBeenCalled(b);
             AndCreateNewBranchShouldHaveBeenCalled();
             AndCommitUpdatesShouldHaveBeenCalled(b);
             AndCreatePullRequestShouldHaveBeenCalled();
@@ -649,7 +649,7 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
             using (WithExistingPullRequest(SynchronizePullRequestResult.InProgressCanUpdate))
             {
                 await WhenUpdateAssetsAsyncIsCalled(b);
-                ThenGetRequiredUpdatesShouldHaveBeenCalled(b, CoherencyMode.Strict);
+                ThenGetRequiredUpdatesShouldHaveBeenCalled(b);
                 AndCommitUpdatesShouldHaveBeenCalled(b);
                 AndUpdatePullRequestShouldHaveBeenCalled();
                 AndShouldHavePullRequestCheckReminder();
@@ -699,7 +699,7 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
 
             await WhenUpdateAssetsAsyncIsCalled(b);
 
-            ThenGetRequiredUpdatesShouldHaveBeenCalled(b, CoherencyMode.Strict);
+            ThenGetRequiredUpdatesShouldHaveBeenCalled(b);
             AndSubscriptionShouldBeUpdatedForMergedPullRequest(b);
         }
 
@@ -723,7 +723,7 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
 
             await WhenUpdateAssetsAsyncIsCalled(b);
 
-            ThenGetRequiredUpdatesShouldHaveBeenCalled(b, CoherencyMode.Strict);
+            ThenGetRequiredUpdatesShouldHaveBeenCalled(b);
             AndCreateNewBranchShouldHaveBeenCalled();
             AndCommitUpdatesShouldHaveBeenCalled(b);
             AndCreatePullRequestShouldHaveBeenCalled();


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade-services/issues/2911

Recently we removed the fallback to Legacy coherency algorithm in Maestro++ https://github.com/dotnet/arcade-services/issues/2687 so that only Strict one is in use. Now we need to remove the Legacy algorithm itself from Darc.

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Darc `update-dependencies` command no longer has `legacy-coherency` option. Darc supports Strict Coherency Algorithm only.