### PR TITLE
Get build information after adding it to channel

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
@@ -158,6 +158,9 @@ internal class AddBuildToChannelOperation : Operation
                 return Constants.ErrorCode;
             }
 
+            // Get the latest build information to verify the channels
+            build = await remote.GetBuildAsync(build.Id);
+
             Console.WriteLine($"Assigning build '{build.Id}' to the following channel(s):");
             foreach (var channel in targetChannels)
             {


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade-services/issues/2914

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Display full build information after adding it to a channel