### PR TITLE
Delete over-the-size-limit patch files

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -351,6 +351,9 @@ public class VmrPatchHandler : IVmrPatchHandler
         _logger.LogWarning("Patch {name} targeting {path} is too large (>1GB). Repo will be split into smaller patches." +
             "Please note that there might be mismatches in non-global cloaking rules.", patchName, applicationPath);
 
+        _logger.LogDebug("Deleting too large patch {path}", patchName);
+        _fileSystem.DeleteFile(patch.Path);
+
         // If the patch is more than 1GB, new must start over and break it down into smaller patches
         var files = _fileSystem.GetFiles(workingDir);
         var directories = _fileSystem.GetDirectories(workingDir);

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -950,6 +950,9 @@ public class VmrPatchHandlerTests
             new VmrIngestionPatch(expectedPatchName + ".1.1", RepoVmrPath / "large-dir-1" / "large-dir-2"),
             new VmrIngestionPatch(expectedPatchName + ".1.2", RepoVmrPath / "large-dir-1" / "small-dir"),
         });
+
+        _fileSystem.Verify(x => x.DeleteFile(expectedPatchName), Times.Once);
+        _fileSystem.Verify(x => x.DeleteFile(expectedPatchName + ".1"), Times.Once);
     }
 
     [Test]


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/2876

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Started deleting unused large (>1GB) VMR patches