### PR TITLE
Start pipeline build on refs/heads/branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/rollout-issue.md
+++ b/.github/ISSUE_TEMPLATE/rollout-issue.md
@@ -16,11 +16,11 @@ This issue tracks the `arcade-services` repository rollout. On top of the [Rollo
 ## Build status check (Monday)
 - [ ] Check the status of the [dotnet-arcade-services-weekly](https://dev.azure.com/dnceng/internal/_build?definitionId=993) pipeline
 - [ ] Rotate any secrets that need manual rotation
-- [ ] In case the build is failing, try to fix it and ensure the [arcade-services-internal-ci](https://dev.azure.com/dnceng/internal/_build?definitionId=252) pipeline is green
+- [ ] Check the status of the [arcade-services-internal-ci](https://dev.azure.com/dnceng/internal/_build?definitionId=252) pipeline. Try to fix issues, if any, so that we have a green build before the rollout day.
 - [ ] Check the `Rollout` column in the [Product Construction](https://github.com/orgs/dotnet/projects/276) board - move any issues rolled-out last week into `Done`
 
 ## Rollout preparation (Tuesday)
-- [ ] Check the vendor prepared the rollout:
+- [ ] Check that the vendor prepared the rollout:
   - Thread on the [Rollout channel](https://teams.microsoft.com/l/channel/19%3a72e283b51f9e4567ba24a35328562df4%40thread.skype/Rollout?groupId=147df318-61de-4f04-8f7b-ecd328c256bb&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47)
   - Rollout issue in [AzDO](https://dev.azure.com/dnceng/internal/_workitems/)
   - Rollout PR in `arcade-services`
@@ -30,7 +30,7 @@ This issue tracks the `arcade-services` repository rollout. On top of the [Rollo
 - [ ] Merge the already prepared rollout PR (⚠️ **DO NOT SQUASH**)
 - [ ] Link the rollout build to the [Rollout build](#rollout-build) section of this issue
 - [ ] Verify that Maestro opened a production => main PR in `arcade-services` with the rollout merge commit ([example](https://github.com/dotnet/arcade-services/pull/2741)). There should be no changes in the PR to any files. **Do not merge the PR yet**.
-- [ ] Ensure the build is green and stops at the "Approval" phase
+- [ ] Ensure the build is green and stops at the `Approval` phase
 
 ## Rollout day (Wednesday)
 - [ ] Approve the `Approval` stage of the rollout build (that has been already started the day before)

--- a/src/Microsoft.DotNet.Darc/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -1198,13 +1198,15 @@ This pull request has not been merged because Maestro++ is waiting on the follow
             .ToDictionary(x => x.Key, x => new AzureDevOpsPipelineResourceParameter(x.Value))
             ?? new Dictionary<string, AzureDevOpsPipelineResourceParameter>();
 
+        var repositoryBranch = sourceBranch.StartsWith("refs/heads/") ? sourceBranch : $"refs/heads/{sourceBranch}";
+
         var body = new AzureDevOpsPipelineRunDefinition
         {
             Resources = new AzureDevOpsRunResourcesParameters
             {
                 Repositories = new Dictionary<string, AzureDevOpsRepositoryResourceParameter>
                 {
-                    { "self", new AzureDevOpsRepositoryResourceParameter($"refs/heads/{sourceBranch}", sourceVersion) }
+                    { "self", new AzureDevOpsRepositoryResourceParameter(repositoryBranch, sourceVersion) }
                 },
                 Pipelines = pipelineResourceParameters
             },

--- a/src/Microsoft.DotNet.Darc/DarcLib.AzDev/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib.AzDev/AzureDevOpsClient.cs
@@ -28,6 +28,8 @@ public class AzureDevOpsClient : RemoteRepoBase, IRemoteGitRepo, IAzureDevOpsCli
 
     private const int MaxPullRequestDescriptionLength = 4000;
 
+    private const string RefsHeadsPrefix = "refs/heads/";
+
     private static readonly string AzureDevOpsHostPattern = @"dev\.azure\.com\";
 
     private static readonly string CommentMarker =
@@ -342,8 +344,8 @@ public class AzureDevOpsClient : RemoteRepoBase, IRemoteGitRepo, IAzureDevOpsCli
         // all of the other APIs we use do not support them (e.g. get an item at branch X).
         // At the time this code was written, the API always returned the refs with this prefix,
         // so verify this is the case.
-        const string refsHeads = "refs/heads/";
-        if (!pr.TargetRefName.StartsWith(refsHeads) || !pr.SourceRefName.StartsWith(refsHeads))
+
+        if (!pr.TargetRefName.StartsWith(RefsHeadsPrefix) || !pr.SourceRefName.StartsWith(RefsHeadsPrefix))
         {
             throw new NotImplementedException("Expected that source and target ref names returned from pull request API include refs/heads");
         }
@@ -352,8 +354,8 @@ public class AzureDevOpsClient : RemoteRepoBase, IRemoteGitRepo, IAzureDevOpsCli
         {
             Title = pr.Title,
             Description = pr.Description,
-            BaseBranch = pr.TargetRefName.Substring(refsHeads.Length),
-            HeadBranch = pr.SourceRefName.Substring(refsHeads.Length),
+            BaseBranch = pr.TargetRefName.Substring(RefsHeadsPrefix.Length),
+            HeadBranch = pr.SourceRefName.Substring(RefsHeadsPrefix.Length),
         };
     }
 
@@ -375,8 +377,8 @@ public class AzureDevOpsClient : RemoteRepoBase, IRemoteGitRepo, IAzureDevOpsCli
             {
                 Title = pullRequest.Title,
                 Description = TruncateDescriptionIfNeeded(pullRequest.Description),
-                SourceRefName = "refs/heads/" + pullRequest.HeadBranch,
-                TargetRefName = "refs/heads/" + pullRequest.BaseBranch,
+                SourceRefName = RefsHeadsPrefix + pullRequest.HeadBranch,
+                TargetRefName = RefsHeadsPrefix + pullRequest.BaseBranch,
             },
             projectName,
             repoName);
@@ -1198,7 +1200,7 @@ This pull request has not been merged because Maestro++ is waiting on the follow
             .ToDictionary(x => x.Key, x => new AzureDevOpsPipelineResourceParameter(x.Value))
             ?? new Dictionary<string, AzureDevOpsPipelineResourceParameter>();
 
-        var repositoryBranch = sourceBranch.StartsWith("refs/heads/") ? sourceBranch : $"refs/heads/{sourceBranch}";
+        var repositoryBranch = sourceBranch.StartsWith(RefsHeadsPrefix) ? sourceBranch : RefsHeadsPrefix + sourceBranch;
 
         var body = new AzureDevOpsPipelineRunDefinition
         {


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
Add `refs/heads/` to branch name only if it doesn't start with it already so that the method can be called with the full branch name `$(Build.SourceBranch)` 

Issue: https://github.com/dotnet/arcade-services/issues/2845

This method will be used to start a run of Stage-DotNet-Validate-publish from Stage-DotNet-Prepare-Artifacts.
`$(Build.SourceBranch)` gives you the whole name starting with `refs/head/..` while `$(Build.SourceBranchName)` cuts off everything before the last slash and doesn't work for branches like `mhristova/branch`

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
SKIP IN RELEASE NOTES