### PR TITLE
Put the new endpoint configuration in the correct place

### DIFF
--- a/src/Maestro/Maestro.Web/PackageRoot/ServiceManifest.xml
+++ b/src/Maestro/Maestro.Web/PackageRoot/ServiceManifest.xml
@@ -35,6 +35,7 @@
            listen. Please note that if your service is partitioned, this port is shared with 
            replicas of different partitions that are placed in your code. -->
       <Endpoint Protocol="http" Name="ServiceEndpoint" Type="Input" Port="8080" />
+      <Endpoint Name="ServiceEndpointHttp" Port="8088" Protocol="http"/>
     </Endpoints>
   </Resources>
 </ServiceManifest>

--- a/src/Maestro/Maestro.Web/PackageRoot/ServiceManifest.xml
+++ b/src/Maestro/Maestro.Web/PackageRoot/ServiceManifest.xml
@@ -35,7 +35,7 @@
            listen. Please note that if your service is partitioned, this port is shared with 
            replicas of different partitions that are placed in your code. -->
       <Endpoint Protocol="http" Name="ServiceEndpoint" Type="Input" Port="8080" />
-      <Endpoint Name="ServiceEndpointHttp" Port="8088" Type="Input" Protocol="http" />
+      <Endpoint Protocol="http" Name="ServiceEndpoint" Type="Input" Port="8088" />
     </Endpoints>
   </Resources>
 </ServiceManifest>

--- a/src/Maestro/Maestro.Web/PackageRoot/ServiceManifest.xml
+++ b/src/Maestro/Maestro.Web/PackageRoot/ServiceManifest.xml
@@ -35,7 +35,7 @@
            listen. Please note that if your service is partitioned, this port is shared with 
            replicas of different partitions that are placed in your code. -->
       <Endpoint Protocol="http" Name="ServiceEndpoint" Type="Input" Port="8080" />
-      <Endpoint Name="ServiceEndpointHttp" Port="8088" Protocol="http"/>
+      <Endpoint Name="ServiceEndpointHttp" Port="8088" Protocol="http" Type="Input" />
     </Endpoints>
   </Resources>
 </ServiceManifest>

--- a/src/Maestro/Maestro.Web/PackageRoot/ServiceManifest.xml
+++ b/src/Maestro/Maestro.Web/PackageRoot/ServiceManifest.xml
@@ -35,7 +35,7 @@
            listen. Please note that if your service is partitioned, this port is shared with 
            replicas of different partitions that are placed in your code. -->
       <Endpoint Protocol="http" Name="ServiceEndpoint" Type="Input" Port="8080" />
-      <Endpoint Name="ServiceEndpointHttp" Port="8088" Protocol="http" Type="Input" />
+      <Endpoint Name="ServiceEndpointHttp" Port="8088" Type="Input" Protocol="http" />
     </Endpoints>
   </Resources>
 </ServiceManifest>

--- a/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
@@ -57,7 +57,6 @@
     <ResourceOverrides>
       <Endpoints>
         <Endpoint Name="ServiceEndpoint" Port="[WebPort]" Protocol="[WebProtocol]" />
-        <Endpoint Name="ServiceEndpointHttp" Port="8088" Protocol="http"/>
       </Endpoints>
     </ResourceOverrides>
     <EnvironmentOverrides CodePackageRef="Code">


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade-services/issues/2783
The original PR (https://github.com/dotnet/arcade-services/pull/2948) wasn't correct. I added the endpoint in the `Override` section, but there was nothing to override, which broke the deployment https://dev.azure.com/dnceng/internal/_build/results?buildId=2288375&view=logs&j=b277f1ae-44e7-5ce4-4818-00049b2c7654&t=300ea8c8-976b-58c1-6a89-17701eb43612&l=87
<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Not release note worthy