### PR TITLE
Hide CODEOWNERS generation behind an option

### DIFF
--- a/src/Maestro/Maestro.MergePolicies/ValidateCoherencyMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/ValidateCoherencyMergePolicy.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Maestro.Contracts;
 using Maestro.MergePolicyEvaluation;

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
@@ -37,6 +37,7 @@ internal class InitializeOperation : VmrOperationBase<IVmrInitializer>
             additionalRemotes,
             _options.ReadMeTemplate,
             _options.TpnTemplate,
+            _options.GenerateCodeowners,
             _options.DiscardPatches,
             cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
@@ -36,6 +36,7 @@ internal class UpdateOperation : VmrOperationBase<IVmrUpdater>
             additionalRemotes,
             _options.ReadMeTemplate,
             _options.TpnTemplate,
+            _options.GenerateCodeowners,
             _options.DiscardPatches,
             cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrSyncCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrSyncCommandLineOptions.cs
@@ -24,6 +24,9 @@ internal abstract class VmrSyncCommandLineOptions : VmrCommandLineOptions
     [Option("tpn-template", Required = false, HelpText = "Path to a template for generating VMRs THIRD-PARTY-NOTICES file. Leave empty to skip generation.")]
     public string TpnTemplate { get; set; }
 
+    [Option("generate-codeowners", Required = false, HelpText = "Generate a common CODEOWNERS file for all repositories.")]
+    public bool GenerateCodeowners { get; set; } = false;
+
     [Option("discard-patches", Required = false, HelpText = "Delete .patch files created during the sync.")]
     public bool DiscardPatches { get; set; } = false;
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
@@ -22,6 +22,7 @@ public interface IVmrInitializer
     /// <param name="additionalRemotes">Additional git remotes to use when fetching</param>
     /// <param name="readmeTemplatePath">Path to VMR's README.md template</param>
     /// <param name="tpnTemplatePath">Path to VMR's THIRD-PARTY-NOTICES.md template</param>
+    /// <param name="generateCodeowners">Whether to generate a CODEOWNERS file</param>
     /// <param name="discardPatches">Whether to clean up genreated .patch files after their used</param>
     Task InitializeRepository(
         string mappingName,
@@ -32,6 +33,7 @@ public interface IVmrInitializer
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? readmeTemplatePath,
         string? tpnTemplatePath,
+        bool generateCodeowners,
         bool discardPatches,
         CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
@@ -21,6 +21,7 @@ public interface IVmrUpdater
     /// <param name="additionalRemotes">Additional git remotes to use when fetching</param>
     /// <param name="readmeTemplatePath">Path to VMR's README.md template</param>
     /// <param name="tpnTemplatePath">Path to VMR's THIRD-PARTY-NOTICES.md template</param>
+    /// <param name="generateCodeowners">Whether to generate a CODEOWNERS file</param>
     /// <param name="discardPatches">Whether to clean up genreated .patch files after their used</param>
     Task UpdateRepository(
         string mappingName,
@@ -31,6 +32,7 @@ public interface IVmrUpdater
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? readmeTemplatePath,
         string? tpnTemplatePath,
+        bool generateCodeowners,
         bool discardPatches,
         CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -82,6 +82,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? readmeTemplatePath,
         string? tpnTemplatePath,
+        bool generateCodeowners,
         bool discardPatches,
         CancellationToken cancellationToken)
     {
@@ -137,6 +138,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
                     additionalRemotes,
                     readmeTemplatePath,
                     tpnTemplatePath,
+                    generateCodeowners,
                     discardPatches,
                     cancellationToken);
             }
@@ -165,6 +167,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? readmeTemplatePath,
         string? tpnTemplatePath,
+        bool generateCodeowners,
         bool discardPatches,
         CancellationToken cancellationToken)
     {
@@ -200,6 +203,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
             reapplyVmrPatches: true,
             readmeTemplatePath,
             tpnTemplatePath,
+            generateCodeowners,
             discardPatches,
             cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -74,6 +74,7 @@ public abstract class VmrManagerBase
         bool reapplyVmrPatches,
         string? readmeTemplatePath,
         string? tpnTemplatePath,
+        bool generateCodeowners,
         bool discardPatches,
         CancellationToken cancellationToken)
     {
@@ -145,7 +146,10 @@ public abstract class VmrManagerBase
             await UpdateThirdPartyNoticesAsync(tpnTemplatePath, cancellationToken);
         }
 
-        await _codeownersGenerator.UpdateCodeowners(cancellationToken);
+        if (generateCodeowners)
+        {
+            await _codeownersGenerator.UpdateCodeowners(cancellationToken);
+        }
 
         // Commit without adding files as they were added to index directly
         await CommitAsync(commitMessage, author);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -114,6 +114,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? readmeTemplatePath,
         string? tpnTemplatePath,
+        bool generateCodeowners,
         bool discardPatches,
         CancellationToken cancellationToken)
     {
@@ -169,6 +170,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 additionalRemotes,
                 readmeTemplatePath,
                 tpnTemplatePath,
+                generateCodeowners,
                 discardPatches,
                 cancellationToken);
         }
@@ -181,6 +183,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 additionalRemotes,
                 readmeTemplatePath,
                 tpnTemplatePath,
+                generateCodeowners,
                 discardPatches,
                 cancellationToken);
         }
@@ -193,6 +196,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? readmeTemplatePath,
         string? tpnTemplatePath,
+        bool generateCodeowners,
         bool discardPatches,
         CancellationToken cancellationToken)
     {
@@ -309,6 +313,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 reapplyVmrPatches,
                 readmeTemplatePath,
                 tpnTemplatePath,
+                generateCodeowners,
                 discardPatches,
                 cancellationToken);
         }
@@ -338,6 +343,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 reapplyVmrPatches,
                 readmeTemplatePath,
                 tpnTemplatePath,
+                generateCodeowners,
                 discardPatches,
                 cancellationToken);
 
@@ -359,6 +365,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? readmeTemplatePath,
         string? tpnTemplatePath,
+        bool generateCodeowners,
         bool discardPatches,
         CancellationToken cancellationToken)
     {
@@ -442,6 +449,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                     additionalRemotes,
                     readmeTemplatePath,
                     tpnTemplatePath,
+                    generateCodeowners,
                     discardPatches,
                     cancellationToken);
             }

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
@@ -111,7 +111,7 @@ public class VmrSyncRepoChangesTest :  VmrTestsBase
         Directory.CreateDirectory(Path.GetDirectoryName(ProductRepoPath / VmrInfo.CodeownersPath)!);
         await File.WriteAllTextAsync(ProductRepoPath / VmrInfo.CodeownersPath, "# This is a first repo's CODEOWNERS\nfoo/bar @some/team");
         await GitOperations.CommitAll(ProductRepoPath, "Add submodule");
-        await UpdateRepoToLastCommit(Constants.ProductRepoName, ProductRepoPath);
+        await UpdateRepoToLastCommit(Constants.ProductRepoName, ProductRepoPath, generateCodeowners: true);
 
         var expectedFilesFromRepos = new List<LocalPath>
         {
@@ -156,7 +156,7 @@ public class VmrSyncRepoChangesTest :  VmrTestsBase
         await GitOperations.PullMain(ProductRepoPath / submoduleRelativePath);
         
         await GitOperations.CommitAll(ProductRepoPath, "Checkout submodule");
-        await UpdateRepoToLastCommit(Constants.ProductRepoName, ProductRepoPath);
+        await UpdateRepoToLastCommit(Constants.ProductRepoName, ProductRepoPath, generateCodeowners: true);
 
         expectedFiles.Add(additionalSubmoduleFilePath);
         expectedFiles.Add(submodulePathInVmr / VmrInfo.CodeownersPath);
@@ -186,7 +186,7 @@ public class VmrSyncRepoChangesTest :  VmrTestsBase
         await GitOperations.RemoveSubmodule(ProductRepoPath, submoduleRelativePath);
         await File.WriteAllTextAsync(VmrPath / VmrInfo.CodeownersPath, "My new content in the CODEOWNERS\n\n### CONTENT BELOW IS AUTO-GENERATED AND MANUAL CHANGES WILL BE OVERWRITTEN ###\n");
         await GitOperations.CommitAll(ProductRepoPath, "Remove the submodule");
-        await UpdateRepoToLastCommit(Constants.ProductRepoName, ProductRepoPath);
+        await UpdateRepoToLastCommit(Constants.ProductRepoName, ProductRepoPath, generateCodeowners: true);
 
         expectedFiles.Remove(submoduleFilePath);
         expectedFiles.Remove(additionalSubmoduleFilePath);

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -156,7 +156,7 @@ public abstract class VmrTestsBase
     private async Task CallDarcInitialize(string repository, string commit, LocalPath sourceMappingsPath)
     {
         var vmrInitializer = _serviceProvider.Value.GetRequiredService<IVmrInitializer>();
-        await vmrInitializer.InitializeRepository(repository, commit, null, true, sourceMappingsPath, Array.Empty<AdditionalRemote>(), null, null, true, _cancellationToken.Token);
+        await vmrInitializer.InitializeRepository(repository, commit, null, true, sourceMappingsPath, Array.Empty<AdditionalRemote>(), null, null, false, true, _cancellationToken.Token);
     }
 
     protected async Task CallDarcUpdate(string repository, string commit)
@@ -167,7 +167,7 @@ public abstract class VmrTestsBase
     protected async Task CallDarcUpdate(string repository, string commit, AdditionalRemote[] additionalRemotes)
     {
         var vmrUpdater = _serviceProvider.Value.GetRequiredService<IVmrUpdater>();
-        await vmrUpdater.UpdateRepository(repository, commit, null, false, true, additionalRemotes, null, null, true, _cancellationToken.Token);
+        await vmrUpdater.UpdateRepository(repository, commit, null, false, true, additionalRemotes, null, null, false, true, _cancellationToken.Token);
     }
 
     protected async Task<List<string>> CallDarcCloakedFileScan(string baselinesFilePath)

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -147,10 +147,10 @@ public abstract class VmrTestsBase
         await CallDarcInitialize(repoName, commit, sourceMappings);
     }
 
-    protected async Task UpdateRepoToLastCommit(string repoName, NativePath repoPath)
+    protected async Task UpdateRepoToLastCommit(string repoName, NativePath repoPath, bool generateCodeowners = false)
     {
         var commit = await GitOperations.GetRepoLastCommit(repoPath);
-        await CallDarcUpdate(repoName, commit);
+        await CallDarcUpdate(repoName, commit, generateCodeowners);
     }
 
     private async Task CallDarcInitialize(string repository, string commit, LocalPath sourceMappingsPath)
@@ -159,15 +159,15 @@ public abstract class VmrTestsBase
         await vmrInitializer.InitializeRepository(repository, commit, null, true, sourceMappingsPath, Array.Empty<AdditionalRemote>(), null, null, false, true, _cancellationToken.Token);
     }
 
-    protected async Task CallDarcUpdate(string repository, string commit)
+    protected async Task CallDarcUpdate(string repository, string commit, bool generateCodeowners = false)
     {
-        await CallDarcUpdate(repository, commit, Array.Empty<AdditionalRemote>());
+        await CallDarcUpdate(repository, commit, Array.Empty<AdditionalRemote>(), generateCodeowners);
     }
 
-    protected async Task CallDarcUpdate(string repository, string commit, AdditionalRemote[] additionalRemotes)
+    protected async Task CallDarcUpdate(string repository, string commit, AdditionalRemote[] additionalRemotes, bool generateCodeowners = false)
     {
         var vmrUpdater = _serviceProvider.Value.GetRequiredService<IVmrUpdater>();
-        await vmrUpdater.UpdateRepository(repository, commit, null, false, true, additionalRemotes, null, null, false, true, _cancellationToken.Token);
+        await vmrUpdater.UpdateRepository(repository, commit, null, false, true, additionalRemotes, null, null, generateCodeowners, true, _cancellationToken.Token);
     }
 
     protected async Task<List<string>> CallDarcCloakedFileScan(string baselinesFilePath)


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/2913

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
VMR synchronization only generates a `CODEOWNERS` file when asked