### PR TITLE
Add http port listener

### DIFF
--- a/src/Maestro/Maestro.Web/MaestroDelegatedStatelessWebService.cs
+++ b/src/Maestro/Maestro.Web/MaestroDelegatedStatelessWebService.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using System.Fabric;
+using System;
+using Microsoft.ServiceFabric.Services.Runtime;
+using Microsoft.ServiceFabric.Services.Communication.Runtime;
+using System.Collections.Generic;
+using Microsoft.ServiceFabric.Services.Communication.AspNetCore;
+using System.IO;
+using Microsoft.DotNet.ServiceFabric.ServiceHost;
+using Microsoft.Extensions.Hosting;
+
+namespace Maestro.Web;
+
+public class MaestroDelegatedStatelessWebService<TStartup> : StatelessService where TStartup : class
+{
+    private readonly Action<IWebHostBuilder> _configureHost;
+    private readonly Action<IServiceCollection> _configureServices;
+
+    public MaestroDelegatedStatelessWebService(
+        StatelessServiceContext context,
+        Action<IWebHostBuilder> configureHost,
+        Action<IServiceCollection> configureServices) : base(context)
+    {
+        _configureHost = configureHost;
+        _configureServices = configureServices;
+    }
+
+    private ServiceInstanceListener CreateServiceInstanceListener(string endpointName)
+        => new ServiceInstanceListener(
+                context =>
+                {
+                    return new HttpSysCommunicationListener(
+                        context,
+                        "ServiceEndpoint",
+                        (url, listener) =>
+                        {
+                            var builder = new WebHostBuilder()
+                                .UseHttpSys()
+                                .UseContentRoot(Directory.GetCurrentDirectory())
+                                .UseSetting(WebHostDefaults.ApplicationKey,
+                                    typeof(TStartup).Assembly.GetName().Name);
+                            _configureHost(builder);
+
+                            return builder.ConfigureServices(
+                                    services =>
+                                    {
+                                        services.AddSingleton<ServiceContext>(context);
+                                        services.AddSingleton(context);
+                                        services.AddSingleton<IServiceLoadReporter>(new StatelessServiceLoadReporter(Partition));
+                                        services.AddSingleton<IStartup>(
+                                            provider =>
+                                            {
+                                                var env = provider.GetRequiredService<IHostEnvironment>();
+                                                return new DelegatedStatelessWebServiceStartup<TStartup>(
+                                                    provider,
+                                                    env,
+                                                    _configureServices);
+                                            });
+                                    })
+                                .UseServiceFabricIntegration(listener, ServiceFabricIntegrationOptions.None)
+                                .UseUrls(url)
+                                .Build();
+                        });
+                });
+
+    protected override IEnumerable<ServiceInstanceListener> CreateServiceInstanceListeners()
+    {
+        return new[]
+        {
+            CreateServiceInstanceListener("ServiceEndpoint"),
+            CreateServiceInstanceListener("ServiceEndpointHttp")
+        };
+    }
+}

--- a/src/Maestro/Maestro.Web/MaestroDelegatedStatelessWebService.cs
+++ b/src/Maestro/Maestro.Web/MaestroDelegatedStatelessWebService.cs
@@ -35,7 +35,7 @@ public class MaestroDelegatedStatelessWebService<TStartup> : StatelessService wh
                 {
                     return new HttpSysCommunicationListener(
                         context,
-                        "ServiceEndpoint",
+                        endpointName,
                         (url, listener) =>
                         {
                             var builder = new WebHostBuilder()

--- a/src/Maestro/Maestro.Web/MaestroServiceHost.cs
+++ b/src/Maestro/Maestro.Web/MaestroServiceHost.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.ApplicationInsights.Channel;
+using System.Fabric.Health;
+using System.Fabric;
+using System.Net;
+using System.Threading;
+using System;
+using Microsoft.DotNet.ServiceFabric.ServiceHost;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Maestro.Web;
+
+public class MaestroServiceHost : ServiceHost
+{
+    private MaestroServiceHost() { }
+
+    /// <summary>
+    ///     Configure and run a new ServiceHost
+    /// </summary>
+    public new static void Run(Action<ServiceHost> configure)
+    {
+        // Because of this issue, the activity tracking causes
+        // arbitrarily HttpClient calls to crash, so disable it until
+        // it is fixed
+        // https://github.com/dotnet/runtime/issues/36908
+        AppContext.SetSwitch("System.Net.Http.EnableActivityPropagation", false);
+        CodePackageActivationContext packageActivationContext = FabricRuntime.GetActivationContext();
+        try
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+            ServicePointManager.CheckCertificateRevocationList = true;
+            JsonConvert.DefaultSettings =
+                () => new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None };
+            var loggingServices = new ServiceCollection();
+            ConfigureLoggingServices(loggingServices);
+            using var loggingServiceProvider = loggingServices.BuildServiceProvider();
+            try
+            {
+                var loggerFactory = loggingServiceProvider.GetRequiredService<ILoggerFactory>();
+                using var eventListener = ServiceHostEventListener.ListenToEventSources(loggerFactory,
+                    // event sources we are interested in
+                    // Service Fabric sources
+                    "ServiceFramework",
+                    "ActorFramework",
+                    // aspnet sources
+                    "Microsoft.AspNetCore.Hosting",
+                    "Microsoft.AspNetCore.Http.Connections",
+                    "Microsoft-AspNetCore-Server-Kestrel",
+                    // dotnet sources
+                    "System.Data.DataCommonEventSource");
+                var host = new MaestroServiceHost();
+                configure(host);
+                host.Start();
+                packageActivationContext.ReportDeployedServicePackageHealth(
+                    new HealthInformation("ServiceHost", "ServiceHost.Run", HealthState.Ok));
+                Thread.Sleep(Timeout.Infinite);
+            }
+            finally
+            {
+                try
+                {
+                    loggingServiceProvider.GetService<ITelemetryChannel>()?.Flush();
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed to flush application insights telemetry channel. {ex}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            packageActivationContext.ReportDeployedServicePackageHealth(
+                new HealthInformation("ServiceHost", "ServiceHost.Run", HealthState.Error)
+                {
+                    Description = $"Unhandled Exception: {ex}"
+                },
+                new HealthReportSendOptions { Immediate = true });
+            Thread.Sleep(5000);
+            Environment.Exit(-1);
+        }
+    }
+
+    public new ServiceHost RegisterStatelessWebService<TStartup>(string serviceTypeName, Action<IWebHostBuilder> configureWebHost = null) where TStartup : class
+    {
+        RegisterStatelessService(
+            serviceTypeName,
+            context => new MaestroDelegatedStatelessWebService<TStartup>(
+                context,
+                configureWebHost ?? (builder => { }),
+                ApplyConfigurationToServices));
+        return ConfigureServices(builder => builder.AddScoped<TStartup>());
+    }
+}

--- a/src/Maestro/Maestro.Web/MaestroServiceHostWebSite.cs
+++ b/src/Maestro/Maestro.Web/MaestroServiceHostWebSite.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.DncEng.Configuration.Extensions;
+using Microsoft.DotNet.ServiceFabric.ServiceHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Maestro.Web;
+
+public static class MaestroServiceHostWebSite<TStartup>
+    where TStartup : class
+{
+    /// <summary>
+    ///     This is the entry point of the service host process.
+    /// </summary>
+    [PublicAPI]
+    public static void Run(string serviceTypeName)
+    {
+        if (ServiceFabricHelpers.RunningInServiceFabric())
+        {
+            ServiceFabricMain(serviceTypeName);
+        }
+        else
+        {
+            NonServiceFabricMain();
+        }
+    }
+
+    private static void NonServiceFabricMain()
+    {
+        new WebHostBuilder().UseKestrel(o =>
+        {
+            // Default 32k, which isn't enough for oauth cookies from GitHub for people with many teams/claims
+            o.Limits.MaxRequestHeadersTotalSize = 65536;
+        }
+            )
+            .UseContentRoot(AppContext.BaseDirectory)
+            .ConfigureAppConfiguration((context, builder) =>
+            {
+                builder.AddDefaultJsonConfiguration(context.HostingEnvironment, serviceProvider: null);
+            })
+            .ConfigureServices(ServiceHost.ConfigureDefaultServices)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IServiceLoadReporter>(new EmptyServiceLoadReporter());
+            })
+            .ConfigureLogging(
+                builder =>
+                {
+                    builder.AddFilter(level => level > LogLevel.Debug);
+                    builder.AddConsole();
+                })
+            .UseStartup<TStartup>()
+            .UseUrls("http://localhost:8080/")
+            .CaptureStartupErrors(true)
+            .Build()
+            .Run();
+    }
+
+    private static void ServiceFabricMain(string serviceTypeName)
+    {
+        MaestroServiceHost.Run(host => host.RegisterStatelessWebService<TStartup>(serviceTypeName,
+            hostBuilder =>
+            {
+                hostBuilder.ConfigureAppConfiguration((context, builder) =>
+                {
+                    builder.AddDefaultJsonConfiguration(context.HostingEnvironment, serviceProvider: null);
+                });
+            }));
+    }
+}

--- a/src/Maestro/Maestro.Web/Program.cs
+++ b/src/Maestro/Maestro.Web/Program.cs
@@ -9,6 +9,6 @@ internal static class Program
 {
     private static void Main()
     {
-        ServiceHostWebSite<Startup>.Run("Maestro.WebType");
+        MaestroServiceHostWebSite<Startup>.Run("Maestro.WebType");
     }
 }


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade-services/issues/2783
This is a temporary workaround to add a HTTP Listener on port 8088. This PR will be reverted once all traffic is going through the App gateway.
Most of the code in this PR is copied from https://github.com/dotnet/dnceng-shared/blob/main/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Add http listener