### PR TITLE
Use C# 10 to match .NET 6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     -->   
     <NoWarn>$(NoWarn);MSB3270</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>10</LangVersion>
     <IsShipping>false</IsShipping>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <DebugType>Full</DebugType>


### PR DESCRIPTION
This PR prevents Visual Studio from hinting language features which will not be available during runtime as we are at .NET 6.0:
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version

https://github.com/dotnet/arcade-services/issues/2978

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Not release not worthy