### PR TITLE
Add `darc vmr backflow` command

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
@@ -18,7 +18,7 @@ public abstract class Operation : IDisposable
 
     protected ILogger<Operation> Logger { get; }
 
-    protected Operation(CommandLineOptions options, IServiceCollection? services = null)
+    protected Operation(ICommandLineOptions options, IServiceCollection? services = null)
     {
         // Because the internal logging in DarcLib tends to be chatty and non-useful,
         // we remap the --verbose switch onto 'info', --debug onto highest level, and the

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 #nullable enable
@@ -21,7 +22,6 @@ internal class BackflowOperation : VmrOperationBase<IVmrBackflower>
     {
         { "create-patches", BackflowAction.CreatePatches },
         { "apply-patches", BackflowAction.ApplyPatches },
-        // { "create-prs", BackflowAction.CreatePRs },
     }.ToImmutableDictionary();
 
     public BackflowOperation(BackflowCommandLineOptions options)
@@ -49,7 +49,7 @@ internal class BackflowOperation : VmrOperationBase<IVmrBackflower>
         await vmrBackflower.BackflowAsync(
             ParseAction(_options.Action),
             repoName,
-            targetDirectory,
+            new NativePath(targetDirectory),
             additionalRemotes,
             cancellationToken);
     }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+#nullable enable
+namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
+
+internal class BackflowOperation : VmrOperationBase<IVmrBackflower>
+{
+    private readonly BackflowCommandLineOptions _options;
+
+    public BackflowOperation(BackflowCommandLineOptions options)
+        : base(options)
+    {
+        _options = options;
+    }
+
+    protected override async Task ExecuteInternalAsync(
+        IVmrBackflower vmrBackflower,
+        string repoName,
+        string? targetDirectory,
+        IReadOnlyCollection<AdditionalRemote> additionalRemotes,
+        CancellationToken cancellationToken)
+    {
+        targetDirectory ??= Path.Combine(
+            _options.RepositoryDirectory ?? throw new ArgumentException($"No target directory specified for repository {repoName}"),
+            repoName);
+
+        if (!Directory.Exists(targetDirectory))
+        {
+            throw new FileNotFoundException($"Could not find directory {targetDirectory}");
+        }
+
+        await vmrBackflower.BackflowAsync(repoName, targetDirectory, additionalRemotes);
+    }
+}

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
@@ -38,6 +38,6 @@ internal class BackflowOperation : VmrOperationBase<IVmrBackflower>
             throw new FileNotFoundException($"Could not find directory {targetDirectory}");
         }
 
-        await vmrBackflower.BackflowAsync(repoName, targetDirectory, additionalRemotes);
+        await vmrBackflower.BackflowAsync(repoName, targetDirectory, additionalRemotes, cancellationToken);
     }
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
@@ -21,8 +21,7 @@ internal class BackflowOperation : VmrOperationBase<IVmrBackflower>
     {
         { "create-patches", BackflowAction.CreatePatches },
         { "apply-patches", BackflowAction.ApplyPatches },
-        { "create-branches", BackflowAction.CreateBranches },
-        { "create-prs", BackflowAction.CreatePRs },
+        // { "create-prs", BackflowAction.CreatePRs },
     }.ToImmutableDictionary();
 
     public BackflowOperation(BackflowCommandLineOptions options)
@@ -47,7 +46,12 @@ internal class BackflowOperation : VmrOperationBase<IVmrBackflower>
             throw new FileNotFoundException($"Could not find directory {targetDirectory}");
         }
 
-        await vmrBackflower.BackflowAsync(ParseAction(_options.), repoName, targetDirectory, additionalRemotes, cancellationToken);
+        await vmrBackflower.BackflowAsync(
+            ParseAction(_options.Action),
+            repoName,
+            targetDirectory,
+            additionalRemotes,
+            cancellationToken);
     }
 
     private static BackflowAction ParseAction(string value)

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/VmrOperationBase.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/VmrOperationBase.cs
@@ -17,9 +17,9 @@ namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
 internal abstract class VmrOperationBase<TVmrManager> : Operation where TVmrManager : notnull
 {
-    private readonly VmrSyncCommandLineOptions _options;
+    private readonly IBaseVmrCommandLineOptions _options;
 
-    protected VmrOperationBase(VmrSyncCommandLineOptions options)
+    protected VmrOperationBase(IBaseVmrCommandLineOptions options)
         : base(options, options.RegisterServices())
     {
         _options = options;
@@ -41,7 +41,7 @@ internal abstract class VmrOperationBase<TVmrManager> : Operation where TVmrMana
         TVmrManager vmrManager = Provider.GetRequiredService<TVmrManager>();
 
         IEnumerable<(string Name, string? Revision)> repoNamesWithRevisions = repositories
-            .Select(a => a.Split(':') is string[] parts && parts.Length == 2
+            .Select(a => a.Split(':', 2) is string[] parts && parts.Length == 2
                 ? (Name: parts[0], Revision: parts[1])
                 : (a, null));
 
@@ -49,7 +49,6 @@ internal abstract class VmrOperationBase<TVmrManager> : Operation where TVmrMana
         if (_options.AdditionalRemotes != null)
         {
             additionalRemotes = _options.AdditionalRemotes
-                .Split(',', StringSplitOptions.RemoveEmptyEntries)
                 .Select(a => a.Split(':', 2))
                 .Select(parts => new AdditionalRemote(parts[0], parts[1]))
                 .ToImmutableArray();

--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -7,7 +7,7 @@ using Microsoft.DotNet.DarcLib;
 
 namespace Microsoft.DotNet.Darc.Options;
 
-public abstract class CommandLineOptions
+public abstract class CommandLineOptions : ICommandLineOptions
 {
     [Option('p', "password", HelpText = "BAR password.")]
     [RedactFromLogging]

--- a/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Darc.Operations;
+using Microsoft.DotNet.DarcLib;
+
+namespace Microsoft.DotNet.Darc.Options;
+public interface ICommandLineOptions
+{
+    string AzureDevOpsPat { get; set; }
+    string BuildAssetRegistryBaseUri { get; set; }
+    string BuildAssetRegistryPassword { get; set; }
+    bool Debug { get; set; }
+    string GitHubPat { get; set; }
+    string GitLocation { get; set; }
+    DarcOutputType OutputFormat { get; set; }
+    bool Verbose { get; set; }
+
+    Operation GetOperation();
+    RemoteConfiguration GetRemoteConfiguration();
+}

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/BackflowCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/BackflowCommandLineOptions.cs
@@ -20,7 +20,7 @@ internal class BackflowCommandLineOptions : VmrCommandLineOptions, IBaseVmrComma
         "Path can be ommitted when ")]
     public IEnumerable<string> Repositories { get; set; }
 
-    [Option("action", Required = false, HelpText = "Backflow action to perform with the target repo. One of <create-patches|apply-patches|create-branches|create-prs>. Defaults to create-patches")]
+    [Option("action", Required = false, HelpText = "Backflow action to perform with the target repo. One of <create-patches|apply-patches>. Defaults to create-patches")]
     public string Action { get; set; } = "create-patches";
 
     [Option("repository-dirs", Required = false, HelpText = "Path to where all repositories are checked out to (directory names must match mapping names). " +

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/BackflowCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/BackflowCommandLineOptions.cs
@@ -17,7 +17,7 @@ internal class BackflowCommandLineOptions : VmrCommandLineOptions, IBaseVmrComma
     public IEnumerable<string> AdditionalRemotes { get; set; }
 
     [Value(0, Required = true, HelpText = "Repositories to backflow in the form of NAME:PATH with mapping name and local path to the target repository. " +
-        "Path can be ommitted when ")]
+        "Path can be ommitted when --repository-dirs is supplied.")]
     public IEnumerable<string> Repositories { get; set; }
 
     [Option("action", Required = false, HelpText = "Backflow action to perform with the target repo. One of <create-patches|apply-patches>. Defaults to create-patches")]

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/BackflowCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/BackflowCommandLineOptions.cs
@@ -20,6 +20,9 @@ internal class BackflowCommandLineOptions : VmrCommandLineOptions, IBaseVmrComma
         "Path can be ommitted when ")]
     public IEnumerable<string> Repositories { get; set; }
 
+    [Option("action", Required = false, HelpText = "Backflow action to perform with the target repo. One of <create-patches|apply-patches|create-branches|create-prs>. Defaults to create-patches")]
+    public string Action { get; set; } = "create-patches";
+
     [Option("repository-dirs", Required = false, HelpText = "Path to where all repositories are checked out to (directory names must match mapping names). " +
         "Substitutes the need to specify path for every backflown repository")]
     public string RepositoryDirectory { get; set; }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/BackflowCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/BackflowCommandLineOptions.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using CommandLine;
+using Microsoft.DotNet.Darc.Operations;
+using Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
+
+namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
+
+[Verb("backflow", HelpText = "Flows code changes from the VMR back to target repositories.")]
+internal class BackflowCommandLineOptions : VmrCommandLineOptions, IBaseVmrCommandLineOptions
+{
+    [Option("additional-remotes", Required = false, HelpText =
+        "List of additional remote URIs to add to mappings in the format [mapping name]:[remote URI]. " +
+        "Example: installer:https://github.com/myfork/installer,sdk:/local/path/to/sdk")]
+    public IEnumerable<string> AdditionalRemotes { get; set; }
+
+    [Value(0, Required = true, HelpText = "Repositories to backflow in the form of NAME:PATH with mapping name and local path to the target repository. " +
+        "Path can be ommitted when ")]
+    public IEnumerable<string> Repositories { get; set; }
+
+    [Option("repository-dirs", Required = false, HelpText = "Path to where all repositories are checked out to (directory names must match mapping names). " +
+        "Substitutes the need to specify path for every backflown repository")]
+    public string RepositoryDirectory { get; set; }
+
+    [Option("discard-patches", Required = false, HelpText = "Delete .patch files created during the sync.")]
+    public bool DiscardPatches { get; set; } = false;
+
+    public override Operation GetOperation() => new BackflowOperation(this);
+}

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/IBaseVmrCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/IBaseVmrCommandLineOptions.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
+
+internal interface IBaseVmrCommandLineOptions : ICommandLineOptions
+{
+    string VmrPath { get; }
+
+    string TmpPath { get; }
+
+    IEnumerable<string> AdditionalRemotes { get; }
+
+    IEnumerable<string> Repositories { get; }
+
+    IServiceCollection RegisterServices();
+}

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrSyncCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrSyncCommandLineOptions.cs
@@ -6,12 +6,12 @@ using CommandLine;
 
 namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
-internal abstract class VmrSyncCommandLineOptions : VmrCommandLineOptions
+internal abstract class VmrSyncCommandLineOptions : VmrCommandLineOptions, IBaseVmrCommandLineOptions
 {
     [Option("additional-remotes", Required = false, HelpText =
-        "Comma separated list of additional remote URIs to add to mappings in the format [mapping name]:[remote URI]. " +
+        "List of additional remote URIs to add to mappings in the format [mapping name]:[remote URI]. " +
         "Example: installer:https://github.com/myfork/installer,sdk:/local/path/to/sdk")]
-    public string AdditionalRemotes { get; set; }
+    public IEnumerable<string> AdditionalRemotes { get; set; }
     
     [Value(0, Required = true, HelpText =
         "Repository names in the form of NAME or NAME:REVISION where REVISION is a commit SHA or other git reference (branch, tag). " +

--- a/src/Microsoft.DotNet.Darc/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Program.cs
@@ -113,6 +113,7 @@ internal static class Program
     {
         typeof(InitializeCommandLineOptions),
         typeof(UpdateCommandLineOptions),
+        typeof(BackflowCommandLineOptions),
         typeof(GenerateTpnCommandLineOptions),
         typeof(CloakedFileScanOptions),
         typeof(BinaryFileScanOptions),

--- a/src/Microsoft.DotNet.Darc/DarcLib/Constants.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Constants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.DarcLib;
@@ -11,6 +11,12 @@ public class Constants
 
     // Well known ID of an empty commit (can be used as a "commit zero" when diffing)
     public const string EmptyGitObject = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
+    // String used to mark the commit as automated
+    public const string AUTOMATION_COMMIT_TAG = "[[ commit created by automation ]]";
+
+    // Character we use in the commit messages to indicate the change
+    public const string Arrow = " → ";
 
     public const string GitHubUrlPrefix = "https://github.com/";
     public const string AzureDevOpsUrlPrefix = "https://dev.azure.com/";

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
@@ -124,4 +124,16 @@ public interface ILocalGitRepo : IGitRepo
         string repoPath,
         string remoteUri,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves SHA of a commit that last change a given line in a given file.
+    /// </summary>
+    /// <param name="repoPath">Path to the repository</param>
+    /// <param name="relativeFilePath">Relative path to the file inside of the repository</param>
+    /// <param name="line">Line to blame</param>
+    /// <returns>SHA of a commit that last change a given line in a given file</returns>
+    Task<string> BlameLineAsync(
+        string repoPath,
+        string relativeFilePath,
+        int line);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
@@ -126,7 +126,7 @@ public interface ILocalGitRepo : IGitRepo
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Retrieves SHA of a commit that last change a given line in a given file.
+    /// Retrieves SHA of a commit that last changed a given line in a given file.
     /// </summary>
     /// <param name="repoPath">Path to the repository</param>
     /// <param name="relativeFilePath">Relative path to the file inside of the repository</param>

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
@@ -126,7 +126,7 @@ public interface ILocalGitRepo : IGitRepo
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Retrieves SHA of a commit that last changed a given line in a given file.
+    /// Retrieves SHA of the commit that last changed the given line in the given file.
     /// </summary>
     /// <param name="repoPath">Path to the repository</param>
     /// <param name="relativeFilePath">Relative path to the file inside of the repository</param>

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
@@ -131,7 +131,7 @@ public interface ILocalGitRepo : IGitRepo
     /// <param name="repoPath">Path to the repository</param>
     /// <param name="relativeFilePath">Relative path to the file inside of the repository</param>
     /// <param name="line">Line to blame</param>
-    /// <returns>SHA of a commit that last change a given line in a given file</returns>
+    /// <returns>SHA of the commit that last changed the given line in the given file</returns>
     Task<string> BlameLineAsync(
         string repoPath,
         string relativeFilePath,

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -651,8 +651,9 @@ public class LocalGitClient : ILocalGitRepo
         var args = new[]
         {
             "blame",
+            "--first-parent",
             "-slL",
-            line.ToString(),
+            $"{line},{line}",
             relativeFilePath,
         };
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -645,4 +645,19 @@ public class LocalGitClient : ILocalGitRepo
         result.ThrowIfFailed($"Failed to fetch from {remoteUri} in {repoPath}");
         return result.StandardOutput.Trim();
     }
+
+    public async Task<string> BlameLineAsync(string repoPath, string relativeFilePath, int line)
+    {
+        var args = new[]
+        {
+            "blame",
+            "-slL",
+            line.ToString(),
+            relativeFilePath,
+        };
+
+        var result = await _processManager.ExecuteGit(repoPath, args);
+        result.ThrowIfFailed($"Failed to blame line {line} of {repoPath}{Path.DirectorySeparatorChar}{relativeFilePath}");
+        return result.StandardOutput.Trim().Split(' ').First();
+    }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeBackflower.cs
@@ -33,6 +33,10 @@ public enum BackflowAction
     ApplyPatches,
 }
 
+/// <summary>
+/// This class is responsible for taking changes done to a repo in the VMR and backflowing them into the repo.
+/// It only makes patches/changes locally, no other effects are done.
+/// </summary>
 public class CodeBackflower : IVmrBackflower
 {
     private readonly IVmrInfo _vmrInfo;
@@ -135,7 +139,6 @@ public class CodeBackflower : IVmrBackflower
 
         _logger.LogInformation("Created branch {branchName} in {repoDir}", branchName, repoDirectory);
 
-        // Apply patches
         foreach (var patch in patches)
         {
             await _vmrPatchHandler.ApplyPatch(patch, repoDirectory, cancellationToken);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeBackflower.cs
@@ -86,6 +86,7 @@ public class CodeBackflower : IVmrBackflower
             return;
         }
 
+        // When we only care about patch creation, we print the paths of the patches we have created and return
         if (action == BackflowAction.CreatePatches)
         {
             var message = new StringBuilder();
@@ -103,14 +104,12 @@ public class CodeBackflower : IVmrBackflower
             return;
         }
 
+        // Let's apply the patches onto the target repo
         _logger.LogInformation("Synchronizing {repo} from {repoSourceSha}", mappingName, repo.CommitSha);
         _logger.LogDebug($"VMR range to be synchronized: {{sourceSha}} {Constants.Arrow} {{targetSha}}", vmrSourceSha, vmrTargetSha);
 
-        var patchName = $"{Commit.GetShortSha(vmrSourceSha)}-{Commit.GetShortSha(vmrTargetSha)}";
-        var branchName = $"backflow/" + patchName;
-        patchName = $"{mappingName}.{patchName}.patch";
+        var branchName = $"backflow/{Commit.GetShortSha(vmrSourceSha)}-{Commit.GetShortSha(vmrTargetSha)}";
 
-        // Checkout repo at base commit and create a working branch
         string[] remotes = additionalRemotes
             .Where(r => r.Mapping == mappingName)
             .Select(r => r.RemoteUri)

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeBackflower.cs
@@ -100,7 +100,7 @@ public class CodeBackflower : IVmrBackflower
         }
 
         _logger.LogInformation("Synchronizing {repo} from {repoSourceSha}", mappingName, repo.CommitSha);
-        _logger.LogDebug($"VMR range to be synchronized: {{sourceSha}} {VmrUpdater.Arrow} {{targetSha}}", vmrSourceSha, vmrTargetSha);
+        _logger.LogDebug($"VMR range to be synchronized: {{sourceSha}} {Constants.Arrow} {{targetSha}}", vmrSourceSha, vmrTargetSha);
 
         var patchName = $"{Commit.GetShortSha(vmrSourceSha)}-{Commit.GetShortSha(vmrTargetSha)}";
         var branchName = $"backflow/" + patchName;
@@ -141,6 +141,14 @@ public class CodeBackflower : IVmrBackflower
             await _vmrPatchHandler.ApplyPatch(patch, repoDirectory, cancellationToken);
         }
 
+        var commitMessage = $"""
+            [VMR] Code backflow {Commit.GetShortSha(vmrSourceSha)}{Constants.Arrow}{Commit.GetShortSha(vmrTargetSha)}
+
+            {Constants.AUTOMATION_COMMIT_TAG}
+            """;
+
+        await _localGitClient.CommitAsync(repoDirectory, commitMessage, allowEmpty: false, cancellationToken: cancellationToken);
+
         _logger.LogInformation("New branch {branch} with backflown code is ready in {repoDir}", branchName, repoDirectory);
     }
 
@@ -163,7 +171,7 @@ public class CodeBackflower : IVmrBackflower
             return new();
         }
 
-        _logger.LogDebug($"VMR range to be synchronized: {{sourceSha}} {VmrUpdater.Arrow} {{targetSha}}", vmrSourceSha, vmrTargetSha);
+        _logger.LogDebug($"VMR range to be synchronized: {{sourceSha}} {Constants.Arrow} {{targetSha}}", vmrSourceSha, vmrTargetSha);
 
         var patchName = $"{Commit.GetShortSha(vmrSourceSha)}-{Commit.GetShortSha(vmrTargetSha)}";
         var workBranchName = $"backflow/" + patchName;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeBackflower.cs
@@ -22,7 +22,7 @@ public interface IVmrBackflower
     Task BackflowAsync(
         BackflowAction action,
         string repoName,
-        string targetDirectory,
+        NativePath targetDirectory,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken);
 }
@@ -31,36 +31,32 @@ public enum BackflowAction
 {
     CreatePatches,
     ApplyPatches,
-    // CreatePRs,
 }
 
-public class VmrBackflower : IVmrBackflower
+public class CodeBackflower : IVmrBackflower
 {
     private readonly IVmrInfo _vmrInfo;
     private readonly ISourceManifest _sourceManifest;
     private readonly ILocalGitRepo _localGitClient;
     private readonly IVmrPatchHandler _vmrPatchHandler;
     private readonly IWorkBranchFactory _workBranchFactory;
-    private readonly IRepositoryCloneManager _cloneManager;
     private readonly IFileSystem _fileSystem;
-    private readonly ILogger<VmrBackflower> _logger;
+    private readonly ILogger<CodeBackflower> _logger;
 
-    public VmrBackflower(
+    public CodeBackflower(
         IVmrInfo vmrInfo,
         ISourceManifest sourceManifest,
         ILocalGitRepo localGitClient,
         IVmrPatchHandler vmrPatchHandler,
         IWorkBranchFactory workBranchFactory,
         IFileSystem fileSystem,
-        ILogger<VmrBackflower> logger,
-        IRepositoryCloneManager cloneManager)
+        ILogger<CodeBackflower> logger)
     {
         _vmrInfo = vmrInfo;
         _sourceManifest = sourceManifest;
         _localGitClient = localGitClient;
         _vmrPatchHandler = vmrPatchHandler;
         _workBranchFactory = workBranchFactory;
-        _cloneManager = cloneManager;
         _fileSystem = fileSystem;
         _logger = logger;
     }
@@ -74,7 +70,7 @@ public class VmrBackflower : IVmrBackflower
     public async Task BackflowAsync(
         BackflowAction action,
         string mappingName,
-        string repoDirectory,
+        NativePath repoDirectory,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken)
     {
@@ -142,7 +138,7 @@ public class VmrBackflower : IVmrBackflower
         // Apply patches
         foreach (var patch in patches)
         {
-            await _vmrPatchHandler.ApplyPatch(patch, new NativePath(repoDirectory), cancellationToken);
+            await _vmrPatchHandler.ApplyPatch(patch, repoDirectory, cancellationToken);
         }
 
         _logger.LogInformation("New branch {branch} with backflown code is ready in {repoDir}", branchName, repoDirectory);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -12,7 +12,10 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IVmrPatchHandler
 {
-    Task ApplyPatch(VmrIngestionPatch patch, CancellationToken cancellationToken);
+    Task ApplyPatch(
+        VmrIngestionPatch patch,
+        NativePath targetDirectory,
+        CancellationToken cancellationToken);
 
     Task<List<VmrIngestionPatch>> CreatePatches(
         SourceMapping mapping,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -19,11 +19,11 @@ public interface IVmrPatchHandler
 
     Task<List<VmrIngestionPatch>> CreatePatches(
         SourceMapping mapping,
-        LocalPath repoPath,
+        NativePath repoPath,
         string sha1,
         string sha2,
-        LocalPath destDir,
-        LocalPath tmpPath,
+        NativePath destDir,
+        NativePath tmpPath,
         CancellationToken cancellationToken);
 
     Task<List<VmrIngestionPatch>> CreatePatches(
@@ -33,7 +33,7 @@ public interface IVmrPatchHandler
         string? path,
         IReadOnlyCollection<string>? filters,
         bool relativePaths,
-        LocalPath workingDir,
+        NativePath workingDir,
         UnixPath? applicationPath,
         CancellationToken cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -34,7 +34,9 @@ public interface IVmrPatchHandler
         UnixPath? applicationPath,
         CancellationToken cancellationToken);
 
-    IReadOnlyCollection<string> GetVmrPatches(SourceMapping mapping);
+    IReadOnlyCollection<string> GetVmrPatches(SourceMapping mapping) => GetVmrPatches(mapping.Name);
+
+    IReadOnlyCollection<string> GetVmrPatches(string mappingName);
 
     Task<IReadOnlyCollection<UnixPath>> GetPatchedFiles(string patchPath, CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -23,6 +23,17 @@ public interface IVmrPatchHandler
         LocalPath tmpPath,
         CancellationToken cancellationToken);
 
+    Task<List<VmrIngestionPatch>> CreatePatches(
+        string patchName,
+        string sha1,
+        string sha2,
+        string? path,
+        IReadOnlyCollection<string>? filters,
+        bool relativePaths,
+        LocalPath workingDir,
+        UnixPath? applicationPath,
+        CancellationToken cancellationToken);
+
     IReadOnlyCollection<string> GetVmrPatches(SourceMapping mapping);
 
     Task<IReadOnlyCollection<UnixPath>> GetPatchedFiles(string patchPath, CancellationToken cancellationToken);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -16,9 +16,9 @@ public record AdditionalRemote(string Mapping, string RemoteUri);
 
 public interface IRepositoryCloneManager
 {
-    Task<LocalPath> PrepareClone(string repoUri, string checkoutRef, CancellationToken cancellationToken);
+    Task<NativePath> PrepareClone(string repoUri, string checkoutRef, CancellationToken cancellationToken);
 
-    Task<LocalPath> PrepareClone(
+    Task<NativePath> PrepareClone(
         SourceMapping mapping,
         string[] remotes,
         string checkoutRef,
@@ -34,38 +34,32 @@ public interface IRepositoryCloneManager
 public class RepositoryCloneManager : IRepositoryCloneManager
 {
     private readonly IVmrInfo _vmrInfo;
-    private readonly RemoteConfiguration _remoteConfig;
     private readonly IGitRepoCloner _gitRepoCloner;
     private readonly ILocalGitRepo _localGitRepo;
-    private readonly IProcessManager _processManager;
     private readonly IFileSystem _fileSystem;
     private readonly ILogger<VmrPatchHandler> _logger;
 
     // Map of URI => dir name
-    private readonly Dictionary<string, LocalPath> _clones = new();
+    private readonly Dictionary<string, NativePath> _clones = new();
 
     // Repos we have already pulled updates for during this run
     private readonly List<string> _upToDateRepos = new();
 
     public RepositoryCloneManager(
         IVmrInfo vmrInfo,
-        RemoteConfiguration remoteConfig,
         IGitRepoCloner gitRepoCloner,
         ILocalGitRepo localGitRepo,
-        IProcessManager processManager,
         IFileSystem fileSystem,
         ILogger<VmrPatchHandler> logger)
     {
         _vmrInfo = vmrInfo;
-        _remoteConfig = remoteConfig;
         _gitRepoCloner = gitRepoCloner;
         _localGitRepo = localGitRepo;
-        _processManager = processManager;
         _fileSystem = fileSystem;
         _logger = logger;
     }
 
-    public async Task<LocalPath> PrepareClone(
+    public async Task<NativePath> PrepareClone(
         SourceMapping mapping,
         string[] remoteUris,
         string checkoutRef,
@@ -76,7 +70,7 @@ public class RepositoryCloneManager : IRepositoryCloneManager
             throw new ArgumentException("No remote URIs provided to clone");
         }
 
-        LocalPath path = null!;
+        NativePath path = null!;
         foreach (string remoteUri in remoteUris)
         {
             // Path should be returned the same for all invocations
@@ -89,7 +83,7 @@ public class RepositoryCloneManager : IRepositoryCloneManager
         return path;
     }
 
-    public async Task<LocalPath> PrepareClone(
+    public async Task<NativePath> PrepareClone(
         string repoUri,
         string checkoutRef,
         CancellationToken cancellationToken)
@@ -101,7 +95,7 @@ public class RepositoryCloneManager : IRepositoryCloneManager
         return path;
     }
 
-    private async Task<LocalPath> PrepareCloneInternal(string remoteUri, string dirName, CancellationToken cancellationToken)
+    private async Task<NativePath> PrepareCloneInternal(string remoteUri, string dirName, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.Logging;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+public interface IVmrBackflower
+{
+    Task BackflowAsync(string repoName, string targetDirectory, IReadOnlyCollection<AdditionalRemote> additionalRemotes);
+}
+
+public class VmrBackflower : IVmrBackflower
+{
+    private readonly ISourceManifest _sourceManifest;
+    private readonly ILocalGitRepo _localGitClient;
+    private readonly IVmrPatchHandler _vmrPatchHandler;
+    private readonly IFileSystem _fileSystem;
+    private readonly ILogger<VmrBackflower> _logger;
+
+    public VmrBackflower(
+        ISourceManifest sourceManifest,
+        ILocalGitRepo localGitClient,
+        IVmrPatchHandler vmrPatchHandler,
+        IFileSystem fileSystem,
+        ILogger<VmrBackflower> logger)
+    {
+        _sourceManifest = sourceManifest;
+        _localGitClient = localGitClient;
+        _vmrPatchHandler = vmrPatchHandler;
+        _fileSystem = fileSystem;
+        _logger = logger;
+    }
+
+    public async Task BackflowAsync(string repoName, string targetDirectory, IReadOnlyCollection<AdditionalRemote> additionalRemotes)
+    {
+
+        await Task.CompletedTask;
+    }
+}

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -43,17 +43,17 @@ public interface IVmrInfo
     /// <summary>
     /// Gets a full path leading to sources belonging to a given repo (mapping)
     /// </summary>
-    LocalPath GetRepoSourcesPath(SourceMapping mapping);
+    NativePath GetRepoSourcesPath(SourceMapping mapping);
 
     /// <summary>
     /// Gets a full path leading to sources belonging to a given repo
     /// </summary>
-    LocalPath GetRepoSourcesPath(string mappingName);
+    NativePath GetRepoSourcesPath(string mappingName);
 
     /// <summary>
     /// Gets a full path leading to the source manifest JSON file.
     /// </summary>
-    LocalPath GetSourceManifestPath();
+    NativePath GetSourceManifestPath();
 }
 
 public class VmrInfo : IVmrInfo
@@ -95,11 +95,11 @@ public class VmrInfo : IVmrInfo
     {
     }
 
-    public LocalPath GetRepoSourcesPath(SourceMapping mapping) => GetRepoSourcesPath(mapping.Name);
+    public NativePath GetRepoSourcesPath(SourceMapping mapping) => GetRepoSourcesPath(mapping.Name);
 
-    public LocalPath GetRepoSourcesPath(string mappingName) => VmrPath / SourcesDir / mappingName;
+    public NativePath GetRepoSourcesPath(string mappingName) => VmrPath / SourcesDir / mappingName;
 
     public static UnixPath GetRelativeRepoSourcesPath(SourceMapping mapping) => RelativeSourcesDir / mapping.Name;
 
-    public LocalPath GetSourceManifestPath() => VmrPath / SourcesDir / SourceManifestFileName;
+    public NativePath GetSourceManifestPath() => VmrPath / SourcesDir / SourceManifestFileName;
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -14,12 +14,12 @@ public interface IVmrInfo
     /// <summary>
     /// Path for temporary files (individual repo clones, created patches, etc.)
     /// </summary>
-    LocalPath TmpPath { get; }
+    NativePath TmpPath { get; }
 
     /// <summary>
     /// Path to the root of the VMR
     /// </summary>
-    LocalPath VmrPath { get; }
+    NativePath VmrPath { get; }
 
     /// <summary>
     /// Path within the VMR where VMR patches are stored.
@@ -75,9 +75,9 @@ public class VmrInfo : IVmrInfo
 
     public static UnixPath RelativeSourcesDir { get; } = new("src");
 
-    public LocalPath VmrPath { get; }
+    public NativePath VmrPath { get; }
 
-    public LocalPath TmpPath { get; }
+    public NativePath TmpPath { get; }
 
     public string? PatchesPath { get; set; }
 
@@ -85,7 +85,7 @@ public class VmrInfo : IVmrInfo
 
     public IReadOnlyCollection<(string Source, string? Destination)> AdditionalMappings { get; set; } = Array.Empty<(string, string?)>();
 
-    public VmrInfo(LocalPath vmrPath, LocalPath tmpPath)
+    public VmrInfo(NativePath vmrPath, NativePath tmpPath)
     {
         VmrPath = vmrPath;
         TmpPath = tmpPath;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -29,7 +29,7 @@ public interface IVmrInfo
     string? PatchesPath { get; set; }
 
     /// <summary>
-    /// Path to the source-mappings.json file 
+    /// Path to the source-mappings.json file
     /// </summary>
     string? SourceMappingsPath { get; set; }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -179,7 +179,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
             .Prepend(update.RemoteUri)
             .ToArray();
 
-        var clonePath = await _cloneManager.PrepareClone(
+        NativePath clonePath = await _cloneManager.PrepareClone(
             update.Mapping,
             remotes,
             update.TargetRevision,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -28,7 +28,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
 
         Original commit: {remote}/commit/{newSha}
 
-        {{AUTOMATION_COMMIT_TAG}}
+        {{Constants.AUTOMATION_COMMIT_TAG}}
         """;
 
     // Message used when finalizing the initialization with a merge commit
@@ -36,7 +36,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         $$"""
         Recursive initialization for {name} / {newShaShort}
 
-        {{AUTOMATION_COMMIT_TAG}}
+        {{Constants.AUTOMATION_COMMIT_TAG}}
         """;
 
     private readonly IVmrInfo _vmrInfo;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -17,8 +17,6 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public abstract class VmrManagerBase
 {
-    // String used to mark the commit as automated
-    protected const string AUTOMATION_COMMIT_TAG = "[[ commit created by automation ]]";
     protected const string HEAD = "HEAD";
     protected const string InterruptedSyncExceptionMessage = 
         "A new branch was created for the sync and didn't get merged as the sync " +

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -67,9 +67,9 @@ public abstract class VmrManagerBase
 
     protected async Task<IReadOnlyCollection<VmrIngestionPatch>> UpdateRepoToRevisionAsync(
         VmrDependencyUpdate update,
-        LocalPath clonePath,
+        NativePath clonePath,
         string fromRevision,
-        LibGit2Sharp.Identity author,
+        Identity author,
         string commitMessage,
         bool reapplyVmrPatches,
         string? readmeTemplatePath,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -95,7 +95,7 @@ public abstract class VmrManagerBase
 
         foreach (var patch in patches)
         {
-            await _patchHandler.ApplyPatch(patch, cancellationToken);
+            await _patchHandler.ApplyPatch(patch, _vmrInfo.VmrPath, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
 
             if (discardPatches)
@@ -179,7 +179,7 @@ public abstract class VmrManagerBase
                 continue;
             }
 
-            await _patchHandler.ApplyPatch(patch, cancellationToken);
+            await _patchHandler.ApplyPatch(patch, _vmrInfo.VmrPath, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
         }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -613,14 +613,14 @@ public class VmrPatchHandler : IVmrPatchHandler
         result.ThrowIfFailed("Failed to clean the working tree!");
     }
 
-    public IReadOnlyCollection<string> GetVmrPatches(SourceMapping mapping)
+    public IReadOnlyCollection<string> GetVmrPatches(string mappingName)
     {
         if (_vmrInfo.PatchesPath is null)
         {
             return Array.Empty<string>();
         }
 
-        var mappingPatchesPath = _vmrInfo.VmrPath / _vmrInfo.PatchesPath / mapping.Name;
+        var mappingPatchesPath = _vmrInfo.VmrPath / _vmrInfo.PatchesPath / mappingName;
         if (!_fileSystem.DirectoryExists(mappingPatchesPath))
         {
             return Array.Empty<string>();

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -134,7 +134,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         }
 
         var patches = new List<VmrIngestionPatch>();
-        patches.AddRange(await CreatePatchesSafely(
+        patches.AddRange(await CreatePatches(
             patchName,
             sha1,
             sha2,
@@ -180,7 +180,7 @@ public class VmrPatchHandler : IVmrPatchHandler
                 continue;
             }
 
-            patches.AddRange(await CreatePatchesSafely(
+            patches.AddRange(await CreatePatches(
                 patchName,
                 sha1,
                 sha2,
@@ -330,7 +330,7 @@ public class VmrPatchHandler : IVmrPatchHandler
     /// <summary>
     /// Creates patches and if any is > 1GB, splits it into smaller ones.
     /// </summary>
-    private async Task<List<VmrIngestionPatch>> CreatePatchesSafely(
+    public async Task<List<VmrIngestionPatch>> CreatePatches(
         string patchName,
         string sha1,
         string sha2,
@@ -371,7 +371,7 @@ public class VmrPatchHandler : IVmrPatchHandler
 
             var newPatchname = $"{patchName}.{i + 1}";
 
-            patches.AddRange(await CreatePatchesSafely(
+            patches.AddRange(await CreatePatches(
                 newPatchname,
                 sha1,
                 sha2,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -240,7 +240,7 @@ public class VmrPatchHandler : IVmrPatchHandler
     /// <summary>
     /// Applies a given patch file onto given mapping's subrepository.
     /// </summary>
-    public async Task ApplyPatch(VmrIngestionPatch patch, CancellationToken cancellationToken)
+    public async Task ApplyPatch(VmrIngestionPatch patch, NativePath targetDirectory, CancellationToken cancellationToken)
     {
         var info = _fileSystem.GetFileInfo(patch.Path);
         if (!info.Exists)
@@ -258,7 +258,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         _logger.LogInformation("Applying patch {patchPath} to {path}...", patch.Path, patch.ApplicationPath ?? "root of the VMR");
 
         // This will help ignore some CR/LF issues (e.g. files with both endings)
-        (await _processManager.ExecuteGit(_vmrInfo.VmrPath, new[] { "config", "apply.ignoreWhitespace", "change" }, cancellationToken: cancellationToken))
+        (await _processManager.ExecuteGit(targetDirectory, new[] { "config", "apply.ignoreWhitespace", "change" }, cancellationToken: cancellationToken))
             .ThrowIfFailed("Failed to set git config whitespace settings");
 
         var args = new List<string>
@@ -284,17 +284,17 @@ public class VmrPatchHandler : IVmrPatchHandler
 
             if (!_fileSystem.DirectoryExists(patch.ApplicationPath))
             {
-                _fileSystem.CreateDirectory(_vmrInfo.VmrPath / patch.ApplicationPath);
+                _fileSystem.CreateDirectory(targetDirectory / patch.ApplicationPath);
             }
         }
 
         args.Add(patch.Path);
 
-        var result = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args, cancellationToken: CancellationToken.None);
+        var result = await _processManager.ExecuteGit(targetDirectory, args, cancellationToken: CancellationToken.None);
         result.ThrowIfFailed($"Failed to apply the patch for {patch.ApplicationPath ?? "/"}");
         _logger.LogDebug("{output}", result.ToString());
 
-        await ResetWorkingTreeDirectory(patch.ApplicationPath ?? ".");
+        await ResetWorkingTreeDirectory(targetDirectory, patch.ApplicationPath ?? new UnixPath("."));
     }
 
     /// <summary>
@@ -586,14 +586,14 @@ public class VmrPatchHandler : IVmrPatchHandler
             cancellationToken);
     }
 
-    private async Task ResetWorkingTreeDirectory(string relativePath)
+    private async Task ResetWorkingTreeDirectory(NativePath repoPath, UnixPath relativePath)
     {
         // After we apply the diff to the index, working tree won't have the files so they will be missing
         // We have to reset working tree to the index then
         // This will end up having the working tree match what is staged
-        _logger.LogInformation("Cleaning the working tree directory {path}...", relativePath);
+        _logger.LogInformation("Cleaning the working tree directory {path}...", repoPath/relativePath);
         var args = new string[] { "checkout", relativePath };
-        var result = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args, cancellationToken: CancellationToken.None);
+        var result = await _processManager.ExecuteGit(repoPath, args, cancellationToken: CancellationToken.None);
         
         if (result.Succeeded)
         {
@@ -604,12 +604,12 @@ public class VmrPatchHandler : IVmrPatchHandler
             // In case a submodule was removed, it won't be in the index anymore and the checkout will fail
             // We can just remove the working tree folder then
             _logger.LogInformation("A removed submodule detected. Removing files at {path}...", relativePath);
-            _fileSystem.DeleteDirectory(_vmrInfo.VmrPath / relativePath, true);
+            _fileSystem.DeleteDirectory(repoPath / relativePath, true);
         }
 
         // Also remove untracked files (in case files were removed in index)
         args = new string[] { "clean", "-df", relativePath };
-        result = await _processManager.ExecuteGit(_vmrInfo.VmrPath, args, cancellationToken: CancellationToken.None);
+        result = await _processManager.ExecuteGit(repoPath, args, cancellationToken: CancellationToken.None);
         result.ThrowIfFailed("Failed to clean the working tree!");
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -74,11 +74,11 @@ public class VmrPatchHandler : IVmrPatchHandler
     /// <returns>List of patch files that can be applied on the VMR</returns>
     public async Task<List<VmrIngestionPatch>> CreatePatches(
         SourceMapping mapping,
-        LocalPath repoPath,
+        NativePath repoPath,
         string sha1,
         string sha2,
-        LocalPath destDir,
-        LocalPath tmpPath,
+        NativePath destDir,
+        NativePath tmpPath,
         CancellationToken cancellationToken)
     {
         _logger.LogInformation("Creating patches for {mapping} in {path}..", mapping.Name, destDir);
@@ -92,11 +92,11 @@ public class VmrPatchHandler : IVmrPatchHandler
 
     private async Task<List<VmrIngestionPatch>> CreatePatchesRecursive(
         SourceMapping mapping,
-        LocalPath repoPath,
+        NativePath repoPath,
         string sha1,
         string sha2,
-        LocalPath destDir,
-        LocalPath tmpPath,
+        NativePath destDir,
+        NativePath tmpPath,
         UnixPath relativePath,
         CancellationToken cancellationToken)
     {
@@ -337,7 +337,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         string? path,
         IReadOnlyCollection<string>? filters,
         bool relativePaths,
-        LocalPath workingDir,
+        NativePath workingDir,
         UnixPath? applicationPath,
         CancellationToken cancellationToken)
     {
@@ -423,7 +423,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         string? path,
         IReadOnlyCollection<string>? filters,
         bool relativePaths,
-        LocalPath workingDir,
+        NativePath workingDir,
         UnixPath? applicationPath,
         CancellationToken cancellationToken)
     {
@@ -532,8 +532,8 @@ public class VmrPatchHandler : IVmrPatchHandler
     /// <returns>List of patch files with relatives path respective to the VMR</returns>
     private async Task<List<VmrIngestionPatch>> GetPatchesForSubmoduleChange(
         SourceMapping mapping,
-        LocalPath destDir,
-        LocalPath tmpPath,
+        NativePath destDir,
+        NativePath tmpPath,
         UnixPath relativePath,
         SubmoduleChange change,
         CancellationToken cancellationToken)

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -58,6 +58,7 @@ public static class VmrRegistrations
         services.TryAddTransient<IVmrPatchHandler, VmrPatchHandler>();
         services.TryAddTransient<IVmrUpdater, VmrUpdater>();
         services.TryAddTransient<IVmrInitializer, VmrInitializer>();
+        services.TryAddTransient<IVmrBackflower, VmrBackflower>();
         services.TryAddTransient<IVmrRepoVersionResolver, VmrRepoVersionResolver>();
         services.TryAddSingleton<IVmrDependencyTracker, VmrDependencyTracker>();
         services.TryAddTransient<IWorkBranchFactory, WorkBranchFactory>();

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -58,7 +58,7 @@ public static class VmrRegistrations
         services.TryAddTransient<IVmrPatchHandler, VmrPatchHandler>();
         services.TryAddTransient<IVmrUpdater, VmrUpdater>();
         services.TryAddTransient<IVmrInitializer, VmrInitializer>();
-        services.TryAddTransient<IVmrBackflower, VmrBackflower>();
+        services.TryAddTransient<IVmrBackflower, CodeBackflower>();
         services.TryAddTransient<IVmrRepoVersionResolver, VmrRepoVersionResolver>();
         services.TryAddSingleton<IVmrDependencyTracker, VmrDependencyTracker>();
         services.TryAddTransient<IWorkBranchFactory, WorkBranchFactory>();

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -213,7 +213,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             .Prepend(update.RemoteUri)
             .ToArray();
 
-        LocalPath clonePath = await _cloneManager.PrepareClone(
+        NativePath clonePath = await _cloneManager.PrepareClone(
             update.Mapping,
             remotes,
             update.TargetRevision,
@@ -338,7 +338,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 update,
                 clonePath,
                 currentSha,
-                new LibGit2Sharp.Identity(commitToCopy.Author.Name, commitToCopy.Author.Email),
+                new Identity(commitToCopy.Author.Name, commitToCopy.Author.Email),
                 message,
                 reapplyVmrPatches,
                 readmeTemplatePath,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -24,6 +24,9 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 /// </summary>
 public class VmrUpdater : VmrManagerBase, IVmrUpdater
 {
+    // Character we use in the commit messages to indicate the change
+    public const string Arrow = " → ";
+
     // Message used when synchronizing a single commit
     private const string SingleCommitMessage =
         $$"""
@@ -59,9 +62,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         
         {{AUTOMATION_COMMIT_TAG}}
         """;
-
-    // Character we use in the commit messages to indicate the change
-    private const string Arrow = " → ";
 
     private readonly IVmrInfo _vmrInfo;
     private readonly IVmrDependencyTracker _dependencyTracker;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -24,9 +24,6 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 /// </summary>
 public class VmrUpdater : VmrManagerBase, IVmrUpdater
 {
-    // Character we use in the commit messages to indicate the change
-    public const string Arrow = " → ";
-
     // Message used when synchronizing a single commit
     private const string SingleCommitMessage =
         $$"""
@@ -34,13 +31,13 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
         Original commit: {remote}/commit/{newSha}
         
-        {{AUTOMATION_COMMIT_TAG}}
+        {{Constants.AUTOMATION_COMMIT_TAG}}
         """;
 
     // Message used when synchronizing multiple commits as one
     private const string SquashCommitMessage =
         $$"""
-        [{name}] Sync {oldShaShort}{{Arrow}}{newShaShort}
+        [{name}] Sync {oldShaShort}{{Constants.Arrow}}{newShaShort}
         Diff: {remote}/compare/{oldSha}..{newSha}
         
         From: {remote}/commit/{oldSha}
@@ -49,18 +46,18 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         Commits:
         {commitMessage}
         
-        {{AUTOMATION_COMMIT_TAG}}
+        {{Constants.AUTOMATION_COMMIT_TAG}}
         """;
 
     // Message used when finalizing the sync with a merge commit
     private const string MergeCommitMessage =
         $$"""
-        [Recursive sync] {name} / {oldShaShort}{{Arrow}}{newShaShort}
+        [Recursive sync] {name} / {oldShaShort}{{Constants.Arrow}}{newShaShort}
         
         Updated repositories:
         {commitMessage}
         
-        {{AUTOMATION_COMMIT_TAG}}
+        {{Constants.AUTOMATION_COMMIT_TAG}}
         """;
 
     private readonly IVmrInfo _vmrInfo;
@@ -372,8 +369,8 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         string originalRootSha = GetCurrentVersion(rootUpdate.Mapping);
         _logger.LogInformation("Recursive update for {repo} / {from}{arrow}{to}",
             rootUpdate.Mapping.Name,
-            DarcLib.Commit.GetShortSha(originalRootSha),
-            Arrow,
+            Commit.GetShortSha(originalRootSha),
+            Constants.Arrow,
             rootUpdate.TargetRevision);
 
         var updates = (await GetAllDependenciesAsync(rootUpdate, additionalRemotes, cancellationToken)).ToList();
@@ -393,7 +390,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
         var workBranchName = "sync" +
             $"/{rootUpdate.Mapping.Name}" +
-            $"/{DarcLib.Commit.GetShortSha(GetCurrentVersion(rootUpdate.Mapping))}-{rootUpdate.TargetRevision}";
+            $"/{Commit.GetShortSha(GetCurrentVersion(rootUpdate.Mapping))}-{rootUpdate.TargetRevision}";
         IWorkBranch workBranch = await _workBranchFactory.CreateWorkBranchAsync(_vmrInfo.VmrPath, workBranchName);
 
         // Collection of all affected VMR patches we will need to restore after the sync
@@ -435,7 +432,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                     update.Parent.Name,
                     update.Mapping.Name,
                     currentSha,
-                    Arrow,
+                    Constants.Arrow,
                     update.TargetRevision);
             }
 
@@ -480,10 +477,10 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
         foreach (var update in updatedDependencies)
         {
-            var fromShort = DarcLib.Commit.GetShortSha(update.TargetVersion);
-            var toShort = DarcLib.Commit.GetShortSha(update.TargetRevision);
+            var fromShort = Commit.GetShortSha(update.TargetVersion);
+            var toShort = Commit.GetShortSha(update.TargetRevision);
             summaryMessage
-                .AppendLine($"  - {update.Mapping.Name} / {fromShort}{Arrow}{toShort}")
+                .AppendLine($"  - {update.Mapping.Name} / {fromShort}{Constants.Arrow}{toShort}")
                 .AppendLine($"    {update.RemoteUri}/compare/{update.TargetVersion}..{update.TargetRevision}");
         }
 

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
@@ -19,21 +19,18 @@ public class RepositoryCloneManagerTests
     private const string RepoUri = "https://github.com/dotnet/test-repo";
     private const string Ref = "e7f4f5f758f08b1c5abb1e51ea735ca20e7f83a4";
 
-    private readonly RemoteConfiguration _remoteConfiguration = new(null, null);
-
     private readonly Mock<IVmrInfo> _vmrInfo = new();
     private readonly Mock<ILocalGitRepo> _localGitRepo = new();
-    private readonly Mock<IProcessManager> _processManager = new();
     private readonly Mock<IFileSystem> _fileSystem = new();
     private readonly Mock<IGitRepoCloner> _repoCloner = new();
     private RepositoryCloneManager _manager = null!;
 
-    private readonly LocalPath _tmpDir;
+    private readonly NativePath _tmpDir;
     private readonly LocalPath _clonePath;
 
     public RepositoryCloneManagerTests()
     {
-        _tmpDir = new UnixPath("/data/tmp");
+        _tmpDir = new NativePath("/data/tmp");
         _clonePath = _tmpDir / "62B2F7243B6B94DA";
     }
 
@@ -47,9 +44,6 @@ public class RepositoryCloneManagerTests
 
         _localGitRepo.Reset();
 
-        _processManager.Reset();
-        _processManager.SetReturnsDefault(Task.FromResult(new ProcessExecutionResult() { ExitCode = 0 }));
-
         _fileSystem.Reset();
         _fileSystem
             .Setup(x => x.PathCombine(It.IsAny<string>(), It.IsAny<string>()))
@@ -59,10 +53,8 @@ public class RepositoryCloneManagerTests
 
         _manager = new RepositoryCloneManager(
             _vmrInfo.Object,
-            _remoteConfiguration,
             _repoCloner.Object,
             _localGitRepo.Object,
-            _processManager.Object,
             _fileSystem.Object,
             new NullLogger<VmrPatchHandler>());
     }
@@ -131,7 +123,6 @@ public class RepositoryCloneManagerTests
 
         void ResetCalls()
         {
-            _processManager.ResetCalls();
             _repoCloner.ResetCalls();
             _localGitRepo.ResetCalls();
         }

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -142,7 +142,7 @@ public class VmrPatchHandlerTests
         _fileSystem.SetReturnsDefault(Mock.Of<IFileInfo>(x => x.Exists == true && x.Length == 1243));
 
         // Act
-        await _patchHandler.ApplyPatch(patch, new CancellationToken());
+        await _patchHandler.ApplyPatch(patch, _vmrInfo.VmrPath, new CancellationToken());
 
         // Verify
         VerifyGitCall(new List<string>

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -167,7 +167,7 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithNoSubmodulesTest()
     {
         // Setup
-        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        NativePath expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
 
         // Act
         var patches = await _patchHandler.CreatePatches(
@@ -202,9 +202,9 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithAdditionalMappingsTest()
     {
         // Setup
-        string expectedPatchName1 = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
-        string expectedPatchName2 = _patchDir / $"root-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}-1.patch";
-        string expectedPatchName3 = _patchDir / $"eng_common-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}-2.patch";
+        NativePath expectedPatchName1 = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        NativePath expectedPatchName2 = _patchDir / $"root-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}-1.patch";
+        NativePath expectedPatchName3 = _patchDir / $"eng_common-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}-2.patch";
 
         _vmrInfo.Reset();
         _vmrInfo
@@ -262,7 +262,7 @@ public class VmrPatchHandlerTests
             "--patch",
             "--binary",
             "--output",
-            new NativePath(expectedPatchName2),
+            expectedPatchName2,
             "--relative",
             $"{Sha1}..{Sha2}",
             "--",
@@ -284,7 +284,7 @@ public class VmrPatchHandlerTests
             "--patch",
             "--binary",
             "--output",
-            new NativePath(expectedPatchName3),
+            expectedPatchName3,
             "--relative",
             $"{Sha1}..{Sha2}",
             "--",
@@ -313,7 +313,7 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithSubmoduleWithoutChangesTest()
     {
         // Setup
-        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        NativePath expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
 
         // Return the same info for both
         _localGitRepo
@@ -366,8 +366,8 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithSubmoduleAddedTest()
     {
         // Setup
-        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
-        string expectedSubmodulePatchName = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(SubmoduleSha1)}.patch";
+        NativePath expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        NativePath expectedSubmodulePatchName = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(SubmoduleSha1)}.patch";
 
         // Return no submodule for first SHA, one for second
         _localGitRepo
@@ -436,8 +436,8 @@ public class VmrPatchHandlerTests
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
-            new VmrIngestionPatch(expectedPatchName, RepoVmrPath),
-            new VmrIngestionPatch(expectedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path),
+            new(expectedPatchName, RepoVmrPath),
+            new(expectedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path),
         });
     }
 
@@ -453,9 +453,9 @@ public class VmrPatchHandlerTests
             "https://github.com/dotnet/external-2",
             nestedSubmoduleSha1);
 
-        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
-        string expectedSubmodulePatchName = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(SubmoduleSha1)}.patch";
-        string expectedNestedSubmodulePatchName = _patchDir / $"{nestedSubmoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(nestedSubmoduleSha1)}.patch";
+        NativePath expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        NativePath expectedSubmodulePatchName = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(SubmoduleSha1)}.patch";
+        NativePath expectedNestedSubmodulePatchName = _patchDir / $"{nestedSubmoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(nestedSubmoduleSha1)}.patch";
         
         // Return no submodule for first SHA, one for second
         _localGitRepo
@@ -556,9 +556,9 @@ public class VmrPatchHandlerTests
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
-            new VmrIngestionPatch(expectedPatchName, RepoVmrPath),
-            new VmrIngestionPatch(expectedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path),
-            new VmrIngestionPatch(expectedNestedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path / nestedSubmoduleInfo.Path),
+            new(expectedPatchName, RepoVmrPath),
+            new(expectedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path),
+            new(expectedNestedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path / nestedSubmoduleInfo.Path),
         });
     }
 
@@ -566,8 +566,8 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithSubmoduleRemovedTest()
     {
         // Setup
-        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
-        string expectedSubmodulePatchName = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(SubmoduleSha1)}-{Commit.GetShortSha(Constants.EmptyGitObject)}.patch";
+        NativePath expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        NativePath expectedSubmodulePatchName = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(SubmoduleSha1)}-{Commit.GetShortSha(Constants.EmptyGitObject)}.patch";
 
         // Return no submodule for first SHA, one for second
         _localGitRepo
@@ -636,8 +636,8 @@ public class VmrPatchHandlerTests
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
-            new VmrIngestionPatch(expectedPatchName, RepoVmrPath),
-            new VmrIngestionPatch(expectedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path),
+            new(expectedPatchName, RepoVmrPath),
+            new(expectedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path),
         });
     }
 
@@ -645,8 +645,8 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithSubmoduleCommitChangedTest()
     {
         // Setup
-        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
-        string expectedSubmodulePatchName = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(SubmoduleSha1)}-{Commit.GetShortSha(SubmoduleSha2)}.patch";
+        NativePath expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        NativePath expectedSubmodulePatchName = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(SubmoduleSha1)}-{Commit.GetShortSha(SubmoduleSha2)}.patch";
 
         _localGitRepo
             .Setup(x => x.GetGitSubmodulesAsync(_clonePath, Sha1))
@@ -714,8 +714,8 @@ public class VmrPatchHandlerTests
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
-            new VmrIngestionPatch(expectedPatchName, RepoVmrPath),
-            new VmrIngestionPatch(expectedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path),
+            new(expectedPatchName, RepoVmrPath),
+            new(expectedSubmodulePatchName, RepoVmrPath / _submoduleInfo.Path),
         });
     }
 
@@ -723,9 +723,9 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithSubmoduleUrlChangedTest()
     {
         // Setup
-        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
-        string expectedSubmodulePatchName1 = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(SubmoduleSha1)}-{Commit.GetShortSha(Constants.EmptyGitObject)}.patch";
-        string expectedSubmodulePatchName2 = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(SubmoduleSha2)}.patch";
+        NativePath expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        NativePath expectedSubmodulePatchName1 = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(SubmoduleSha1)}-{Commit.GetShortSha(Constants.EmptyGitObject)}.patch";
+        NativePath expectedSubmodulePatchName2 = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(SubmoduleSha2)}.patch";
 
         _localGitRepo
             .Setup(x => x.GetGitSubmodulesAsync(_clonePath, Sha1))
@@ -816,9 +816,9 @@ public class VmrPatchHandlerTests
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
-            new VmrIngestionPatch(expectedPatchName, RepoVmrPath),
-            new VmrIngestionPatch(expectedSubmodulePatchName1, RepoVmrPath / _submoduleInfo.Path),
-            new VmrIngestionPatch(expectedSubmodulePatchName2, RepoVmrPath / _submoduleInfo.Path),
+            new(expectedPatchName, RepoVmrPath),
+            new(expectedSubmodulePatchName1, RepoVmrPath / _submoduleInfo.Path),
+            new(expectedSubmodulePatchName2, RepoVmrPath / _submoduleInfo.Path),
         });
     }
 
@@ -883,7 +883,7 @@ public class VmrPatchHandlerTests
          *  │       └── c.txt
          *  └── root-file
          */
-        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        NativePath expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
 
         var largeDir1 = _clonePath / "large-dir-1";
         var largeDir2 = largeDir1 / "large-dir-2";
@@ -947,9 +947,9 @@ public class VmrPatchHandlerTests
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
-            new VmrIngestionPatch(expectedPatchName + ".2", RepoVmrPath),
-            new VmrIngestionPatch(expectedPatchName + ".1.1", RepoVmrPath / "large-dir-1" / "large-dir-2"),
-            new VmrIngestionPatch(expectedPatchName + ".1.2", RepoVmrPath / "large-dir-1" / "small-dir"),
+            new(expectedPatchName + ".2", RepoVmrPath),
+            new(expectedPatchName + ".1.1", RepoVmrPath / "large-dir-1" / "large-dir-2"),
+            new(expectedPatchName + ".1.2", RepoVmrPath / "large-dir-1" / "small-dir"),
         });
 
         _fileSystem.Verify(x => x.DeleteFile(expectedPatchName), Times.Once);
@@ -960,7 +960,7 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithAFileTooLargeTest()
     {
         // This test verifies that we cannot ingest files over 1GB in size with a reasonable error
-        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        NativePath expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
 
         // Patch for the whole repo
         _fileSystem

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -27,6 +27,7 @@ public class VmrPatchHandlerTests
 
     private static readonly UnixPath SRC = new("src");
     private static readonly UnixPath RepoVmrPath = SRC / IndividualRepoName;
+    private static readonly NativePath TmpDir = new("/tmp");
 
     private readonly GitSubmoduleInfo _submoduleInfo = new(
         "external-1",
@@ -49,9 +50,9 @@ public class VmrPatchHandlerTests
     private readonly Mock<IFileSystem> _fileSystem = new();
     private VmrPatchHandler _patchHandler = null!;
 
-    private readonly UnixPath _vmrPath;
-    private readonly UnixPath _clonePath;
-    private readonly UnixPath _patchDir;
+    private readonly NativePath _vmrPath;
+    private readonly NativePath _clonePath;
+    private readonly NativePath _patchDir;
 
     private readonly SourceMapping _testRepoMapping = new(
         Name: IndividualRepoName,
@@ -68,9 +69,9 @@ public class VmrPatchHandlerTests
 
     public VmrPatchHandlerTests()
     {
-        _vmrPath = new UnixPath("/data/vmr");
-        _clonePath = new UnixPath("/tmp/" + IndividualRepoName);
-        _patchDir = new UnixPath("/tmp/patch");
+        _vmrPath = new NativePath("/data/vmr");
+        _clonePath = new NativePath(TmpDir / "" + IndividualRepoName);
+        _patchDir = new NativePath(TmpDir / "patch");
     }
     
     [SetUp]
@@ -98,7 +99,7 @@ public class VmrPatchHandlerTests
         _cloneManager.Reset();
         _cloneManager
             .Setup(x => x.PrepareClone(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string uri, string _, CancellationToken _) => new UnixPath("/tmp/" + uri.Split("/").Last()));
+            .ReturnsAsync((string uri, string _, CancellationToken _) => new NativePath(TmpDir / "" + uri.Split("/").Last()));
 
         _processManager.Reset();
         _processManager
@@ -138,11 +139,11 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesTest()
     {
         // Setup
-        var patch = new VmrIngestionPatch($"{_patchDir}/test-repo.patch", RepoVmrPath);
+        var patch = new VmrIngestionPatch(_patchDir / "test-repo.patch", RepoVmrPath);
         _fileSystem.SetReturnsDefault(Mock.Of<IFileInfo>(x => x.Exists == true && x.Length == 1243));
 
         // Act
-        await _patchHandler.ApplyPatch(patch, _vmrInfo.VmrPath, new CancellationToken());
+        await _patchHandler.ApplyPatch(patch, _vmrInfo.Object.VmrPath, new CancellationToken());
 
         // Verify
         VerifyGitCall(new List<string>
@@ -166,7 +167,7 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithNoSubmodulesTest()
     {
         // Setup
-        string expectedPatchName = $"{_patchDir}/{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
 
         // Act
         var patches = await _patchHandler.CreatePatches(
@@ -175,7 +176,7 @@ public class VmrPatchHandlerTests
             Sha1,
             Sha2,
             _patchDir,
-            new UnixPath("/tmp"),
+            TmpDir,
             CancellationToken.None);
 
         var expectedArgs = GetExpectedGitDiffArguments(expectedPatchName, Sha1, Sha2, null);
@@ -201,9 +202,9 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithAdditionalMappingsTest()
     {
         // Setup
-        string expectedPatchName1 = $"{_patchDir}/{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
-        string expectedPatchName2 = $"{_patchDir}/root-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}-1.patch";
-        string expectedPatchName3 = $"{_patchDir}/eng_common-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}-2.patch";
+        string expectedPatchName1 = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        string expectedPatchName2 = _patchDir / $"root-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}-1.patch";
+        string expectedPatchName3 = _patchDir / $"eng_common-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}-2.patch";
 
         _vmrInfo.Reset();
         _vmrInfo
@@ -221,10 +222,10 @@ public class VmrPatchHandlerTests
             });
 
         _fileSystem
-            .Setup(x => x.DirectoryExists($"{_clonePath}/SourceBuild/tarball/content"))
+            .Setup(x => x.DirectoryExists(_clonePath / "SourceBuild/tarball/content"))
             .Returns(true);
         _fileSystem
-            .Setup(x => x.DirectoryExists($"{_clonePath}/eng/common"))
+            .Setup(x => x.DirectoryExists(_clonePath / "eng/common"))
             .Returns(true);
         _fileSystem
             .Setup(x => x.GetFileName(SRC / _testRepoMapping.Name / "SourceBuild/tarball/content"))
@@ -240,7 +241,7 @@ public class VmrPatchHandlerTests
             Sha1,
             Sha2,
             _patchDir,
-            new UnixPath("/tmp"),
+            TmpDir,
             CancellationToken.None);
 
         var expectedArgs = GetExpectedGitDiffArguments(expectedPatchName1, Sha1, Sha2, null);
@@ -261,7 +262,7 @@ public class VmrPatchHandlerTests
             "--patch",
             "--binary",
             "--output",
-            expectedPatchName2,
+            new NativePath(expectedPatchName2),
             "--relative",
             $"{Sha1}..{Sha2}",
             "--",
@@ -272,7 +273,7 @@ public class VmrPatchHandlerTests
             .Verify(x => x.Execute("git",
                 expectedArgs,
                 It.IsAny<TimeSpan?>(),
-                $"{_clonePath}/SourceBuild/tarball/content",
+                _clonePath / "SourceBuild/tarball/content",
                 It.IsAny<Dictionary<string, string>>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -283,7 +284,7 @@ public class VmrPatchHandlerTests
             "--patch",
             "--binary",
             "--output",
-            expectedPatchName3,
+            new NativePath(expectedPatchName3),
             "--relative",
             $"{Sha1}..{Sha2}",
             "--",
@@ -294,7 +295,7 @@ public class VmrPatchHandlerTests
             .Verify(x => x.Execute("git",
                 expectedArgs,
                 It.IsAny<TimeSpan?>(),
-                $"{_clonePath}/eng/common",
+                _clonePath / "eng/common",
                 It.IsAny<Dictionary<string, string>>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -312,7 +313,7 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithSubmoduleWithoutChangesTest()
     {
         // Setup
-        string expectedPatchName = $"{_patchDir}/{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
 
         // Return the same info for both
         _localGitRepo
@@ -330,7 +331,7 @@ public class VmrPatchHandlerTests
             Sha1,
             Sha2,
             _patchDir,
-            new UnixPath("/tmp"),
+            TmpDir,
             CancellationToken.None);
 
         var expectedArgs = GetExpectedGitDiffArguments(expectedPatchName, Sha1, Sha2, new[] { _submoduleInfo.Path });
@@ -365,8 +366,8 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithSubmoduleAddedTest()
     {
         // Setup
-        string expectedPatchName = $"{_patchDir}/{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
-        string expectedSubmodulePatchName = $"{_patchDir}/{_submoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(SubmoduleSha1)}.patch";
+        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        string expectedSubmodulePatchName = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(SubmoduleSha1)}.patch";
 
         // Return no submodule for first SHA, one for second
         _localGitRepo
@@ -384,7 +385,7 @@ public class VmrPatchHandlerTests
             Sha1,
             Sha2,
             _patchDir,
-            new UnixPath("/tmp"),
+            TmpDir,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -411,7 +412,7 @@ public class VmrPatchHandlerTests
             .Verify(x => x.Execute("git",
                 expectedArgs,
                 It.IsAny<TimeSpan?>(),
-                "/tmp/external-1",
+                TmpDir / "external-1",
                 It.IsAny<Dictionary<string, string>>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -452,9 +453,9 @@ public class VmrPatchHandlerTests
             "https://github.com/dotnet/external-2",
             nestedSubmoduleSha1);
 
-        string expectedPatchName = $"{_patchDir}/{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
-        string expectedSubmodulePatchName = $"{_patchDir}/{_submoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(SubmoduleSha1)}.patch";
-        string expectedNestedSubmodulePatchName = $"{_patchDir}/{nestedSubmoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(nestedSubmoduleSha1)}.patch";
+        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        string expectedSubmodulePatchName = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(SubmoduleSha1)}.patch";
+        string expectedNestedSubmodulePatchName = _patchDir / $"{nestedSubmoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(nestedSubmoduleSha1)}.patch";
         
         // Return no submodule for first SHA, one for second
         _localGitRepo
@@ -466,7 +467,7 @@ public class VmrPatchHandlerTests
             .ReturnsAsync(new List<GitSubmoduleInfo> { _submoduleInfo });
 
         _localGitRepo
-            .Setup(x => x.GetGitSubmodulesAsync("/tmp/external-1", SubmoduleSha1))
+            .Setup(x => x.GetGitSubmodulesAsync(TmpDir / "external-1", SubmoduleSha1))
             .ReturnsAsync(new List<GitSubmoduleInfo> { nestedSubmoduleInfo });
 
         // Act
@@ -476,7 +477,7 @@ public class VmrPatchHandlerTests
             Sha1,
             Sha2,
             _patchDir,
-            new UnixPath("/tmp"),
+            TmpDir,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -504,7 +505,7 @@ public class VmrPatchHandlerTests
             .Verify(x => x.Execute("git",
                 expectedArgs,
                 It.IsAny<TimeSpan?>(),
-                "/tmp/external-1",
+                TmpDir / "external-1",
                 It.IsAny<Dictionary<string, string>>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -522,7 +523,7 @@ public class VmrPatchHandlerTests
             .Verify(x => x.Execute("git",
                 expectedArgs,
                 It.IsAny<TimeSpan?>(),
-                "/tmp/external-2",
+                TmpDir / "external-2",
                 It.IsAny<Dictionary<string, string>>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -565,8 +566,8 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithSubmoduleRemovedTest()
     {
         // Setup
-        string expectedPatchName = $"{_patchDir}/{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
-        string expectedSubmodulePatchName = $"{_patchDir}/{_submoduleInfo.Name}-{Commit.GetShortSha(SubmoduleSha1)}-{Commit.GetShortSha(Constants.EmptyGitObject)}.patch";
+        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        string expectedSubmodulePatchName = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(SubmoduleSha1)}-{Commit.GetShortSha(Constants.EmptyGitObject)}.patch";
 
         // Return no submodule for first SHA, one for second
         _localGitRepo
@@ -584,7 +585,7 @@ public class VmrPatchHandlerTests
             Sha1,
             Sha2,
             _patchDir,
-            new UnixPath("/tmp"),
+            TmpDir,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -611,7 +612,7 @@ public class VmrPatchHandlerTests
             .Verify(x => x.Execute("git",
                 expectedArgs,
                 It.IsAny<TimeSpan?>(),
-                "/tmp/external-1",
+                TmpDir / "external-1",
                 It.IsAny<Dictionary<string, string>>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -644,8 +645,8 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithSubmoduleCommitChangedTest()
     {
         // Setup
-        string expectedPatchName = $"{_patchDir}/{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
-        string expectedSubmodulePatchName = $"{_patchDir}/{_submoduleInfo.Name}-{Commit.GetShortSha(SubmoduleSha1)}-{Commit.GetShortSha(SubmoduleSha2)}.patch";
+        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        string expectedSubmodulePatchName = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(SubmoduleSha1)}-{Commit.GetShortSha(SubmoduleSha2)}.patch";
 
         _localGitRepo
             .Setup(x => x.GetGitSubmodulesAsync(_clonePath, Sha1))
@@ -662,7 +663,7 @@ public class VmrPatchHandlerTests
             Sha1,
             Sha2,
             _patchDir,
-            new UnixPath("/tmp"),
+            TmpDir,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -689,7 +690,7 @@ public class VmrPatchHandlerTests
             .Verify(x => x.Execute("git",
                 expectedArgs,
                 It.IsAny<TimeSpan?>(),
-                "/tmp/external-1",
+                TmpDir / "external-1",
                 It.IsAny<Dictionary<string, string>>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -722,9 +723,9 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithSubmoduleUrlChangedTest()
     {
         // Setup
-        string expectedPatchName = $"{_patchDir}/{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
-        string expectedSubmodulePatchName1 = $"{_patchDir}/{_submoduleInfo.Name}-{Commit.GetShortSha(SubmoduleSha1)}-{Commit.GetShortSha(Constants.EmptyGitObject)}.patch";
-        string expectedSubmodulePatchName2 = $"{_patchDir}/{_submoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(SubmoduleSha2)}.patch";
+        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        string expectedSubmodulePatchName1 = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(SubmoduleSha1)}-{Commit.GetShortSha(Constants.EmptyGitObject)}.patch";
+        string expectedSubmodulePatchName2 = _patchDir / $"{_submoduleInfo.Name}-{Commit.GetShortSha(Constants.EmptyGitObject)}-{Commit.GetShortSha(SubmoduleSha2)}.patch";
 
         _localGitRepo
             .Setup(x => x.GetGitSubmodulesAsync(_clonePath, Sha1))
@@ -741,7 +742,7 @@ public class VmrPatchHandlerTests
             Sha1,
             Sha2,
             _patchDir,
-            new UnixPath("/tmp"),
+            TmpDir,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -768,7 +769,7 @@ public class VmrPatchHandlerTests
             .Verify(x => x.Execute("git",
                 expectedArgs,
                 It.IsAny<TimeSpan?>(),
-                "/tmp/external-1",
+                TmpDir / "external-1",
                 It.IsAny<Dictionary<string, string>>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -783,7 +784,7 @@ public class VmrPatchHandlerTests
             .Verify(x => x.Execute("git",
                 expectedArgs,
                 It.IsAny<TimeSpan?>(),
-                "/tmp/external-2",
+                TmpDir / "external-2",
                 It.IsAny<Dictionary<string, string>>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -828,7 +829,7 @@ public class VmrPatchHandlerTests
         _vmrInfo.Reset();
         _vmrInfo
             .SetupGet(x => x.VmrPath)
-            .Returns(new UnixPath("/data/vmr/"));
+            .Returns(new NativePath("/data/vmr/"));
         _vmrInfo
             .Setup(x => x.GetRepoSourcesPath(It.IsAny<SourceMapping>()))
             .Returns((SourceMapping mapping) => _vmrPath / VmrInfo.SourcesDir / mapping.Name);
@@ -842,11 +843,11 @@ public class VmrPatchHandlerTests
             _fileSystem.Object,
             new NullLogger<VmrPatchHandler>());
 
-        var patch = new VmrIngestionPatch($"{_patchDir}/test-repo.patch", RepoVmrPath);
+        var patch = new VmrIngestionPatch(_patchDir / $"test-repo.patch", RepoVmrPath);
         _fileSystem.SetReturnsDefault(Mock.Of<IFileInfo>(x => x.Exists == true && x.Length == 1243));
 
         // Act
-        await _patchHandler.ApplyPatch(patch, new CancellationToken());
+        await _patchHandler.ApplyPatch(patch, _vmrInfo.Object.VmrPath, new CancellationToken());
 
         // Verify
         VerifyGitCall(new List<string>
@@ -858,14 +859,14 @@ public class VmrPatchHandlerTests
             RepoVmrPath,
             patch.Path,
         },
-        _vmrPath + "/");
+        _vmrPath / "/");
 
         VerifyGitCall(new string[]
         {
             "checkout",
             RepoVmrPath,
         },
-        _vmrPath + "/");
+        _vmrPath / "/");
     }
 
     [Test]
@@ -882,7 +883,7 @@ public class VmrPatchHandlerTests
          *  │       └── c.txt
          *  └── root-file
          */
-        string expectedPatchName = $"{_patchDir}/{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
 
         var largeDir1 = _clonePath / "large-dir-1";
         var largeDir2 = largeDir1 / "large-dir-2";
@@ -926,7 +927,7 @@ public class VmrPatchHandlerTests
             Sha1,
             Sha2,
             _patchDir,
-            new UnixPath("/tmp"),
+            TmpDir,
             CancellationToken.None);
 
         var expectedArgs = GetExpectedGitDiffArguments(expectedPatchName, Sha1, Sha2, null);
@@ -959,7 +960,7 @@ public class VmrPatchHandlerTests
     public async Task CreatePatchesWithAFileTooLargeTest()
     {
         // This test verifies that we cannot ingest files over 1GB in size with a reasonable error
-        string expectedPatchName = $"{_patchDir}/{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
+        string expectedPatchName = _patchDir / $"{IndividualRepoName}-{Commit.GetShortSha(Sha1)}-{Commit.GetShortSha(Sha2)}.patch";
 
         // Patch for the whole repo
         _fileSystem
@@ -986,7 +987,7 @@ public class VmrPatchHandlerTests
             Sha1,
             Sha2,
             _patchDir,
-            new UnixPath("/tmp"),
+            TmpDir,
             CancellationToken.None);
 
         // Verify
@@ -1000,13 +1001,13 @@ public class VmrPatchHandlerTests
     private void VerifyGitCall(string[] expectedArguments, string repoDir, Times? times = null)
     {
         _processManager
-            .Verify(x => x.ExecuteGit(repoDir, expectedArguments, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()), times ?? Times.Once());
+            .Verify(x => x.ExecuteGit(repoDir, expectedArguments, It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()), times ?? Times.Once());
     }
 
     private void VerifyGitCall(IEnumerable<string> expectedArguments, string repoDir, Times? times = null)
     {
         _processManager
-            .Verify(x => x.ExecuteGit(repoDir, expectedArguments, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()), times ?? Times.Once());
+            .Verify(x => x.ExecuteGit(repoDir, expectedArguments, It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()), times ?? Times.Once());
     }
 
     private static IEnumerable<string> GetExpectedGitDiffArguments(
@@ -1021,7 +1022,7 @@ public class VmrPatchHandlerTests
             "--patch",
             "--binary",
             "--output",
-            patchPath,
+            new NativePath(patchPath),
             $"{Sha1}..{Sha2}",
             "--",
             ":(glob,attr:!vmr-ignore)*.*",

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPusherTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPusherTests.cs
@@ -43,7 +43,7 @@ public class VmrPusherTests
     {
         var mockHttpClientFactory = new MockHttpClientFactory();
 
-        var responseMsg = "{\"data\":{\"somerepo\":{\"object\":null}}}";
+        var responseMsg = """{"data":{"somerepo":{"object":null}}}""";
         mockHttpClientFactory.AddCannedResponse(
             GraphQLUri, 
             responseMsg, 
@@ -67,14 +67,14 @@ public class VmrPusherTests
     [Test]
     public async Task PublicCommitsArePushedTest()
     {
-        LocalPath vmrPath = new NativePath("vmr");
+        NativePath vmrPath = new NativePath("vmr");
 
         _vmrInfo.Reset();
         _vmrInfo.SetupGet(i => i.VmrPath).Returns(vmrPath);
 
         var mockHttpClientFactory = new MockHttpClientFactory();
 
-        var responseMsg = "{\"data\":{\"somerepo\":{\"object\": {\"id\": \"C_kwDOBjr6NNoAKGNjYjQ2YWU5M2E4MjhkYjE4MWIzMTBkZTBkMmIwNTI1MWQ0ZDcxNDA\"}}}}";
+        var responseMsg = """{"data":{"somerepo":{"object": {"id": "C_kwDOBjr6NNoAKGNjYjQ2YWU5M2E4MjhkYjE4MWIzMTBkZTBkMmIwNTI1MWQ0ZDcxNDA"}}}}""";
         mockHttpClientFactory.AddCannedResponse(
             GraphQLUri,
             responseMsg,


### PR DESCRIPTION
- There are no tests yet as it is expected that this functionality might change a bit. We will add tests once we are able to also flow package versions. This was manually tested though.
- This change also utilizes `NativePath` more frequently whenever we expect a local file system path.

https://github.com/dotnet/arcade-services/issues/2979

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Added `darc vmr backflow` command