### PR TITLE
Run half of the tests on the new url

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -260,13 +260,13 @@ stages:
     parameters:
       ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/production') }}:
         DeploymentEnvironment: Staging
-        MaestroTestEndpoint: https://maestro-int.westus2.cloudapp.azure.com
+        MaestroTestEndpoints: https://maestro-int.westus2.cloudapp.azure.com,https://maestro.int-dot.net
         PublishProfile: Int
         Subscription: NetHelixStaging
         VariableGroup: MaestroInt KeyVault
       ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/production') }}:
         DeploymentEnvironment: Production
-        MaestroTestEndpoint: https://maestro-prod.westus2.cloudapp.azure.com
+        MaestroTestEndpoints: https://maestro-prod.westus2.cloudapp.azure.com
         PublishProfile: Prod
         Subscription: NetHelix
         VariableGroup: MaestroProd KeyVault

--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -48,7 +48,7 @@ If you want to run the C# scenario tests (make sure that you followed the gettin
    1. AZDO_TOKEN Get a Azure DevOps PAT from https://dnceng.visualstudio.com/_usersSettings/tokens (or appropriately matching project name if not dnceng)
    1. MAESTRO_TOKEN : Get a maestro bearer token (you can create one after running maestro app)
    1. DARC_PACKAGE_SOURCE : Get the path to the darc nuget package (which would be in `arcade-services\artifacts\packages\Debug\NonShipping\`, see below for getting this built)
-   1. MAESTRO_BASEURI : Run ngrok and get the https url
+   1. MAESTRO_BASEURIS : Run ngrok and get the https url
 
 Generally this is easiest if you want to debug both sides to simply have two instances of Visual Studio 2019 running. See below if you do not have the file paths mentioned for DARC_PACKAGE_SOURCE
 
@@ -59,7 +59,7 @@ Since Visual Studio's Debug Environment variable settings do not apply to debugg
 1. set GITHUB_TOKEN=...
 1. set MAESTRO_TOKEN=...
 1. set DARC_PACKAGE_SOURCE=...
-1. set MAESTRO_BASEURI=https://blahblahblah.ngrok.io
+1. set MAESTRO_BASEURIS=https://blahblahblah.ngrok.io
 1. "C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\Common7\IDE\devenv.com" (adjusted for your VS version / drive)
 
 When debugging the tests, you can check this via the Immediate window, e.g. by running `System.Environment.GetEnvironmentVariable("GITHUB_TOKEN")`

--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -8,7 +8,7 @@ parameters:
   type: string
 - name: VariableGroup
   type: string
-- name: MaestroTestEndpoint
+- name: MaestroTestEndpoints
   type: string
 
   # --- Secret Variable group requirements ---
@@ -145,7 +145,7 @@ stages:
           Maestro.ScenarioTests.dll
         searchFolder: $(Pipeline.Workspace)/Maestro.ScenarioTests
       env:
-        MAESTRO_BASEURI: ${{ parameters.MaestroTestEndpoint }}
+        MAESTRO_BASEURIS: ${{ parameters.MaestroTestEndpoints }}
         MAESTRO_TOKEN: $(scenario-test-maestro-token)
         GITHUB_TOKEN: $(maestro-scenario-test-github-token)
         AZDO_TOKEN: $(dn-bot-dnceng-build-rw-code-rw-release-rw)
@@ -156,7 +156,8 @@ stages:
         nuget sources add -Name "dotnet-core" -Source "https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json"
       displayName: Add nuget Sources
     - powershell: |
-        $versionEndpoint = "${{ parameters.MaestroTestEndpoint }}/api/assets/darc-version?api-version=2019-01-16"
+        $maestroTestEndpoint = ${{ parameters.MaestroTestEndpoints }}.Split(',')[0]
+        $versionEndpoint = "$maestroTestEndpoint/api/assets/darc-version?api-version=2019-01-16"
         $latestDarcVersion = $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
         Write-Host "##vso[task.setvariable variable=darcVersion]$latestDarcVersion"
         Write-Host "Using Darc version $latestDarcVersion to run the tests"

--- a/src/Maestro/maestro-angular/src/index.html
+++ b/src/Maestro/maestro-angular/src/index.html
@@ -71,7 +71,7 @@
 
   <script type="application/javascript">
   window.applicationData = {
-    brand: 'Maestro++',
+    brand: 'Maestro++asd',
     userName: 'Nobody',
     authorized: true,
     themes: [

--- a/test/Maestro.ScenarioTests/ScenarioTests_AzDoFlow.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_AzDoFlow.cs
@@ -107,7 +107,7 @@ namespace Maestro.ScenarioTests
         {
             TestContext.WriteLine("Azure DevOps Dependency Flow, batched");
 
-            TestParameters parameters = await TestParameters.GetAsync();
+            TestParameters parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
             SetTestParameters(parameters);
             EndToEndFlowLogic testLogic = new EndToEndFlowLogic(parameters);
             List<DependencyDetail> expectedDependencies = expectedAzDoDependenciesSource1.Concat(expectedAzDoDependenciesSource2).ToList();

--- a/test/Maestro.ScenarioTests/ScenarioTests_Clone.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Clone.cs
@@ -21,7 +21,7 @@ namespace Maestro.ScenarioTests
         {
             TestContext.WriteLine("Darc-Clone repo end to end test");
 
-            TestParameters parameters = await TestParameters.GetAsync();
+            TestParameters parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
             SetTestParameters(parameters);
 
             string sourceRepoName = "core-sdk";

--- a/test/Maestro.ScenarioTests/ScenarioTests_Dependencies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Dependencies.cs
@@ -28,7 +28,7 @@ namespace Maestro.ScenarioTests
         [Test]
         public async Task ArcadeDependencies_EndToEnd()
         {
-            _parameters = await TestParameters.GetAsync();
+            _parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
             SetTestParameters(_parameters);
 
             string source1RepoName = TestRepository.TestRepo1Name;

--- a/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
@@ -23,7 +23,7 @@ namespace Maestro.ScenarioTests
         [SetUp]
         public async Task InitializeAsync()
         {
-            _parameters = await TestParameters.GetAsync();
+            _parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
             SetTestParameters(_parameters);
         }
 

--- a/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
@@ -35,7 +35,7 @@ namespace Maestro.ScenarioTests
             string channel1Name = $"SubscriptionEndToEnd_TestChannel1_{Environment.MachineName}";
             string channel2Name = $"SubscriptionEndToEnd_TestChannel2_{Environment.MachineName}";
 
-            _parameters = await TestParameters.GetAsync();
+            _parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
             SetTestParameters(_parameters);
 
             string repo1Uri = GetRepoUrl(repo1Name);

--- a/test/Maestro.ScenarioTests/TestParameters.cs
+++ b/test/Maestro.ScenarioTests/TestParameters.cs
@@ -54,8 +54,6 @@ namespace Maestro.ScenarioTests
 
         public static async Task<TestParameters> GetAsync()
         {
-            
-
             var testDir = TemporaryDirectory.Get();
             var testDirSharedWrapper = Shareable.Create(testDir);
 

--- a/test/Maestro.ScenarioTests/TestParameters.cs
+++ b/test/Maestro.ScenarioTests/TestParameters.cs
@@ -20,13 +20,13 @@ namespace Maestro.ScenarioTests
     {
         internal readonly TemporaryDirectory _dir;
 
-        private static string[] maestroBaseUris;
+        private static readonly string[] maestroBaseUris;
         private static int maestroBaseUriIndex = 0;
-        private static string maestroToken;
-        private static string githubToken;
-        private static string darcPackageSource;
-        private static string azdoToken;
-        private static SemaphoreSlim mutex;
+        private static readonly string maestroToken;
+        private static readonly string githubToken;
+        private static readonly string darcPackageSource;
+        private static readonly string azdoToken;
+        private static readonly SemaphoreSlim mutex;
 
         static TestParameters()
         {
@@ -48,10 +48,7 @@ namespace Maestro.ScenarioTests
         private static string GetMaestroBaseUri()
         {
             var maestroBaseUri = maestroBaseUris[maestroBaseUriIndex];
-            maestroBaseUriIndex =
-                maestroBaseUriIndex == maestroBaseUris.Length - 1
-                ? 0
-                : maestroBaseUriIndex + 1;
+            maestroBaseUriIndex = (maestroBaseUriIndex + 1) % maestroBaseUris.Length;
             return maestroBaseUri; 
         }
 

--- a/test/Maestro.ScenarioTests/TestParameters.cs
+++ b/test/Maestro.ScenarioTests/TestParameters.cs
@@ -36,7 +36,7 @@ namespace Maestro.ScenarioTests
 
             maestroBaseUris = (Environment.GetEnvironmentVariable("MAESTRO_BASEURIS")
                     ?? userSecrets["MAESTRO_BASEURIS"]
-                    ?? "https://maestro-int.westus2.cloudapp.azure.com")
+                    ?? "https://maestro.int-dot.com")
                     .Split(',');
             maestroToken = Environment.GetEnvironmentVariable("MAESTRO_TOKEN") ?? userSecrets["MAESTRO_TOKEN"];
             githubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? userSecrets["GITHUB_TOKEN"];

--- a/test/Maestro.ScenarioTests/TestParameters.cs
+++ b/test/Maestro.ScenarioTests/TestParameters.cs
@@ -43,7 +43,7 @@ namespace Maestro.ScenarioTests
             azdoToken = Environment.GetEnvironmentVariable("AZDO_TOKEN") ?? userSecrets["AZDO_TOKEN"];
         }
 
-        /// <param name="useNonPrimaryEndpoint">If set to true, the test will atempt to use the secondary endpoint, if provided</param>
+        /// <param name="useNonPrimaryEndpoint">If set to true, the test will atempt to use the non primary endpoint, if provided</param>
         public static async Task<TestParameters> GetAsync(bool useNonPrimaryEndpoint = false)
         {
             var testDir = TemporaryDirectory.Get();


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade-services/issues/2988
Started: https://dev.azure.com/dnceng/internal/_build/results?buildId=2298595&view=results for testing purposes
<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Run some Maestro Scenario tests on the new URL