### PR TITLE
Count neutral status checks as successful

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
@@ -986,12 +986,12 @@ public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
                             switch (run.Conclusion?.Value)
                             {
                                 case CheckConclusion.Success:
+                                case CheckConclusion.Neutral:
                                     state = CheckState.Success;
                                     break;
                                 case CheckConclusion.ActionRequired:
                                 case CheckConclusion.Cancelled:
                                 case CheckConclusion.Failure:
-                                case CheckConclusion.Neutral:
                                 case CheckConclusion.TimedOut:
                                     state = CheckState.Failure;
                                     break;


### PR DESCRIPTION
When an AzDO PR check is skipped, it is listed as completed, with a neutral conclusion. Usually we skip things on purpose and do not count these as failures. Interpret the check as such so that the Maestro merge policy bot doesn't show an X.

<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->


<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description

Count Neutrual (skipped) checks as passing.