### PR TITLE
Detect package version change even when SHA stays the same

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
@@ -30,8 +30,7 @@ internal class UpdateOperation : VmrOperationBase<IVmrUpdater>
         await vmrManager.UpdateRepository(
             repoName,
             targetRevision,
-            null,
-            _options.NoSquash,
+            targetVersion: null,
             _options.Recursive,
             additionalRemotes,
             _options.ReadMeTemplate,

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/UpdateCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/UpdateCommandLineOptions.cs
@@ -11,9 +11,6 @@ namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 [Verb("update", HelpText = "Updates given repo(s) in the VMR to match given refs.")]
 internal class UpdateCommandLineOptions : VmrSyncCommandLineOptions
 {
-    [Option("no-squash", HelpText = "Synchronizes commit by commit instead of squashing all updates into one.")]
-    public bool NoSquash { get; set; } = false;
-    
     [Option('r', "recursive", Required = false, HelpText = $"Process also dependencies (from {VersionFiles.VersionDetailsXml}) recursively.")]
     public bool Recursive { get; set; } = false;
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
@@ -27,7 +27,6 @@ public interface IVmrUpdater
         string mappingName,
         string? targetRevision,
         string? targetVersion,
-        bool noSquash,
         bool updateDependencies,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? readmeTemplatePath,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -91,7 +91,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         string mappingName,
         string? targetRevision,
         string? targetVersion,
-        bool noSquash,
         bool updateDependencies,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? readmeTemplatePath,
@@ -142,7 +141,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         {
             await UpdateRepositoryRecursively(
                 dependencyUpdate,
-                noSquash,
                 additionalRemotes,
                 readmeTemplatePath,
                 tpnTemplatePath,
@@ -154,7 +152,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         {
             await UpdateRepositoryInternal(
                 dependencyUpdate,
-                noSquash,
                 reapplyVmrPatches: true,
                 additionalRemotes,
                 readmeTemplatePath,
@@ -167,7 +164,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
     private async Task<IReadOnlyCollection<VmrIngestionPatch>> UpdateRepositoryInternal(
         VmrDependencyUpdate update,
-        bool noSquash,
         bool reapplyVmrPatches,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? readmeTemplatePath,
@@ -179,11 +175,14 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         VmrDependencyVersion currentVersion = _dependencyTracker.GetDependencyVersion(update.Mapping)
             ?? throw new Exception($"Failed to find current version for {update.Mapping.Name}");
 
-        _logger.LogInformation("Synchronizing {name} from {current} to {repo} / {revision}{oneByOne}",
-            update.Mapping.Name, currentVersion.Sha, update.RemoteUri, update.TargetRevision, noSquash ? " one commit at a time" : string.Empty);
+        _logger.LogInformation("Synchronizing {name} from {current} to {repo} / {revision}",
+            update.Mapping.Name,
+            currentVersion.Sha,
+            update.RemoteUri,
+            update.TargetRevision);
 
         // Do we need to change anything?
-        if (update.TargetRevision != null && currentVersion?.Sha == update.TargetRevision)
+        if (currentVersion.Sha == update.TargetRevision)
         {
             if (currentVersion.PackageVersion != update.TargetVersion || update.TargetVersion == null)
             {
@@ -259,7 +258,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
     /// </summary>
     private async Task UpdateRepositoryRecursively(
         VmrDependencyUpdate rootUpdate,
-        bool noSquash,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? readmeTemplatePath,
         string? tpnTemplatePath,
@@ -336,7 +334,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             {
                 patchesToReapply = await UpdateRepositoryInternal(
                     update,
-                    noSquash,
                     false,
                     additionalRemotes,
                     readmeTemplatePath,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -184,11 +184,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         // Do we need to change anything?
         if (currentVersion.Sha == update.TargetRevision)
         {
-            if (currentVersion.PackageVersion != update.TargetVersion || update.TargetVersion == null)
-            {
-                _logger.LogInformation("Repository {repo} is already at {sha}", update.Mapping.Name, update.TargetRevision);
-            }
-            else
+            if (currentVersion.PackageVersion != update.TargetVersion && update.TargetVersion != null)
             {
                 await UpdateTargetVersionOnly(
                     update.TargetRevision,
@@ -196,6 +192,10 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                     update.Mapping,
                     currentVersion,
                     cancellationToken);
+            }
+            else
+            {
+                _logger.LogInformation("Repository {repo} is already at {sha}", update.Mapping.Name, update.TargetRevision);
             }
 
             return Array.Empty<VmrIngestionPatch>();
@@ -356,10 +356,10 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
             updatedDependencies.Add(update with
             {
-                // We the SHA again because original target could have been a branch name
+                // We resolve the SHA again because original target could have been a branch name
                 TargetRevision = GetCurrentVersion(update.Mapping),
 
-                // We also store the original version so that later we use it in the commit message
+                // We also store the original SHA (into the version!) so that later we use it in the commit message
                 TargetVersion = currentSha,
             });
         }
@@ -693,7 +693,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         cancellationToken.ThrowIfCancellationRequested();
         await _localGitClient.StageAsync(_vmrInfo.VmrPath, filesToAdd, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
-        await CommitAsync($"Updated package version of {mapping.Name} metadata to {targetVersion}", author: null);
+        await CommitAsync($"Updated package version of {mapping.Name} to {targetVersion}", author: null);
     }
 
     private class RepositoryNotInitializedException : Exception

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
@@ -88,7 +88,10 @@ public class VmrSyncRepoChangesTest :  VmrTestsBase
         CheckFileContents(_productRepoPath / VersionFiles.VersionDetailsXml, versionDetails, removeEmptyLines: false);
         await GitOperations.CheckAllIsCommitted(VmrPath);
         var sourceManifest = SourceManifest.FromJson(VmrPath / VmrInfo.SourcesDir / VmrInfo.SourceManifestFileName);
+
         sourceManifest.GetVersion(Constants.DependencyRepoName)!.PackageVersion.Should().Be("8.0.1");
+        (await File.ReadAllTextAsync(VmrPath / VmrInfo.GitInfoSourcesDir / Constants.DependencyRepoName + ".props")).Should().Contain("8.0.1");
+        (await File.ReadAllTextAsync(VmrPath / VmrInfo.GitInfoSourcesDir / AllVersionsPropsFile.FileName)).Should().Contain("8.0.1");
     }
 
     [Test]

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -160,7 +160,7 @@ public abstract class VmrTestsBase
     protected async Task CallDarcUpdate(string repository, string commit, AdditionalRemote[] additionalRemotes, bool generateCodeowners = false)
     {
         var vmrUpdater = _serviceProvider.Value.GetRequiredService<IVmrUpdater>();
-        await vmrUpdater.UpdateRepository(repository, commit, null, false, true, additionalRemotes, null, null, generateCodeowners, true, _cancellationToken.Token);
+        await vmrUpdater.UpdateRepository(repository, commit, null, true, additionalRemotes, null, null, generateCodeowners, true, _cancellationToken.Token);
     }
 
     protected async Task<List<string>> CallDarcCloakedFileScan(string baselinesFilePath)

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -216,7 +216,7 @@ public abstract class VmrTestsBase
         return files;
     }
 
-    internal async Task<string> CopyRepoAndCreateVersionDetails(
+    protected async Task<string> CopyRepoAndCreateVersionDetails(
         NativePath currentTestDir,
         string repoName,
         IDictionary<string, List<string>>? dependencies = null)


### PR DESCRIPTION
Resolves a problem found in https://github.com/dotnet/arcade-services/issues/3010

When we get 2 builds from the same SHA, the VMR would not update the package version in its metadata as it would assume no changes are needed.

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Detect package version change even when SHA stays the same