### PR TITLE
Use `git remote update` instead of `git fetch`

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Actions/Local.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
 using NuGet.Versioning;
@@ -166,7 +167,7 @@ public class Local : ILocal
     public async Task<string> AddRemoteIfMissingAsync(string repoDir, string repoUrl)
     {
         string remoteName = await _gitClient.AddRemoteIfMissingAsync(repoDir, repoUrl);
-        await _gitClient.FetchAsync(repoDir, repoUrl);
+        await _gitClient.UpdateRemoteAsync(repoDir, remoteName);
         return remoteName;
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -1398,7 +1398,7 @@ public class DependencyFileManager : IDependencyFileManager
             }
             catch (Exception e)
             {
-                _logger.LogError("Unable to use regex to determine repo information from feed", e);
+                _logger.LogError(e, "Unable to use regex to determine repo information from feed");
                 repoNameFromFeed = unableToResolveName;
             }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
@@ -63,11 +63,11 @@ public interface ILocalGitClient
     Task CreateBranchAsync(string repoPath, string branchName, bool overwriteExistingBranch = false);
 
     /// <summary>
-    ///     Fetches from a given remote URI.
+    ///     Fetches from a given remote.
     /// </summary>
     /// <param name="repoPath">Path of the local repository</param>
-    /// <param name="remoteUri">Remote git repository</param>
-    Task<string> FetchAsync(string repoPath, string remoteUri, CancellationToken cancellationToken = default);
+    /// <param name="remoteName">Name of an already existing remote</param>
+    Task UpdateRemoteAsync(string repoPath, string remoteName, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Retrieves a file's content from git index (works with bare repositories).

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeBackflower.cs
@@ -124,10 +124,10 @@ public class CodeBackflower : IVmrBackflower
         {
             _logger.LogInformation("Failed to checkout {sha} in {repo}, will fetch from all remotes and try again...", repo.CommitSha, repoDirectory);
 
-            foreach (var remote in remotes)
+            foreach (var remoteUri in remotes)
             {
-                await _localGitClient.AddRemoteIfMissingAsync(repoDirectory, remote, cancellationToken);
-                await _localGitClient.FetchAsync(repoDirectory, remote, cancellationToken);
+                var remoteName = await _localGitClient.AddRemoteIfMissingAsync(repoDirectory, remoteUri, cancellationToken);
+                await _localGitClient.UpdateRemoteAsync(repoDirectory, remoteName, cancellationToken);
             }
 
             await _localGitClient.CheckoutAsync(repoDirectory, repo.CommitSha);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -116,10 +116,11 @@ public class RepositoryCloneManager : IRepositoryCloneManager
         else
         {
             _logger.LogDebug("Clone of {repo} found in {clonePath}", remoteUri, clonePath);
-            await _localGitRepo.AddRemoteIfMissingAsync(clonePath, remoteUri, cancellationToken);
+            var remote = await _localGitRepo.AddRemoteIfMissingAsync(clonePath, remoteUri, cancellationToken);
 
-            // We need to perform a full fetch and not the one provided by localGitRepo as we want all commits
-            await _localGitRepo.FetchAsync(clonePath, remoteUri, cancellationToken);
+            // We cannot do `fetch --all` as tokens might be needed but fetch +refs/heads/*:+refs/remotes/origin/* doesn't fetch new refs
+            // So we need to call `remote update origin` to fetch everything
+            await _localGitRepo.UpdateRemoteAsync(clonePath, remote, cancellationToken);
         }
 
         _upToDateRepos.Add(remoteUri);

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
@@ -141,7 +141,7 @@ public class RepositoryCloneManagerTests
         
         path.Should().Be(clonePath);
         _repoCloner.Verify(x => x.CloneNoCheckoutAsync(mapping.DefaultRemote, clonePath, null), Times.Never);
-        _localGitRepo.Verify(x => x.FetchAsync(clonePath, mapping.DefaultRemote, default), Times.Never);
+        _localGitRepo.Verify(x => x.UpdateRemoteAsync(clonePath, "default", default), Times.Never);
         _localGitRepo.Verify(x => x.CheckoutAsync(clonePath, Ref), Times.Once);
 
         // A third clone with a new remote
@@ -152,7 +152,7 @@ public class RepositoryCloneManagerTests
         _repoCloner.Verify(x => x.CloneNoCheckoutAsync(RepoUri, clonePath, null), Times.Never);
         _localGitRepo.Verify(x => x.AddRemoteIfMissingAsync(clonePath, newRemote, It.IsAny<CancellationToken>()), Times.Once);
         _localGitRepo.Verify(x => x.CheckoutAsync(clonePath, Ref), Times.Once);
-        _localGitRepo.Verify(x => x.FetchAsync(clonePath, newRemote, default), Times.Once);
+        _localGitRepo.Verify(x => x.UpdateRemoteAsync(clonePath, "new", default), Times.Once);
 
         // Same again, should be cached
         ResetCalls();
@@ -162,7 +162,7 @@ public class RepositoryCloneManagerTests
         _repoCloner.Verify(x => x.CloneNoCheckoutAsync(RepoUri, clonePath, null), Times.Never);
         _localGitRepo.Verify(x => x.AddRemoteIfMissingAsync(clonePath, newRemote, It.IsAny<CancellationToken>()), Times.Never);
         _localGitRepo.Verify(x => x.CheckoutAsync(clonePath, Ref + "3"), Times.Once);
-        _localGitRepo.Verify(x => x.FetchAsync(clonePath, mapping.DefaultRemote, default), Times.Never);
+        _localGitRepo.Verify(x => x.UpdateRemoteAsync(clonePath, "new", default), Times.Never);
 
         // Call with URI directly
         ResetCalls();
@@ -172,7 +172,7 @@ public class RepositoryCloneManagerTests
         _repoCloner.Verify(x => x.CloneNoCheckoutAsync(RepoUri, clonePath, null), Times.Never);
         _localGitRepo.Verify(x => x.AddRemoteIfMissingAsync(clonePath, RepoUri, It.IsAny<CancellationToken>()), Times.Never);
         _localGitRepo.Verify(x => x.CheckoutAsync(clonePath, Ref + "4"), Times.Once);
-        _localGitRepo.Verify(x => x.FetchAsync(clonePath, mapping.DefaultRemote, default), Times.Never);
+        _localGitRepo.Verify(x => x.UpdateRemoteAsync(clonePath, "new", default), Times.Never);
 
         // Call with the second URI directly
         ResetCalls();
@@ -182,6 +182,6 @@ public class RepositoryCloneManagerTests
         _repoCloner.Verify(x => x.CloneNoCheckoutAsync(RepoUri, clonePath, null), Times.Never);
         _localGitRepo.Verify(x => x.AddRemoteIfMissingAsync(clonePath, newRemote, It.IsAny<CancellationToken>()), Times.Never);
         _localGitRepo.Verify(x => x.CheckoutAsync(clonePath, Ref + "5"), Times.Once);
-        _localGitRepo.Verify(x => x.FetchAsync(clonePath, mapping.DefaultRemote, default), Times.Never);
+        _localGitRepo.Verify(x => x.UpdateRemoteAsync(clonePath, "new", default), Times.Never);
     }
 }


### PR DESCRIPTION
I found during some testing that when new refs are created in a remote and the local repo gets very outdated, not all new refs are pulled properly.
This change uses a new way to synchronize a remote once it's added/needs to be refreshed.

https://github.com/dotnet/arcade-services/issues/2982

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Started using `git remote update` instead of `git fetch`