### PR TITLE
Fix running secret manage and scenario tests

### DIFF
--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -121,8 +121,10 @@ stages:
     timeoutInMinutes: 100
     steps:
     - download: current
+      displayName: Download Darc
       artifact: PackageArtifacts
     - download: current
+      displayName: Download ScenarioTets
       artifact: Maestro.ScenarioTests
 
     - task: NuGetToolInstaller@1
@@ -130,10 +132,8 @@ stages:
       inputs:
         versionSpec: 5.3.x
 
-    - task: UseDotNet@2
+    - powershell: .\eng\common\build.ps1 -restore
       displayName: Install .NET
-      inputs:
-        useGlobalJson: true
 
     - task: VSTest@2
       displayName: Maestro Scenario Tests

--- a/eng/templates/stages/secret-validation.yml
+++ b/eng/templates/stages/secret-validation.yml
@@ -24,8 +24,7 @@ stages:
 
     steps:
     - powershell: |
-        . .\eng\common\tools.ps1
-        InitializeDotNetCli -install $true
+        .\eng\common\build.ps1 -restore
         .\.dotnet\dotnet tool restore
       displayName: Install Secret Manager
 


### PR DESCRIPTION
This was broken by the move to the 8.0 Arcade: https://github.com/dotnet/arcade-services/issues/3053

Tested here: https://dev.azure.com/dnceng/internal/_build/results?buildId=2317181&view=logs&j=4d9f00d7-d155-5977-7b70-2e6b79720ff2&t=b6bdfb3b-13bb-5ba7-3230-bffa36e2e1b9

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Not release notes worthy