### PR TITLE
Add a VMR sync switch to use public repos only

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
@@ -39,5 +39,6 @@ internal class InitializeOperation : VmrOperationBase<IVmrInitializer>
             _options.TpnTemplate,
             _options.GenerateCodeowners,
             _options.DiscardPatches,
+            _options.PublicUrisOnly,
             cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
@@ -37,5 +37,6 @@ internal class UpdateOperation : VmrOperationBase<IVmrUpdater>
             _options.TpnTemplate,
             _options.GenerateCodeowners,
             _options.DiscardPatches,
+            _options.PublicUrisOnly,
             cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrSyncCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrSyncCommandLineOptions.cs
@@ -29,4 +29,7 @@ internal abstract class VmrSyncCommandLineOptions : VmrCommandLineOptions, IBase
 
     [Option("discard-patches", Required = false, HelpText = "Delete .patch files created during the sync.")]
     public bool DiscardPatches { get; set; } = false;
+
+    [Option("public-uris-only", Required = false, HelpText = "Turns internal AzDO repository URIs into public GitHub ones.")]
+    public bool PublicUrisOnly { get; set; } = false;
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitRepoUrlParser.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitRepoUrlParser.cs
@@ -48,4 +48,30 @@ public static class GitRepoUrlParser
 
         throw new Exception("Unsupported format of repository url " + uri);
     }
+
+    public static string ConvertInternalUriToPublic(string uri)
+    {
+        if (!uri.StartsWith(Constants.AzureDevOpsUrlPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return uri;
+        }
+
+        string[] repoParts = uri.Substring(uri.LastIndexOf('/') + 1).Split('-', 2);
+        if (repoParts.Length != 2)
+        {
+            return uri;
+        }
+
+        string org = repoParts[0];
+        string repo = repoParts[1];
+
+        // The internal Nuget.Client repo has suffix which needs to be accounted for.
+        const string trustedSuffix = "-Trusted";
+        if (uri.EndsWith(trustedSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            repo = repo.Substring(0, repo.Length - trustedSuffix.Length);
+        }
+
+        return $"{Constants.GitHubUrlPrefix}{org}/{repo}";
+    }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -188,6 +188,8 @@ public class LocalGitClient : ILocalGitClient
     {
         var result = await _processManager.ExecuteGit(repoPath, new[] { "remote", "update", remoteName }, cancellationToken: cancellationToken);
         result.ThrowIfFailed($"Failed to update {repoPath} from remote {remoteName}");
+        result = await _processManager.ExecuteGit(repoPath, new[] { "fetch", "--tags", remoteName }, cancellationToken: cancellationToken);
+        result.ThrowIfFailed($"Failed to update {repoPath} from remote {remoteName}");
     }
 
     public async Task<List<GitSubmoduleInfo>> GetGitSubmodulesAsync(string repoPath, string commit)

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
@@ -24,6 +24,7 @@ public interface IVmrInitializer
     /// <param name="tpnTemplatePath">Path to VMR's THIRD-PARTY-NOTICES.md template</param>
     /// <param name="generateCodeowners">Whether to generate a CODEOWNERS file</param>
     /// <param name="discardPatches">Whether to clean up genreated .patch files after their used</param>
+    /// <param name="publicUrisOnly">Whether to turn internal AzDO repository URIs into public GitHub ones</param>
     Task InitializeRepository(
         string mappingName,
         string? targetRevision,
@@ -35,5 +36,6 @@ public interface IVmrInitializer
         string? tpnTemplatePath,
         bool generateCodeowners,
         bool discardPatches,
+        bool publicUrisOnly,
         CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
@@ -23,6 +23,7 @@ public interface IVmrUpdater
     /// <param name="tpnTemplatePath">Path to VMR's THIRD-PARTY-NOTICES.md template</param>
     /// <param name="generateCodeowners">Whether to generate a CODEOWNERS file</param>
     /// <param name="discardPatches">Whether to clean up genreated .patch files after their used</param>
+    /// <param name="publicUrisOnly">Whether to turn internal AzDO repository URIs into public GitHub ones</param>
     Task UpdateRepository(
         string mappingName,
         string? targetRevision,
@@ -33,5 +34,6 @@ public interface IVmrUpdater
         string? tpnTemplatePath,
         bool generateCodeowners,
         bool discardPatches,
+        bool publicUrisOnly,
         CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -86,6 +86,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         string? tpnTemplatePath,
         bool generateCodeowners,
         bool discardPatches,
+        bool publicUrisOnly,
         CancellationToken cancellationToken)
     {
         await _dependencyTracker.InitializeSourceMappings(sourceMappingsPath);
@@ -116,7 +117,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         try
         {
             IEnumerable<VmrDependencyUpdate> updates = initializeDependencies
-            ? await GetAllDependenciesAsync(rootUpdate, additionalRemotes, cancellationToken)
+            ? await GetAllDependenciesAsync(rootUpdate, additionalRemotes, publicUrisOnly, cancellationToken)
             : new[] { rootUpdate };
 
             foreach (var update in updates)
@@ -142,6 +143,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
                     tpnTemplatePath,
                     generateCodeowners,
                     discardPatches,
+                    publicUrisOnly,
                     cancellationToken);
             }
         }
@@ -171,6 +173,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         string? tpnTemplatePath,
         bool generateCodeowners,
         bool discardPatches,
+        bool publicUrisOnly,
         CancellationToken cancellationToken)
     {
         _logger.LogInformation("Initializing {name} at {revision}..", update.Mapping.Name, update.TargetRevision);
@@ -207,6 +210,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
             tpnTemplatePath,
             generateCodeowners,
             discardPatches,
+            publicUrisOnly,
             cancellationToken);
 
         _logger.LogInformation("Initialization of {name} finished", update.Mapping.Name);
@@ -215,6 +219,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
     protected override Task<IReadOnlyCollection<VmrIngestionPatch>> RestoreVmrPatchedFilesAsync(
         SourceMapping mapping,
         IReadOnlyCollection<VmrIngestionPatch> patches,
+        bool publicUrisOnly,
         CancellationToken cancellationToken)
     {
         // We only need to apply VMR patches that belong to the mapping, nothing to restore from before

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -149,7 +149,19 @@ public abstract class VmrTestsBase
     private async Task CallDarcInitialize(string repository, string commit, LocalPath sourceMappingsPath)
     {
         var vmrInitializer = _serviceProvider.Value.GetRequiredService<IVmrInitializer>();
-        await vmrInitializer.InitializeRepository(repository, commit, null, true, sourceMappingsPath, Array.Empty<AdditionalRemote>(), null, null, false, true, _cancellationToken.Token);
+        await vmrInitializer.InitializeRepository(
+            mappingName: repository,
+            targetRevision: commit,
+            targetVersion: null,
+            initializeDependencies: true,
+            sourceMappingsPath: sourceMappingsPath,
+            additionalRemotes: Array.Empty<AdditionalRemote>(),
+            readmeTemplatePath: null,
+            tpnTemplatePath: null,
+            generateCodeowners: false,
+            discardPatches: true,
+            publicUrisOnly: false,
+            cancellationToken: _cancellationToken.Token);
     }
 
     protected async Task CallDarcUpdate(string repository, string commit, bool generateCodeowners = false)
@@ -160,7 +172,18 @@ public abstract class VmrTestsBase
     protected async Task CallDarcUpdate(string repository, string commit, AdditionalRemote[] additionalRemotes, bool generateCodeowners = false)
     {
         var vmrUpdater = _serviceProvider.Value.GetRequiredService<IVmrUpdater>();
-        await vmrUpdater.UpdateRepository(repository, commit, null, true, additionalRemotes, null, null, generateCodeowners, true, _cancellationToken.Token);
+        await vmrUpdater.UpdateRepository(
+            mappingName: repository,
+            targetRevision: commit,
+            targetVersion: null,
+            updateDependencies: true,
+            additionalRemotes: additionalRemotes,
+            readmeTemplatePath: null,
+            tpnTemplatePath: null,
+            generateCodeowners: generateCodeowners,
+            discardPatches: true,
+            publicUrisOnly: false,
+            cancellationToken: _cancellationToken.Token);
     }
 
     protected async Task<List<string>> CallDarcCloakedFileScan(string baselinesFilePath)

--- a/test/Microsoft.DotNet.DarcLib.Tests/Helpers/GitRepoUrlParserTest.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Helpers/GitRepoUrlParserTest.cs
@@ -46,4 +46,14 @@ public class GitRepoUrlParserTest
         name.Should().Be("repo-name");
         org.Should().Be("org");
     }
+
+
+    [Test]
+    [TestCase("https://dev.azure.com/dnceng/internal/_git/org-repo-name", "https://github.com/org/repo-name")]
+    [TestCase("https://github.com/org/repo-name", "https://github.com/org/repo-name")]
+    [TestCase("https://dev.azure.com/devdiv/DevDiv/_git/NuGet-NuGet.Client-Trusted", "https://github.com/NuGet/NuGet.Client")]
+    public void ConvertInternalUriToPublicTest(string internalUri, string publicUri)
+    {
+        GitRepoUrlParser.ConvertInternalUriToPublic(internalUri).Should().Be(publicUri);
+    }
 }


### PR DESCRIPTION
Adds a new switch that makes the VMR sync only use public GH repos. The idea is that we would turn this on for PRs.

Requirement detected in https://github.com/dotnet/installer/issues/17809 and in https://github.com/dotnet/installer/issues/17785

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Added a switch that restricts VMR sync to public repos only