### PR TITLE
Publish build logs through Arcade

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,6 +149,18 @@ stages:
           inputs:
             versionSpec: 12.x
 
+        - task: NuGetToolInstaller@0
+          displayName: Install NuGet
+          inputs:
+            versionSpec: 6.1.x
+
+        - task: NuGetCommand@2
+          displayName: Restore Packages
+          inputs:
+            command: restore
+            solution: "**/*.sln"
+            feedstoUse: config
+
         - powershell: eng\set-version-parameters.ps1
           displayName: Calculate Release Versions
 
@@ -163,7 +175,6 @@ stages:
         - script: eng\common\cibuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
-            -restore
             $(_InternalBuildArgs)
             /p:Test=false
             /P:Sign=false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,6 +163,7 @@ stages:
         - script: eng\common\cibuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
+            -restore
             $(_InternalBuildArgs)
             /p:Test=false
             /P:Sign=false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,12 +67,10 @@ stages:
     parameters:
       artifacts:
         publish:
+          logs: true
           ${{ if in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production') }}:
             artifacts: true
-            logs: true
             manifests: true
-          ${{ else }}:
-            logs: true
       enableTelemetry: true
       enableMicrobuild: false
       enablePublishTestResults: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,16 +66,8 @@ stages:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableTelemetry: true
-      publish:
-        artifacts: true
-        logs: true
-        manifests: true
-      ${{ if in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production') }}:
-        enablePublishBuildArtifacts: true
-        enablePublishBuildAssets: true
-      ${{ else }}:
-        enablePublishBuildArtifacts: false
-        enablePublishBuildAssets: false
+      enablePublishBuildArtifacts: true
+      enablePublishBuildAssets: true
       enableMicrobuild: false
       enablePublishTestResults: false
       enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,9 +65,15 @@ stages:
   jobs:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
+      artifacts:
+        publish:
+          ${{ if in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production') }}:
+            artifacts: true
+            logs: true
+            manifests: true
+          ${{ else }}:
+            logs: true
       enableTelemetry: true
-      enablePublishBuildArtifacts: true
-      enablePublishBuildAssets: true
       enableMicrobuild: false
       enablePublishTestResults: false
       enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,18 +149,6 @@ stages:
           inputs:
             versionSpec: 12.x
 
-        - task: NuGetToolInstaller@0
-          displayName: Install NuGet
-          inputs:
-            versionSpec: 6.1.x
-
-        - task: NuGetCommand@2
-          displayName: Restore Packages
-          inputs:
-            command: restore
-            solution: "**/*.sln"
-            feedstoUse: config
-
         - powershell: eng\set-version-parameters.ps1
           displayName: Calculate Release Versions
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,11 @@ stages:
   jobs:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
+      enableTelemetry: true
+      publish:
+        artifacts: true
+        logs: true
+        manifests: true
       ${{ if in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production') }}:
         enablePublishBuildArtifacts: true
         enablePublishBuildAssets: true
@@ -74,8 +79,7 @@ stages:
       enableMicrobuild: false
       enablePublishTestResults: false
       enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
-      enableTelemetry: true
-      helixRepo: dotnet/arcade-services
+
       jobs:
       - job: Windows_NT
         timeoutInMinutes: 90
@@ -89,7 +93,6 @@ stages:
 
         variables:
         - _InternalBuildArgs: ''
-        - _ProductionArgs: ''
 
         # Only enable publishing in non-public, non PR scenarios.
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -173,7 +176,6 @@ stages:
             -configuration $(_BuildConfig)
             -prepareMachine
             $(_InternalBuildArgs)
-            $(_ProductionArgs)
             /p:Test=false
             /P:Sign=false
           name: Build
@@ -231,8 +233,6 @@ stages:
           - publish: $(Build.SourcesDirectory)\artifacts\bin\Maestro.ScenarioTests\$(_BuildConfig)\net6.0\publish
             artifact: Maestro.ScenarioTests
             displayName: Publish Maestro Scenario Tests
-
-        - template: /eng/common/templates/steps/publish-logs.yml
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production')) }}:
   - template: /eng/common/templates/post-build/post-build.yml

--- a/eng/templates/steps/test.yml
+++ b/eng/templates/steps/test.yml
@@ -21,7 +21,7 @@ steps:
       --no-build
       --logger "trx;LogFilePrefix=TestResults-"
       -v normal
-      /bl:$(Build.SourcesDirectory)/artifacts/log/Debug/UnitTest.binlog
+      /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/UnitTest.binlog
       --
       "RunConfiguration.ResultsDirectory=$(Build.ArtifactStagingDirectory)\TestResults"
       RunConfiguration.MapCpuCount=4


### PR DESCRIPTION
We will get these artifacts:
![image](https://github.com/dotnet/arcade-services/assets/7013027/6aac17bb-8aae-4145-9e96-0d05e2f6221f)


https://github.com/dotnet/arcade-services/issues/3074

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Not release notes worthy