### PR TITLE
Lazy-fetch repos during VMR sync to allow internal->public merges

### DIFF
--- a/src/Maestro/Maestro.DataProviders/DarcRemoteFactory.cs
+++ b/src/Maestro/Maestro.DataProviders/DarcRemoteFactory.cs
@@ -62,7 +62,7 @@ public class DarcRemoteFactory : IRemoteFactory
             string normalizedUrl = AzureDevOpsClient.NormalizeUrl(repoUrl);
 
             long installationId = await Context.GetInstallationId(normalizedUrl);
-            var repoType = GitRepoTypeParser.ParseFromUri(normalizedUrl);
+            var repoType = GitRepoUrlParser.ParseTypeFromUri(normalizedUrl);
 
             if (repoType == GitRepoType.GitHub && installationId == default)
             {

--- a/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
+++ b/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
@@ -73,7 +73,7 @@ public class DarcRemoteFactory : IRemoteFactory
             }
 
             long installationId = await _context.GetInstallationId(normalizedUrl);
-            var repoType = GitRepoTypeParser.ParseFromUri(normalizedUrl);
+            var repoType = GitRepoUrlParser.ParseTypeFromUri(normalizedUrl);
 
             if (repoType == GitRepoType.GitHub && installationId == default)
             {
@@ -92,7 +92,7 @@ public class DarcRemoteFactory : IRemoteFactory
 
             var gitExe = _localGit.GetPathToLocalGit();
 
-            IRemoteGitRepo remoteGitClient = GitRepoTypeParser.ParseFromUri(normalizedUrl) switch
+            IRemoteGitRepo remoteGitClient = GitRepoUrlParser.ParseTypeFromUri(normalizedUrl) switch
             {
                 GitRepoType.GitHub => installationId == default
                     ? throw new GithubApplicationInstallationException($"No installation is available for repository '{normalizedUrl}'")

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
@@ -102,7 +102,7 @@ internal class LocalSettings
 
         if (!string.IsNullOrEmpty(repoUri))
         {
-            darcSettings.GitType = GitRepoTypeParser.ParseFromUri(repoUri);
+            darcSettings.GitType = GitRepoUrlParser.ParseTypeFromUri(repoUri);
             switch (darcSettings.GitType)
             {
                 case GitRepoType.GitHub:

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/FileSystem.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/FileSystem.cs
@@ -29,6 +29,8 @@ public class FileSystem : IFileSystem
 
     public string? GetFileName(string? path) => Path.GetFileName(path);
 
+    public string GetTempFileName() => Path.GetTempFileName();
+
     public string PathCombine(string path1, string path2) => Path.Combine(path1, path2);
 
     public void WriteToFile(string path, string content)

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitRepoType.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitRepoType.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Microsoft.DotNet.DarcLib.Helpers;
 
 public enum GitRepoType
@@ -11,24 +9,4 @@ public enum GitRepoType
     AzureDevOps,
     Local,
     None
-}
-
-public static class GitRepoTypeParser
-{
-    public static GitRepoType ParseFromUri(string pathOrUri)
-    {
-        if (!Uri.TryCreate(pathOrUri, UriKind.Absolute, out Uri parsedUri))
-        {
-            return GitRepoType.None;
-        }
-
-        return parsedUri switch
-        {
-            { IsFile: true } => GitRepoType.Local,
-            { Host: "github.com" } => GitRepoType.GitHub,
-            { Host: var host } when host is "dev.azure.com" => GitRepoType.AzureDevOps,
-            { Host: var host } when host.EndsWith("visualstudio.com") => GitRepoType.AzureDevOps,
-            _ => GitRepoType.None,
-        };
-    }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitRepoUrlParser.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitRepoUrlParser.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.Helpers;

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitRepoUrlParser.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitRepoUrlParser.cs
@@ -48,4 +48,30 @@ public static class GitRepoUrlParser
 
         throw new Exception("Unsupported format of repository url " + uri);
     }
+
+    public static string ConvertInternalUriToPublic(string uri)
+    {
+        if (!uri.StartsWith(Constants.AzureDevOpsUrlPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return uri;
+        }
+
+        string[] repoParts = uri.Substring(uri.LastIndexOf('/') + 1).Split('-', 2);
+        if (repoParts.Length != 2)
+        {
+            return uri;
+        }
+
+        string org = repoParts[0];
+        string repo = repoParts[1];
+
+        // The internal Nuget.Client repo has suffix which needs to be accounted for.
+        const string trustedSuffix = "-Trusted";
+        if (uri.EndsWith(trustedSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            repo = repo.Substring(0, repo.Length - trustedSuffix.Length);
+        }
+
+        return $"{Constants.GitHubUrlPrefix}{org}/{repo}";
+    }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitRepoUrlParser.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitRepoUrlParser.cs
@@ -102,22 +102,7 @@ public static class GitRepoUrlParser
             return uri;
         }
 
-        string[] repoParts = uri.Substring(uri.LastIndexOf('/') + 1).Split('-', 2);
-        if (repoParts.Length != 2)
-        {
-            return uri;
-        }
-
-        string org = repoParts[0];
-        string repo = repoParts[1];
-
-        // The internal Nuget.Client repo has suffix which needs to be accounted for.
-        const string trustedSuffix = "-Trusted";
-        if (uri.EndsWith(trustedSuffix, StringComparison.OrdinalIgnoreCase))
-        {
-            repo = repo.Substring(0, repo.Length - trustedSuffix.Length);
-        }
-
+        var (repo, org) = GetRepoNameAndOwner(uri);
         return $"{Constants.GitHubUrlPrefix}{org}/{repo}";
     }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IFileSystem.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IFileSystem.cs
@@ -27,6 +27,8 @@ public interface IFileSystem
 
     string? GetFileName(string? path);
 
+    public string GetTempFileName();
+
     string? GetDirectoryName(string? path);
 
     string PathCombine(string path1, string path2);

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -188,7 +188,7 @@ public class LocalGitClient : ILocalGitClient
     {
         var result = await _processManager.ExecuteGit(repoPath, new[] { "remote", "update", remoteName }, cancellationToken: cancellationToken);
         result.ThrowIfFailed($"Failed to update {repoPath} from remote {remoteName}");
-        result = await _processManager.ExecuteGit(repoPath, new[] { "fetch", "--tags", remoteName }, cancellationToken: cancellationToken);
+        result = await _processManager.ExecuteGit(repoPath, new[] { "fetch", "--tags", "--force", remoteName }, cancellationToken: cancellationToken);
         result.ThrowIfFailed($"Failed to update {repoPath} from remote {remoteName}");
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -188,6 +188,8 @@ public class LocalGitClient : ILocalGitClient
     {
         var result = await _processManager.ExecuteGit(repoPath, new[] { "remote", "update", remoteName }, cancellationToken: cancellationToken);
         result.ThrowIfFailed($"Failed to update {repoPath} from remote {remoteName}");
+        result = await _processManager.ExecuteGit(repoPath, new[] { "fetch", "--tags", remoteName }, cancellationToken: cancellationToken);
+        result.ThrowIfFailed($"Failed to update {repoPath} from remote {remoteName}");
     }
 
     public async Task<List<GitSubmoduleInfo>> GetGitSubmodulesAsync(string repoPath, string commit)

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
-using Microsoft.TeamFoundation.SourceControl.WebApi;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib;
@@ -21,24 +20,18 @@ namespace Microsoft.DotNet.DarcLib;
 /// </summary>
 public class LocalGitClient : ILocalGitClient
 {
-    private readonly RemoteConfiguration _remoteConfiguration;
     private readonly IProcessManager _processManager;
     private readonly ILogger _logger;
 
-    /// <summary>
-    ///     Construct a new local git client
-    /// </summary>
-    /// <param name="path">Current path</param>
-    public LocalGitClient(RemoteConfiguration remoteConfiguration, IProcessManager processManager, ILogger logger)
+    public LocalGitClient(IProcessManager processManager, ILogger logger)
     {
-        _remoteConfiguration = remoteConfiguration;
         _processManager = processManager;
         _logger = logger;
     }
 
     public async Task<string> GetFileContentsAsync(string relativeFilePath, string repoPath, string branch)
     {
-        string fullPath = Path.Combine(repoPath, relativeFilePath);
+        string fullPath = new NativePath(repoPath) / relativeFilePath;
         if (!Directory.Exists(Path.GetDirectoryName(fullPath)))
         {
             string? parentTwoDirectoriesUp = Path.GetDirectoryName(Path.GetDirectoryName(fullPath));

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
@@ -25,7 +25,7 @@ public class LocalLibGit2Client : LocalGitClient, ILocalLibGit2Client
     private readonly ILogger _logger;
 
     public LocalLibGit2Client(RemoteConfiguration remoteConfiguration, IProcessManager processManager, ILogger logger)
-        : base(remoteConfiguration, processManager, logger)
+        : base(processManager, logger)
     {
         _remoteConfiguration = remoteConfiguration;
         _processManager = processManager;

--- a/src/Microsoft.DotNet.Darc/DarcLib/RemoteConfiguration.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/RemoteConfiguration.cs
@@ -23,7 +23,7 @@ public class RemoteConfiguration
 
     public string? GetTokenForUri(string repoUri)
     {
-        var repoType = GitRepoTypeParser.ParseFromUri(repoUri);
+        var repoType = GitRepoUrlParser.ParseTypeFromUri(repoUri);
 
         return repoType switch
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -17,9 +17,9 @@ public record AdditionalRemote(string Mapping, string RemoteUri);
 
 public interface IRepositoryCloneManager
 {
-    Task<NativePath> PrepareClone(string repoUri, string checkoutRef, CancellationToken cancellationToken);
-
-    Task<NativePath> PrepareClone(
+    Task<NativePath> PrepareCloneAsync(string repoUri, string checkoutRef, CancellationToken cancellationToken);
+    
+    Task<NativePath> PrepareCloneAsync(
         SourceMapping mapping,
         IReadOnlyCollection<string> remotes,
         string checkoutRef,
@@ -33,7 +33,7 @@ public interface IRepositoryCloneManager
     /// <param name="requestedRefs">List of commits that </param>
     /// <param name="checkoutRef">Ref to check out at the end</param>
     /// <returns>Path to the clone</returns>
-    Task<NativePath> PrepareClone(
+    Task<NativePath> PrepareCloneAsync(
         SourceMapping mapping,
         IReadOnlyCollection<string> remoteUris,
         IReadOnlyCollection<string> requestedRefs,
@@ -75,7 +75,7 @@ public class RepositoryCloneManager : IRepositoryCloneManager
         _logger = logger;
     }
 
-    public async Task<NativePath> PrepareClone(
+    public async Task<NativePath> PrepareCloneAsync(
         SourceMapping mapping,
         IReadOnlyCollection<string> remoteUris,
         string checkoutRef,
@@ -99,7 +99,7 @@ public class RepositoryCloneManager : IRepositoryCloneManager
         return path;
     }
 
-    public async Task<NativePath> PrepareClone(
+    public async Task<NativePath> PrepareCloneAsync(
         string repoUri,
         string checkoutRef,
         CancellationToken cancellationToken)
@@ -111,7 +111,7 @@ public class RepositoryCloneManager : IRepositoryCloneManager
         return path;
     }
 
-    public async Task<NativePath> PrepareClone(
+    public async Task<NativePath> PrepareCloneAsync(
         SourceMapping mapping,
         IReadOnlyCollection<string> remoteUris,
         IReadOnlyCollection<string> requestedRefs,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -21,7 +21,7 @@ public interface IRepositoryCloneManager
 
     Task<NativePath> PrepareClone(
         SourceMapping mapping,
-        string[] remotes,
+        IReadOnlyCollection<string> remotes,
         string checkoutRef,
         CancellationToken cancellationToken);
 
@@ -77,11 +77,11 @@ public class RepositoryCloneManager : IRepositoryCloneManager
 
     public async Task<NativePath> PrepareClone(
         SourceMapping mapping,
-        string[] remoteUris,
+        IReadOnlyCollection<string> remoteUris,
         string checkoutRef,
         CancellationToken cancellationToken)
     {
-        if (remoteUris.Length == 0)
+        if (remoteUris.Count == 0)
         {
             throw new ArgumentException("No remote URIs provided to clone");
         }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -148,7 +148,7 @@ public class RepositoryCloneManager : IRepositoryCloneManager
 
                 if (refsToVerify.Count == 0)
                 {
-                    _logger.LogDebug("All requested refs ({refs}) found in {repo}", string.Join(", ", refsToVerify), path);
+                    _logger.LogDebug("All requested refs ({refs}) found in {repo}", string.Join(", ", requestedRefs), path);
                     break;
                 }
             }
@@ -156,7 +156,7 @@ public class RepositoryCloneManager : IRepositoryCloneManager
 
         if (refsToVerify.Count > 0)
         {
-            throw new Exception($"Failed to find all requested refs ({string.Join(", ", refsToVerify)}) in {string.Join(", ", remoteUris)}");
+            throw new Exception($"Failed to find all requested refs ({string.Join(", ", requestedRefs)}) in {string.Join(", ", remoteUris)}");
         }
 
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -17,8 +17,28 @@ public record AdditionalRemote(string Mapping, string RemoteUri);
 
 public interface IRepositoryCloneManager
 {
-    Task<NativePath> PrepareCloneAsync(string repoUri, string checkoutRef, CancellationToken cancellationToken);
-    
+    /// <summary>
+    /// Clones a target repo URI into a given directory and checks out a given ref.
+    /// When clone is already present, it is re-used and we only fetch.
+    /// When given remotes have already been fetched during this run, they are not fetched again.
+    /// </summary>
+    /// <param name="repoUri">Remote to fetch from</param>
+    /// <param name="checkoutRef">Ref to check out at the end</param>
+    /// <returns>Path to the clone</returns>
+    Task<NativePath> PrepareCloneAsync(
+        string repoUri,
+        string checkoutRef,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Clones a repo in a target directory, fetches from given remotes and checks out a given ref.
+    /// When clone is already present, it is re-used and only remotes are fetched.
+    /// When given remotes have already been fetched during this run, they are not fetched again.
+    /// </summary>
+    /// <param name="mapping">VMR repo mapping to associate the clone with</param>
+    /// <param name="remotes">Remotes to fetch from</param>
+    /// <param name="checkoutRef">Ref to check out at the end</param>
+    /// <returns>Path to the clone</returns>
     Task<NativePath> PrepareCloneAsync(
         SourceMapping mapping,
         IReadOnlyCollection<string> remotes,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
@@ -71,7 +71,7 @@ public class VmrDependencyTracker : IVmrDependencyTracker
     public async Task InitializeSourceMappings(string? sourceMappingsPath = null)
     {
         sourceMappingsPath ??= _vmrInfo.SourceMappingsPath;
-        sourceMappingsPath ??= VmrInfo.DefaultRelativeSourceMappingsPath;
+        sourceMappingsPath ??= _vmrInfo.VmrPath / VmrInfo.DefaultRelativeSourceMappingsPath;
         _mappings = await _sourceMappingParser.ParseMappings(sourceMappingsPath);
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
@@ -70,7 +70,8 @@ public class VmrDependencyTracker : IVmrDependencyTracker
 
     public async Task InitializeSourceMappings(string? sourceMappingsPath = null)
     {
-        sourceMappingsPath ??= _vmrInfo.VmrPath / VmrInfo.SourcesDir / VmrInfo.SourceMappingsFileName;
+        sourceMappingsPath ??= _vmrInfo.SourceMappingsPath;
+        sourceMappingsPath ??= VmrInfo.DefaultRelativeSourceMappingsPath;
         _mappings = await _sourceMappingParser.ParseMappings(sourceMappingsPath);
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
@@ -69,7 +69,6 @@ public class VmrDependencyTracker : IVmrDependencyTracker
 
     public async Task InitializeSourceMappings(string? sourceMappingsPath = null)
     {
-        sourceMappingsPath ??= _vmrInfo.SourceMappingsPath;
         sourceMappingsPath ??= _vmrInfo.VmrPath / VmrInfo.DefaultRelativeSourceMappingsPath;
         _mappings = await _sourceMappingParser.ParseMappings(sourceMappingsPath);
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrGitClientFactory.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrGitClientFactory.cs
@@ -32,7 +32,7 @@ public class VmrGitClientFactory : IGitRepoFactory
         _loggerFactory = loggerFactory;
     }
 
-    public IGitRepo CreateClient(string repoUri) => GitRepoTypeParser.ParseFromUri(repoUri) switch
+    public IGitRepo CreateClient(string repoUri) => GitRepoUrlParser.ParseTypeFromUri(repoUri) switch
     {
         GitRepoType.AzureDevOps => new AzureDevOpsClient(
             _processManager.GitExecutable,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -77,7 +77,7 @@ public class VmrInfo : IVmrInfo
 
     public static UnixPath DefaultRelativeSourceMappingsPath { get; } = RelativeSourcesDir / SourceMappingsFileName;
 
-    public static UnixPath RelativeSourceManifestPath { get; } = RelativeSourcesDir / SourceManifestFileName;
+    public static UnixPath DefaultRelativeSourceManifestPath { get; } = RelativeSourcesDir / SourceManifestFileName;
 
     public NativePath VmrPath { get; }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -75,6 +75,10 @@ public class VmrInfo : IVmrInfo
 
     public static UnixPath RelativeSourcesDir { get; } = new("src");
 
+    public static UnixPath DefaultRelativeSourceMappingsPath { get; } = RelativeSourcesDir / SourceMappingsFileName;
+
+    public static UnixPath RelativeSourceManifestPath { get; } = RelativeSourcesDir / SourceManifestFileName;
+
     public NativePath VmrPath { get; }
 
     public NativePath TmpPath { get; }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -181,7 +181,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
             .Prepend(update.RemoteUri)
             .ToArray();
 
-        NativePath clonePath = await _cloneManager.PrepareClone(
+        NativePath clonePath = await _cloneManager.PrepareCloneAsync(
             update.Mapping,
             remotes,
             new[] { update.TargetRevision },

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -184,6 +184,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         NativePath clonePath = await _cloneManager.PrepareClone(
             update.Mapping,
             remotes,
+            new[] { update.TargetRevision },
             update.TargetRevision,
             cancellationToken);
 
@@ -199,6 +200,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         await UpdateRepoToRevisionAsync(
             update,
             clonePath,
+            additionalRemotes,
             Constants.EmptyGitObject,
             author: null,
             commitMessage,
@@ -215,6 +217,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
     protected override Task<IReadOnlyCollection<VmrIngestionPatch>> RestoreVmrPatchedFilesAsync(
         SourceMapping mapping,
         IReadOnlyCollection<VmrIngestionPatch> patches,
+        IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken)
     {
         // We only need to apply VMR patches that belong to the mapping, nothing to restore from before

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -218,8 +218,7 @@ public abstract class VmrManagerBase
             var remotes = additionalRemotes
                 .Where(r => r.Mapping == repo.Mapping.Name)
                 .Select(r => r.RemoteUri)
-                .Prepend(repo.RemoteUri)
-                .ToArray();
+                .Prepend(repo.RemoteUri);
 
             IEnumerable<DependencyDetail>? repoDependencies = null;
             foreach (var remoteUri in remotes)

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -64,6 +64,7 @@ public abstract class VmrManagerBase
     protected async Task<IReadOnlyCollection<VmrIngestionPatch>> UpdateRepoToRevisionAsync(
         VmrDependencyUpdate update,
         NativePath clonePath,
+        IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string fromRevision,
         (string Name, string Email)? author,
         string commitMessage,
@@ -87,7 +88,7 @@ public abstract class VmrManagerBase
         // Get a list of patches that need to be reverted for this update so that repo changes can be applied
         // This includes all patches that are also modified by the current change
         // (happens when we update repo from which the VMR patches come)
-        var vmrPatchesToRestore = await RestoreVmrPatchedFilesAsync(update.Mapping, patches, cancellationToken);
+        var vmrPatchesToRestore = await RestoreVmrPatchedFilesAsync(update.Mapping, patches, additionalRemotes, cancellationToken);
 
         foreach (var patch in patches)
         {
@@ -315,6 +316,7 @@ public abstract class VmrManagerBase
     protected abstract Task<IReadOnlyCollection<VmrIngestionPatch>> RestoreVmrPatchedFilesAsync(
         SourceMapping mapping,
         IReadOnlyCollection<VmrIngestionPatch> patches,
+        IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken);
 
     /// <summary>

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -539,7 +539,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         CancellationToken cancellationToken)
     {
         var checkoutCommit = change.Before == Constants.EmptyGitObject ? change.After : change.Before;
-        var clonePath = await _cloneManager.PrepareClone(change.Url, checkoutCommit, cancellationToken);   
+        var clonePath = await _cloneManager.PrepareCloneAsync(change.Url, checkoutCommit, cancellationToken);   
 
         // We are only interested in filters specific to submodule's path
         ImmutableArray<string> GetSubmoduleFilters(IReadOnlyCollection<string> filters)

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -204,7 +204,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             .OrderBy(GitRepoUrlParser.ParseTypeFromUri, Comparer<GitRepoType>.Create(GitRepoUrlParser.OrderByLocalPublicOther))
             .ToArray();
 
-        NativePath clonePath = await _cloneManager.PrepareClone(
+        NativePath clonePath = await _cloneManager.PrepareCloneAsync(
             update.Mapping,
             remotes,
             requestedRefs: new[] { currentVersion.Sha, update.TargetRevision },
@@ -508,11 +508,11 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                     .Distinct()
                     .ToList();
 
-                clonePath = await _cloneManager.PrepareClone(sourceMapping, remotes, new[] { source.CommitSha }, source.CommitSha, cancellationToken);
+                clonePath = await _cloneManager.PrepareCloneAsync(sourceMapping, remotes, new[] { source.CommitSha }, source.CommitSha, cancellationToken);
             }
             else
             {
-                clonePath = await _cloneManager.PrepareClone(source.RemoteUri, source.CommitSha, cancellationToken);
+                clonePath = await _cloneManager.PrepareCloneAsync(source.RemoteUri, source.CommitSha, cancellationToken);
             }
 
             foreach ((UnixPath repoPath, UnixPath pathInVmr) in group)

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -739,8 +739,12 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             {
                 _logger.LogDebug("Looking for a new version of {file} in {repo}", relativePath, remote);
                 sourceMappingContent = await gitClient.GetFileContentsAsync(relativePath, remote, targetRevision);
-                _logger.LogDebug("Found new version of {file} in {repo}", relativePath, remote);
-                break;
+
+                if (sourceMappingContent != null)
+                {
+                    _logger.LogDebug("Found new version of {file} in {repo}", relativePath, remote);
+                    break;
+                }
             }
             catch
             {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -502,7 +502,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 var remotes = additionalRemotes
                     .Where(r => r.Mapping == sourceMapping.Name)
                     .Select(r => r.RemoteUri)
-                    .Prepend(sourceMapping.DefaultRef)
+                    .Prepend(sourceMapping.DefaultRemote)
                     .Append(source.RemoteUri)
                     .OrderBy(GitRepoUrlParser.ParseTypeFromUri, Comparer<GitRepoType>.Create(GitRepoUrlParser.OrderByLocalPublicOther))
                     .Distinct()

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
@@ -87,7 +87,7 @@ public class VmrSyncRepoChangesTest :  VmrTestsBase
         CheckDirectoryContents(VmrPath, expectedFiles);
         CheckFileContents(_productRepoPath / VersionFiles.VersionDetailsXml, versionDetails, removeEmptyLines: false);
         await GitOperations.CheckAllIsCommitted(VmrPath);
-        var sourceManifest = SourceManifest.FromJson(VmrPath / VmrInfo.RelativeSourceManifestPath);
+        var sourceManifest = SourceManifest.FromJson(VmrPath / VmrInfo.DefaultRelativeSourceManifestPath);
 
         sourceManifest.GetVersion(Constants.DependencyRepoName)!.PackageVersion.Should().Be("8.0.1");
         (await File.ReadAllTextAsync(VmrPath / VmrInfo.GitInfoSourcesDir / Constants.DependencyRepoName + ".props")).Should().Contain("8.0.1");

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
@@ -87,7 +87,7 @@ public class VmrSyncRepoChangesTest :  VmrTestsBase
         CheckDirectoryContents(VmrPath, expectedFiles);
         CheckFileContents(_productRepoPath / VersionFiles.VersionDetailsXml, versionDetails, removeEmptyLines: false);
         await GitOperations.CheckAllIsCommitted(VmrPath);
-        var sourceManifest = SourceManifest.FromJson(VmrPath / VmrInfo.SourcesDir / VmrInfo.SourceManifestFileName);
+        var sourceManifest = SourceManifest.FromJson(VmrPath / VmrInfo.RelativeSourceManifestPath);
 
         sourceManifest.GetVersion(Constants.DependencyRepoName)!.PackageVersion.Should().Be("8.0.1");
         (await File.ReadAllTextAsync(VmrPath / VmrInfo.GitInfoSourcesDir / Constants.DependencyRepoName + ".props")).Should().Contain("8.0.1");

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -94,8 +94,8 @@ public abstract class VmrTestsBase
         var expectedFiles = new List<LocalPath>
         {
             vmrPath / VmrInfo.GitInfoSourcesDir / AllVersionsPropsFile.FileName,
-            Info.GetSourceManifestPath(),
-            vmrPath / VmrInfo.SourcesDir / VmrInfo.SourceMappingsFileName
+            vmrPath / VmrInfo.RelativeSourceManifestPath,
+            vmrPath / VmrInfo.DefaultRelativeSourceMappingsPath,
         };
 
         foreach (var repo in syncedRepos)
@@ -136,7 +136,7 @@ public abstract class VmrTestsBase
     protected async Task InitializeRepoAtLastCommit(string repoName, NativePath repoPath, LocalPath? sourceMappingsPath = null)
     {
         var commit = await GitOperations.GetRepoLastCommit(repoPath);
-        var sourceMappings = sourceMappingsPath ?? VmrPath / VmrInfo.SourcesDir / VmrInfo.SourceMappingsFileName;
+        var sourceMappings = sourceMappingsPath ?? VmrPath / VmrInfo.DefaultRelativeSourceMappingsPath;
         await CallDarcInitialize(repoName, commit, sourceMappings);
     }
 
@@ -257,7 +257,7 @@ public abstract class VmrTestsBase
             DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault
         };
 
-        File.WriteAllText(VmrPath / VmrInfo.SourcesDir / VmrInfo.SourceMappingsFileName,
+        File.WriteAllText(VmrPath / VmrInfo.DefaultRelativeSourceMappingsPath,
             JsonSerializer.Serialize(sourceMappings, settings));
         
         await GitOperations.CommitAll(VmrPath, "Add source mappings");

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -82,7 +82,7 @@ public abstract class VmrTestsBase
     protected abstract Task CopyVmrForCurrentTest();
 
     private IServiceProvider CreateServiceProvider() => new ServiceCollection()
-        .AddLogging(b => b.AddConsole().AddFilter(l => l >= LogLevel.Information))
+        .AddLogging(b => b.AddConsole().AddFilter(l => l >= LogLevel.Debug))
         .AddVmrManagers("git", VmrPath, TmpPath, null, null)
         .BuildServiceProvider();
 

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -94,7 +94,7 @@ public abstract class VmrTestsBase
         var expectedFiles = new List<LocalPath>
         {
             vmrPath / VmrInfo.GitInfoSourcesDir / AllVersionsPropsFile.FileName,
-            vmrPath / VmrInfo.RelativeSourceManifestPath,
+            vmrPath / VmrInfo.DefaultRelativeSourceManifestPath,
             vmrPath / VmrInfo.DefaultRelativeSourceMappingsPath,
         };
 

--- a/test/Microsoft.DotNet.DarcLib.Tests/Helpers/GitRepoUrlParserTest.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Helpers/GitRepoUrlParserTest.cs
@@ -46,4 +46,14 @@ public class GitRepoUrlParserTest
         name.Should().Be("repo-name");
         org.Should().Be("org");
     }
+
+
+    [Test]
+    [TestCase("https://dev.azure.com/dnceng/internal/_git/org-repo-name", "https://github.com/org/repo-name")]
+    [TestCase("https://github.com/org/repo-name", "https://github.com/org/repo-name")]
+    [TestCase("https://dev.azure.com/devdiv/DevDiv/_git/NuGet-NuGet.Client-Trusted", "https://github.com/NuGet/NuGet.Client")]
+    public void ConvertInternalUriToPublicTest(string internalUri, string publicUri)
+    {
+        GitRepoUrlParser.ConvertInternalUriToPublic(internalUri).Should().Be(publicUri);
+    }
 }

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
@@ -63,11 +63,11 @@ public class RepositoryCloneManagerTests
     [Test]
     public async Task RepoIsClonedOnceTest()
     {
-        var path = await _manager.PrepareClone(RepoUri, Ref, default);
+        var path = await _manager.PrepareCloneAsync(RepoUri, Ref, default);
         path.Should().Be(_clonePath);
-        path = await _manager.PrepareClone(RepoUri, "main", default);
+        path = await _manager.PrepareCloneAsync(RepoUri, "main", default);
         path.Should().Be(_clonePath);
-        path = await _manager.PrepareClone(RepoUri, "main", default);
+        path = await _manager.PrepareCloneAsync(RepoUri, "main", default);
         path.Should().Be(_clonePath);
 
         _repoCloner.Verify(x => x.CloneNoCheckoutAsync(RepoUri, _clonePath, null), Times.Once);
@@ -82,9 +82,9 @@ public class RepositoryCloneManagerTests
             .Setup(x => x.DirectoryExists(_clonePath))
             .Returns(true);
 
-        var path = await _manager.PrepareClone(RepoUri, Ref, default);
+        var path = await _manager.PrepareCloneAsync(RepoUri, Ref, default);
         path.Should().Be(_clonePath);
-        path = await _manager.PrepareClone(RepoUri, "main", default);
+        path = await _manager.PrepareCloneAsync(RepoUri, "main", default);
         path.Should().Be(_clonePath);
 
         _repoCloner.Verify(x => x.CloneNoCheckoutAsync(RepoUri, _clonePath, null), Times.Never);
@@ -129,7 +129,7 @@ public class RepositoryCloneManagerTests
         }
 
         // Clone for the first time
-        var path = await _manager.PrepareClone(mapping, new[] { mapping.DefaultRemote }, "main", default);
+        var path = await _manager.PrepareCloneAsync(mapping, new[] { mapping.DefaultRemote }, "main", default);
         path.Should().Be(clonePath);
 
         _repoCloner.Verify(x => x.CloneNoCheckoutAsync(mapping.DefaultRemote, clonePath, null), Times.Once);
@@ -137,7 +137,7 @@ public class RepositoryCloneManagerTests
 
         // A second clone of the same
         ResetCalls();
-        path = await _manager.PrepareClone(mapping, new[] { mapping.DefaultRemote }, Ref, default);
+        path = await _manager.PrepareCloneAsync(mapping, new[] { mapping.DefaultRemote }, Ref, default);
         
         path.Should().Be(clonePath);
         _repoCloner.Verify(x => x.CloneNoCheckoutAsync(mapping.DefaultRemote, clonePath, null), Times.Never);
@@ -146,7 +146,7 @@ public class RepositoryCloneManagerTests
 
         // A third clone with a new remote
         ResetCalls();
-        path = await _manager.PrepareClone(mapping, new[] { mapping.DefaultRemote, newRemote }, Ref, default);
+        path = await _manager.PrepareCloneAsync(mapping, new[] { mapping.DefaultRemote, newRemote }, Ref, default);
         
         path.Should().Be(clonePath);
         _repoCloner.Verify(x => x.CloneNoCheckoutAsync(RepoUri, clonePath, null), Times.Never);
@@ -156,7 +156,7 @@ public class RepositoryCloneManagerTests
 
         // Same again, should be cached
         ResetCalls();
-        path = await _manager.PrepareClone(mapping, new[] { mapping.DefaultRemote, newRemote }, Ref + "3", default);
+        path = await _manager.PrepareCloneAsync(mapping, new[] { mapping.DefaultRemote, newRemote }, Ref + "3", default);
         
         path.Should().Be(clonePath);
         _repoCloner.Verify(x => x.CloneNoCheckoutAsync(RepoUri, clonePath, null), Times.Never);
@@ -166,7 +166,7 @@ public class RepositoryCloneManagerTests
 
         // Call with URI directly
         ResetCalls();
-        path = await _manager.PrepareClone(RepoUri, Ref + "4", default);
+        path = await _manager.PrepareCloneAsync(RepoUri, Ref + "4", default);
 
         path.Should().Be(clonePath);
         _repoCloner.Verify(x => x.CloneNoCheckoutAsync(RepoUri, clonePath, null), Times.Never);
@@ -176,7 +176,7 @@ public class RepositoryCloneManagerTests
 
         // Call with the second URI directly
         ResetCalls();
-        path = await _manager.PrepareClone(newRemote, Ref + "5", default);
+        path = await _manager.PrepareCloneAsync(newRemote, Ref + "5", default);
 
         path.Should().Be(clonePath);
         _repoCloner.Verify(x => x.CloneNoCheckoutAsync(RepoUri, clonePath, null), Times.Never);

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -98,7 +98,7 @@ public class VmrPatchHandlerTests
 
         _cloneManager.Reset();
         _cloneManager
-            .Setup(x => x.PrepareClone(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.PrepareCloneAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string uri, string _, CancellationToken _) => new NativePath(TmpDir / "" + uri.Split("/").Last()));
 
         _processManager.Reset();
@@ -347,7 +347,7 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.PrepareClone(_submoduleInfo.Url, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            .Verify(x => x.PrepareCloneAsync(_submoduleInfo.Url, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
 
         patches.Should().ContainSingle();
         patches.Single().Should().Be(new VmrIngestionPatch(expectedPatchName, RepoVmrPath));
@@ -418,7 +418,7 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.PrepareClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            .Verify(x => x.PrepareCloneAsync(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
         _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(2));
 
@@ -511,7 +511,7 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.PrepareClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            .Verify(x => x.PrepareCloneAsync(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
         // Verify diff for the nested submodule
         expectedArgs = GetExpectedGitDiffArguments(
@@ -529,7 +529,7 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.PrepareClone(nestedSubmoduleInfo.Url, nestedSubmoduleSha1, It.IsAny<CancellationToken>()), Times.Once);
+            .Verify(x => x.PrepareCloneAsync(nestedSubmoduleInfo.Url, nestedSubmoduleSha1, It.IsAny<CancellationToken>()), Times.Once);
 
         _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(3));
 
@@ -618,7 +618,7 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.PrepareClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            .Verify(x => x.PrepareCloneAsync(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
         _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(2));
 
@@ -696,7 +696,7 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.PrepareClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            .Verify(x => x.PrepareCloneAsync(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
         _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(2));
 
@@ -790,10 +790,10 @@ public class VmrPatchHandlerTests
                 Times.Once);
 
         _cloneManager
-            .Verify(x => x.PrepareClone(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            .Verify(x => x.PrepareCloneAsync(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
         _cloneManager
-            .Verify(x => x.PrepareClone("https://github.com/dotnet/external-2", SubmoduleSha2, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            .Verify(x => x.PrepareCloneAsync("https://github.com/dotnet/external-2", SubmoduleSha2, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
         _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(3));
 


### PR DESCRIPTION
When we synchronize commits from different remotes (i.e. GitHub vs AzDO), we will gradually fetch first from available (local) and public (GitHub) repos. If we find the commits there, we won't fetch from others (AzDO) internal ones.

This enables flow when commits can come from internal AzDO but can already be available in GitHub already. The synchronization into the VMR will work even in public (when merging `internal/release` to `release`) even though source-manifest or target commits are have AzDO URIs in `Version.Details.xml` associated with them. 

Tests will be added later, we need this in to unblock https://github.com/dotnet/installer/issues/17809 and https://github.com/dotnet/installer/issues/17785

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Lazy-fetch repos during VMR sync to allow internal->public merges