### PR TITLE
Order remotes when reading dependency tree

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -219,7 +219,9 @@ public abstract class VmrManagerBase
             var remotes = additionalRemotes
                 .Where(r => r.Mapping == repo.Mapping.Name)
                 .Select(r => r.RemoteUri)
-                .Prepend(repo.RemoteUri);
+                .Append(repo.RemoteUri)
+                .Prepend(repo.Mapping.DefaultRemote)
+                .OrderBy(GitRepoUrlParser.ParseTypeFromUri, Comparer<GitRepoType>.Create(GitRepoUrlParser.OrderByLocalPublicOther));
 
             IEnumerable<DependencyDetail>? repoDependencies = null;
             foreach (var remoteUri in remotes)


### PR DESCRIPTION
Improvement of https://github.com/dotnet/arcade-services/issues/3080 to first fetch from local directories and public GitHub repos during the VMR sync

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Not release notes worthy