### PR TITLE
Use different auth header when cloning AzDO/GitHub repos

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/GitNativeRepoCloner.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitNativeRepoCloner.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
@@ -17,13 +16,16 @@ namespace Microsoft.DotNet.DarcLib;
 /// </summary>
 public class GitNativeRepoCloner : IGitRepoCloner
 {
-    private readonly RemoteConfiguration _remoteConfiguration;
+    private readonly ILocalGitClient _localGitClient;
     private readonly IProcessManager _processManager;
     private readonly ILogger _logger;
 
-    public GitNativeRepoCloner(RemoteConfiguration remoteConfiguration, IProcessManager processManager, ILogger logger)
+    public GitNativeRepoCloner(
+        ILocalGitClient localGitClient,
+        IProcessManager processManager,
+        ILogger logger)
     {
-        _remoteConfiguration = remoteConfiguration;
+        _localGitClient = localGitClient;
         _processManager = processManager;
         _logger = logger;
     }
@@ -49,19 +51,8 @@ public class GitNativeRepoCloner : IGitRepoCloner
         _logger.LogInformation("Cloning {repoUri} to {targetDirectory}", repoUri, targetDirectory);
 
         var args = new List<string>();
-        var envVars = new Dictionary<string, string>
-        {
-            { "GIT_TERMINAL_PROMPT", "0" }
-        };
-
-        string? token = _remoteConfiguration.GetTokenForUri(repoUri);
-
-        if (!string.IsNullOrEmpty(token))
-        {
-            const string ENV_VAR_NAME = "GIT_REMOTE_PAT";
-            args.Add($"--config-env=http.extraheader={ENV_VAR_NAME}");
-            envVars[ENV_VAR_NAME] = GetAuthorizationHeaderArgument(token);
-        }
+        var envVars = new Dictionary<string, string>();
+        _localGitClient.AddGitAuthHeader(args, envVars, repoUri);
 
         if (gitDirectory != null)
         {
@@ -92,11 +83,5 @@ public class GitNativeRepoCloner : IGitRepoCloner
             result = await _processManager.ExecuteGit(targetDirectory, "checkout", commit);
             result.ThrowIfFailed($"Failed to check out {commit} in {targetDirectory}");
         }
-    }
-
-    public static string GetAuthorizationHeaderArgument(string token)
-    {
-        var encodedToken = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Constants.GitHubBotUserName}:{token}"));
-        return $"Authorization: Basic {encodedToken}";
     }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
@@ -133,4 +133,11 @@ public interface ILocalGitClient
         string repoPath,
         IEnumerable<string> pathsToStage,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Add the authorization header to the git command line arguments and environment variables.
+    /// </summary>
+    /// <param name="args">Where to add the new argument into</param>
+    /// <param name="envVars">Where to add the new variables into</param>
+    public void AddGitAuthHeader(IList<string> args, IDictionary<string, string> envVars, string repoUri);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
@@ -25,7 +25,7 @@ public class LocalLibGit2Client : LocalGitClient, ILocalLibGit2Client
     private readonly ILogger _logger;
 
     public LocalLibGit2Client(RemoteConfiguration remoteConfiguration, IProcessManager processManager, ILogger logger)
-        : base(processManager, logger)
+        : base(remoteConfiguration, processManager, logger)
     {
         _remoteConfiguration = remoteConfiguration;
         _processManager = processManager;


### PR DESCRIPTION
Seems like Azure DevOps changed the header it requires and the sync started failing: https://github.com/dotnet/arcade-services/issues/3075
The PR also uses tokens for a subsequential `remote update` and `remote fetch`.

- Azure DevOps: `Authorization: Bearer [BASE64 TOKEN]`
- GitHub: `Authorization: Basic [TOKEN]`

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Use different auth header when cloning AzDO/GitHub repos