### PR TITLE
Fix git auth header creation

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -201,14 +201,14 @@ public class LocalGitClient : ILocalGitClient
         result.ThrowIfFailed($"No remote named {remoteName} in {repoPath}");
         var remoteUri = result.StandardOutput.Trim();
 
-        var args = new[] { "remote", "update", remoteName };
+        List<string> args = new() { "remote", "update", remoteName };
         var envVars = new Dictionary<string, string>();
         AddGitAuthHeader(args, envVars, remoteUri);
 
         result = await _processManager.ExecuteGit(repoPath, args, cancellationToken: cancellationToken);
         result.ThrowIfFailed($"Failed to update {repoPath} from remote {remoteName}");
 
-        args = new[] { "fetch", "--tags", "--force", remoteName };
+        args = new() { "fetch", "--tags", "--force", remoteName };
         envVars = new Dictionary<string, string>();
         AddGitAuthHeader(args, envVars, remoteUri);
 


### PR DESCRIPTION
Bug introduced in https://github.com/dotnet/arcade-services/issues/3091

Manifested as:
```
      System.NotSupportedException: Collection was of a fixed size.
         at System.SZArrayHelper.Add[T](T value)
         at Microsoft.DotNet.DarcLib.LocalGitClient.AddGitAuthHeader(IList`1 args, IDictionary`2 envVars, String repoUri) in /_/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs:line 369
         at Microsoft.DotNet.DarcLib.LocalGitClient.UpdateRemoteAsync(String repoPath, String remoteName, CancellationToken cancellationToken) in /_/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs:line 206
         at Microsoft.DotNet.DarcLib.Local.AddRemoteIfMissingAsync(String repoDir, String repoUrl) in /_/src/Microsoft.DotNet.Darc/DarcLib/Actions/Local.cs:line 170
         at Microsoft.DotNet.Darc.Operations.CloneOperation.HandleMasterCopy(RemoteFactory remoteFactory, String repoUrl, String masterGitRepoPath, String masterRepoGitDirPath) in /_/src/Microsoft.DotNet.Darc/Darc/Operations/CloneOperation.cs:line 262
         at Microsoft.DotNet.Darc.Operations.CloneOperation.ExecuteAsync() in /_/src/Microsoft.DotNet.Darc/Darc/Operations/CloneOperation.cs:line 130
```

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Not release notes worthy