### PR TITLE
Some UX tweaks:

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/GetRepoVersionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/GetRepoVersionCommandLineOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 [Verb("get-version", HelpText = "Gets the current version (a SHA) of a repository in the VMR.")]
 internal class GetRepoVersionCommandLineOptions : VmrCommandLineOptionsBase
 {
-    [Value(0, Required = true, HelpText = "Repository names (e.g. runtime) to get the versions for.")]
+    [Value(0, HelpText = "Repository names (e.g. runtime) to get the versions for.")]
     public IEnumerable<string> Repositories { get; set; } = Array.Empty<string>();
 
     public override Operation GetOperation() => new GetRepoVersionOperation(this);

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrCommandLineOptionsBase.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrCommandLineOptionsBase.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
 internal abstract class VmrCommandLineOptionsBase : CommandLineOptions
 {
-    [Option("vmr", Required = true, HelpText = "Path to the VMR; defaults to nearest git root above the current working directory.")]
+    [Option("vmr", HelpText = "Path to the VMR; defaults to nearest git root above the current working directory.")]
     public string VmrPath { get; set; } = Environment.CurrentDirectory;
 
     protected IServiceCollection RegisterServices(string? tmpPath)

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
@@ -41,7 +41,7 @@ public class SourceMappingParser : ISourceMappingParser
         if (!mappingFile.Exists)
         {
             throw new FileNotFoundException(
-                $"Failed to find {VmrInfo.SourceMappingsFileName} file.",
+                $"Failed to find {VmrInfo.SourceMappingsFileName} file. Please ensure this repo is a VMR.",
                 mappingFilePath);
         }
 


### PR DESCRIPTION
- Remove required == true on the VMR path and version list options. They have reasonable defaults.
- When no repo to list a version for is specified, list all repos.
- Print a better error when the source-mappings file isn't found.