### PR TITLE
Use long SHAs in AzDO PR descriptions

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
@@ -178,18 +178,9 @@ public class PullRequestDescriptionBuilder
 
     public static string GetChangesURI(string repoURI, string fromSha, string toSha)
     {
-        if (repoURI == null)
-        {
-            throw new ArgumentNullException(nameof(repoURI));
-        }
-        if (fromSha == null)
-        {
-            throw new ArgumentNullException(nameof(fromSha));
-        }
-        if (toSha == null)
-        {
-            throw new ArgumentNullException(nameof(toSha));
-        }
+        ArgumentNullException.ThrowIfNull(repoURI);
+        ArgumentNullException.ThrowIfNull(fromSha);
+        ArgumentNullException.ThrowIfNull(toSha);
 
         if (repoURI.Contains("github.com"))
         {

--- a/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
@@ -176,28 +176,29 @@ public class PullRequestDescriptionBuilder
         return regex.Matches(_description.ToString()).Select(m => Int32.Parse(m.ToString())).DefaultIfEmpty(0).Max() + 1;
     }
 
-    public static string GetChangesURI(string repoURI, string from, string to)
+    public static string GetChangesURI(string repoURI, string fromSha, string toSha)
     {
         if (repoURI == null)
         {
             throw new ArgumentNullException(nameof(repoURI));
         }
-        if (from == null)
+        if (fromSha == null)
         {
-            throw new ArgumentNullException(nameof(from));
+            throw new ArgumentNullException(nameof(fromSha));
         }
-        if (to == null)
+        if (toSha == null)
         {
-            throw new ArgumentNullException(nameof(to));
+            throw new ArgumentNullException(nameof(toSha));
         }
-
-        string fromSha = from.Length > _comparisonShaLength ? from.Substring(0, _comparisonShaLength) : from;
-        string toSha = to.Length > _comparisonShaLength ? to.Substring(0, _comparisonShaLength) : to;
 
         if (repoURI.Contains("github.com"))
         {
-            return $"{repoURI}/compare/{fromSha}...{toSha}";
+            string fromShortSha = fromSha.Length > _comparisonShaLength ? fromSha.Substring(0, _comparisonShaLength) : fromSha;
+            string toShortSha = toSha.Length > _comparisonShaLength ? toSha.Substring(0, _comparisonShaLength) : toSha;
+        
+            return $"{repoURI}/compare/{fromShortSha}...{toShortSha}";
         }
+
         return $"{repoURI}/branches?baseVersion=GC{fromSha}&targetVersion=GC{toSha}&_a=files";
     }
 

--- a/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
@@ -30,7 +30,7 @@ public class PullRequestDescriptionBuilder
 
     private readonly StringBuilder _description;
 
-    private const int _comparisonShaLength = 10;
+    public const int GitHubComparisonShaLength = 10;
 
     private int _startingReferenceId;
 
@@ -193,12 +193,13 @@ public class PullRequestDescriptionBuilder
 
         if (repoURI.Contains("github.com"))
         {
-            string fromShortSha = fromSha.Length > _comparisonShaLength ? fromSha.Substring(0, _comparisonShaLength) : fromSha;
-            string toShortSha = toSha.Length > _comparisonShaLength ? toSha.Substring(0, _comparisonShaLength) : toSha;
+            string fromShortSha = fromSha.Length > GitHubComparisonShaLength ? fromSha.Substring(0, GitHubComparisonShaLength) : fromSha;
+            string toShortSha = toSha.Length > GitHubComparisonShaLength ? toSha.Substring(0, GitHubComparisonShaLength) : toSha;
         
             return $"{repoURI}/compare/{fromShortSha}...{toShortSha}";
         }
 
+        // Azdo commit comparison doesn't work with short shas
         return $"{repoURI}/branches?baseVersion=GC{fromSha}&targetVersion=GC{toSha}&_a=files";
     }
 

--- a/test/SubscriptionActorService.Tests/PullRequestDescriptionBuilderTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestDescriptionBuilderTests.cs
@@ -204,4 +204,32 @@ matches
         new object[] { regexTestString3, 1},
         new object [] { regexTestString4, 5},
     };
+
+    public void ShouldReturnCorrectChangesURIForGitHub()
+    {
+        var repoURI = "https://github.com/dotnet/arcade-services";
+        var fromSha = "c0b723ce00a751db0dcf93789abd58577bad155a";
+        var fromShortSha = fromSha.Substring(0, PullRequestDescriptionBuilder.GitHubComparisonShaLength);
+        var toSha = "7455af499329f6a5ed6ef3fc2a5c794ea86933d3";
+        var toShortSha = toSha.Substring(0, PullRequestDescriptionBuilder.GitHubComparisonShaLength);
+
+        var changesUrl = PullRequestDescriptionBuilder.GetChangesURI(repoURI, fromSha, toSha);
+
+        var expectedChangeUrl = $"{repoURI}/compare/{fromShortSha}...{toShortSha}";
+
+        changesUrl.Should().Be(expectedChangeUrl);
+    }
+
+    public void ShouldReturnCorrectChangesURIForAzDo()
+    {
+        var repoURI = "https://dev.azure.com/dnceng/internal/_git/dotnet-arcade-services";
+        var fromSha = "689a78855b241afedff9919529d812b1f08f6f76";
+        var toSha = "d0adee0f8bfebd04a6fb7ad7f9fb1d53b1ed8ac9";
+
+        var changesUrl = PullRequestDescriptionBuilder.GetChangesURI(repoURI, fromSha, toSha);
+
+        var expectedChangesUrl = $"{repoURI}/branches?baseVersion=GC{fromSha}&targetVersion=GC{toSha}&_a=files";
+
+        changesUrl.Should().Be(expectedChangesUrl);
+    }
 }


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade-services/issues/3114

I couldn't find any document online that says that using short shas works on AzDo, like it does on GitHub. Also did manual testing
<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Use full sha for commit comparison on AzDo