### PR TITLE
Support the `Source` element in `Version.Details.xml`

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependencyGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependencyGraphOperation.cs
@@ -21,13 +21,12 @@ internal class GetDependencyGraphOperation : Operation
 {
     private readonly GetDependencyGraphCommandLineOptions _options;
     private readonly LocalLibGit2Client _gitClient;
-    private readonly HashSet<string> _flatList = new();
 
     public GetDependencyGraphOperation(GetDependencyGraphCommandLineOptions options)
         : base(options)
     {
         _options = options;
-        _gitClient = new LocalLibGit2Client(options.GetRemoteConfiguration(), new ProcessManager(Logger, _options.GitLocation), Logger);
+        _gitClient = new LocalLibGit2Client(options.GetRemoteConfiguration(), new ProcessManager(Logger, _options.GitLocation), new FileSystem(), Logger);
     }
 
     public override async Task<int> ExecuteAsync()

--- a/src/Microsoft.DotNet.Darc/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Actions/Remote.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml;
 using Maestro.MergePolicyEvaluation;
+using Microsoft.DotNet.DarcLib.Models;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
@@ -956,7 +957,7 @@ public sealed class Remote : IRemote
         }
 
         GitFileContentContainer fileContainer =
-            await _fileManager.UpdateDependencyFiles(itemsToUpdate, repoUri, branch, oldDependencies, targetDotNetVersion);
+            await _fileManager.UpdateDependencyFiles(itemsToUpdate, sourceDependency: null, repoUri, branch, oldDependencies, targetDotNetVersion);
         List<GitFile> filesToCommit = new List<GitFile>();
 
         if (mayNeedArcadeUpdate)
@@ -1215,8 +1216,9 @@ public sealed class Remote : IRemote
         bool loadAssetLocations = false)
     {
         CheckForValidGitClient();
-        var dependencies = (await _fileManager.ParseVersionDetailsXmlAsync(repoUri, branchOrCommit)).Where(
-            dependency => string.IsNullOrEmpty(name) || dependency.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        VersionDetails versionDetails = await _fileManager.ParseVersionDetailsXmlAsync(repoUri, branchOrCommit);
+        var dependencies = versionDetails.Dependencies
+            .Where(dependency => string.IsNullOrEmpty(name) || dependency.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
 
         if (loadAssetLocations)
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -230,13 +230,7 @@ public class DependencyFileManager : IDependencyFileManager
 
         foreach (DependencyDetail itemToUpdate in itemsToUpdate)
         {
-            if (string.IsNullOrEmpty(itemToUpdate.Version) ||
-                string.IsNullOrEmpty(itemToUpdate.Name) ||
-                string.IsNullOrEmpty(itemToUpdate.Commit) ||
-                string.IsNullOrEmpty(itemToUpdate.RepoUri))
-            {
-                throw new DarcException($"Either the name, version, commit or repo uri of dependency '{itemToUpdate.Name}' was empty.");
-            }
+            itemToUpdate.Validate();
 
             // Double check that the dependency is not pinned
             if (itemToUpdate.Pinned)
@@ -286,13 +280,13 @@ public class DependencyFileManager : IDependencyFileManager
 
         foreach (DependencyDetail itemToUpdate in itemsToUpdate)
         {
-            if (string.IsNullOrEmpty(itemToUpdate.Version) ||
-                string.IsNullOrEmpty(itemToUpdate.Name) ||
-                string.IsNullOrEmpty(itemToUpdate.Commit) ||
-                string.IsNullOrEmpty(itemToUpdate.RepoUri))
+            try
             {
-                throw new DarcException($"Either the name, version, commit or repo uri of dependency '{itemToUpdate.Name}' in " +
-                                        $"repo '{repoUri}' and branch '{branch}' was empty.");
+                itemToUpdate.Validate();
+            }
+            catch (DarcException e)
+            {
+                throw new DarcException(e.Message + $" in repo '{repoUri}' and branch '{branch}'", e);
             }
 
             UpdateVersionFiles(versionProps, globalJson, toolsConfigurationJson, itemToUpdate);

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -207,7 +207,6 @@ public class DependencyFileManager : IDependencyFileManager
         return element;
     }
 
-    // TODO: This is a hack to make the PoC work but eventually we should update dependencies properly
     public void UpdateVersionDetails(
         XmlDocument versionDetails,
         IEnumerable<DependencyDetail> itemsToUpdate,

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -284,21 +284,6 @@ public class DependencyFileManager : IDependencyFileManager
         JObject toolsConfigurationJson = await ReadDotNetToolsConfigJsonAsync(repoUri, branch);
         XmlDocument nugetConfig = await ReadNugetConfigAsync(repoUri, branch);
 
-        // Adds/updates the <Source> element
-        if (sourceDependency != null)
-        {
-            var sourceNode = versionDetails.SelectSingleNode($"//{VersionDetailsParser.SourceElementName}");
-            if (sourceNode == null)
-            {
-                sourceNode = versionDetails.CreateElement(VersionDetailsParser.SourceElementName);
-                var dependenciesNode = versionDetails.SelectSingleNode($"//{VersionDetailsParser.DependenciesElementName}");
-                dependenciesNode.PrependChild(sourceNode);
-            }
-
-            SetAttribute(versionDetails, sourceNode, VersionDetailsParser.UriElementName, sourceDependency.Uri);
-            SetAttribute(versionDetails, sourceNode, VersionDetailsParser.ShaElementName, sourceDependency.Sha);
-        }
-
         foreach (DependencyDetail itemToUpdate in itemsToUpdate)
         {
             if (string.IsNullOrEmpty(itemToUpdate.Version) ||

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.Models;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -125,7 +126,7 @@ public class DependencyFileManager : IDependencyFileManager
         return await ReadXmlFileAsync(VersionFiles.NugetConfig, repoUri, branch);
     }
 
-    public async Task<IEnumerable<DependencyDetail>> ParseVersionDetailsXmlAsync(string repoUri, string branch, bool includePinned = true)
+    public async Task<VersionDetails> ParseVersionDetailsXmlAsync(string repoUri, string branch, bool includePinned = true)
     {
         if (!string.IsNullOrEmpty(branch))
         {
@@ -156,7 +157,8 @@ public class DependencyFileManager : IDependencyFileManager
         string repoUri,
         string branch)
     {
-        var existingDependencies = await ParseVersionDetailsXmlAsync(repoUri, branch);
+        var versionDetails = await ParseVersionDetailsXmlAsync(repoUri, branch);
+        var existingDependencies = versionDetails.Dependencies;
         if (existingDependencies.Any(dep => dep.Name.Equals(dependency.Name, StringComparison.OrdinalIgnoreCase)))
         {
             throw new DependencyException($"Dependency {dependency.Name} already exists in this repository");
@@ -205,27 +207,27 @@ public class DependencyFileManager : IDependencyFileManager
         return element;
     }
 
-    /// <summary>
-    ///
-    /// </summary>
-    /// <param name="itemsToUpdate"></param>
-    /// <param name="repoUri"></param>
-    /// <param name="branch"></param>
-    /// <param name="oldDependencies"></param>
-    /// <param name="incomingDotNetSdkVersion"></param>
-    /// <returns></returns>
-    public async Task<GitFileContentContainer> UpdateDependencyFiles(
+    // TODO: This is a hack to make the PoC work but eventually we should update dependencies properly
+    public void UpdateVersionDetails(
+        XmlDocument versionDetails,
         IEnumerable<DependencyDetail> itemsToUpdate,
-        string repoUri,
-        string branch,
-        IEnumerable<DependencyDetail> oldDependencies,
-        SemanticVersion incomingDotNetSdkVersion)
+        SourceDependency sourceDependency,
+        IEnumerable<DependencyDetail> oldDependencies)
     {
-        XmlDocument versionDetails = await ReadVersionDetailsXmlAsync(repoUri, branch);
-        XmlDocument versionProps = await ReadVersionPropsAsync(repoUri, branch);
-        JObject globalJson = await ReadGlobalJsonAsync(repoUri, branch);
-        JObject toolsConfigurationJson = await ReadDotNetToolsConfigJsonAsync(repoUri, branch);
-        XmlDocument nugetConfig = await ReadNugetConfigAsync(repoUri, branch);
+        // Adds/updates the <Source> element
+        if (sourceDependency != null)
+        {
+            var sourceNode = versionDetails.SelectSingleNode($"//{VersionDetailsParser.SourceElementName}");
+            if (sourceNode == null)
+            {
+                sourceNode = versionDetails.CreateElement(VersionDetailsParser.SourceElementName);
+                var dependenciesNode = versionDetails.SelectSingleNode($"//{VersionDetailsParser.DependenciesElementName}");
+                dependenciesNode.PrependChild(sourceNode);
+            }
+
+            SetAttribute(versionDetails, sourceNode, VersionDetailsParser.UriElementName, sourceDependency.Uri);
+            SetAttribute(versionDetails, sourceNode, VersionDetailsParser.ShaElementName, sourceDependency.Sha);
+        }
 
         foreach (DependencyDetail itemToUpdate in itemsToUpdate)
         {
@@ -234,8 +236,7 @@ public class DependencyFileManager : IDependencyFileManager
                 string.IsNullOrEmpty(itemToUpdate.Commit) ||
                 string.IsNullOrEmpty(itemToUpdate.RepoUri))
             {
-                throw new DarcException($"Either the name, version, commit or repo uri of dependency '{itemToUpdate.Name}' in " +
-                                        $"repo '{repoUri}' and branch '{branch}' was empty.");
+                throw new DarcException($"Either the name, version, commit or repo uri of dependency '{itemToUpdate.Name}' was empty.");
             }
 
             // Double check that the dependency is not pinned
@@ -267,8 +268,53 @@ public class DependencyFileManager : IDependencyFileManager
             SetAttribute(versionDetails, nodeToUpdate, VersionDetailsParser.NameAttributeName, itemToUpdate.Name);
             SetElement(versionDetails, nodeToUpdate, VersionDetailsParser.ShaElementName, itemToUpdate.Commit);
             SetElement(versionDetails, nodeToUpdate, VersionDetailsParser.UriElementName, itemToUpdate.RepoUri);
+        }
+    }
+
+    public async Task<GitFileContentContainer> UpdateDependencyFiles(
+        IEnumerable<DependencyDetail> itemsToUpdate,
+        SourceDependency sourceDependency,
+        string repoUri,
+        string branch,
+        IEnumerable<DependencyDetail> oldDependencies,
+        SemanticVersion incomingDotNetSdkVersion)
+    {
+        XmlDocument versionDetails = await ReadVersionDetailsXmlAsync(repoUri, branch);
+        XmlDocument versionProps = await ReadVersionPropsAsync(repoUri, branch);
+        JObject globalJson = await ReadGlobalJsonAsync(repoUri, branch);
+        JObject toolsConfigurationJson = await ReadDotNetToolsConfigJsonAsync(repoUri, branch);
+        XmlDocument nugetConfig = await ReadNugetConfigAsync(repoUri, branch);
+
+        // Adds/updates the <Source> element
+        if (sourceDependency != null)
+        {
+            var sourceNode = versionDetails.SelectSingleNode($"//{VersionDetailsParser.SourceElementName}");
+            if (sourceNode == null)
+            {
+                sourceNode = versionDetails.CreateElement(VersionDetailsParser.SourceElementName);
+                var dependenciesNode = versionDetails.SelectSingleNode($"//{VersionDetailsParser.DependenciesElementName}");
+                dependenciesNode.PrependChild(sourceNode);
+            }
+
+            SetAttribute(versionDetails, sourceNode, VersionDetailsParser.UriElementName, sourceDependency.Uri);
+            SetAttribute(versionDetails, sourceNode, VersionDetailsParser.ShaElementName, sourceDependency.Sha);
+        }
+
+        foreach (DependencyDetail itemToUpdate in itemsToUpdate)
+        {
+            if (string.IsNullOrEmpty(itemToUpdate.Version) ||
+                string.IsNullOrEmpty(itemToUpdate.Name) ||
+                string.IsNullOrEmpty(itemToUpdate.Commit) ||
+                string.IsNullOrEmpty(itemToUpdate.RepoUri))
+            {
+                throw new DarcException($"Either the name, version, commit or repo uri of dependency '{itemToUpdate.Name}' in " +
+                                        $"repo '{repoUri}' and branch '{branch}' was empty.");
+            }
+
             UpdateVersionFiles(versionProps, globalJson, toolsConfigurationJson, itemToUpdate);
         }
+
+        UpdateVersionDetails(versionDetails, itemsToUpdate, sourceDependency, oldDependencies);
 
         // Combine the two sets of dependencies. If an asset is present in the itemsToUpdate,
         // prefer that one over the old dependencies
@@ -1006,14 +1052,14 @@ public class DependencyFileManager : IDependencyFileManager
     /// <returns>Async task</returns>
     public async Task<bool> Verify(string repo, string branch)
     {
-        Task<IEnumerable<DependencyDetail>> dependencyDetails;
+        Task<VersionDetails> versionDetails;
         Task<XmlDocument> versionProps;
         Task<JObject> globalJson;
         Task<JObject> dotnetToolsJson;
 
         try
         {
-            dependencyDetails = ParseVersionDetailsXmlAsync(repo, branch);
+            versionDetails = ParseVersionDetailsXmlAsync(repo, branch);
         }
         catch (Exception e)
         {
@@ -1054,28 +1100,28 @@ public class DependencyFileManager : IDependencyFileManager
         List<Task<bool>> verificationTasks = new List<Task<bool>>()
         {
             VerifyNoDuplicatedProperties(await versionProps),
-            VerifyNoDuplicatedDependencies(await dependencyDetails),
+            VerifyNoDuplicatedDependencies((await versionDetails).Dependencies),
             VerifyMatchingVersionProps(
-                await dependencyDetails,
+                (await versionDetails).Dependencies,
                 await versionProps,
                 out Task<HashSet<string>> utilizedVersionPropsDependencies),
             VerifyMatchingGlobalJson(
-                await dependencyDetails,
+                (await versionDetails).Dependencies,
                 await globalJson,
                 out Task<HashSet<string>> utilizedGlobalJsonDependencies),
             VerifyUtilizedDependencies(
-                await dependencyDetails,
+                (await versionDetails).Dependencies,
                 new List<HashSet<string>>
                 {
                     await utilizedVersionPropsDependencies,
                     await utilizedGlobalJsonDependencies
                 }),
             VerifyMatchingDotNetToolsJson(
-                await dependencyDetails,
+                (await versionDetails).Dependencies,
                 await dotnetToolsJson)
         };
 
-        var results = await Task.WhenAll<bool>(verificationTasks);
+        var results = await Task.WhenAll(verificationTasks);
         return results.All(result => result);
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/FileSystem.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/FileSystem.cs
@@ -47,4 +47,31 @@ public class FileSystem : IFileSystem
     public IFileInfo GetFileInfo(string path) => new FileInfoWrapper(path);
 
     public Task<string> ReadAllTextAsync(string path) => File.ReadAllTextAsync(path);
+
+    public void CopyDirectory(string sourceDir, string destinationDir, bool recursive)
+    {
+        var dir = new DirectoryInfo(sourceDir);
+        if (!dir.Exists)
+        {
+            throw new DirectoryNotFoundException($"Source directory not found: {dir.FullName}");
+        }
+
+        DirectoryInfo[] dirs = dir.GetDirectories();
+        Directory.CreateDirectory(destinationDir);
+
+        foreach (FileInfo file in dir.GetFiles())
+        {
+            string targetFilePath = Path.Combine(destinationDir, file.Name);
+            file.CopyTo(targetFilePath);
+        }
+
+        if (recursive)
+        {
+            foreach (DirectoryInfo subDir in dirs)
+            {
+                string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
+                CopyDirectory(subDir.FullName, newDestinationDir, true);
+            }
+        }
+    }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IDependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IDependencyFileManager.cs
@@ -5,9 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Xml;
+using Microsoft.DotNet.DarcLib.Models;
 using Newtonsoft.Json.Linq;
 using NuGet.Versioning;
 
+#nullable enable
 namespace Microsoft.DotNet.DarcLib;
 
 /// <summary>
@@ -20,9 +22,9 @@ public interface IDependencyFileManager
 
     Dictionary<string, HashSet<string>> FlattenLocationsAndSplitIntoGroups(Dictionary<string, HashSet<string>> assetLocationMap);
 
-    List<(string key, string feed)> GetPackageSources(XmlDocument nugetConfig, Func<string, bool> filter = null);
+    List<(string key, string feed)> GetPackageSources(XmlDocument nugetConfig, Func<string, bool>? filter = null);
 
-    Task<IEnumerable<DependencyDetail>> ParseVersionDetailsXmlAsync(string repoUri, string branch, bool includePinned = true);
+    Task<VersionDetails> ParseVersionDetailsXmlAsync(string repoUri, string branch, bool includePinned = true);
 
     Task<JObject> ReadDotNetToolsConfigJsonAsync(string repoUri, string branch);
 
@@ -34,8 +36,15 @@ public interface IDependencyFileManager
 
     Task<XmlDocument> ReadVersionPropsAsync(string repoUri, string branch);
 
+    void UpdateVersionDetails(
+        XmlDocument versionDetails,
+        IEnumerable<DependencyDetail> itemsToUpdate,
+        SourceDependency sourceDependency,
+        IEnumerable<DependencyDetail> oldDependencies);
+
     Task<GitFileContentContainer> UpdateDependencyFiles(
         IEnumerable<DependencyDetail> itemsToUpdate,
+        SourceDependency? sourceDependency,
         string repoUri,
         string branch,
         IEnumerable<DependencyDetail> oldDependencies,

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IFileSystem.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IFileSystem.cs
@@ -37,6 +37,8 @@ public interface IFileSystem
 
     void CopyFile(string sourceFileName, string destFileName, bool overwrite = false);
 
+    void CopyDirectory(string sourceDir, string destinationDir, bool recursive);
+
     FileStream GetFileStream(string path, FileMode mode, FileAccess access);
 
     IFileInfo GetFileInfo(string path);

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/LocalPath.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/LocalPath.cs
@@ -70,6 +70,8 @@ public abstract class LocalPath
 /// </summary>
 public class NativePath : LocalPath
 {
+    public static readonly NativePath CurrentDir = new(".");
+
     public NativePath(string path) : this(path, true)
     {
     }
@@ -95,6 +97,8 @@ public class NativePath : LocalPath
 /// </summary>
 public class UnixPath : LocalPath
 {
+    public static readonly UnixPath CurrentDir = new(".");
+
     public UnixPath(string path) : this(path, true)
     {
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.DarcLib.Helpers;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib;
@@ -27,11 +28,13 @@ public interface ILocalGitClient
     /// <param name="repoPath">Path to the repository</param>
     /// <param name="relativeFilePath">Relative path to the file inside of the repository</param>
     /// <param name="line">Line to blame</param>
+    /// <param name="blameFromCommit">Blame older commits than a given one</param>
     /// <returns>SHA of the commit that last changed the given line in the given file</returns>
     Task<string> BlameLineAsync(
         string repoPath,
         string relativeFilePath,
-        int line);
+        int line,
+        string? blameFromCommit = null);
 
     /// <summary>
     ///     Checkout the repo to the specified state.
@@ -39,6 +42,13 @@ public interface ILocalGitClient
     /// <param name="repoPath">Path to a git repository</param>
     /// <param name="refToCheckout">Tag, branch, or commit to checkout</param>
     Task CheckoutAsync(string repoPath, string refToCheckout);
+
+    /// <summary>
+    /// Resets the working tree (or a given subpath) to match the index.
+    /// </summary>
+    /// <param name="repoPath">Path to the root of the repo</param>
+    /// <param name="relativePath">Relative path inside of the repo to reset only (or none if the whole repo)</param>
+    Task ResetWorkingTree(NativePath repoPath, UnixPath? relativePath = null);
 
     /// <summary>
     ///     Commits files by calling git commit (not through Libgit2sharp)

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -23,12 +23,18 @@ public class LocalGitClient : ILocalGitClient
 {
     private readonly RemoteConfiguration _remoteConfiguration;
     private readonly IProcessManager _processManager;
+    private readonly IFileSystem _fileSystem;
     private readonly ILogger _logger;
 
-    public LocalGitClient(RemoteConfiguration remoteConfiguration, IProcessManager processManager, ILogger logger)
+    public LocalGitClient(
+        RemoteConfiguration remoteConfiguration,
+        IProcessManager processManager,
+        IFileSystem fileSystem,
+        ILogger logger)
     {
         _remoteConfiguration = remoteConfiguration;
         _processManager = processManager;
+        _fileSystem = fileSystem;
         _logger = logger;
     }
 
@@ -63,6 +69,42 @@ public class LocalGitClient : ILocalGitClient
     {
         var result = await _processManager.ExecuteGit(repoPath, new[] { "checkout", refToCheckout });
         result.ThrowIfFailed($"Failed to check out {refToCheckout} in {repoPath}");
+    }
+
+    public async Task ResetWorkingTree(NativePath repoPath, UnixPath? relativePath = null)
+    {
+        relativePath ??= UnixPath.CurrentDir;
+
+        // After we apply the diff to the index, working tree won't have the files so they will be missing
+        // We have to reset working tree to the index then
+        // This will end up having the working tree match what is staged
+        _logger.LogInformation("Cleaning the working tree directory {path}...", repoPath / relativePath);
+        var args = new string[] { "checkout", relativePath };
+        var result = await _processManager.ExecuteGit(repoPath, args, cancellationToken: CancellationToken.None);
+
+        if (result.Succeeded)
+        {
+            _logger.LogDebug("{output}", result.ToString());
+        }
+        else if (result.StandardError.Contains($"pathspec '{relativePath}' did not match any file(s) known to git"))
+        {
+            // No files in the directory
+            if (relativePath == UnixPath.CurrentDir)
+            {
+                _logger.LogDebug("Failed to reset working tree of {repo} as it was empty", repoPath);
+            }
+            else
+            {
+                // In case a submodule was removed, it won't be in the index anymore and the checkout will fail
+                // We can just remove the working tree folder then
+                _logger.LogInformation("A removed submodule detected. Removing files at {path}...", relativePath);
+                _fileSystem.DeleteDirectory(repoPath / relativePath, true);
+            }
+        }
+
+        // Also remove untracked files (in case files were removed in index)
+        result = await _processManager.ExecuteGit(repoPath, ["clean", "-df", relativePath], cancellationToken: CancellationToken.None);
+        result.ThrowIfFailed("Failed to clean the working tree!");
     }
 
     public async Task CreateBranchAsync(string repoPath, string branchName, bool overwriteExistingBranch = false)
@@ -334,12 +376,13 @@ public class LocalGitClient : ILocalGitClient
         return result.StandardOutput;
     }
 
-    public async Task<string> BlameLineAsync(string repoPath, string relativeFilePath, int line)
+    public async Task<string> BlameLineAsync(string repoPath, string relativeFilePath, int line, string? blameFromCommit = null)
     {
-        var args = new[]
+        var args = new List<string>
         {
             "blame",
             "--first-parent",
+            blameFromCommit != null ? blameFromCommit + '^' : Constants.HEAD,
             "-slL",
             $"{line},{line}",
             relativeFilePath,

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
@@ -24,8 +24,8 @@ public class LocalLibGit2Client : LocalGitClient, ILocalLibGit2Client
     private readonly IProcessManager _processManager;
     private readonly ILogger _logger;
 
-    public LocalLibGit2Client(RemoteConfiguration remoteConfiguration, IProcessManager processManager, ILogger logger)
-        : base(remoteConfiguration, processManager, logger)
+    public LocalLibGit2Client(RemoteConfiguration remoteConfiguration, IProcessManager processManager, IFileSystem fileSystem, ILogger logger)
+        : base(remoteConfiguration, processManager, fileSystem, logger)
     {
         _remoteConfiguration = remoteConfiguration;
         _processManager = processManager;

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DependencyDetail.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DependencyDetail.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.DotNet.DarcLib;
@@ -97,4 +98,13 @@ public class DependencyDetail
     /// Information whether dependency is needed for source-build.
     /// </summary>
     public SourceBuildInfo SourceBuild { get; set; }
+
+    public void Validate()
+    {
+        const string Message = "{0} of the dependency detail record is empty";
+        _ = Version ?? throw new DarcException(string.Format(Message, nameof(Version)));
+        _ = Name ?? throw new DarcException(string.Format(Message, nameof(Name)));
+        _ = Commit ?? throw new DarcException(string.Format(Message, nameof(Commit)));
+        _ = RepoUri ?? throw new DarcException(string.Format(Message, nameof(RepoUri)));
+    }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DependencyGraph.cs
@@ -813,7 +813,7 @@ public class DependencyGraph
             {
                 // If a repo folder or a mapping was not set we use the current parent's 
                 // parent folder.
-                var gitClient = new LocalLibGit2Client(new RemoteConfiguration(null, null), new ProcessManager(logger, gitExecutable), logger);
+                var gitClient = new LocalLibGit2Client(new RemoteConfiguration(null, null), new ProcessManager(logger, gitExecutable), new FileSystem(), logger);
                 string parent = await gitClient.GetRootDirAsync();
                 folder = Directory.GetParent(parent).FullName;
             }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VersionDetails.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VersionDetails.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.DarcLib.Models;
+
+public record VersionDetails(
+    IReadOnlyCollection<DependencyDetail> Dependencies,
+    SourceDependency? Source);
+
+public record SourceDependency(string Uri, string Sha);
+

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
@@ -22,6 +22,7 @@ public interface ISourceManifest
     void UpdateSubmodule(SubmoduleRecord submodule);
     void UpdateVersion(string repository, string uri, string sha, string? packageVersion);
     VmrDependencyVersion? GetVersion(string repository);
+    void Refresh(string sourceManifestPath);
 }
 
 /// <summary>
@@ -30,10 +31,11 @@ public interface ISourceManifest
 /// </summary>
 public class SourceManifest : ISourceManifest
 {
-    private readonly SortedSet<RepositoryRecord> _repositories;
-    private readonly SortedSet<SubmoduleRecord> _submodules;
+    private SortedSet<RepositoryRecord> _repositories;
+    private SortedSet<SubmoduleRecord> _submodules;
 
     public IReadOnlyCollection<IVersionedSourceComponent> Repositories => _repositories;
+
     public IReadOnlyCollection<ISourceComponent> Submodules => _submodules;
 
     public SourceManifest(IEnumerable<RepositoryRecord> repositories, IEnumerable<SubmoduleRecord> submodules)
@@ -111,6 +113,13 @@ public class SourceManifest : ISourceManifest
         };
 
         return JsonSerializer.Serialize(data, options);
+    }
+
+    public void Refresh(string sourceManifestPath)
+    {
+        var newManifst = FromJson(sourceManifestPath);
+        _repositories = newManifst._repositories;
+        _submodules = newManifst._submodules;
     }
 
     public static SourceManifest FromJson(string path)

--- a/src/Microsoft.DotNet.Darc/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/RemoteRepoBase.cs
@@ -36,7 +36,7 @@ public class RemoteRepoBase : GitRepoCloner
         ILogger logger,
         ProcessManager processManager,
         RemoteConfiguration remoteConfiguration)
-        : base(remoteConfiguration, new LocalLibGit2Client(remoteConfiguration, processManager, logger), logger)
+        : base(remoteConfiguration, new LocalLibGit2Client(remoteConfiguration, processManager, new FileSystem(), logger), logger)
     {
         TemporaryRepositoryPath = temporaryRepositoryPath;
         GitExecutable = gitExecutable;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeBackflower.cs
@@ -209,7 +209,7 @@ public class CodeBackflower : IVmrBackflower
 
     private async Task<string> GetShaOfLastSyncForRepo(IVersionedSourceComponent repo)
     {
-        var manifestPath = _vmrInfo.GetSourceManifestPath();
+        var manifestPath = _vmrInfo.SourceManifestPath;
 
         using (var stream = _fileSystem.GetFileStream(manifestPath, FileMode.Open, FileAccess.Read))
         using (var reader = new StreamReader(stream))

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -30,7 +30,7 @@ public interface IVmrPatchHandler
         string patchName,
         string sha1,
         string sha2,
-        string? path,
+        UnixPath? path,
         IReadOnlyCollection<string>? filters,
         bool relativePaths,
         NativePath workingDir,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
@@ -23,7 +23,7 @@ public interface IVmrUpdater
     /// <param name="tpnTemplatePath">Path to VMR's THIRD-PARTY-NOTICES.md template</param>
     /// <param name="generateCodeowners">Whether to generate a CODEOWNERS file</param>
     /// <param name="discardPatches">Whether to clean up genreated .patch files after their used</param>
-    Task UpdateRepository(
+    Task<bool> UpdateRepository(
         string mappingName,
         string? targetRevision,
         string? targetVersion,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
@@ -23,6 +23,7 @@ public interface IVmrUpdater
     /// <param name="tpnTemplatePath">Path to VMR's THIRD-PARTY-NOTICES.md template</param>
     /// <param name="generateCodeowners">Whether to generate a CODEOWNERS file</param>
     /// <param name="discardPatches">Whether to clean up genreated .patch files after their used</param>
+    /// <returns>True if the repository was updated, false if it was already up to date</returns>
     Task<bool> UpdateRepository(
         string mappingName,
         string? targetRevision,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
@@ -79,7 +79,7 @@ public class VmrDependencyTracker : IVmrDependencyTracker
         _repoVersions.SerializeToXml(_allVersionsFilePath);
 
         _sourceManifest.UpdateVersion(update.Mapping.Name, update.RemoteUri, update.TargetRevision, update.TargetVersion);
-        _fileSystem.WriteToFile(_vmrInfo.GetSourceManifestPath(), _sourceManifest.ToJson());
+        _fileSystem.WriteToFile(_vmrInfo.SourceManifestPath, _sourceManifest.ToJson());
 
         // Root repository of an update does not have a package version associated with it
         // For installer, we leave whatever was there (e.g. 8.0.100)
@@ -136,7 +136,7 @@ public class VmrDependencyTracker : IVmrDependencyTracker
             }
         }
 
-        _fileSystem.WriteToFile(_vmrInfo.GetSourceManifestPath(), _sourceManifest.ToJson());
+        _fileSystem.WriteToFile(_vmrInfo.SourceManifestPath, _sourceManifest.ToJson());
     }
 
     private string GetGitInfoFilePath(SourceMapping mapping) => GetGitInfoFilePath(mapping.Name);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrGitClientFactory.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrGitClientFactory.cs
@@ -18,17 +18,20 @@ public class VmrGitClientFactory : IGitRepoFactory
     private readonly IVmrInfo _vmrInfo;
     private readonly RemoteConfiguration _remoteConfiguration;
     private readonly IProcessManager _processManager;
+    private readonly IFileSystem _fileSystem;
     private readonly ILoggerFactory _loggerFactory;
 
     public VmrGitClientFactory(
         IVmrInfo vmrInfo,
         RemoteConfiguration remoteConfiguration,
         IProcessManager processManager,
+        IFileSystem fileSystem,
         ILoggerFactory loggerFactory)
     {
         _vmrInfo = vmrInfo;
         _remoteConfiguration = remoteConfiguration;
         _processManager = processManager;
+        _fileSystem = fileSystem;
         _loggerFactory = loggerFactory;
     }
 
@@ -48,7 +51,7 @@ public class VmrGitClientFactory : IGitRepoFactory
             // Caching not in use for Darc local client.
             null),
 
-        GitRepoType.Local => new LocalLibGit2Client(_remoteConfiguration, _processManager, _loggerFactory.CreateLogger<LocalGitClient>()),
+        GitRepoType.Local => new LocalLibGit2Client(_remoteConfiguration, _processManager, _fileSystem, _loggerFactory.CreateLogger<LocalGitClient>()),
 
         _ => throw new ArgumentException("Unknown git repository type", nameof(repoUri)),
     };

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -14,12 +14,12 @@ public interface IVmrInfo
     /// <summary>
     /// Path for temporary files (individual repo clones, created patches, etc.)
     /// </summary>
-    NativePath TmpPath { get; }
+    NativePath TmpPath { get; set; }
 
     /// <summary>
     /// Path to the root of the VMR
     /// </summary>
-    NativePath VmrPath { get; }
+    NativePath VmrPath { get; set; }
 
     /// <summary>
     /// Path within the VMR where VMR patches are stored.
@@ -32,6 +32,11 @@ public interface IVmrInfo
     /// Path to the source-mappings.json file
     /// </summary>
     string? SourceMappingsPath { get; set; }
+
+    /// <summary>
+    /// Gets a full path leading to the source manifest JSON file.
+    /// </summary>
+    NativePath SourceManifestPath { get; }
 
     /// <summary>
     /// Additionally mapped directories that are copied to non-src/ locations within the VMR.
@@ -49,11 +54,6 @@ public interface IVmrInfo
     /// Gets a full path leading to sources belonging to a given repo
     /// </summary>
     NativePath GetRepoSourcesPath(string mappingName);
-
-    /// <summary>
-    /// Gets a full path leading to the source manifest JSON file.
-    /// </summary>
-    NativePath GetSourceManifestPath();
 }
 
 public class VmrInfo : IVmrInfo
@@ -79,9 +79,9 @@ public class VmrInfo : IVmrInfo
 
     public static UnixPath DefaultRelativeSourceManifestPath { get; } = RelativeSourcesDir / SourceManifestFileName;
 
-    public NativePath VmrPath { get; }
+    public NativePath VmrPath { get; set; }
 
-    public NativePath TmpPath { get; }
+    public NativePath TmpPath { get; set; }
 
     public string? PatchesPath { get; set; }
 
@@ -93,6 +93,7 @@ public class VmrInfo : IVmrInfo
     {
         VmrPath = vmrPath;
         TmpPath = tmpPath;
+        SourceManifestPath = vmrPath / SourcesDir / SourceManifestFileName;
     }
 
     public VmrInfo(string vmrPath, string tmpPath) : this(new NativePath(vmrPath), new NativePath(tmpPath))
@@ -103,7 +104,9 @@ public class VmrInfo : IVmrInfo
 
     public NativePath GetRepoSourcesPath(string mappingName) => VmrPath / SourcesDir / mappingName;
 
-    public static UnixPath GetRelativeRepoSourcesPath(SourceMapping mapping) => RelativeSourcesDir / mapping.Name;
+    public static UnixPath GetRelativeRepoSourcesPath(SourceMapping mapping) => GetRelativeRepoSourcesPath(mapping.Name);
 
-    public NativePath GetSourceManifestPath() => VmrPath / SourcesDir / SourceManifestFileName;
+    public static UnixPath GetRelativeRepoSourcesPath(string mappingName) => RelativeSourcesDir / mappingName;
+
+    public NativePath SourceManifestPath { get; }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -78,7 +78,7 @@ public static class VmrRegistrations
         services.TryAddSingleton<ISourceManifest>(sp =>
         {
             var configuration = sp.GetRequiredService<IVmrInfo>();
-            return SourceManifest.FromJson(configuration.GetSourceManifestPath());
+            return SourceManifest.FromJson(configuration.SourceManifestPath);
         });
 
         return services;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -186,7 +186,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 return Array.Empty<VmrIngestionPatch>();
             }
 
-            throw new EmptySyncException($"Repository {update.Mapping} is already at {update.TargetRevision}");
+            throw new EmptySyncException($"Repository {update.Mapping.Name} is already at {update.TargetRevision}");
         }
 
         _logger.LogInformation("Synchronizing {name} from {current} to {repo} / {revision}",
@@ -342,7 +342,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             catch (EmptySyncException e)
             {
                 _logger.LogWarning(e.Message);
-                return false;
+                continue;
             }
             catch (Exception)
             {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -152,7 +152,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             }
             catch (EmptySyncException e)
             {
-                // TODO: Clean up the work branch?
                 _logger.LogInformation(e.Message);
                 return false;
             }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -90,7 +90,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         _workBranchFactory = workBranchFactory;
     }
 
-    public async Task UpdateRepository(
+    public async Task<bool> UpdateRepository(
         string mappingName,
         string? targetRevision,
         string? targetVersion,
@@ -126,7 +126,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
         if (updateDependencies)
         {
-            await UpdateRepositoryRecursively(
+            return await UpdateRepositoryRecursively(
                 dependencyUpdate,
                 additionalRemotes,
                 readmeTemplatePath,
@@ -137,15 +137,25 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         }
         else
         {
-            await UpdateRepositoryInternal(
-                dependencyUpdate,
-                reapplyVmrPatches: true,
-                additionalRemotes,
-                readmeTemplatePath,
-                tpnTemplatePath,
-                generateCodeowners,
-                discardPatches,
-                cancellationToken);
+            try
+            {
+                var patchesToReapply = await UpdateRepositoryInternal(
+                        dependencyUpdate,
+                        reapplyVmrPatches: true,
+                        additionalRemotes,
+                        readmeTemplatePath,
+                        tpnTemplatePath,
+                        generateCodeowners,
+                        discardPatches,
+                        cancellationToken);
+                return true;
+            }
+            catch (EmptySyncException e)
+            {
+                // TODO: Clean up the work branch?
+                _logger.LogInformation(e.Message);
+                return false;
+            }
         }
     }
 
@@ -162,12 +172,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         VmrDependencyVersion currentVersion = _dependencyTracker.GetDependencyVersion(update.Mapping)
             ?? throw new Exception($"Failed to find current version for {update.Mapping.Name}");
 
-        _logger.LogInformation("Synchronizing {name} from {current} to {repo} / {revision}",
-            update.Mapping.Name,
-            currentVersion.Sha,
-            update.RemoteUri,
-            update.TargetRevision);
-
         // Do we need to change anything?
         if (currentVersion.Sha == update.TargetRevision)
         {
@@ -179,14 +183,17 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                     update.Mapping,
                     currentVersion,
                     cancellationToken);
-            }
-            else
-            {
-                _logger.LogInformation("Repository {repo} is already at {sha}", update.Mapping.Name, update.TargetRevision);
+                return Array.Empty<VmrIngestionPatch>();
             }
 
-            return Array.Empty<VmrIngestionPatch>();
+            throw new EmptySyncException($"Repository {update.Mapping} is already at {update.TargetRevision}");
         }
+
+        _logger.LogInformation("Synchronizing {name} from {current} to {repo} / {revision}",
+            update.Mapping.Name,
+            currentVersion.Sha,
+            update.RemoteUri,
+            update.TargetRevision);
 
         // Sort remotes so that we go Local -> GitHub -> AzDO
         // This makes the synchronization work even for cases when we can't access internal repos
@@ -215,12 +222,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         {
             TargetRevision = await _localGitClient.GetShaForRefAsync(clonePath, update.TargetRevision)
         };
-
-        if (currentVersion.Sha == update.TargetRevision)
-        {
-            _logger.LogInformation("No new commits found to synchronize");
-            return Array.Empty<VmrIngestionPatch>();
-        }
 
         _logger.LogInformation("Updating {repo} from {current} to {next}..",
             update.Mapping.Name, Commit.GetShortSha(currentVersion.Sha), Commit.GetShortSha(update.TargetRevision));
@@ -251,7 +252,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
     /// Updates a repository and all of it's dependencies recursively starting with a given mapping.
     /// Always updates to the first version found per repository in the dependency tree.
     /// </summary>
-    private async Task UpdateRepositoryRecursively(
+    private async Task<bool> UpdateRepositoryRecursively(
         VmrDependencyUpdate rootUpdate,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? readmeTemplatePath,
@@ -261,6 +262,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         CancellationToken cancellationToken)
     {
         string originalRootSha = GetCurrentVersion(rootUpdate.Mapping);
+
         _logger.LogInformation("Recursive update for {repo} / {from}{arrow}{to}",
             rootUpdate.Mapping.Name,
             Commit.GetShortSha(originalRootSha),
@@ -337,7 +339,12 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                     discardPatches,
                     cancellationToken);
             }
-            catch(Exception)
+            catch (EmptySyncException e)
+            {
+                _logger.LogWarning(e.Message);
+                return false;
+            }
+            catch (Exception)
             {
                 _logger.LogWarning(
                     InterruptedSyncExceptionMessage,
@@ -411,6 +418,8 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             rootUpdate.Mapping.Name,
             Environment.NewLine,
             summaryMessage);
+
+        return updatedDependencies.Any();
     }
 
     /// <summary>
@@ -635,7 +644,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             DeleteRepository(repo.Path);
         }
 
-        var sourceManifestPath = _vmrInfo.GetSourceManifestPath();
+        var sourceManifestPath = _vmrInfo.SourceManifestPath;
         _fileSystem.WriteToFile(sourceManifestPath, _sourceManifest.ToJson());
 
         if (readmeTemplatePath != null)
@@ -667,7 +676,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         }
 
         _sourceManifest.RemoveRepository(repo);
-        _logger.LogInformation("Removed record for repository {name} from {file}", repo, _vmrInfo.GetSourceManifestPath());
+        _logger.LogInformation("Removed record for repository {name} from {file}", repo, _vmrInfo.SourceManifestPath);
 
         if (_dependencyTracker.RemoveRepositoryVersion(repo))
         {
@@ -707,7 +716,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         var filesToAdd = new List<string>
         {
             VmrInfo.GitInfoSourcesDir,
-            _vmrInfo.GetSourceManifestPath()
+            _vmrInfo.SourceManifestPath
         };
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -778,11 +787,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             ?? throw new Exception($"No mapping named '{mapping.Name}' found");
     }
 
-    private class RepositoryNotInitializedException : Exception
+    private class RepositoryNotInitializedException(string message) : Exception(message)
     {
-        public RepositoryNotInitializedException(string message)
-            : base(message)
-        {
-        }
     }
 }

--- a/test/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
+++ b/test/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
@@ -65,7 +65,7 @@ internal class DependencyTestDriver
 
         // Set up a git file manager
         var processManager = new ProcessManager(NullLogger.Instance, "git");
-        GitClient = new LocalLibGit2Client(new RemoteConfiguration(), processManager, NullLogger.Instance);
+        GitClient = new LocalLibGit2Client(new RemoteConfiguration(), processManager, new FileSystem(), NullLogger.Instance);
         _versionDetailsParser = new VersionDetailsParser();
         DependencyFileManager = new DependencyFileManager(GitClient, _versionDetailsParser, NullLogger.Instance);
 
@@ -88,6 +88,7 @@ internal class DependencyTestDriver
     {
         GitFileContentContainer container = await DependencyFileManager.UpdateDependencyFiles(
             dependencies,
+            sourceDependency: null,
             TemporaryRepositoryPath,
             null,
             null,
@@ -100,10 +101,11 @@ internal class DependencyTestDriver
     {
         string testVersionDetailsXmlPath = Path.Combine(RootExpectedOutputsPath, VersionFiles.VersionDetailsXml);
         string versionDetailsContents = File.ReadAllText(testVersionDetailsXmlPath);
-        IEnumerable<DependencyDetail> dependencies = _versionDetailsParser.ParseVersionDetailsXml(versionDetailsContents, false);
+        IEnumerable<DependencyDetail> dependencies = _versionDetailsParser.ParseVersionDetailsXml(versionDetailsContents, false).Dependencies;
 
         GitFileContentContainer container = await DependencyFileManager.UpdateDependencyFiles(
             dependencies,
+            sourceDependency: null,
             TemporaryRepositoryPath,
             null,
             null,

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/Constants.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/Constants.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
 public class Constants
 {
-    public static readonly string VersionDetailsTemplate = 
+    public const string VersionDetailsTemplate = 
 @"<?xml version=""1.0"" encoding=""utf-8""?>
 <Dependencies>
     <ProductDependencies>
@@ -17,19 +17,20 @@ public class Constants
 
     public static readonly string EmptyVersionDetails = string.Format(VersionDetailsTemplate, string.Empty);
     
-    public static readonly string DependencyTemplate = 
+    public const string DependencyTemplate = 
 @"<Dependency Name=""{0}"" Version=""8.0.0"">
     <Uri>{1}</Uri>
     <Sha>{2}</Sha>
     <SourceBuild RepoName=""{0}"" ManagedOnly=""true"" />
 </Dependency>";
 
-    public static readonly string ProductRepoName = "product-repo1";
-    public static readonly string DependencyRepoName = "dependency";
-    public static readonly string SecondRepoName = "product-repo2";
-    public static readonly string InstallerRepoName = "installer";
-    public static readonly string VmrName = "vmr";
-    public static readonly string TmpFolderName = "tmp";
-    public static readonly string PatchesFolderName = "patches";
+    public const string ProductRepoName = "product-repo1";
+    public const string DependencyRepoName = "dependency";
+    public const string SecondRepoName = "product-repo2";
+    public const string InstallerRepoName = "installer";
+    public const string VmrName = "vmr";
+    public const string TmpFolderName = "tmp";
+    public const string PatchesFolderName = "patches";
+
     public static string GetRepoFileName(string repoName) => repoName + "-file.txt";
 }

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/GitOperationsHelper.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/GitOperationsHelper.cs
@@ -10,25 +10,25 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
-public class GitOperationsHelper
+internal class GitOperationsHelper
 {
-    public readonly IProcessManager ProcessManager;
+    private readonly IProcessManager _processManager;
     
     public GitOperationsHelper()
     {
-        ProcessManager = new ProcessManager(new NullLogger<ProcessManager>(), "git");
+        _processManager = new ProcessManager(new NullLogger<ProcessManager>(), "git");
     }
     
     public async Task CommitAll(NativePath repo, string commitMessage, bool allowEmpty = false)
     {
-        var result = await ProcessManager.ExecuteGit(repo, "add", "-A");
+        var result = await _processManager.ExecuteGit(repo, "add", "-A");
 
         if (!allowEmpty)
         {
             result.ThrowIfFailed($"No files to add in {repo}");
         }
 
-        result = await ProcessManager.ExecuteGit(repo, "commit", "-m", commitMessage);
+        result = await _processManager.ExecuteGit(repo, "commit", "-m", commitMessage);
         if (!allowEmpty)
         {
             result.ThrowIfFailed($"No changes to commit in {repo}");
@@ -37,21 +37,27 @@ public class GitOperationsHelper
 
     public async Task InitialCommit(NativePath repo)
     {
-        await ProcessManager.ExecuteGit(repo, "init", "-b", "main");
+        await _processManager.ExecuteGit(repo, "init", "-b", "main");
         await ConfigureGit(repo);
         await CommitAll(repo, "Initial commit", allowEmpty: true);
     }
 
     public async Task<string> GetRepoLastCommit(NativePath repo)
     {
-        var log = await ProcessManager.ExecuteGit(repo, "log", "--format=format:%H");
+        var log = await _processManager.ExecuteGit(repo, "log", "--format=format:%H");
         return log.StandardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).First();
     }
 
     public async Task CheckAllIsCommitted(string repo)
     {
-        var gitStatus = await ProcessManager.ExecuteGit(repo, "status", "--porcelain");
+        var gitStatus = await _processManager.ExecuteGit(repo, "status", "--porcelain");
         gitStatus.StandardOutput.Should().BeEmpty();
+    }
+
+    public async Task Checkout(NativePath repo, string gitRef)
+    {
+        var result = await _processManager.ExecuteGit(repo, "checkout", gitRef);
+        result.ThrowIfFailed($"Could not checkout {gitRef} in {repo}");
     }
 
     public async Task InitializeSubmodule(
@@ -60,7 +66,7 @@ public class GitOperationsHelper
         string submoduleUrl,
         string pathInRepo)
     {
-        await ProcessManager.ExecuteGit(
+        await _processManager.ExecuteGit(
             repo,
             "-c",
             "protocol.file.allow=always",
@@ -72,7 +78,7 @@ public class GitOperationsHelper
             submoduleUrl,
             pathInRepo);
 
-        await ProcessManager.ExecuteGit(
+        await _processManager.ExecuteGit(
             repo,
             "submodule",
             "update",
@@ -92,22 +98,68 @@ public class GitOperationsHelper
 
     public Task RemoveSubmodule(NativePath repo, string submoduleRelativePath)
     {
-        return ProcessManager.ExecuteGit(repo, "rm", "-f", submoduleRelativePath);
+        return _processManager.ExecuteGit(repo, "rm", "-f", submoduleRelativePath);
     }
 
     public Task PullMain(NativePath repo)
     {
-        return ProcessManager.ExecuteGit(repo, "pull", "origin", "main");
+        return _processManager.ExecuteGit(repo, "pull", "origin", "main");
     }
 
     public Task ChangeSubmoduleUrl(NativePath repo, LocalPath submodulePath, LocalPath newUrl)
     {
-        return ProcessManager.ExecuteGit(repo, "submodule", "set-url", submodulePath, newUrl);
+        return _processManager.ExecuteGit(repo, "submodule", "set-url", submodulePath, newUrl);
+    }
+
+    public async Task MergePrBranch(NativePath repo, string branch, string targetBranch = "main")
+    {
+        var result = await _processManager.ExecuteGit(repo, "checkout", targetBranch);
+        result.ThrowIfFailed($"Could not checkout main branch in {repo}");
+
+        result = await _processManager.ExecuteGit(repo, "merge", "--squash", branch);
+        result.ThrowIfFailed($"Could not merge branch {branch} to {targetBranch} in {repo}");
+
+        await CommitAll(repo, $"Merged branch {branch} into {targetBranch}");
     }
 
     private async Task ConfigureGit(NativePath repo)
     {
-        await ProcessManager.ExecuteGit(repo, "config", "user.email", DarcLib.Constants.DarcBotEmail);
-        await ProcessManager.ExecuteGit(repo, "config", "user.name", DarcLib.Constants.DarcBotName);
+        await _processManager.ExecuteGit(repo, "config", "user.email", DarcLib.Constants.DarcBotEmail);
+        await _processManager.ExecuteGit(repo, "config", "user.name", DarcLib.Constants.DarcBotName);
+    }
+
+    // mergeTheirs behaviour:
+    //     null: abort merge
+    //     true: merge using theirs
+    //     false: merge using ours
+    public async Task VerifyMergeConflict(
+        NativePath repo,
+        string branch,
+        string? expectedFileInConflict = null,
+        bool? mergeTheirs = null,
+        string targetBranch = "main")
+    {
+        var result = await _processManager.ExecuteGit(repo, "checkout", targetBranch);
+        result.ThrowIfFailed($"Could not checkout main branch in {repo}");
+
+        result = await _processManager.ExecuteGit(repo, "merge", "--no-commit", "--no-ff", branch);
+        result.Succeeded.Should().BeFalse($"Expected merge conflict in {repo} but none happened");
+
+        if (expectedFileInConflict != null)
+        {
+            result.StandardOutput.Should().Contain($"CONFLICT (content): Merge conflict in {expectedFileInConflict}");
+        }
+
+        if (mergeTheirs.HasValue)
+        {
+            result = await _processManager.ExecuteGit(repo, "checkout", mergeTheirs.Value ? "--theirs" : "--ours", ".");
+            result.ThrowIfFailed($"Failed to merge {(mergeTheirs.Value ? "theirs" : "ours")} {repo}");
+            await CommitAll(repo, $"Merged {branch} into {targetBranch} {(mergeTheirs.Value ? "using " + targetBranch : "using " + targetBranch)}");
+        }
+        else
+        {
+            result = await _processManager.ExecuteGit(repo, "merge", "--abort");
+            result.ThrowIfFailed($"Failed to abort merge in {repo}");
+        }
     }
 }

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/LoadSourceMappingsFromInstallerTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/LoadSourceMappingsFromInstallerTest.cs
@@ -13,7 +13,7 @@ using NUnit.Framework;
 
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
-public class LoadSourceMappingsFromInstallerTest : VmrTestsBase
+internal class LoadSourceMappingsFromInstallerTest : VmrTestsBase
 {
     private SourceMappingFile _sourceMappings = null!;
     private readonly JsonSerializerOptions _jsonSettings;

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrBinaryFileScannerTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrBinaryFileScannerTest.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
 [TestFixture]
-public class VmrBinaryFileScannerTest : VmrTestsBase
+internal class VmrBinaryFileScannerTest : VmrTestsBase
 {
     [Test]
     public async Task VmrBinaryFileScannerTests()

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCloakedFileScannerTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCloakedFileScannerTest.cs
@@ -1,24 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 #nullable enable 
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
 [TestFixture]
-public class VmrCloakedFileScannerTest : VmrTestsBase
+internal class VmrCloakedFileScannerTest : VmrTestsBase
 {
     [Test]
     public async Task VmrCloakedFileScannerTests()
@@ -32,7 +29,7 @@ public class VmrCloakedFileScannerTest : VmrTestsBase
         // Test the scanner when there are no cloaked files to be found
         var list = await CallDarcCloakedFileScan(baselinesFilePath);
 
-        list.Count().Should().Be(0);
+        list.Should().BeEmpty();
 
         var newFilePath = VmrPath / "src" / Constants.ProductRepoName / "src";
         Directory.CreateDirectory(newFilePath);

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrMultipleRemotesTests.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrMultipleRemotesTests.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
-public class VmrMultipleRemotesTests : VmrTestsBase
+internal class VmrMultipleRemotesTests : VmrTestsBase
 {
     private NativePath FirstDependencyPath => CurrentTestDirectory / (Constants.DependencyRepoName + "1");
     private NativePath SecondDependencyPath => CurrentTestDirectory / (Constants.DependencyRepoName + "2");

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchAddingFileTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchAddingFileTest.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
 [TestFixture]
-public class VmrPatchAddingFileTest : VmrPatchesTestsBase
+internal class VmrPatchAddingFileTest : VmrPatchesTestsBase
 {
     private readonly string _productRepoNewFile = "new-file.txt";
 

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchAddingSubmoduleFileTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchAddingSubmoduleFileTest.cs
@@ -14,7 +14,7 @@ using NUnit.Framework;
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
 [TestFixture]
-public class VmrPatchAddingSubmoduleFileTest : VmrPatchesTestsBase
+internal class VmrPatchAddingSubmoduleFileTest : VmrPatchesTestsBase
 {
     public VmrPatchAddingSubmoduleFileTest() : base("add-submodule-file.patch")
     {

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchChangingFileTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchChangingFileTest.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
 [TestFixture]
-public class VmrPatchChangingFileTest : VmrPatchesTestsBase
+internal class VmrPatchChangingFileTest : VmrPatchesTestsBase
 {
     public VmrPatchChangingFileTest() : base("example.patch")
     {

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchRemovingFileTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchRemovingFileTest.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
 [TestFixture]
-public class VmrPatchRemovingFileTest : VmrPatchesTestsBase
+internal class VmrPatchRemovingFileTest : VmrPatchesTestsBase
 {
     public VmrPatchRemovingFileTest() : base("remove-file.patch")
     {

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchesTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchesTestsBase.cs
@@ -11,7 +11,7 @@ using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
-public class VmrPatchesTestsBase : VmrTestsBase
+internal class VmrPatchesTestsBase : VmrTestsBase
 {
     protected string PatchFileName { get; private set; } = null!;
     protected NativePath InstallerPatchesDir { get; private set; } = null!;

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrRecursiveSyncTests.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrRecursiveSyncTests.cs
@@ -11,10 +11,9 @@ using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using NUnit.Framework;
 
-
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
-public class VmrRecursiveSyncTests : VmrTestsBase
+internal class VmrRecursiveSyncTests : VmrTestsBase
 {
     [Test]
     public async Task RecursiveUpdatePreservesDependencyVersionTest()

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrRepoDeletionTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrRepoDeletionTest.cs
@@ -16,7 +16,7 @@ using NUnit.Framework;
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
 [TestFixture]
-public class VmrRepoDeletionTest : VmrTestsBase
+internal class VmrRepoDeletionTest : VmrTestsBase
 {
     private SourceMappingFile _sourceMappings = null!;
     private readonly JsonSerializerOptions _jsonSettings;
@@ -50,7 +50,7 @@ public class VmrRepoDeletionTest : VmrTestsBase
 
         var expectedFiles = GetExpectedFilesInVmr(
             VmrPath,
-            [Constants.InstallerRepoName, Constants.ProductRepoName],
+            new[] { Constants.InstallerRepoName, Constants.ProductRepoName },
             expectedFilesFromRepos);
 
         CheckDirectoryContents(VmrPath, expectedFiles);
@@ -82,13 +82,13 @@ public class VmrRepoDeletionTest : VmrTestsBase
 
         expectedFiles = GetExpectedFilesInVmr(
             VmrPath,
-            [Constants.InstallerRepoName],
+            new[] { Constants.InstallerRepoName },
             expectedFilesFromRepos);
 
         CheckDirectoryContents(VmrPath, expectedFiles);
 
         var versions = AllVersionsPropsFile.DeserializeFromXml(VmrPath / VmrInfo.GitInfoSourcesDir / AllVersionsPropsFile.FileName);
-        versions.Versions.Keys.Should().BeEquivalentTo(["installerGitCommitHash"]);
+        versions.Versions.Keys.Should().BeEquivalentTo(new string[] { "installerGitCommitHash" });
 
         var sourceManifest = SourceManifest.FromJson(Info.SourceManifestPath);
         sourceManifest.Repositories.Should().HaveCount(1);
@@ -106,16 +106,16 @@ public class VmrRepoDeletionTest : VmrTestsBase
         {
             PatchesPath = "src/installer/patches/",
             SourceMappingsPath = "src/installer/src/SourceBuild/content/source-mappings.json",
-            AdditionalMappings =
-            [
+            AdditionalMappings = new List<AdditionalMappingSetting>
+            {
                 new AdditionalMappingSetting
                 {
                     Source = "src/installer/src/SourceBuild/content/source-mappings.json",
                     Destination = "src"
                 }
-            ],
-            Mappings =
-            [
+            },
+            Mappings = new List<SourceMappingSetting>
+            {
                 new SourceMappingSetting
                 {
                     Name = Constants.InstallerRepoName,
@@ -126,7 +126,7 @@ public class VmrRepoDeletionTest : VmrTestsBase
                     Name = Constants.ProductRepoName,
                     DefaultRemote = ProductRepoPath,
                 },
-            ]
+            }
         };
 
         Directory.CreateDirectory(InstallerRepoPath / "src" / "SourceBuild" / "content");

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrRepoDeletionTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrRepoDeletionTest.cs
@@ -50,7 +50,7 @@ public class VmrRepoDeletionTest : VmrTestsBase
 
         var expectedFiles = GetExpectedFilesInVmr(
             VmrPath,
-            new[] { Constants.InstallerRepoName, Constants.ProductRepoName },
+            [Constants.InstallerRepoName, Constants.ProductRepoName],
             expectedFilesFromRepos);
 
         CheckDirectoryContents(VmrPath, expectedFiles);
@@ -82,15 +82,15 @@ public class VmrRepoDeletionTest : VmrTestsBase
 
         expectedFiles = GetExpectedFilesInVmr(
             VmrPath,
-            new[] { Constants.InstallerRepoName },
+            [Constants.InstallerRepoName],
             expectedFilesFromRepos);
 
         CheckDirectoryContents(VmrPath, expectedFiles);
 
         var versions = AllVersionsPropsFile.DeserializeFromXml(VmrPath / VmrInfo.GitInfoSourcesDir / AllVersionsPropsFile.FileName);
-        versions.Versions.Keys.Should().BeEquivalentTo(new string[] { "installerGitCommitHash" });
+        versions.Versions.Keys.Should().BeEquivalentTo(["installerGitCommitHash"]);
 
-        var sourceManifest = SourceManifest.FromJson(Info.GetSourceManifestPath());
+        var sourceManifest = SourceManifest.FromJson(Info.SourceManifestPath);
         sourceManifest.Repositories.Should().HaveCount(1);
         sourceManifest.Repositories.First().Path.Should().Be("installer");
 
@@ -106,16 +106,16 @@ public class VmrRepoDeletionTest : VmrTestsBase
         {
             PatchesPath = "src/installer/patches/",
             SourceMappingsPath = "src/installer/src/SourceBuild/content/source-mappings.json",
-            AdditionalMappings = new List<AdditionalMappingSetting>
-            {
+            AdditionalMappings =
+            [
                 new AdditionalMappingSetting
                 {
                     Source = "src/installer/src/SourceBuild/content/source-mappings.json",
                     Destination = "src"
                 }
-            },
-            Mappings = new List<SourceMappingSetting>
-            {
+            ],
+            Mappings =
+            [
                 new SourceMappingSetting
                 {
                     Name = Constants.InstallerRepoName,
@@ -126,7 +126,7 @@ public class VmrRepoDeletionTest : VmrTestsBase
                     Name = Constants.ProductRepoName,
                     DefaultRemote = ProductRepoPath,
                 },
-            }
+            ]
         };
 
         Directory.CreateDirectory(InstallerRepoPath / "src" / "SourceBuild" / "content");

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncAdditionalMappingsTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncAdditionalMappingsTest.cs
@@ -14,7 +14,7 @@ using NUnit.Framework;
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
 [TestFixture]
-public class VmrSyncAdditionalMappingsTest : VmrTestsBase
+internal class VmrSyncAdditionalMappingsTest : VmrTestsBase
 {
     private readonly string _fileName = "special-file.txt";
     private readonly string _fileRelativePath = new NativePath("content") / "special-file.txt";

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
@@ -15,7 +15,7 @@ using NUnit.Framework;
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
 [TestFixture]
-public class VmrSyncRepoChangesTest :  VmrTestsBase
+internal class VmrSyncRepoChangesTest :  VmrTestsBase
 {
     private readonly string _dependencyFileName = "dependency-file.txt";
     private string _productRepoFileName = Constants.GetRepoFileName(Constants.ProductRepoName);

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -10,7 +10,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
@@ -20,10 +19,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 
-
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
-public abstract class VmrTestsBase
+internal abstract class VmrTestsBase
 {
     protected NativePath CurrentTestDirectory { get; private set; } = null!;
     protected NativePath ProductRepoPath { get; private set; } = null!;

--- a/test/Microsoft.DotNet.DarcLib.Tests/Helpers/VersionDetailsParserTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Helpers/VersionDetailsParserTests.cs
@@ -38,10 +38,10 @@ public class VersionDetailsParserTests
             """;
 
         var parser = new VersionDetailsParser();
-        var dependencies = parser.ParseVersionDetailsXml(VersionDetailsXml);
+        var versionDetails = parser.ParseVersionDetailsXml(VersionDetailsXml);
 
-        dependencies.Should().HaveCount(3);
-        dependencies.Should().Contain(d => d.Name == "NETStandard.Library.Ref"
+        versionDetails.Dependencies.Should().HaveCount(3);
+        versionDetails.Dependencies.Should().Contain(d => d.Name == "NETStandard.Library.Ref"
             && d.Version == "2.1.0"
             && d.RepoUri == "https://github.com/dotnet/core-setup"
             && d.Commit == "7d57652f33493fa022125b7f63aad0d70c52d810"
@@ -50,7 +50,7 @@ public class VersionDetailsParserTests
             && d.SourceBuild == null
             && d.Type == DependencyType.Product);
 
-        dependencies.Should().Contain(d => d.Name == "NuGet.Build.Tasks"
+        versionDetails.Dependencies.Should().Contain(d => d.Name == "NuGet.Build.Tasks"
             && d.Version == "6.4.0-preview.1.51"
             && d.RepoUri == "https://github.com/nuget/nuget.client"
             && d.Commit == "745617ea6fc239737c80abb424e13faca4249bf1"
@@ -61,7 +61,7 @@ public class VersionDetailsParserTests
             && !d.SourceBuild.ManagedOnly
             && d.Type == DependencyType.Product);
 
-        dependencies.Should().Contain(d => d.Name == "Microsoft.DotNet.Arcade.Sdk"
+        versionDetails.Dependencies.Should().Contain(d => d.Name == "Microsoft.DotNet.Arcade.Sdk"
             && d.Version == "7.0.0-beta.22426.1"
             && d.RepoUri == "https://github.com/dotnet/arcade"
             && d.Commit == "692746db3f08766bc29e91e826ff15e5e8a82b44"
@@ -72,6 +72,8 @@ public class VersionDetailsParserTests
             && d.SourceBuild.ManagedOnly
             && d.SourceBuild.TarballOnly
             && d.Type == DependencyType.Toolset);
+
+        versionDetails.Source.Should().BeNull();
     }
 
     [Test]
@@ -84,8 +86,8 @@ public class VersionDetailsParserTests
             """;
 
         var parser = new VersionDetailsParser();
-        var dependencies = parser.ParseVersionDetailsXml(VersionDetailsXml);
-        dependencies.Should().BeEmpty();
+        var versionDetails = parser.ParseVersionDetailsXml(VersionDetailsXml);
+        versionDetails.Dependencies.Should().BeEmpty();
     }
 
     [Test]
@@ -130,5 +132,42 @@ public class VersionDetailsParserTests
         var parser = new VersionDetailsParser();
         var action = () => parser.ParseVersionDetailsXml(VersionDetailsXml);
         action.Should().Throw<DarcException>().WithMessage("*is not a valid boolean*");
+    }
+
+    [Test]
+    public void IsVmrCodeflowParsedTest()
+    {
+        const string VersionDetailsXml =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Dependencies>
+              <Source Uri="https://github.com/dotnet/dotnet" Sha="86ba5fba7c39323011c2bfc6b713142affc76171" />
+              <ProductDependencies>
+                <Dependency Name="NETStandard.Library.Ref" Version="2.1.0" Pinned="true">
+                  <Uri>https://github.com/dotnet/core-setup</Uri>
+                  <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
+                </Dependency>
+                <Dependency Name="NuGet.Build.Tasks" Version="6.4.0-preview.1.51" CoherentParentDependency="Microsoft.NET.Sdk">
+                  <Uri>https://github.com/nuget/nuget.client</Uri>
+                  <Sha>745617ea6fc239737c80abb424e13faca4249bf1</Sha>
+                  <SourceBuildTarball RepoName="nuget-client" />
+                </Dependency>
+              </ProductDependencies>
+              <ToolsetDependencies>
+                <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22426.1">
+                  <Uri>https://github.com/dotnet/arcade</Uri>
+                  <Sha>692746db3f08766bc29e91e826ff15e5e8a82b44</Sha>
+                  <SourceBuild RepoName="arcade" ManagedOnly="true" TarballOnly="true" />
+                </Dependency>
+              </ToolsetDependencies>
+            </Dependencies>
+            """;
+
+        var parser = new VersionDetailsParser();
+        var versionDetails = parser.ParseVersionDetailsXml(VersionDetailsXml);
+
+        versionDetails.Source.Should().NotBeNull();
+        versionDetails.Source.Uri.Should().Be("https://github.com/dotnet/dotnet");
+        versionDetails.Source.Sha.Should().Be("86ba5fba7c39323011c2bfc6b713142affc76171");
     }
 }


### PR DESCRIPTION
This PR is an extract of changes that will later be needed by the VMR backflow but are not directly unrelated and can be checked in separately.
- Adds a support for a new XML element that will denote the last synchronization point of the repo with the VMR
    ```xml
    <?xml version="1.0" encoding="utf-8"?>
    <Dependencies>
      <Source Uri="https://github.com/dotnet/dotnet" Sha="86ba5fba7c39323011c2bfc6b713142affc76171" />
      <ProductDependencies>
        <Dependency Name="NETStandard.Library.Ref" Version="2.1.0" Pinned="true">
          <Uri>https://github.com/dotnet/core-setup</Uri>
          <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
        </Dependency>
      </ProductDependencies>
      <ToolsetDependencies>
        <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22426.1">
          <Uri>https://github.com/dotnet/arcade</Uri>
          <Sha>692746db3f08766bc29e91e826ff15e5e8a82b44</Sha>
          <SourceBuild RepoName="arcade" ManagedOnly="true" TarballOnly="true" />
        </Dependency>
      </ToolsetDependencies>
    </Dependencies>
    ```
- Also brings in some changes that will be needed for the VMR backflow changes later:
    - VMR update returns false when no changes to sync
    - Couple of local git calls added (reset working tree, blame in history)
    - Possibility to refresh source manifest information in the VMR
    - Other small improvements to the code and the tests

https://github.com/dotnet/arcade-services/issues/2996

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Adds a support for a new XML `Source` element in `Version.Details.xml`