### PR TITLE
Stop using a deprecated YamlDotNet package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -118,7 +118,6 @@
     <PackageVersion Include="System.Text.Encodings.Web" Version="7.0.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Verify.NUnit" Version="19.6" />
-    <PackageVersion Include="YamlDotNet" Version="9.1.4" />
-    <PackageVersion Include="YamlDotNet.Signed" Version="5.3.0" />
+    <PackageVersion Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Darc/Darc/Microsoft.DotNet.Darc.csproj
+++ b/src/Microsoft.DotNet.Darc/Darc/Microsoft.DotNet.Darc.csproj
@@ -21,6 +21,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="YamlDotNet.Signed" />
+    <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/3139

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Updated the `YamlDotNet` library