### PR TITLE
Resolve compiler messages in `ScenarioTests`, use `FluentAssertions`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -98,7 +98,7 @@
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="19.224.0-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.14" />
-    <PackageVersion Include="Moq" Version="4.20.69" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NuGet.Configuration" Version="6.7.0" />
     <PackageVersion Include="NuGet.Packaging" Version="6.7.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="CoreHealthMonitor" Version="$(CoreHealthMonitorVersion)" />
     <PackageVersion Include="EntityFrameworkCore.Triggers" Version="1.1.1" />
     <PackageVersion Include="FluentAssertions.Json" Version="5.5.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.11.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="8.6.2" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="LibGit2Sharp" Version="0.27.2" />
@@ -51,7 +51,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.1.0" />
-    <PackageVersion Include="Microsoft.CodeCoverage" Version="17.4.1" />
+    <PackageVersion Include="Microsoft.CodeCoverage" Version="17.8.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.4" />
     <PackageVersion Include="Microsoft.DncEng.CommandLineLib" Version="$(MicrosoftDncEngCommandLineLibVersion)" />
@@ -98,13 +98,13 @@
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="19.224.0-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.14" />
-    <PackageVersion Include="Moq" Version="4.8.3" />
+    <PackageVersion Include="Moq" Version="4.20.69" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NuGet.Configuration" Version="6.7.0" />
     <PackageVersion Include="NuGet.Packaging" Version="6.7.0" />
     <PackageVersion Include="NuGet.Protocol" Version="6.7.0" />
-    <PackageVersion Include="NUnit" Version="3.13.3" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageVersion Include="NUnit" Version="4.0.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="Octokit" Version="0.49.0" />
     <PackageVersion Include="ServiceFabricMocks" Version="$(ServiceFabricMocksVersion)" />
     <PackageVersion Include="System.Drawing.Common" Version="7.0.0" />

--- a/test/Maestro.ScenarioTests/AsyncDisposable.cs
+++ b/test/Maestro.ScenarioTests/AsyncDisposable.cs
@@ -5,26 +5,25 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+public class AsyncDisposable : IAsyncDisposable
 {
-    public class AsyncDisposable : IAsyncDisposable
+    private Func<ValueTask> _dispose;
+
+    public static IAsyncDisposable Create(Func<ValueTask> dispose)
     {
-        private Func<ValueTask> _dispose;
+        return new AsyncDisposable(dispose);
+    }
 
-        public static IAsyncDisposable Create(Func<ValueTask> dispose)
-        {
-            return new AsyncDisposable(dispose);
-        }
+    private AsyncDisposable(Func<ValueTask> dispose)
+    {
+        _dispose = dispose;
+    }
 
-        private AsyncDisposable(Func<ValueTask> dispose)
-        {
-            _dispose = dispose;
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            Func<ValueTask> dispose = Interlocked.Exchange(ref _dispose, null);
-            return dispose?.Invoke() ?? new ValueTask(Task.CompletedTask);
-        }
+    public ValueTask DisposeAsync()
+    {
+        Func<ValueTask> dispose = Interlocked.Exchange(ref _dispose, null);
+        return dispose?.Invoke() ?? new ValueTask(Task.CompletedTask);
     }
 }

--- a/test/Maestro.ScenarioTests/AsyncDisposableValue.cs
+++ b/test/Maestro.ScenarioTests/AsyncDisposableValue.cs
@@ -5,37 +5,36 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+public class AsyncDisposableValue<T> : IAsyncDisposable
 {
-    public class AsyncDisposableValue<T> : IAsyncDisposable
+    private Func<T, ValueTask> _dispose;
+
+    public T Value { get; }
+
+    internal AsyncDisposableValue(T value, Func<T, ValueTask> dispose)
     {
-        private Func<T, ValueTask> _dispose;
-
-        public T Value { get; }
-
-        internal AsyncDisposableValue(T value, Func<T, ValueTask> dispose)
-        {
-            Value = value;
-            _dispose = dispose;
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            Func<T, ValueTask> dispose = Interlocked.Exchange(ref _dispose, null);
-            return dispose?.Invoke(Value) ?? new ValueTask(Task.CompletedTask);
-        }
+        Value = value;
+        _dispose = dispose;
     }
 
-    public static class AsyncDisposableValue
+    public ValueTask DisposeAsync()
     {
-        public static AsyncDisposableValue<T> Create<T>(T value, Func<T, ValueTask> dispose)
-        {
-            return new AsyncDisposableValue<T>(value, dispose);
-        }
+        Func<T, ValueTask> dispose = Interlocked.Exchange(ref _dispose, null);
+        return dispose?.Invoke(Value) ?? new ValueTask(Task.CompletedTask);
+    }
+}
 
-        public static AsyncDisposableValue<T> Create<T>(T value, Func<ValueTask> dispose)
-        {
-            return new AsyncDisposableValue<T>(value, _ => dispose());
-        }
+public static class AsyncDisposableValue
+{
+    public static AsyncDisposableValue<T> Create<T>(T value, Func<T, ValueTask> dispose)
+    {
+        return new AsyncDisposableValue<T>(value, dispose);
+    }
+
+    public static AsyncDisposableValue<T> Create<T>(T value, Func<ValueTask> dispose)
+    {
+        return new AsyncDisposableValue<T>(value, _ => dispose());
     }
 }

--- a/test/Maestro.ScenarioTests/Disposable.cs
+++ b/test/Maestro.ScenarioTests/Disposable.cs
@@ -4,25 +4,24 @@
 using System;
 using System.Threading;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+public class Disposable : IDisposable
 {
-    public class Disposable : IDisposable
+    private Action _dispose;
+
+    public static IDisposable Create(Action dispose)
     {
-        private Action _dispose;
+        return new Disposable(dispose);
+    }
 
-        public static IDisposable Create(Action dispose)
-        {
-            return new Disposable(dispose);
-        }
+    private Disposable(Action dispose)
+    {
+        _dispose = dispose;
+    }
 
-        private Disposable(Action dispose)
-        {
-            _dispose = dispose;
-        }
-
-        public void Dispose()
-        {
-            Interlocked.Exchange(ref _dispose, null)?.Invoke();
-        }
+    public void Dispose()
+    {
+        Interlocked.Exchange(ref _dispose, null)?.Invoke();
     }
 }

--- a/test/Maestro.ScenarioTests/EndToEndFlowLogic.cs
+++ b/test/Maestro.ScenarioTests/EndToEndFlowLogic.cs
@@ -45,12 +45,12 @@ internal class EndToEndFlowLogic : MaestroScenarioTestBase
 
         TestContext.WriteLine($"Adding a subscription from {source1RepoName} to {targetRepoName}");
         await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionAsync(testChannelName, source1RepoName, targetRepoName, targetBranch,
-            UpdateFrequency.None.ToString(), "maestro-auth-test", additionalOptions: new List<string> { "--batchable" },
+            UpdateFrequency.None.ToString(), "maestro-auth-test", additionalOptions: ["--batchable"],
             sourceIsAzDo: isAzDoTest, targetIsAzDo: isAzDoTest);
 
         TestContext.WriteLine($"Adding a subscription from {source2RepoName} to {targetRepoName}");
         await using AsyncDisposableValue<string> subscription2Id = await CreateSubscriptionAsync(testChannelName, source2RepoName, targetRepoName, targetBranch,
-            UpdateFrequency.None.ToString(), "maestro-auth-test", additionalOptions: new List<string> { "--batchable" },
+            UpdateFrequency.None.ToString(), "maestro-auth-test", additionalOptions: ["--batchable"],
             sourceIsAzDo: isAzDoTest, targetIsAzDo: isAzDoTest);
 
         TestContext.WriteLine("Set up build1 for intake into target repository");
@@ -176,9 +176,9 @@ internal class EndToEndFlowLogic : MaestroScenarioTestBase
             await using (await CheckoutBranchAsync(targetBranch))
             {
                 TestContext.WriteLine("Adding dependencies to target repo");
-                await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
+                await AddDependenciesToLocalRepo(reposFolder.Directory, [.. sourceAssets], sourceRepoUri);
 
-                await AddDependenciesToLocalRepo(reposFolder.Directory, childSourceAssets.ToList(), childSourceRepoUri, coherentParent);
+                await AddDependenciesToLocalRepo(reposFolder.Directory, [.. childSourceAssets], childSourceRepoUri, coherentParent);
 
                 TestContext.WriteLine("Pushing branch to remote");
                 await GitCommitAsync("Add dependencies");
@@ -218,7 +218,7 @@ internal class EndToEndFlowLogic : MaestroScenarioTestBase
             targetBranch,
             UpdateFrequency.None.ToString(),
             "maestro-auth-test",
-            additionalOptions: new List<string> { "--validate-coherency" },
+            additionalOptions: ["--validate-coherency"],
             trigger: true,
             sourceIsAzDo: false,
             targetIsAzDo: false);
@@ -257,7 +257,7 @@ internal class EndToEndFlowLogic : MaestroScenarioTestBase
                     await RunGitAsync("checkout", targetBranch);
                     await RunGitAsync("pull", "origin", targetBranch);
 
-                    await AddDependenciesToLocalRepo(reposFolder.Directory, childSourceAssets.ToList(), childSourceRepoUri, coherentParent);
+                    await AddDependenciesToLocalRepo(reposFolder.Directory, [.. childSourceAssets], childSourceRepoUri, coherentParent);
                     await GitCommitAsync("Add dependencies 2");
 
                     await using (await PushGitBranchAsync("origin", targetBranch))
@@ -475,7 +475,7 @@ internal class EndToEndFlowLogic : MaestroScenarioTestBase
                 targetBranch,
                 UpdateFrequency.None.ToString(),
                 "maestro-auth-test",
-                additionalOptions: new List<string> { "--all-checks-passed", "--validate-coherency", "--ignore-checks", "license/cla" },
+                additionalOptions: ["--all-checks-passed", "--validate-coherency", "--ignore-checks", "license/cla"],
                 trigger: true,
                 sourceIsAzDo: isAzDoTest,
                 targetIsAzDo: isAzDoTest);

--- a/test/Maestro.ScenarioTests/EndToEndFlowLogic.cs
+++ b/test/Maestro.ScenarioTests/EndToEndFlowLogic.cs
@@ -9,484 +9,488 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client.Models;
 using NUnit.Framework;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+internal class EndToEndFlowLogic : MaestroScenarioTestBase
 {
-    public class EndToEndFlowLogic : MaestroScenarioTestBase
+    private const string SourceBuildNumber = "654321";
+    private const string Source2BuildNumber = "987654";
+    private readonly TestParameters _parameters;
+
+    public EndToEndFlowLogic(TestParameters parameters)
     {
-        private readonly string sourceBuildNumber = "654321";
-        private readonly string source2BuildNumber = "987654";
-        private readonly TestParameters _parameters;
+        _parameters = parameters;
+        SetTestParameters(_parameters);
+    }
 
-        public EndToEndFlowLogic(TestParameters parameters)
+    public async Task DarcBatchedFlowTestBase(
+        string targetBranch,
+        string channelName,
+        IImmutableList<AssetData> source1Assets,
+        IImmutableList<AssetData> source2Assets,
+        List<DependencyDetail> expectedDependencies,
+        bool isAzDoTest)
+    {
+        string source1RepoName = TestRepository.TestRepo1Name;
+        string source2RepoName = TestRepository.TestRepo3Name;
+        string targetRepoName = TestRepository.TestRepo2Name;
+
+        string testChannelName = channelName;
+        string source1RepoUri = isAzDoTest ? GetAzDoRepoUrl(source1RepoName) : GetGitHubRepoUrl(source1RepoName);
+        string source2RepoUri = isAzDoTest ? GetAzDoRepoUrl(source2RepoName) : GetGitHubRepoUrl(source2RepoName);
+        string targetRepoUri = isAzDoTest ? GetAzDoRepoUrl(targetRepoName) : GetGitHubRepoUrl(targetRepoName);
+
+        TestContext.WriteLine($"Creating test channel {testChannelName}");
+        await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
+
+        TestContext.WriteLine($"Adding a subscription from {source1RepoName} to {targetRepoName}");
+        await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionAsync(testChannelName, source1RepoName, targetRepoName, targetBranch,
+            UpdateFrequency.None.ToString(), "maestro-auth-test", additionalOptions: new List<string> { "--batchable" },
+            sourceIsAzDo: isAzDoTest, targetIsAzDo: isAzDoTest);
+
+        TestContext.WriteLine($"Adding a subscription from {source2RepoName} to {targetRepoName}");
+        await using AsyncDisposableValue<string> subscription2Id = await CreateSubscriptionAsync(testChannelName, source2RepoName, targetRepoName, targetBranch,
+            UpdateFrequency.None.ToString(), "maestro-auth-test", additionalOptions: new List<string> { "--batchable" },
+            sourceIsAzDo: isAzDoTest, targetIsAzDo: isAzDoTest);
+
+        TestContext.WriteLine("Set up build1 for intake into target repository");
+        Build build1 = await CreateBuildAsync(source1RepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, SourceBuildNumber, source1Assets);
+        await AddBuildToChannelAsync(build1.Id, testChannelName);
+
+        TestContext.WriteLine("Set up build2 for intake into target repository");
+        Build build2 = await CreateBuildAsync(source2RepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, SourceBuildNumber, source2Assets);
+        await AddBuildToChannelAsync(build2.Id, testChannelName);
+
+        TestContext.WriteLine("Cloning target repo to prepare the target branch");
+
+        TemporaryDirectory reposFolder = isAzDoTest ? await CloneAzDoRepositoryAsync(targetRepoName, targetBranch) : await CloneRepositoryAsync(targetRepoName);
+
+        using (ChangeDirectory(reposFolder.Directory))
         {
-            _parameters = parameters;
-            SetTestParameters(_parameters);
-        }
-
-        public async Task DarcBatchedFlowTestBase(string targetBranch, string channelName, IImmutableList<AssetData> source1Assets, IImmutableList<AssetData> source2Assets,
-            List<DependencyDetail> expectedDependencies, bool isAzDoTest)
-        {
-            string source1RepoName = TestRepository.TestRepo1Name;
-            string source2RepoName = TestRepository.TestRepo3Name;
-            string targetRepoName = TestRepository.TestRepo2Name;
-
-            string testChannelName = channelName;
-            string source1RepoUri = isAzDoTest ? GetAzDoRepoUrl(source1RepoName) : GetRepoUrl(source1RepoName);
-            string source2RepoUri = isAzDoTest ? GetAzDoRepoUrl(source2RepoName) : GetRepoUrl(source2RepoName);
-            string targetRepoUri = isAzDoTest ? GetAzDoRepoUrl(targetRepoName) : GetRepoUrl(targetRepoName);
-
-            TestContext.WriteLine($"Creating test channel {testChannelName}");
-            await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
-
-            TestContext.WriteLine($"Adding a subscription from {source1RepoName} to {targetRepoName}");
-            await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionAsync(testChannelName, source1RepoName, targetRepoName, targetBranch,
-                UpdateFrequency.None.ToString(), "maestro-auth-test", additionalOptions: new List<string> { "--batchable" },
-                sourceIsAzDo: isAzDoTest, targetIsAzDo: isAzDoTest);
-
-            TestContext.WriteLine($"Adding a subscription from {source2RepoName} to {targetRepoName}");
-            await using AsyncDisposableValue<string> subscription2Id = await CreateSubscriptionAsync(testChannelName, source2RepoName, targetRepoName, targetBranch,
-                UpdateFrequency.None.ToString(), "maestro-auth-test", additionalOptions: new List<string> { "--batchable" },
-                sourceIsAzDo: isAzDoTest, targetIsAzDo: isAzDoTest);
-
-            TestContext.WriteLine("Set up build1 for intake into target repository");
-            Build build1 = await CreateBuildAsync(source1RepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, sourceBuildNumber, source1Assets);
-            await AddBuildToChannelAsync(build1.Id, testChannelName);
-
-            TestContext.WriteLine("Set up build2 for intake into target repository");
-            Build build2 = await CreateBuildAsync(source2RepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, sourceBuildNumber, source2Assets);
-            await AddBuildToChannelAsync(build2.Id, testChannelName);
-
-            TestContext.WriteLine("Cloning target repo to prepare the target branch");
-
-            TemporaryDirectory reposFolder = isAzDoTest ? await CloneAzDoRepositoryAsync(targetRepoName, targetBranch) : await CloneRepositoryAsync(targetRepoName);
-
-            using (ChangeDirectory(reposFolder.Directory))
+            await using (await CheckoutBranchAsync(targetBranch))
             {
-                await using (await CheckoutBranchAsync(targetBranch))
+                TestContext.WriteLine("Adding dependencies to target repo");
+                await AddDependenciesToLocalRepo(reposFolder.Directory, source1Assets.ToList(), targetRepoUri);
+                await AddDependenciesToLocalRepo(reposFolder.Directory, source2Assets.ToList(), targetRepoUri);
+
+                TestContext.WriteLine("Pushing branch to remote");
+                await GitCommitAsync("Add dependencies");
+                await using (await PushGitBranchAsync("origin", targetBranch))
                 {
-                    TestContext.WriteLine("Adding dependencies to target repo");
-                    await AddDependenciesToLocalRepo(reposFolder.Directory, source1Assets.ToList(), targetRepoUri);
-                    await AddDependenciesToLocalRepo(reposFolder.Directory, source2Assets.ToList(), targetRepoUri);
+                    TestContext.WriteLine("Trigger the dependency update");
+                    await TriggerSubscriptionAsync(subscription1Id.Value);
+                    await TriggerSubscriptionAsync(subscription2Id.Value);
 
-                    TestContext.WriteLine("Pushing branch to remote");
-                    await GitCommitAsync("Add dependencies");
-                    await using (await PushGitBranchAsync("origin", targetBranch))
+                    TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
+
+                    if (isAzDoTest)
                     {
-                        TestContext.WriteLine("Trigger the dependency update");
-                        await TriggerSubscriptionAsync(subscription1Id.Value);
-                        await TriggerSubscriptionAsync(subscription2Id.Value);
-
-                        TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
-
-                        if (isAzDoTest)
-                        {
-                            await CheckBatchedAzDoPullRequest([source1RepoName, source2RepoName], targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory);
-                        }
-                        else
-                        {
-                            await CheckBatchedGitHubPullRequest(targetBranch, [source1RepoName, source2RepoName], targetRepoName, expectedDependencies, reposFolder.Directory);
-                        }
+                        await CheckBatchedAzDoPullRequest([source1RepoName, source2RepoName], targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory);
+                    }
+                    else
+                    {
+                        await CheckBatchedGitHubPullRequest(targetBranch, [source1RepoName, source2RepoName], targetRepoName, expectedDependencies, reposFolder.Directory);
                     }
                 }
             }
         }
+    }
 
-        public async Task NonBatchedGitHubFlowTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets,
-            List<DependencyDetail> expectedDependencies, bool allChecks = false)
+    public async Task NonBatchedGitHubFlowTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets,
+        List<DependencyDetail> expectedDependencies, bool allChecks = false)
+    {
+        string targetRepoName = TestRepository.TestRepo2Name;
+        string sourceRepoName = TestRepository.TestRepo1Name;
+
+        string testChannelName = channelName;
+        string sourceRepoUri = GetGitHubRepoUrl(sourceRepoName);
+        string targetRepoUri = GetGitHubRepoUrl(targetRepoName);
+
+        TestContext.WriteLine($"Creating test channel {testChannelName}");
+        await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
+
+        await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionForEndToEndTests(
+            testChannelName, sourceRepoName, targetRepoName, targetBranch, allChecks, false);
+
+        TestContext.WriteLine("Set up build for intake into target repository");
+        Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, SourceBuildNumber, sourceAssets);
+        await AddBuildToChannelAsync(build.Id, testChannelName);
+
+        TestContext.WriteLine("Cloning target repo to prepare the target branch");
+        TemporaryDirectory reposFolder = await CloneRepositoryAsync(targetRepoName);
+
+        using (ChangeDirectory(reposFolder.Directory))
         {
-            string targetRepoName = TestRepository.TestRepo2Name;
-            string sourceRepoName = TestRepository.TestRepo1Name;
-
-            string testChannelName = channelName;
-            string sourceRepoUri = GetRepoUrl(sourceRepoName);
-            string targetRepoUri = GetRepoUrl(targetRepoName);
-
-            TestContext.WriteLine($"Creating test channel {testChannelName}");
-            await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
-
-            await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionForEndToEndTests(
-                testChannelName, sourceRepoName, targetRepoName, targetBranch, allChecks, false);
-
-            TestContext.WriteLine("Set up build for intake into target repository");
-            Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, sourceBuildNumber, sourceAssets);
-            await AddBuildToChannelAsync(build.Id, testChannelName);
-
-            TestContext.WriteLine("Cloning target repo to prepare the target branch");
-            TemporaryDirectory reposFolder = await CloneRepositoryAsync(targetRepoName);
-
-            using (ChangeDirectory(reposFolder.Directory))
+            await using (await CheckoutBranchAsync(targetBranch))
             {
-                await using (await CheckoutBranchAsync(targetBranch))
+                TestContext.WriteLine("Adding dependencies to target repo");
+                await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
+
+                TestContext.WriteLine("Pushing branch to remote");
+                await GitCommitAsync("Add dependencies");
+
+                await using (await PushGitBranchAsync("origin", targetBranch))
                 {
-                    TestContext.WriteLine("Adding dependencies to target repo");
-                    await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
+                    TestContext.WriteLine("Trigger the dependency update");
+                    await TriggerSubscriptionAsync(subscription1Id.Value);
 
-                    TestContext.WriteLine("Pushing branch to remote");
-                    await GitCommitAsync("Add dependencies");
+                    TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
 
-                    await using (await PushGitBranchAsync("origin", targetBranch))
-                    {
-                        TestContext.WriteLine("Trigger the dependency update");
-                        await TriggerSubscriptionAsync(subscription1Id.Value);
-
-                        TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
-
-                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: true, isUpdated: false);
-                    }
+                    await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: true, isUpdated: false);
                 }
             }
         }
+    }
 
-        public async Task NonBatchedGitHubFlowCoherencyTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets,
-            IImmutableList<AssetData> childSourceAssets, List<DependencyDetail> expectedDependencies, string coherentParent, bool allChecks)
+    public async Task NonBatchedGitHubFlowCoherencyTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets,
+        IImmutableList<AssetData> childSourceAssets, List<DependencyDetail> expectedDependencies, string coherentParent, bool allChecks)
+    {
+        string targetRepoName = TestRepository.TestRepo3Name;
+        string sourceRepoName = TestRepository.TestRepo2Name;
+        string childRepoName = TestRepository.TestRepo1Name;
+
+        string testChannelName = channelName;
+        string sourceRepoUri = GetGitHubRepoUrl(sourceRepoName);
+        string targetRepoUri = GetGitHubRepoUrl(targetRepoName);
+        string childSourceRepoUri = GetGitHubRepoUrl(childRepoName);
+
+        TestContext.WriteLine($"Creating test channel {testChannelName}");
+        await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
+
+        await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionForEndToEndTests(
+            testChannelName, sourceRepoName, targetRepoName, targetBranch, allChecks, false);
+
+        TestContext.WriteLine("Set up build for intake into target repository");
+        Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, SourceBuildNumber, sourceAssets);
+        await AddBuildToChannelAsync(build.Id, testChannelName);
+
+        Build build2 = await CreateBuildAsync(childSourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo2Commit,
+            Source2BuildNumber, childSourceAssets);
+        await AddBuildToChannelAsync(build2.Id, testChannelName);
+
+        TestContext.WriteLine("Cloning target repo to prepare the target branch");
+        TemporaryDirectory reposFolder = await CloneRepositoryAsync(targetRepoName);
+
+        using (ChangeDirectory(reposFolder.Directory))
         {
-            string targetRepoName = TestRepository.TestRepo3Name;
-            string sourceRepoName = TestRepository.TestRepo2Name;
-            string childRepoName = TestRepository.TestRepo1Name;
-
-            string testChannelName = channelName;
-            string sourceRepoUri = GetRepoUrl(sourceRepoName);
-            string targetRepoUri = GetRepoUrl(targetRepoName);
-            string childSourceRepoUri = GetRepoUrl(childRepoName);
-
-            TestContext.WriteLine($"Creating test channel {testChannelName}");
-            await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
-
-            await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionForEndToEndTests(
-                testChannelName, sourceRepoName, targetRepoName, targetBranch, allChecks, false);
-
-            TestContext.WriteLine("Set up build for intake into target repository");
-            Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, sourceBuildNumber, sourceAssets);
-            await AddBuildToChannelAsync(build.Id, testChannelName);
-
-            Build build2 = await CreateBuildAsync(childSourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo2Commit,
-                source2BuildNumber, childSourceAssets);
-            await AddBuildToChannelAsync(build2.Id, testChannelName);
-
-            TestContext.WriteLine("Cloning target repo to prepare the target branch");
-            TemporaryDirectory reposFolder = await CloneRepositoryAsync(targetRepoName);
-
-            using (ChangeDirectory(reposFolder.Directory))
+            await using (await CheckoutBranchAsync(targetBranch))
             {
-                await using (await CheckoutBranchAsync(targetBranch))
+                TestContext.WriteLine("Adding dependencies to target repo");
+                await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
+
+                await AddDependenciesToLocalRepo(reposFolder.Directory, childSourceAssets.ToList(), childSourceRepoUri, coherentParent);
+
+                TestContext.WriteLine("Pushing branch to remote");
+                await GitCommitAsync("Add dependencies");
+
+                await using (await PushGitBranchAsync("origin", targetBranch)) {
+                    TestContext.WriteLine("Trigger the dependency update");
+                    await TriggerSubscriptionAsync(subscription1Id.Value);
+
+                    TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
+
+                    await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: allChecks, isUpdated: false);
+                }
+            }
+        }
+    }
+
+    public async Task NonBatchedGitHubFlowCoherencyOnlyTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets,
+        IImmutableList<AssetData> childSourceAssets, List<DependencyDetail> expectedNonCoherencyDependencies,
+        List<DependencyDetail> expectedCoherencyDependencies, string coherentParent)
+    {
+        string targetRepoName = TestRepository.TestRepo3Name;
+        string sourceRepoName = TestRepository.TestRepo2Name;
+        string childRepoName = TestRepository.TestRepo1Name;
+
+        string testChannelName = channelName;
+        string sourceRepoUri = GetGitHubRepoUrl(sourceRepoName);
+        string targetRepoUri = GetGitHubRepoUrl(targetRepoName);
+        string childSourceRepoUri = GetGitHubRepoUrl(childRepoName);
+
+        TestContext.WriteLine($"Creating test channel {testChannelName}");
+        await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
+
+        await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionAsync(
+            testChannelName,
+            sourceRepoName,
+            targetRepoName,
+            targetBranch,
+            UpdateFrequency.None.ToString(),
+            "maestro-auth-test",
+            additionalOptions: new List<string> { "--validate-coherency" },
+            trigger: true,
+            sourceIsAzDo: false,
+            targetIsAzDo: false);
+
+        TestContext.WriteLine("Set up build for intake into target repository");
+        Build build1 = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit,
+            SourceBuildNumber, sourceAssets);
+        await AddBuildToChannelAsync(build1.Id, testChannelName);
+
+        Build build2 = await CreateBuildAsync(childSourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo2Commit,
+            Source2BuildNumber, childSourceAssets);
+        await AddBuildToChannelAsync(build2.Id, testChannelName);
+
+        TestContext.WriteLine("Cloning target repo to prepare the target branch");
+        TemporaryDirectory reposFolder = await CloneRepositoryAsync(targetRepoName);
+
+        using (ChangeDirectory(reposFolder.Directory))
+        {
+            await using (await CheckoutBranchAsync(targetBranch))
+            {
+                TestContext.WriteLine("Adding dependencies to target repo");
+                await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
+
+                TestContext.WriteLine("Pushing branch to remote");
+                await GitCommitAsync("Add dependencies 1");
+
+                await using (await PushGitBranchAsync("origin", targetBranch))
                 {
-                    TestContext.WriteLine("Adding dependencies to target repo");
-                    await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
+                    TestContext.WriteLine("Trigger the dependency update");
+                    await TriggerSubscriptionAsync(subscription1Id.Value);
+
+                    TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
+
+                    await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedNonCoherencyDependencies, reposFolder.Directory, isCompleted: true, isUpdated: false);
+
+                    await RunGitAsync("checkout", targetBranch);
+                    await RunGitAsync("pull", "origin", targetBranch);
 
                     await AddDependenciesToLocalRepo(reposFolder.Directory, childSourceAssets.ToList(), childSourceRepoUri, coherentParent);
+                    await GitCommitAsync("Add dependencies 2");
 
-                    TestContext.WriteLine("Pushing branch to remote");
-                    await GitCommitAsync("Add dependencies");
-
-                    await using (await PushGitBranchAsync("origin", targetBranch)) {
+                    await using (await PushGitBranchAsync("origin", targetBranch))
+                    {
                         TestContext.WriteLine("Trigger the dependency update");
                         await TriggerSubscriptionAsync(subscription1Id.Value);
 
                         TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
 
-                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: allChecks, isUpdated: false);
+                        string expectedPRTitle = $"[{targetBranch}] Update dependencies to ensure coherency";
+                        await CheckGitHubPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedCoherencyDependencies, reposFolder.Directory, isCompleted: false, isUpdated: false);
                     }
                 }
             }
         }
+    }
 
-        public async Task NonBatchedGitHubFlowCoherencyOnlyTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets,
-            IImmutableList<AssetData> childSourceAssets, List<DependencyDetail> expectedNonCoherencyDependencies,
-            List<DependencyDetail> expectedCoherencyDependencies, string coherentParent)
+    public async Task NonBatchedUpdatingGitHubFlowTestBase(string targetBranch, string channelName, IImmutableList<AssetData> source1Assets, IImmutableList<AssetData> source1AssetsUpdated,
+        List<DependencyDetail> expectedDependencies, List<DependencyDetail> expectedUpdatedDependencies, bool allChecks = false)
+    {
+        string targetRepoName = TestRepository.TestRepo2Name;
+        string sourceRepoName = TestRepository.TestRepo1Name;
+        string sourceBranch = TestRepository.SourceBranch;
+
+        string testChannelName = channelName;
+        string sourceRepoUri = GetGitHubRepoUrl(sourceRepoName);
+        string targetRepoUri = GetGitHubRepoUrl(targetRepoName);
+
+        TestContext.WriteLine($"Creating test channel {testChannelName}");
+        await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
+
+        await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionForEndToEndTests(
+            testChannelName, sourceRepoName, targetRepoName, targetBranch, allChecks, false);
+
+        TestContext.WriteLine("Set up build for intake into target repository");
+        Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, SourceBuildNumber, source1Assets);
+        await AddBuildToChannelAsync(build.Id, testChannelName);
+
+        TestContext.WriteLine("Cloning target repo to prepare the target branch");
+        TemporaryDirectory reposFolder = await CloneRepositoryAsync(targetRepoName);
+
+        using (ChangeDirectory(reposFolder.Directory))
         {
-            string targetRepoName = TestRepository.TestRepo3Name;
-            string sourceRepoName = TestRepository.TestRepo2Name;
-            string childRepoName = TestRepository.TestRepo1Name;
+            await using (await CheckoutBranchAsync(targetBranch))
+            {
 
-            string testChannelName = channelName;
-            string sourceRepoUri = GetRepoUrl(sourceRepoName);
-            string targetRepoUri = GetRepoUrl(targetRepoName);
-            string childSourceRepoUri = GetRepoUrl(childRepoName);
+                TestContext.WriteLine("Adding dependencies to target repo");
+                await AddDependenciesToLocalRepo(reposFolder.Directory, source1Assets.ToList(), sourceRepoUri);
 
-            TestContext.WriteLine($"Creating test channel {testChannelName}");
-            await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
+                TestContext.WriteLine("Pushing branch to remote");
+                await GitCommitAsync("Add dependencies");
 
-            await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionAsync(
+                await using (await PushGitBranchAsync("origin", targetBranch))
+                {
+                    TestContext.WriteLine("Trigger the dependency update");
+                    await TriggerSubscriptionAsync(subscription1Id.Value);
+
+                    TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
+                    await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, allChecks);
+
+                    TestContext.WriteLine("Set up another build for intake into target repository");
+                    Build build2 = await CreateBuildAsync(sourceRepoUri, sourceBranch, TestRepository.CoherencyTestRepo2Commit, Source2BuildNumber, source1AssetsUpdated);
+
+                    TestContext.WriteLine("Trigger the dependency update");
+                    await TriggerSubscriptionAsync(subscription1Id.Value);
+
+                    TestContext.WriteLine($"Waiting for PR to be updated in {targetRepoUri}");
+                    await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedUpdatedDependencies, reposFolder.Directory, allChecks, true);
+
+                    // Then remove the second build from the channel, trigger the sub again, and it should revert back to the original dependency set
+                    TestContext.Write("Remove the build from the channel and verify that the original dependencies are restored");
+                    await DeleteBuildFromChannelAsync(build2.Id.ToString(), testChannelName);
+
+                    TestContext.WriteLine("Trigger the dependency update");
+                    await TriggerSubscriptionAsync(subscription1Id.Value);
+
+                    TestContext.WriteLine($"Waiting for PR to be updated in {targetRepoUri}");
+
+                    await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, allChecks, true);
+                }
+            }
+        }
+    }
+
+    public async Task NonBatchedUpdatingAzDoFlowTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets, IImmutableList<AssetData> updatedSourceAssets,
+        List<DependencyDetail> expectedDependencies, List<DependencyDetail> expectedUpdatedDependencies)
+    {
+        string targetRepoName = TestRepository.TestRepo2Name;
+        string sourceRepoName = TestRepository.TestRepo1Name;
+        string sourceBranch = TestRepository.SourceBranch;
+
+        string testChannelName = channelName;
+        string sourceRepoUri = GetAzDoRepoUrl(sourceRepoName);
+        string targetRepoUri = GetAzDoRepoUrl(targetRepoName);
+
+        TestContext.WriteLine($"Creating test channel {testChannelName}");
+        await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
+
+        await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionForEndToEndTests(
+            testChannelName, sourceRepoName, targetRepoName, targetBranch, false, true);
+
+        TestContext.WriteLine("Set up build for intake into target repository");
+        Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, SourceBuildNumber, sourceAssets);
+        await AddBuildToChannelAsync(build.Id, testChannelName);
+
+        TestContext.WriteLine("Cloning target repo to prepare the target branch");
+        TemporaryDirectory reposFolder = await CloneAzDoRepositoryAsync(targetRepoName, targetBranch);
+
+        using (ChangeDirectory(reposFolder.Directory))
+        {
+            await using (await CheckoutBranchAsync(targetBranch))
+            {
+                TestContext.WriteLine("Adding dependencies to target repo");
+                await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
+
+                TestContext.WriteLine("Pushing branch to remote");
+                await GitCommitAsync("Add dependencies");
+
+                await using (await PushGitBranchAsync("origin", targetBranch))
+                {
+                    TestContext.WriteLine("Trigger the dependency update");
+                    await TriggerSubscriptionAsync(subscription1Id.Value);
+
+                    TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
+                    await CheckNonBatchedAzDoPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: false, isUpdated: false);
+
+                    TestContext.WriteLine("Set up another build for intake into target repository");
+                    Build build2 = await CreateBuildAsync(sourceRepoUri, sourceBranch, TestRepository.CoherencyTestRepo2Commit, Source2BuildNumber, updatedSourceAssets);
+
+                    TestContext.WriteLine("Trigger the dependency update");
+                    await TriggerSubscriptionAsync(subscription1Id.Value);
+
+                    TestContext.WriteLine($"Waiting for PR to be updated in {targetRepoUri}");
+                    await CheckNonBatchedAzDoPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedUpdatedDependencies, reposFolder.Directory, isCompleted: false, isUpdated: true);
+
+                    // Then remove the second build from the channel, trigger the sub again, and it should revert back to the original dependency set
+                    TestContext.Write("Remove the build from the channel and verify that the original dependencies are restored");
+                    await DeleteBuildFromChannelAsync(build2.Id.ToString(), testChannelName);
+
+                    TestContext.WriteLine("Trigger the dependency update");
+                    await TriggerSubscriptionAsync(subscription1Id.Value);
+
+                    TestContext.WriteLine($"Waiting for PR to be updated in {targetRepoUri}");
+                    await CheckNonBatchedAzDoPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: false, isUpdated: true);
+                }
+            }
+        }
+    }
+
+    public async Task NonBatchedAzDoFlowTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets,
+        List<DependencyDetail> expectedDependencies, bool allChecks = false, bool isFeedTest = false, string[] expectedFeeds = null, string[] notExpectedFeeds = null)
+    {
+        string targetRepoName = TestRepository.TestRepo2Name;
+        string sourceRepoName = TestRepository.TestRepo1Name;
+
+        string testChannelName = channelName;
+        string sourceRepoUri = GetAzDoRepoUrl(sourceRepoName);
+        string targetRepoUri = GetAzDoRepoUrl(targetRepoName);
+
+        TestContext.WriteLine($"Creating test channel {testChannelName}");
+        await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
+
+        await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionForEndToEndTests(
+            testChannelName, sourceRepoName, targetRepoName, targetBranch, allChecks, true);
+
+        TestContext.WriteLine("Set up build for intake into target repository");
+        Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, SourceBuildNumber, sourceAssets);
+        await AddBuildToChannelAsync(build.Id, testChannelName);
+
+        TestContext.WriteLine("Cloning target repo to prepare the target branch");
+        TemporaryDirectory reposFolder = await CloneAzDoRepositoryAsync(targetRepoName, targetBranch);
+
+        using (ChangeDirectory(reposFolder.Directory))
+        {
+            await using (await CheckoutBranchAsync(targetBranch))
+            {
+                TestContext.WriteLine("Adding dependencies to target repo");
+                await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
+
+                TestContext.WriteLine("Pushing branch to remote");
+                await GitCommitAsync("Add dependencies");
+
+                await using (await PushGitBranchAsync("origin", targetBranch))
+                {
+                    TestContext.WriteLine("Trigger the dependency update");
+                    await TriggerSubscriptionAsync(subscription1Id.Value);
+
+                    TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
+
+                    if (allChecks)
+                    {
+                        await CheckNonBatchedAzDoPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: true, isUpdated: false);
+                        return;
+                    }
+
+                    if (isFeedTest)
+                    {
+                        await CheckNonBatchedAzDoPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: false, isUpdated: false, expectedFeeds: expectedFeeds, notExpectedFeeds: notExpectedFeeds);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    private async Task<AsyncDisposableValue<string>> CreateSubscriptionForEndToEndTests(string testChannelName, string sourceRepoName,
+        string targetRepoName, string targetBranch, bool allChecks, bool isAzDoTest)
+    {
+        if (allChecks)
+        {
+            return await CreateSubscriptionAsync(
                 testChannelName,
                 sourceRepoName,
                 targetRepoName,
                 targetBranch,
                 UpdateFrequency.None.ToString(),
                 "maestro-auth-test",
-                additionalOptions: new List<string> { "--validate-coherency" },
+                additionalOptions: new List<string> { "--all-checks-passed", "--validate-coherency", "--ignore-checks", "license/cla" },
                 trigger: true,
-                sourceIsAzDo: false,
-                targetIsAzDo: false);
-
-            TestContext.WriteLine("Set up build for intake into target repository");
-            Build build1 = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit,
-                sourceBuildNumber, sourceAssets);
-            await AddBuildToChannelAsync(build1.Id, testChannelName);
-
-            Build build2 = await CreateBuildAsync(childSourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo2Commit,
-                source2BuildNumber, childSourceAssets);
-            await AddBuildToChannelAsync(build2.Id, testChannelName);
-
-            TestContext.WriteLine("Cloning target repo to prepare the target branch");
-            TemporaryDirectory reposFolder = await CloneRepositoryAsync(targetRepoName);
-
-            using (ChangeDirectory(reposFolder.Directory))
-            {
-                await using (await CheckoutBranchAsync(targetBranch))
-                {
-                    TestContext.WriteLine("Adding dependencies to target repo");
-                    await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
-
-                    TestContext.WriteLine("Pushing branch to remote");
-                    await GitCommitAsync("Add dependencies 1");
-
-                    await using (await PushGitBranchAsync("origin", targetBranch))
-                    {
-                        TestContext.WriteLine("Trigger the dependency update");
-                        await TriggerSubscriptionAsync(subscription1Id.Value);
-
-                        TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
-
-                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedNonCoherencyDependencies, reposFolder.Directory, isCompleted: true, isUpdated: false);
-
-                        await RunGitAsync("checkout", targetBranch);
-                        await RunGitAsync("pull", "origin", targetBranch);
-
-                        await AddDependenciesToLocalRepo(reposFolder.Directory, childSourceAssets.ToList(), childSourceRepoUri, coherentParent);
-                        await GitCommitAsync("Add dependencies 2");
-
-                        await using (await PushGitBranchAsync("origin", targetBranch))
-                        {
-                            TestContext.WriteLine("Trigger the dependency update");
-                            await TriggerSubscriptionAsync(subscription1Id.Value);
-
-                            TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
-
-                            string expectedPRTitle = $"[{targetBranch}] Update dependencies to ensure coherency";
-                            await CheckGitHubPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedCoherencyDependencies, reposFolder.Directory, isCompleted: false, isUpdated: false);
-                        }
-                    }
-                }
-            }
+                sourceIsAzDo: isAzDoTest,
+                targetIsAzDo: isAzDoTest);
         }
-
-        public async Task NonBatchedUpdatingGitHubFlowTestBase(string targetBranch, string channelName, IImmutableList<AssetData> source1Assets, IImmutableList<AssetData> source1AssetsUpdated,
-            List<DependencyDetail> expectedDependencies, List<DependencyDetail> expectedUpdatedDependencies, bool allChecks = false)
+        else
         {
-            string targetRepoName = TestRepository.TestRepo2Name;
-            string sourceRepoName = TestRepository.TestRepo1Name;
-            string sourceBranch = TestRepository.SourceBranch;
-
-            string testChannelName = channelName;
-            string sourceRepoUri = GetRepoUrl(sourceRepoName);
-            string targetRepoUri = GetRepoUrl(targetRepoName);
-
-            TestContext.WriteLine($"Creating test channel {testChannelName}");
-            await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
-
-            await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionForEndToEndTests(
-                testChannelName, sourceRepoName, targetRepoName, targetBranch, allChecks, false);
-
-            TestContext.WriteLine("Set up build for intake into target repository");
-            Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, sourceBuildNumber, source1Assets);
-            await AddBuildToChannelAsync(build.Id, testChannelName);
-
-            TestContext.WriteLine("Cloning target repo to prepare the target branch");
-            TemporaryDirectory reposFolder = await CloneRepositoryAsync(targetRepoName);
-
-            using (ChangeDirectory(reposFolder.Directory))
-            {
-                await using (await CheckoutBranchAsync(targetBranch))
-                {
-
-                    TestContext.WriteLine("Adding dependencies to target repo");
-                    await AddDependenciesToLocalRepo(reposFolder.Directory, source1Assets.ToList(), sourceRepoUri);
-
-                    TestContext.WriteLine("Pushing branch to remote");
-                    await GitCommitAsync("Add dependencies");
-
-                    await using (await PushGitBranchAsync("origin", targetBranch))
-                    {
-                        TestContext.WriteLine("Trigger the dependency update");
-                        await TriggerSubscriptionAsync(subscription1Id.Value);
-
-                        TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
-                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, allChecks);
-
-                        TestContext.WriteLine("Set up another build for intake into target repository");
-                        Build build2 = await CreateBuildAsync(sourceRepoUri, sourceBranch, TestRepository.CoherencyTestRepo2Commit, source2BuildNumber, source1AssetsUpdated);
-
-                        TestContext.WriteLine("Trigger the dependency update");
-                        await TriggerSubscriptionAsync(subscription1Id.Value);
-
-                        TestContext.WriteLine($"Waiting for PR to be updated in {targetRepoUri}");
-                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedUpdatedDependencies, reposFolder.Directory, allChecks, true);
-
-                        // Then remove the second build from the channel, trigger the sub again, and it should revert back to the original dependency set
-                        TestContext.Write("Remove the build from the channel and verify that the original dependencies are restored");
-                        await DeleteBuildFromChannelAsync(build2.Id.ToString(), testChannelName);
-
-                        TestContext.WriteLine("Trigger the dependency update");
-                        await TriggerSubscriptionAsync(subscription1Id.Value);
-
-                        TestContext.WriteLine($"Waiting for PR to be updated in {targetRepoUri}");
-
-                        await CheckNonBatchedGitHubPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, allChecks, true);
-                    }
-                }
-            }
-        }
-
-        public async Task NonBatchedUpdatingAzDoFlowTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets, IImmutableList<AssetData> updatedSourceAssets,
-            List<DependencyDetail> expectedDependencies, List<DependencyDetail> expectedUpdatedDependencies)
-        {
-            string targetRepoName = TestRepository.TestRepo2Name;
-            string sourceRepoName = TestRepository.TestRepo1Name;
-            string sourceBranch = TestRepository.SourceBranch;
-
-            string testChannelName = channelName;
-            string sourceRepoUri = GetAzDoRepoUrl(sourceRepoName);
-            string targetRepoUri = GetAzDoRepoUrl(targetRepoName);
-
-            TestContext.WriteLine($"Creating test channel {testChannelName}");
-            await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
-
-            await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionForEndToEndTests(
-                testChannelName, sourceRepoName, targetRepoName, targetBranch, false, true);
-
-            TestContext.WriteLine("Set up build for intake into target repository");
-            Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, sourceBuildNumber, sourceAssets);
-            await AddBuildToChannelAsync(build.Id, testChannelName);
-
-            TestContext.WriteLine("Cloning target repo to prepare the target branch");
-            TemporaryDirectory reposFolder = await CloneAzDoRepositoryAsync(targetRepoName, targetBranch);
-
-            using (ChangeDirectory(reposFolder.Directory))
-            {
-                await using (await CheckoutBranchAsync(targetBranch))
-                {
-                    TestContext.WriteLine("Adding dependencies to target repo");
-                    await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
-
-                    TestContext.WriteLine("Pushing branch to remote");
-                    await GitCommitAsync("Add dependencies");
-
-                    await using (await PushGitBranchAsync("origin", targetBranch))
-                    {
-                        TestContext.WriteLine("Trigger the dependency update");
-                        await TriggerSubscriptionAsync(subscription1Id.Value);
-
-                        TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
-                        await CheckNonBatchedAzDoPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: false, isUpdated: false);
-
-                        TestContext.WriteLine("Set up another build for intake into target repository");
-                        Build build2 = await CreateBuildAsync(sourceRepoUri, sourceBranch, TestRepository.CoherencyTestRepo2Commit, source2BuildNumber, updatedSourceAssets);
-
-                        TestContext.WriteLine("Trigger the dependency update");
-                        await TriggerSubscriptionAsync(subscription1Id.Value);
-
-                        TestContext.WriteLine($"Waiting for PR to be updated in {targetRepoUri}");
-                        await CheckNonBatchedAzDoPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedUpdatedDependencies, reposFolder.Directory, isCompleted: false, isUpdated: true);
-
-                        // Then remove the second build from the channel, trigger the sub again, and it should revert back to the original dependency set
-                        TestContext.Write("Remove the build from the channel and verify that the original dependencies are restored");
-                        await DeleteBuildFromChannelAsync(build2.Id.ToString(), testChannelName);
-
-                        TestContext.WriteLine("Trigger the dependency update");
-                        await TriggerSubscriptionAsync(subscription1Id.Value);
-
-                        TestContext.WriteLine($"Waiting for PR to be updated in {targetRepoUri}");
-                        await CheckNonBatchedAzDoPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: false, isUpdated: true);
-                    }
-                }
-            }
-        }
-
-        public async Task NonBatchedAzDoFlowTestBase(string targetBranch, string channelName, IImmutableList<AssetData> sourceAssets,
-            List<DependencyDetail> expectedDependencies, bool allChecks = false, bool isFeedTest = false, string[] expectedFeeds = null, string[] notExpectedFeeds = null)
-        {
-            string targetRepoName = TestRepository.TestRepo2Name;
-            string sourceRepoName = TestRepository.TestRepo1Name;
-
-            string testChannelName = channelName;
-            string sourceRepoUri = GetAzDoRepoUrl(sourceRepoName);
-            string targetRepoUri = GetAzDoRepoUrl(targetRepoName);
-
-            TestContext.WriteLine($"Creating test channel {testChannelName}");
-            await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
-
-            await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionForEndToEndTests(
-                testChannelName, sourceRepoName, targetRepoName, targetBranch, allChecks, true);
-
-            TestContext.WriteLine("Set up build for intake into target repository");
-            Build build = await CreateBuildAsync(sourceRepoUri, TestRepository.SourceBranch, TestRepository.CoherencyTestRepo1Commit, sourceBuildNumber, sourceAssets);
-            await AddBuildToChannelAsync(build.Id, testChannelName);
-
-            TestContext.WriteLine("Cloning target repo to prepare the target branch");
-            TemporaryDirectory reposFolder = await CloneAzDoRepositoryAsync(targetRepoName, targetBranch);
-
-            using (ChangeDirectory(reposFolder.Directory))
-            {
-                await using (await CheckoutBranchAsync(targetBranch))
-                {
-                    TestContext.WriteLine("Adding dependencies to target repo");
-                    await AddDependenciesToLocalRepo(reposFolder.Directory, sourceAssets.ToList(), sourceRepoUri);
-
-                    TestContext.WriteLine("Pushing branch to remote");
-                    await GitCommitAsync("Add dependencies");
-
-                    await using (await PushGitBranchAsync("origin", targetBranch))
-                    {
-                        TestContext.WriteLine("Trigger the dependency update");
-                        await TriggerSubscriptionAsync(subscription1Id.Value);
-
-                        TestContext.WriteLine($"Waiting on PR to be opened in {targetRepoUri}");
-
-                        if (allChecks)
-                        {
-                            await CheckNonBatchedAzDoPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: true, isUpdated: false);
-                            return;
-                        }
-
-                        if (isFeedTest)
-                        {
-                            await CheckNonBatchedAzDoPullRequest(sourceRepoName, targetRepoName, targetBranch, expectedDependencies, reposFolder.Directory, isCompleted: false, isUpdated: false, expectedFeeds: expectedFeeds, notExpectedFeeds: notExpectedFeeds);
-                            return;
-                        }
-                    }
-                }
-            }
-        }
-
-        private async Task<AsyncDisposableValue<string>> CreateSubscriptionForEndToEndTests(string testChannelName, string sourceRepoName,
-            string targetRepoName, string targetBranch, bool allChecks, bool isAzDoTest)
-        {
-            if (allChecks)
-            {
-                return await CreateSubscriptionAsync(
-                    testChannelName,
-                    sourceRepoName,
-                    targetRepoName,
-                    targetBranch,
-                    UpdateFrequency.None.ToString(),
-                    "maestro-auth-test",
-                    additionalOptions: new List<string> { "--all-checks-passed", "--validate-coherency", "--ignore-checks", "license/cla" },
-                    trigger: true,
-                    sourceIsAzDo: isAzDoTest,
-                    targetIsAzDo: isAzDoTest);
-            }
-            else
-            {
-                return await CreateSubscriptionAsync(
-                    testChannelName,
-                    sourceRepoName,
-                    targetRepoName,
-                    targetBranch,
-                    UpdateFrequency.None.ToString(),
-                    "maestro-auth-test",
-                    sourceIsAzDo: isAzDoTest,
-                    targetIsAzDo: isAzDoTest);
-            }
+            return await CreateSubscriptionAsync(
+                testChannelName,
+                sourceRepoName,
+                targetRepoName,
+                targetBranch,
+                UpdateFrequency.None.ToString(),
+                "maestro-auth-test",
+                sourceIsAzDo: isAzDoTest,
+                targetIsAzDo: isAzDoTest);
         }
     }
 }

--- a/test/Maestro.ScenarioTests/Maestro.ScenarioTests.csproj
+++ b/test/Maestro.ScenarioTests/Maestro.ScenarioTests.csproj
@@ -15,6 +15,12 @@
     <ProjectReference Include="..\..\src\Microsoft.DotNet.Darc\DarcLib\Microsoft.DotNet.DarcLib.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.DotNet.Darc\Darc\Microsoft.DotNet.Darc.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="NUnit3TestAdapter">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
   <Target Name="PublishOnBuild" AfterTargets="Build" DependsOnTargets="Publish">
   </Target>

--- a/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
+++ b/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
@@ -309,7 +309,7 @@ internal class MaestroScenarioTestBase
 
         Microsoft.DotNet.DarcLib.PrStatus expectedPRState = isCompleted ? Microsoft.DotNet.DarcLib.PrStatus.Closed : Microsoft.DotNet.DarcLib.PrStatus.Open;
         var prStatus = await AzDoClient.GetPullRequestStatusAsync(GetAzDoApiRepoUrl(targetRepoName) + $"/pullRequests/{pullRequestId}");
-        Assert.AreEqual(expectedPRState, prStatus);
+        prStatus.Should().Be(expectedPRState);
 
         using (ChangeDirectory(repoDirectory))
         {
@@ -340,7 +340,7 @@ internal class MaestroScenarioTestBase
             var actualDependencies = await RunDarcAsync("get-dependencies");
             var expectedDependenciesString = DependencyCollectionStringBuilder.GetString(expectedDependencies);
 
-            Assert.AreEqual(expectedDependenciesString, actualDependencies, $"Expected: {expectedDependenciesString} \r\n Actual: {actualDependencies}");
+            actualDependencies.Should().Be(expectedDependenciesString);
         }
     }
 

--- a/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
+++ b/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
@@ -22,509 +22,530 @@ using NuGet.Configuration;
 using NUnit.Framework;
 using Octokit;
 
+namespace Maestro.ScenarioTests;
 
-namespace Maestro.ScenarioTests
+internal class MaestroScenarioTestBase
 {
-    public class MaestroScenarioTestBase
+    private TestParameters _parameters;
+
+    protected IMaestroApi MaestroApi => _parameters.MaestroApi;
+
+    protected GitHubClient GitHubApi => _parameters.GitHubApi;
+
+    protected Microsoft.DotNet.DarcLib.AzureDevOpsClient AzDoClient => _parameters.AzDoClient;
+
+    public MaestroScenarioTestBase()
     {
-        private TestParameters _parameters;
+    }
 
-        public IMaestroApi MaestroApi => _parameters.MaestroApi;
+    public void SetTestParameters(TestParameters parameters)
+    {
+        _parameters = parameters;
+    }
 
-        public GitHubClient GitHubApi => _parameters.GitHubApi;
+    protected async Task<PullRequest> WaitForPullRequestAsync(string targetRepo, string targetBranch)
+    {
+        Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepo);
 
-        public Microsoft.DotNet.DarcLib.AzureDevOpsClient AzDoClient => _parameters.AzDoClient;
-
-        public MaestroScenarioTestBase()
+        var attempts = 10;
+        while (attempts-- > 0)
         {
-        }
-
-        public void SetTestParameters(TestParameters parameters)
-        {
-            _parameters = parameters;
-        }
-
-        public async Task<PullRequest> WaitForPullRequestAsync(string targetRepo, string targetBranch)
-        {
-            Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepo).ConfigureAwait(false);
-
-            var attempts = 10;
-            while (attempts-- > 0)
+            IReadOnlyList<PullRequest> prs = await GitHubApi.PullRequest.GetAllForRepository(repo.Id, new PullRequestRequest
             {
-                IReadOnlyList<PullRequest> prs = await GitHubApi.PullRequest.GetAllForRepository(repo.Id, new PullRequestRequest
-                {
-                    State = ItemStateFilter.Open,
-                    Base = targetBranch,
-                }).ConfigureAwait(false);
-                if (prs.Count == 1)
-                {
-                    return prs[0];
-                }
-                if (prs.Count > 1)
-                {
-                    throw new MaestroTestException($"More than one pull request found in {targetRepo} targeting {targetBranch}");
-                }
-
-                await Task.Delay(60 * 1000).ConfigureAwait(false);
-            }
-
-            throw new MaestroTestException($"No pull request was created in {targetRepo} targeting {targetBranch}");
-        }
-
-        public async Task<PullRequest> WaitForUpdatedPullRequestAsync(string targetRepo, string targetBranch, int attempts = 7)
-        {
-            Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepo).ConfigureAwait(false);
-            PullRequest pr = await WaitForPullRequestAsync(targetRepo, targetBranch);
-
-            while (attempts-- > 0)
-            {
-                pr = await GitHubApi.PullRequest.Get(repo.Id, pr.Number);
-
-                if (pr.CreatedAt != pr.UpdatedAt)
-                {
-                    return pr;
-                }
-
-                await Task.Delay(60 * 1000).ConfigureAwait(false);
-            }
-
-            throw new MaestroTestException($"The created pull request for {targetRepo} targeting {targetBranch} was not updated with subsequent subscriptions after creation");
-        }
-
-        public async Task<bool> WaitForMergedPullRequestAsync(string targetRepo, string targetBranch, int attempts = 7)
-        {
-            Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepo).ConfigureAwait(false);
-            PullRequest pr = await WaitForPullRequestAsync(targetRepo, targetBranch);
-
-            while (attempts-- > 0)
-            {
-                TestContext.WriteLine($"Starting check for merge, attempts remaining {attempts}");
-                pr = await GitHubApi.PullRequest.Get(repo.Id, pr.Number);
-
-                if (pr.Merged == true)
-                {
-                    return true;
-                }
-
-                await Task.Delay(60 * 1000).ConfigureAwait(false);
-            }
-
-            throw new MaestroTestException($"The created pull request for {targetRepo} targeting {targetBranch} was not merged within {attempts} minutes");
-        }
-
-        private async Task<int> GetAzDoPullRequestIdAsync(string targetRepoName, string targetBranch)
-        {
-            string searchBaseUrl = GetAzDoRepoUrl(targetRepoName);
-            string apiBaseUrl = GetAzDoApiRepoUrl(targetRepoName);
-            IEnumerable<int> prs = new List<int>();
-
-            int attempts = 10;
-            while (attempts-- > 0)
-            {
-                try
-                {
-                    prs = await SearchPullRequestsAsync(searchBaseUrl, targetBranch).ConfigureAwait(false);
-                }
-                catch (HttpRequestException ex)
-                {
-                    // Returning a 404 is expected before the PR has been created
-                    NUnitLogger logger = new NUnitLogger();
-                    logger.LogInformation($"Searching for AzDo pull requests returned an error: {ex.Message}");
-                }
-
-                if (prs.Count() == 1)
-                {
-                    return prs.FirstOrDefault();
-                }
-
-                if (prs.Count() > 1)
-                {
-                    throw new MaestroTestException($"More than one pull request found in {targetRepoName} targeting {targetBranch}");
-                }
-
-                await Task.Delay(60 * 1000).ConfigureAwait(false);
-            }
-
-            throw new MaestroTestException($"No pull request was created in {searchBaseUrl} targeting {targetBranch}");
-        }
-
-        private async Task<IEnumerable<int>> SearchPullRequestsAsync(string repoUri, string targetPullRequestBranch)
-        {
-            (string accountName, string projectName, string repoName) = Microsoft.DotNet.DarcLib.AzureDevOpsClient.ParseRepoUri(repoUri);
-            var query = new StringBuilder();
-
-            Microsoft.DotNet.DarcLib.AzureDevOpsPrStatus prStatus = Microsoft.DotNet.DarcLib.AzureDevOpsPrStatus.Active;
-            query.Append($"searchCriteria.status={prStatus.ToString().ToLower()}");
-            query.Append($"&searchCriteria.targetRefName=refs/heads/{targetPullRequestBranch}");
-
-            JObject content = await _parameters.AzDoClient.ExecuteAzureDevOpsAPIRequestAsync(
-                HttpMethod.Get,
-                accountName,
-                projectName,
-                $"_apis/git/repositories/{repoName}/pullrequests?{query}",
-                new NUnitLogger()
-                );
-
-            IEnumerable<int> prs = content.Value<JArray>("value").Select(r => r.Value<int>("pullRequestId"));
-
-            return prs;
-        }
-
-        internal async Task<AsyncDisposableValue<Microsoft.DotNet.DarcLib.PullRequest>> GetAzDoPullRequestAsync(int pullRequestId, string targetRepoName, string targetBranch, bool isUpdated, string expectedPRTitle = null)
-        {
-            string repoUri = GetAzDoRepoUrl(targetRepoName);
-            (string accountName, string projectName, string repoName) = Microsoft.DotNet.DarcLib.AzureDevOpsClient.ParseRepoUri(repoUri);
-            string apiBaseUrl = GetAzDoApiRepoUrl(targetRepoName);
-
-            if (string.IsNullOrEmpty(expectedPRTitle))
-            {
-                throw new Exception($"{nameof(expectedPRTitle)} must be defined for AzDo PRs that require an update");
-            }
-
-            for (int tries = 10; tries > 0; tries--)
-            {
-                Microsoft.DotNet.DarcLib.PullRequest pr = await AzDoClient.GetPullRequestAsync($"{apiBaseUrl}/pullRequests/{pullRequestId}");
-                string trimmedTitle = Regex.Replace(pr.Title, @"\s+", " ");
-
-                if (!isUpdated || trimmedTitle == expectedPRTitle)
-                {
-                    return AsyncDisposableValue.Create(pr, async () =>
-                    {
-                        TestContext.WriteLine($"Cleaning up pull request {pr.Title}");
-
-                        try
-                        {
-                            JObject content = await _parameters.AzDoClient.ExecuteAzureDevOpsAPIRequestAsync(
-                                    HttpMethod.Patch,
-                                    accountName,
-                                    projectName,
-                                    $"_apis/git/repositories/{targetRepoName}/pullrequests/{pullRequestId}",
-                                    new NUnitLogger(),
-                                    "{ \"status\" : \"abandoned\"}"
-                                    );
-                        }
-                        catch
-                        {
-                            // If this throws it means that it was cleaned up by a different clean up method first
-                        }
-                    });
-                }
-
-                await Task.Delay(60 * 1000).ConfigureAwait(false);
-            }
-
-            throw new MaestroTestException($"The created pull request for {targetRepoName} targeting {targetBranch} was not updated with subsequent subscriptions after creation");
-        }
-
-        public async Task CheckBatchedGitHubPullRequest(string targetBranch, string[] sourceRepoNames,
-            string targetRepoName, List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies, string repoDirectory)
-        {
-            var repoNames = sourceRepoNames
-                .Select(name => $"{_parameters.GitHubTestOrg}/{name}")
-                .OrderBy(s => s);
-
-            string expectedPRTitle = $"[{targetBranch}] Update dependencies from {string.Join(", ", repoNames)}";
-            await CheckGitHubPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedDependencies, repoDirectory, false, true);
-        }
-
-        public async Task CheckNonBatchedGitHubPullRequest(string sourceRepoName, string targetRepoName, string targetBranch,
-            List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies, string repoDirectory, bool isCompleted = false, bool isUpdated = false)
-        {
-            string expectedPRTitle = $"[{targetBranch}] Update dependencies from {_parameters.GitHubTestOrg}/{sourceRepoName}";
-            await CheckGitHubPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedDependencies, repoDirectory, isCompleted, isUpdated);
-        }
-
-        public async Task CheckGitHubPullRequest(string expectedPRTitle, string targetRepoName, string targetBranch,
-            List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies, string repoDirectory, bool isCompleted, bool isUpdated)
-        {
-            TestContext.WriteLine($"Checking opened PR in {targetBranch} {targetRepoName}");
-            PullRequest pullRequest = isUpdated
-                ? await WaitForUpdatedPullRequestAsync(targetRepoName, targetBranch)
-                : await WaitForPullRequestAsync(targetRepoName, targetBranch);
-
-            pullRequest.Title.Should().Be(expectedPRTitle);
-
-            using (ChangeDirectory(repoDirectory))
-            {
-                await ValidatePullRequestDependencies(targetRepoName, pullRequest.Head.Ref, expectedDependencies);
-
-                if (isCompleted)
-                {
-                    TestContext.WriteLine($"Checking for automatic merging of PR in {targetBranch} {targetRepoName}");
-
-                    await WaitForMergedPullRequestAsync(targetRepoName, targetBranch);
-                }
-            }
-        }
-
-        public async Task CheckBatchedAzDoPullRequest(
-            string[] sourceRepoNames,
-            string targetRepoName,
-            string targetBranch,
-            List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies,
-            string repoDirectory,
-            bool complete = false)
-        {
-            var repoNames = sourceRepoNames
-                .Select(n => $"{_parameters.AzureDevOpsAccount}/{_parameters.AzureDevOpsProject}/{n}")
-                .OrderBy(s => s);
-
-            string expectedPRTitle = $"[{targetBranch}] Update dependencies from {string.Join(", ", repoNames)}";
-            await CheckAzDoPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedDependencies, repoDirectory, complete, true, null, null);
-        }
-
-        public async Task CheckNonBatchedAzDoPullRequest(string sourceRepoName, string targetRepoName, string targetBranch,
-            List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies, string repoDirectory, bool isCompleted = false, bool isUpdated = false,
-            string[] expectedFeeds = null, string[] notExpectedFeeds = null)
-        {
-            string expectedPRTitle = $"[{targetBranch}] Update dependencies from {_parameters.AzureDevOpsAccount}/{_parameters.AzureDevOpsProject}/{sourceRepoName}";
-            await CheckAzDoPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedDependencies, repoDirectory, false, isUpdated, expectedFeeds, notExpectedFeeds);
-        }
-
-        public async Task CheckAzDoPullRequest(string expectedPRTitle, string targetRepoName, string targetBranch,
-            List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies, string repoDirectory, bool isCompleted, bool isUpdated,
-            string[] expectedFeeds, string[] notExpectedFeeds)
-        {
-            string targetRepoUri = GetAzDoApiRepoUrl(targetRepoName);
-            TestContext.WriteLine($"Checking Opened PR in {targetBranch} {targetRepoUri} ...");
-            int pullRequestId = await GetAzDoPullRequestIdAsync(targetRepoName, targetBranch);
-            await using AsyncDisposableValue<Microsoft.DotNet.DarcLib.PullRequest> pullRequest = await GetAzDoPullRequestAsync(pullRequestId, targetRepoName, targetBranch, isUpdated, expectedPRTitle);
-
-            string trimmedTitle = Regex.Replace(pullRequest.Value.Title, @"\s+", " ");
-            trimmedTitle.Should().Be(expectedPRTitle);
-
-            Microsoft.DotNet.DarcLib.PrStatus expectedPRState = isCompleted ? Microsoft.DotNet.DarcLib.PrStatus.Closed : Microsoft.DotNet.DarcLib.PrStatus.Open;
-            var prStatus = await AzDoClient.GetPullRequestStatusAsync(GetAzDoApiRepoUrl(targetRepoName) + $"/pullRequests/{pullRequestId}");
-            Assert.AreEqual(expectedPRState, prStatus);
-
-            using (ChangeDirectory(repoDirectory))
-            {
-                await ValidatePullRequestDependencies(targetRepoName, pullRequest.Value.HeadBranch, expectedDependencies);
-
-                if (expectedFeeds != null && notExpectedFeeds != null)
-                {
-                    TestContext.WriteLine("Validating Nuget feeds in PR branch");
-
-                    ISettings settings = Settings.LoadSpecificSettings(@"./", "nuget.config");
-                    PackageSourceProvider packageSourceProvider = new PackageSourceProvider(settings);
-                    IEnumerable<string> sources = packageSourceProvider.LoadPackageSources().Select(p => p.Source);
-
-                    sources.Should().Contain(expectedFeeds);
-                    sources.Should().NotContain(notExpectedFeeds);
-                }
-            }
-        }
-
-        public async Task ValidatePullRequestDependencies(string targetRepoName, string pullRequestBaseBranch, List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies, int tries = 1)
-        {
-            int triesRemaining = tries;
-            while (triesRemaining-- > 0)
-            {
-                await CheckoutRemoteBranchAsync(pullRequestBaseBranch).ConfigureAwait(false);
-                await RunGitAsync("pull").ConfigureAwait(false);
-
-                string actualDependencies = await RunDarcAsync("get-dependencies").ConfigureAwait(false);
-                string expectedDependenciesString = DependencyCollectionStringBuilder.GetString(expectedDependencies);
-
-                Assert.AreEqual(expectedDependenciesString, actualDependencies, $"Expected: {expectedDependenciesString} \r\n Actual: {actualDependencies}");
-            }
-        }
-
-        public async Task GitCommitAsync(string message)
-        {
-            await RunGitAsync("commit", "-am", message);
-        }
-
-        public async Task<IAsyncDisposable> PushGitBranchAsync(string remote, string branch)
-        {
-            await RunGitAsync("push", "-u", remote, branch);
-            return AsyncDisposable.Create(async () =>
-            {
-                TestContext.WriteLine($"Cleaning up Remote branch {branch}");
-
-                try
-                {
-                    await RunGitAsync("push", remote, "--delete", branch);
-                }
-                catch
-                {
-                    // If this throws it means that it was cleaned up by a different clean up method first
-                }
+                State = ItemStateFilter.Open,
+                Base = targetBranch,
             });
-        }
-
-        public string GetRepoUrl(string org, string repository)
-        {
-            return $"https://github.com/{org}/{repository}";
-        }
-
-        public string GetRepoUrl(string repository)
-        {
-            return GetRepoUrl(_parameters.GitHubTestOrg, repository);
-        }
-
-        public string GetRepoFetchUrl(string repository)
-        {
-            return GetRepoFetchUrl(_parameters.GitHubTestOrg, repository);
-        }
-
-        public string GetRepoFetchUrl(string org, string repository)
-        {
-            return $"https://{_parameters.GitHubUser}:{_parameters.GitHubToken}@github.com/{org}/{repository}";
-        }
-
-        public string GetAzDoRepoUrl(string repoName, string azdoAccount = "dnceng", string azdoProject = "internal")
-        {
-            return $"https://dev.azure.com/{azdoAccount}/{azdoProject}/_git/{repoName}";
-        }
-
-        public string GetAzDoApiRepoUrl(string repoName, string azdoAccount = "dnceng", string azdoProject = "internal")
-        {
-            return $"https://dev.azure.com/{azdoAccount}/{azdoProject}/_apis/git/repositories/{repoName}";
-        }
-
-        public Task<string> RunDarcAsyncWithInput(string input, params string[] args)
-        {
-            return TestHelpers.RunExecutableAsyncWithInput(_parameters.DarcExePath, input, args.Concat(new[]
+            if (prs.Count == 1)
             {
-                "-p", _parameters.MaestroToken,
-                "--bar-uri", _parameters.MaestroBaseUri,
-                "--github-pat", _parameters.GitHubToken,
-                "--azdev-pat", _parameters.AzDoToken,
-            }).ToArray());
-        }
-
-        public Task<string> RunDarcAsync(params string[] args)
-        {
-            return TestHelpers.RunExecutableAsync(_parameters.DarcExePath, args.Concat(new[]
+                return prs[0];
+            }
+            if (prs.Count > 1)
             {
-                "-p", _parameters.MaestroToken,
-                "--bar-uri", _parameters.MaestroBaseUri,
-                "--github-pat", _parameters.GitHubToken,
-                "--azdev-pat", _parameters.AzDoToken,
-            }).ToArray());
+                throw new MaestroTestException($"More than one pull request found in {targetRepo} targeting {targetBranch}");
+            }
+
+            await Task.Delay(60 * 1000);
         }
 
-        public Task<string> RunGitAsync(params string[] args)
+        throw new MaestroTestException($"No pull request was created in {targetRepo} targeting {targetBranch}");
+    }
+
+    private async Task<PullRequest> WaitForUpdatedPullRequestAsync(string targetRepo, string targetBranch, int attempts = 7)
+    {
+        Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepo);
+        PullRequest pr = await WaitForPullRequestAsync(targetRepo, targetBranch);
+
+        while (attempts-- > 0)
         {
-            return TestHelpers.RunExecutableAsync(_parameters.GitExePath, args);
+            pr = await GitHubApi.PullRequest.Get(repo.Id, pr.Number);
+
+            if (pr.CreatedAt != pr.UpdatedAt)
+            {
+                return pr;
+            }
+
+            await Task.Delay(60 * 1000);
         }
 
-        public async Task<AsyncDisposableValue<string>> CreateTestChannelAsync(string testChannelName)
+        throw new MaestroTestException($"The created pull request for {targetRepo} targeting {targetBranch} was not updated with subsequent subscriptions after creation");
+    }
+
+    private async Task<bool> WaitForMergedPullRequestAsync(string targetRepo, string targetBranch, int attempts = 7)
+    {
+        Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepo);
+        PullRequest pr = await WaitForPullRequestAsync(targetRepo, targetBranch);
+
+        while (attempts-- > 0)
         {
-            string message = "";
+            TestContext.WriteLine($"Starting check for merge, attempts remaining {attempts}");
+            pr = await GitHubApi.PullRequest.Get(repo.Id, pr.Number);
+
+            if (pr.Merged == true)
+            {
+                return true;
+            }
+
+            await Task.Delay(60 * 1000);
+        }
+
+        throw new MaestroTestException($"The created pull request for {targetRepo} targeting {targetBranch} was not merged within {attempts} minutes");
+    }
+
+    private async Task<int> GetAzDoPullRequestIdAsync(string targetRepoName, string targetBranch)
+    {
+        string searchBaseUrl = GetAzDoRepoUrl(targetRepoName);
+        string apiBaseUrl = GetAzDoApiRepoUrl(targetRepoName);
+        IEnumerable<int> prs = new List<int>();
+
+        int attempts = 10;
+        while (attempts-- > 0)
+        {
+            try
+            {
+                prs = await SearchPullRequestsAsync(searchBaseUrl, targetBranch);
+            }
+            catch (HttpRequestException ex)
+            {
+                // Returning a 404 is expected before the PR has been created
+                NUnitLogger logger = new NUnitLogger();
+                logger.LogInformation($"Searching for AzDo pull requests returned an error: {ex.Message}");
+            }
+
+            if (prs.Count() == 1)
+            {
+                return prs.FirstOrDefault();
+            }
+
+            if (prs.Count() > 1)
+            {
+                throw new MaestroTestException($"More than one pull request found in {targetRepoName} targeting {targetBranch}");
+            }
+
+            await Task.Delay(60 * 1000);
+        }
+
+        throw new MaestroTestException($"No pull request was created in {searchBaseUrl} targeting {targetBranch}");
+    }
+
+    private async Task<IEnumerable<int>> SearchPullRequestsAsync(string repoUri, string targetPullRequestBranch)
+    {
+        (string accountName, string projectName, string repoName) = Microsoft.DotNet.DarcLib.AzureDevOpsClient.ParseRepoUri(repoUri);
+        var query = new StringBuilder();
+
+        Microsoft.DotNet.DarcLib.AzureDevOpsPrStatus prStatus = Microsoft.DotNet.DarcLib.AzureDevOpsPrStatus.Active;
+        query.Append($"searchCriteria.status={prStatus.ToString().ToLower()}");
+        query.Append($"&searchCriteria.targetRefName=refs/heads/{targetPullRequestBranch}");
+
+        JObject content = await _parameters.AzDoClient.ExecuteAzureDevOpsAPIRequestAsync(
+            HttpMethod.Get,
+            accountName,
+            projectName,
+            $"_apis/git/repositories/{repoName}/pullrequests?{query}",
+            new NUnitLogger()
+            );
+
+        IEnumerable<int> prs = content.Value<JArray>("value").Select(r => r.Value<int>("pullRequestId"));
+
+        return prs;
+    }
+
+    private async Task<AsyncDisposableValue<Microsoft.DotNet.DarcLib.PullRequest>> GetAzDoPullRequestAsync(int pullRequestId, string targetRepoName, string targetBranch, bool isUpdated, string expectedPRTitle = null)
+    {
+        string repoUri = GetAzDoRepoUrl(targetRepoName);
+        (string accountName, string projectName, string repoName) = Microsoft.DotNet.DarcLib.AzureDevOpsClient.ParseRepoUri(repoUri);
+        string apiBaseUrl = GetAzDoApiRepoUrl(targetRepoName);
+
+        if (string.IsNullOrEmpty(expectedPRTitle))
+        {
+            throw new Exception($"{nameof(expectedPRTitle)} must be defined for AzDo PRs that require an update");
+        }
+
+        for (int tries = 10; tries > 0; tries--)
+        {
+            Microsoft.DotNet.DarcLib.PullRequest pr = await AzDoClient.GetPullRequestAsync($"{apiBaseUrl}/pullRequests/{pullRequestId}");
+            string trimmedTitle = Regex.Replace(pr.Title, @"\s+", " ");
+
+            if (!isUpdated || trimmedTitle == expectedPRTitle)
+            {
+                return AsyncDisposableValue.Create(pr, async () =>
+                {
+                    TestContext.WriteLine($"Cleaning up pull request {pr.Title}");
+
+                    try
+                    {
+                        JObject content = await _parameters.AzDoClient.ExecuteAzureDevOpsAPIRequestAsync(
+                                HttpMethod.Patch,
+                                accountName,
+                                projectName,
+                                $"_apis/git/repositories/{targetRepoName}/pullrequests/{pullRequestId}",
+                                new NUnitLogger(),
+                                "{ \"status\" : \"abandoned\"}"
+                                );
+                    }
+                    catch
+                    {
+                        // If this throws it means that it was cleaned up by a different clean up method first
+                    }
+                });
+            }
+
+            await Task.Delay(60 * 1000);
+        }
+
+        throw new MaestroTestException($"The created pull request for {targetRepoName} targeting {targetBranch} was not updated with subsequent subscriptions after creation");
+    }
+
+    protected async Task CheckBatchedGitHubPullRequest(string targetBranch, string[] sourceRepoNames,
+        string targetRepoName, List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies, string repoDirectory)
+    {
+        var repoNames = sourceRepoNames
+            .Select(name => $"{_parameters.GitHubTestOrg}/{name}")
+            .OrderBy(s => s);
+
+        string expectedPRTitle = $"[{targetBranch}] Update dependencies from {string.Join(", ", repoNames)}";
+        await CheckGitHubPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedDependencies, repoDirectory, false, true);
+    }
+
+    protected async Task CheckNonBatchedGitHubPullRequest(string sourceRepoName, string targetRepoName, string targetBranch,
+        List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies, string repoDirectory, bool isCompleted = false, bool isUpdated = false)
+    {
+        string expectedPRTitle = $"[{targetBranch}] Update dependencies from {_parameters.GitHubTestOrg}/{sourceRepoName}";
+        await CheckGitHubPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedDependencies, repoDirectory, isCompleted, isUpdated);
+    }
+
+    protected async Task CheckGitHubPullRequest(string expectedPRTitle, string targetRepoName, string targetBranch,
+        List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies, string repoDirectory, bool isCompleted, bool isUpdated)
+    {
+        TestContext.WriteLine($"Checking opened PR in {targetBranch} {targetRepoName}");
+        PullRequest pullRequest = isUpdated
+            ? await WaitForUpdatedPullRequestAsync(targetRepoName, targetBranch)
+            : await WaitForPullRequestAsync(targetRepoName, targetBranch);
+
+        pullRequest.Title.Should().Be(expectedPRTitle);
+
+        using (ChangeDirectory(repoDirectory))
+        {
+            await ValidatePullRequestDependencies(targetRepoName, pullRequest.Head.Ref, expectedDependencies);
+
+            if (isCompleted)
+            {
+                TestContext.WriteLine($"Checking for automatic merging of PR in {targetBranch} {targetRepoName}");
+
+                await WaitForMergedPullRequestAsync(targetRepoName, targetBranch);
+            }
+        }
+    }
+
+    protected async Task CheckBatchedAzDoPullRequest(
+        string[] sourceRepoNames,
+        string targetRepoName,
+        string targetBranch,
+        List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies,
+        string repoDirectory,
+        bool complete = false)
+    {
+        var repoNames = sourceRepoNames
+            .Select(n => $"{_parameters.AzureDevOpsAccount}/{_parameters.AzureDevOpsProject}/{n}")
+            .OrderBy(s => s);
+
+        string expectedPRTitle = $"[{targetBranch}] Update dependencies from {string.Join(", ", repoNames)}";
+        await CheckAzDoPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedDependencies, repoDirectory, complete, true, null, null);
+    }
+
+    protected async Task CheckNonBatchedAzDoPullRequest(string sourceRepoName, string targetRepoName, string targetBranch,
+        List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies, string repoDirectory, bool isCompleted = false, bool isUpdated = false,
+        string[] expectedFeeds = null, string[] notExpectedFeeds = null)
+    {
+        string expectedPRTitle = $"[{targetBranch}] Update dependencies from {_parameters.AzureDevOpsAccount}/{_parameters.AzureDevOpsProject}/{sourceRepoName}";
+        await CheckAzDoPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedDependencies, repoDirectory, false, isUpdated, expectedFeeds, notExpectedFeeds);
+    }
+
+    protected async Task CheckAzDoPullRequest(string expectedPRTitle, string targetRepoName, string targetBranch,
+        List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies, string repoDirectory, bool isCompleted, bool isUpdated,
+        string[] expectedFeeds, string[] notExpectedFeeds)
+    {
+        string targetRepoUri = GetAzDoApiRepoUrl(targetRepoName);
+        TestContext.WriteLine($"Checking Opened PR in {targetBranch} {targetRepoUri} ...");
+        int pullRequestId = await GetAzDoPullRequestIdAsync(targetRepoName, targetBranch);
+        await using AsyncDisposableValue<Microsoft.DotNet.DarcLib.PullRequest> pullRequest = await GetAzDoPullRequestAsync(pullRequestId, targetRepoName, targetBranch, isUpdated, expectedPRTitle);
+
+        string trimmedTitle = Regex.Replace(pullRequest.Value.Title, @"\s+", " ");
+        trimmedTitle.Should().Be(expectedPRTitle);
+
+        Microsoft.DotNet.DarcLib.PrStatus expectedPRState = isCompleted ? Microsoft.DotNet.DarcLib.PrStatus.Closed : Microsoft.DotNet.DarcLib.PrStatus.Open;
+        var prStatus = await AzDoClient.GetPullRequestStatusAsync(GetAzDoApiRepoUrl(targetRepoName) + $"/pullRequests/{pullRequestId}");
+        Assert.AreEqual(expectedPRState, prStatus);
+
+        using (ChangeDirectory(repoDirectory))
+        {
+            await ValidatePullRequestDependencies(targetRepoName, pullRequest.Value.HeadBranch, expectedDependencies);
+
+            if (expectedFeeds != null && notExpectedFeeds != null)
+            {
+                TestContext.WriteLine("Validating Nuget feeds in PR branch");
+
+                ISettings settings = Settings.LoadSpecificSettings(@"./", "nuget.config");
+                PackageSourceProvider packageSourceProvider = new PackageSourceProvider(settings);
+                IEnumerable<string> sources = packageSourceProvider.LoadPackageSources().Select(p => p.Source);
+
+                sources.Should().Contain(expectedFeeds);
+                sources.Should().NotContain(notExpectedFeeds);
+            }
+        }
+    }
+
+    protected async Task ValidatePullRequestDependencies(string targetRepoName, string pullRequestBaseBranch, List<Microsoft.DotNet.DarcLib.DependencyDetail> expectedDependencies, int tries = 1)
+    {
+        int triesRemaining = tries;
+        while (triesRemaining-- > 0)
+        {
+            await CheckoutRemoteBranchAsync(pullRequestBaseBranch);
+            await RunGitAsync("pull");
+
+            string actualDependencies = await RunDarcAsync("get-dependencies");
+            string expectedDependenciesString = DependencyCollectionStringBuilder.GetString(expectedDependencies);
+
+            Assert.AreEqual(expectedDependenciesString, actualDependencies, $"Expected: {expectedDependenciesString} \r\n Actual: {actualDependencies}");
+        }
+    }
+
+    protected async Task GitCommitAsync(string message)
+    {
+        await RunGitAsync("commit", "-am", message);
+    }
+
+    protected async Task<IAsyncDisposable> PushGitBranchAsync(string remote, string branch)
+    {
+        await RunGitAsync("push", "-u", remote, branch);
+        return AsyncDisposable.Create(async () =>
+        {
+            TestContext.WriteLine($"Cleaning up Remote branch {branch}");
 
             try
             {
-                message = await RunDarcAsync("delete-channel", "--name", testChannelName).ConfigureAwait(false);
+                await RunGitAsync("push", remote, "--delete", branch);
+            }
+            catch
+            {
+                // If this throws it means that it was cleaned up by a different clean up method first
+            }
+        });
+    }
+
+    protected static string GetRepoUrl(string org, string repository)
+    {
+        return $"https://github.com/{org}/{repository}";
+    }
+
+    protected string GetGitHubRepoUrl(string repository)
+    {
+        return GetRepoUrl(_parameters.GitHubTestOrg, repository);
+    }
+
+    protected string GetRepoFetchUrl(string repository)
+    {
+        return GetRepoFetchUrl(_parameters.GitHubTestOrg, repository);
+    }
+
+    protected string GetRepoFetchUrl(string org, string repository)
+    {
+        return $"https://{_parameters.GitHubUser}:{_parameters.GitHubToken}@github.com/{org}/{repository}";
+    }
+
+    protected static string GetAzDoRepoUrl(string repoName, string azdoAccount = "dnceng", string azdoProject = "internal")
+    {
+        return $"https://dev.azure.com/{azdoAccount}/{azdoProject}/_git/{repoName}";
+    }
+
+    protected static string GetAzDoApiRepoUrl(string repoName, string azdoAccount = "dnceng", string azdoProject = "internal")
+    {
+        return $"https://dev.azure.com/{azdoAccount}/{azdoProject}/_apis/git/repositories/{repoName}";
+    }
+
+    protected Task<string> RunDarcAsyncWithInput(string input, params string[] args)
+    {
+        return TestHelpers.RunExecutableAsyncWithInput(_parameters.DarcExePath, input, args.Concat(new[]
+        {
+            "-p", _parameters.MaestroToken,
+            "--bar-uri", _parameters.MaestroBaseUri,
+            "--github-pat", _parameters.GitHubToken,
+            "--azdev-pat", _parameters.AzDoToken,
+        }).ToArray());
+    }
+
+    protected Task<string> RunDarcAsync(params string[] args)
+    {
+        return TestHelpers.RunExecutableAsync(_parameters.DarcExePath, args.Concat(new[]
+        {
+            "-p", _parameters.MaestroToken,
+            "--bar-uri", _parameters.MaestroBaseUri,
+            "--github-pat", _parameters.GitHubToken,
+            "--azdev-pat", _parameters.AzDoToken,
+        }).ToArray());
+    }
+
+    protected Task<string> RunGitAsync(params string[] args)
+    {
+        return TestHelpers.RunExecutableAsync(_parameters.GitExePath, args);
+    }
+
+    protected async Task<AsyncDisposableValue<string>> CreateTestChannelAsync(string testChannelName)
+    {
+        string message = "";
+
+        try
+        {
+            message = await RunDarcAsync("delete-channel", "--name", testChannelName);
+        }
+        catch (MaestroTestException)
+        {
+            // If there are subscriptions associated the the channel then a previous test clean up failed
+            // Run a subscription clean up and try again
+            try
+            {
+                await DeleteSubscriptionsForChannel(testChannelName);
+                await RunDarcAsync("delete-channel", "--name", testChannelName);
             }
             catch (MaestroTestException)
             {
-                // If there are subscriptions associated the the channel then a previous test clean up failed
-                // Run a subscription clean up and try again
-                try
-                {
-                    await DeleteSubscriptionsForChannel(testChannelName).ConfigureAwait(false);
-                    await RunDarcAsync("delete-channel", "--name", testChannelName).ConfigureAwait(false);
-                }
-                catch (MaestroTestException)
-                {
-                    // Otherwise ignore failures from delete-channel, its just a pre-cleanup that isn't really part of the test
-                    // And if the test previously succeeded then it'll fail because the channel doesn't exist
-                }
-            }
-
-            await RunDarcAsync("add-channel", "--name", testChannelName, "--classification", "test").ConfigureAwait(false);
-
-            return AsyncDisposableValue.Create(testChannelName, async () =>
-            {
-                TestContext.WriteLine($"Cleaning up Test Channel {testChannelName}");
-                try
-                {
-                    string doubleDelete = await RunDarcAsync("delete-channel", "--name", testChannelName).ConfigureAwait(false);
-                }
-                catch (MaestroTestException)
-                {
-                    // Ignore failures from delete-channel on cleanup, this delete is here to ensure that the channel is deleted
-                    // even if the test does not do an explicit delete as part of the test. Other failures are typical that the channel has already been deleted.
-                }
-            });
-        }
-        public async Task AddDependenciesToLocalRepo(string repoPath, string name, string repoUri, bool isToolset = false)
-        {
-            using (ChangeDirectory(repoPath))
-            {
-                await RunDarcAsync(new string[] { "add-dependency", "--name", name, "--type", isToolset ? "toolset" : "product", "--repo", repoUri, "--version", "0.0.1" });
+                // Otherwise ignore failures from delete-channel, its just a pre-cleanup that isn't really part of the test
+                // And if the test previously succeeded then it'll fail because the channel doesn't exist
             }
         }
-        public async Task<string> GetTestChannelsAsync()
+
+        await RunDarcAsync("add-channel", "--name", testChannelName, "--classification", "test");
+
+        return AsyncDisposableValue.Create(testChannelName, async () =>
         {
-            return await RunDarcAsync("get-channels").ConfigureAwait(false);
-        }
-
-        public async Task DeleteTestChannelAsync(string testChannelName)
-        {
-            await RunDarcAsync("delete-channel", "--name", testChannelName).ConfigureAwait(false);
-        }
-
-        public async Task<string> AddDefaultTestChannelAsync(string testChannelName, string repoUri, string branchName)
-        {
-            return await RunDarcAsync("add-default-channel", "--channel", testChannelName, "--repo", repoUri, "--branch", branchName, "-q").ConfigureAwait(false);
-        }
-
-        public async Task<string> GetDefaultTestChannelsAsync(string repoUri, string branch)
-        {
-            return await RunDarcAsync("get-default-channels", "--source-repo", repoUri, "--branch", branch).ConfigureAwait(false);
-        }
-
-        public async Task DeleteDefaultTestChannelAsync(string testChannelName, string repoUri, string branch)
-        {
-            await RunDarcAsync("delete-default-channel", "--channel", testChannelName, "--repo", repoUri, "--branch", branch).ConfigureAwait(false);
-        }
-
-        public async Task<AsyncDisposableValue<string>> CreateSubscriptionAsync(
-            string sourceChannelName,
-            string sourceRepo,
-            string targetRepo,
-            string targetBranch,
-            string updateFrequency,
-            string sourceOrg = "dotnet",
-            List<string> additionalOptions = null,
-            bool sourceIsAzDo = false,
-            bool targetIsAzDo = false,
-            bool trigger = false)
-        {
-            string sourceUrl = sourceIsAzDo ? GetAzDoRepoUrl(sourceRepo) : GetRepoUrl(sourceOrg, sourceRepo);
-            string targetUrl = targetIsAzDo ? GetAzDoRepoUrl(targetRepo) : GetRepoUrl(targetRepo);
-
-            string[] command = {"add-subscription", "-q",
-                "--channel", sourceChannelName,
-                "--source-repo", sourceUrl,
-                "--target-repo", targetUrl,
-                "--target-branch", targetBranch,
-                "--update-frequency", updateFrequency,
-                trigger? "--trigger" : "--no-trigger"};
-
-            if (additionalOptions != null)
+            TestContext.WriteLine($"Cleaning up Test Channel {testChannelName}");
+            try
             {
-                command = command.Concat(additionalOptions).ToArray();
+                string doubleDelete = await RunDarcAsync("delete-channel", "--name", testChannelName);
             }
-
-            string output = await RunDarcAsync(command).ConfigureAwait(false);
-
-            Match match = Regex.Match(output, "Successfully created new subscription with id '([a-f0-9-]+)'");
-            if (!match.Success)
+            catch (MaestroTestException)
             {
-                throw new MaestroTestException("Unable to create subscription.");
+                // Ignore failures from delete-channel on cleanup, this delete is here to ensure that the channel is deleted
+                // even if the test does not do an explicit delete as part of the test. Other failures are typical that the channel has already been deleted.
             }
+        });
+    }
+    protected async Task AddDependenciesToLocalRepo(string repoPath, string name, string repoUri, bool isToolset = false)
+    {
+        using (ChangeDirectory(repoPath))
+        {
+            await RunDarcAsync(new string[] { "add-dependency", "--name", name, "--type", isToolset ? "toolset" : "product", "--repo", repoUri, "--version", "0.0.1" });
+        }
+    }
+    protected async Task<string> GetTestChannelsAsync()
+    {
+        return await RunDarcAsync("get-channels");
+    }
 
+    protected async Task DeleteTestChannelAsync(string testChannelName)
+    {
+        await RunDarcAsync("delete-channel", "--name", testChannelName);
+    }
+
+    protected async Task<string> AddDefaultTestChannelAsync(string testChannelName, string repoUri, string branchName)
+    {
+        return await RunDarcAsync("add-default-channel", "--channel", testChannelName, "--repo", repoUri, "--branch", branchName, "-q");
+    }
+
+    protected async Task<string> GetDefaultTestChannelsAsync(string repoUri, string branch)
+    {
+        return await RunDarcAsync("get-default-channels", "--source-repo", repoUri, "--branch", branch);
+    }
+
+    protected async Task DeleteDefaultTestChannelAsync(string testChannelName, string repoUri, string branch)
+    {
+        await RunDarcAsync("delete-default-channel", "--channel", testChannelName, "--repo", repoUri, "--branch", branch);
+    }
+
+    protected async Task<AsyncDisposableValue<string>> CreateSubscriptionAsync(
+        string sourceChannelName,
+        string sourceRepo,
+        string targetRepo,
+        string targetBranch,
+        string updateFrequency,
+        string sourceOrg = "dotnet",
+        List<string> additionalOptions = null,
+        bool sourceIsAzDo = false,
+        bool targetIsAzDo = false,
+        bool trigger = false)
+    {
+        string sourceUrl = sourceIsAzDo ? GetAzDoRepoUrl(sourceRepo) : GetRepoUrl(sourceOrg, sourceRepo);
+        string targetUrl = targetIsAzDo ? GetAzDoRepoUrl(targetRepo) : GetGitHubRepoUrl(targetRepo);
+
+        string[] command = {"add-subscription", "-q",
+            "--channel", sourceChannelName,
+            "--source-repo", sourceUrl,
+            "--target-repo", targetUrl,
+            "--target-branch", targetBranch,
+            "--update-frequency", updateFrequency,
+            trigger? "--trigger" : "--no-trigger"};
+
+        if (additionalOptions != null)
+        {
+            command = command.Concat(additionalOptions).ToArray();
+        }
+
+        string output = await RunDarcAsync(command);
+
+        Match match = Regex.Match(output, "Successfully created new subscription with id '([a-f0-9-]+)'");
+        if (!match.Success)
+        {
+            throw new MaestroTestException("Unable to create subscription.");
+        }
+
+        string subscriptionId = match.Groups[1].Value;
+        return AsyncDisposableValue.Create(subscriptionId, async () =>
+        {
+            TestContext.WriteLine($"Cleaning up Test Subscription {subscriptionId}");
+            try
+            {
+                await RunDarcAsync("delete-subscriptions", "--id", subscriptionId, "--quiet");
+            }
+            catch (MaestroTestException)
+            {
+                // If this throws an exception the most likely cause is that the subscription was deleted as part of the test case
+            }
+        });
+    }
+
+    protected async Task<AsyncDisposableValue<string>> CreateSubscriptionAsync(string yamlDefinition)
+    {
+        string output = await RunDarcAsyncWithInput(yamlDefinition, "add-subscription", "-q", "--read-stdin", "--no-trigger");
+
+        Match match = Regex.Match(output, "Successfully created new subscription with id '([a-f0-9-]+)'");
+        if (match.Success)
+        {
             string subscriptionId = match.Groups[1].Value;
             return AsyncDisposableValue.Create(subscriptionId, async () =>
             {
                 TestContext.WriteLine($"Cleaning up Test Subscription {subscriptionId}");
                 try
                 {
-                    await RunDarcAsync("delete-subscriptions", "--id", subscriptionId, "--quiet").ConfigureAwait(false);
+                    await RunDarcAsync("delete-subscriptions", "--id", subscriptionId, "--quiet");
                 }
                 catch (MaestroTestException)
                 {
@@ -533,400 +554,377 @@ namespace Maestro.ScenarioTests
             });
         }
 
-        public async Task<AsyncDisposableValue<string>> CreateSubscriptionAsync(string yamlDefinition)
-        {
-            string output = await RunDarcAsyncWithInput(yamlDefinition, "add-subscription", "-q", "--read-stdin", "--no-trigger").ConfigureAwait(false);
+        throw new MaestroTestException("Unable to create subscription.");
+    }
 
-            Match match = Regex.Match(output, "Successfully created new subscription with id '([a-f0-9-]+)'");
-            if (match.Success)
+    protected async Task<string> GetSubscriptionInfo(string subscriptionId)
+    {
+        return await RunDarcAsync("get-subscriptions", "--ids", subscriptionId);
+    }
+
+    protected async Task<string> GetSubscriptions(string channelName)
+    {
+        return await RunDarcAsync("get-subscriptions", "--channel", channelName);
+    }
+
+    protected async Task ValidateSubscriptionInfo(string subscriptionId, string expectedSubscriptionInfo)
+    {
+        string subscriptionInfo = await GetSubscriptionInfo(subscriptionId);
+        StringAssert.AreEqualIgnoringCase(expectedSubscriptionInfo, subscriptionInfo);
+    }
+
+    protected async Task SetSubscriptionStatus(bool enableSub, string subscriptionId = null, string channelName = null)
+    {
+        string actionToTake = enableSub ? "--enable" : "-d";
+
+        if (channelName != null)
+        {
+            await RunDarcAsync("subscription-status", actionToTake, "--channel", channelName, "--quiet");
+        }
+        else
+        {
+            await RunDarcAsync("subscription-status", "--id", subscriptionId, actionToTake, "--quiet");
+        }
+    }
+
+    protected async Task<string> DeleteSubscriptionsForChannel(string channelName)
+    {
+        return await RunDarcAsync("delete-subscriptions", "--channel", channelName, "--quiet");
+    }
+
+    protected async Task<string> DeleteSubscriptionById(string subscriptionId)
+    {
+        return await RunDarcAsync("delete-subscriptions", "--id", subscriptionId, "--quiet");
+    }
+
+    protected Task<Build> CreateBuildAsync(string repositoryUrl, string branch, string commit, string buildNumber, IImmutableList<AssetData> assets)
+    {
+        return CreateBuildAsync(repositoryUrl, branch, commit, buildNumber, assets, ImmutableList<BuildRef>.Empty);
+    }
+
+    protected async Task<Build> CreateBuildAsync(string repositoryUrl, string branch, string commit, string buildNumber, IImmutableList<AssetData> assets, IImmutableList<BuildRef> dependencies)
+    {
+        Build build = await MaestroApi.Builds.CreateAsync(new BuildData(
+            commit: commit,
+            azureDevOpsAccount: _parameters.AzureDevOpsAccount,
+            azureDevOpsProject: _parameters.AzureDevOpsProject,
+            azureDevOpsBuildNumber: buildNumber,
+            azureDevOpsRepository: repositoryUrl,
+            azureDevOpsBranch: branch,
+            released: false,
+            stable: false)
+        {
+            AzureDevOpsBuildId = _parameters.AzureDevOpsBuildId,
+            AzureDevOpsBuildDefinitionId = _parameters.AzureDevOpsBuildDefinitionId,
+            GitHubRepository = repositoryUrl,
+            GitHubBranch = branch,
+            Assets = assets,
+            Dependencies = dependencies,
+        });
+
+        return build;
+    }
+
+    protected async Task<string> GetDarcBuildAsync(int buildId)
+    {
+        string buildString = await RunDarcAsync("get-build", "--id", buildId.ToString());
+        return buildString;
+    }
+
+    protected async Task<string> UpdateBuildAsync(int buildId, string updateParams)
+    {
+        string buildString = await RunDarcAsync("update-build", "--id", buildId.ToString(), updateParams);
+        return buildString;
+    }
+
+    protected async Task AddDependenciesToLocalRepo(string repoPath, List<AssetData> dependencies, string repoUri, string coherentParent = "")
+    {
+        using (ChangeDirectory(repoPath))
+        {
+            foreach (AssetData asset in dependencies)
             {
-                string subscriptionId = match.Groups[1].Value;
-                return AsyncDisposableValue.Create(subscriptionId, async () =>
+                List<string> parameters = new List<string>() { "add-dependency", "--name", asset.Name, "--type", "product", "--repo", repoUri };
+
+                if (!String.IsNullOrEmpty(coherentParent))
                 {
-                    TestContext.WriteLine($"Cleaning up Test Subscription {subscriptionId}");
-                    try
-                    {
-                        await RunDarcAsync("delete-subscriptions", "--id", subscriptionId, "--quiet").ConfigureAwait(false);
-                    }
-                    catch (MaestroTestException)
-                    {
-                        // If this throws an exception the most likely cause is that the subscription was deleted as part of the test case
-                    }
-                });
-            }
+                    parameters.Add("--coherent-parent");
+                    parameters.Add(coherentParent);
+                }
+                string[] parameterArr = parameters.ToArray();
 
-            throw new MaestroTestException("Unable to create subscription.");
-        }
-
-        public async Task<string> GetSubscriptionInfo(string subscriptionId)
-        {
-            return await RunDarcAsync("get-subscriptions", "--ids", subscriptionId).ConfigureAwait(false);
-        }
-
-        public async Task<string> GetSubscriptions(string channelName)
-        {
-            return await RunDarcAsync("get-subscriptions", "--channel", channelName);
-        }
-
-        public async Task ValidateSubscriptionInfo(string subscriptionId, string expectedSubscriptionInfo)
-        {
-            string subscriptionInfo = await GetSubscriptionInfo(subscriptionId);
-            StringAssert.AreEqualIgnoringCase(expectedSubscriptionInfo, subscriptionInfo);
-        }
-
-        public async Task SetSubscriptionStatus(bool enableSub, string subscriptionId = null, string channelName = null)
-        {
-            string actionToTake = enableSub ? "--enable" : "-d";
-
-            if (channelName != null)
-            {
-                await RunDarcAsync("subscription-status", actionToTake, "--channel", channelName, "--quiet").ConfigureAwait(false);
-            }
-            else
-            {
-                await RunDarcAsync("subscription-status", "--id", subscriptionId, actionToTake, "--quiet").ConfigureAwait(false);
+                await RunDarcAsync(parameterArr);
             }
         }
+    }
 
-        public async Task<string> DeleteSubscriptionsForChannel(string channelName)
+    protected async Task<string> GatherDrop(int buildId, string outputDir, bool includeReleased, string extraAssetsRegex)
+    {
+        string[] args = new[] { "gather-drop", "--id", buildId.ToString(), "--dry-run", "--output-dir", outputDir };
+
+        if (includeReleased)
         {
-            return await RunDarcAsync("delete-subscriptions", "--channel", channelName, "--quiet");
+            args = args.Append("--include-released").ToArray();
         }
 
-        public async Task<string> DeleteSubscriptionById(string subscriptionId)
+        if (!string.IsNullOrEmpty(extraAssetsRegex))
         {
-            return await RunDarcAsync("delete-subscriptions", "--id", subscriptionId, "--quiet").ConfigureAwait(false);
+            args = args.Append($"--always-download-asset-filters").Append(extraAssetsRegex).ToArray();
         }
 
-        public Task<Build> CreateBuildAsync(string repositoryUrl, string branch, string commit, string buildNumber, IImmutableList<AssetData> assets)
+        return await RunDarcAsync(args);
+    }
+
+    protected async Task TriggerSubscriptionAsync(string subscriptionId)
+    {
+        await MaestroApi.Subscriptions.TriggerSubscriptionAsync(Guid.Parse(subscriptionId));
+    }
+
+    protected async Task<IAsyncDisposable> AddBuildToChannelAsync(int buildId, string channelName)
+    {
+        await RunDarcAsync("add-build-to-channel", "--id", buildId.ToString(), "--channel", channelName, "--skip-assets-publishing");
+        return AsyncDisposable.Create(async () =>
         {
-            return CreateBuildAsync(repositoryUrl, branch, commit, buildNumber, assets, ImmutableList<BuildRef>.Empty);
+            TestContext.WriteLine($"Removing build {buildId} from channel {channelName}");
+            await RunDarcAsync("delete-build-from-channel", "--id", buildId.ToString(), "--channel", channelName);
+        });
+    }
+
+    protected async Task DeleteBuildFromChannelAsync(string buildId, string channelName)
+    {
+        await RunDarcAsync("delete-build-from-channel", "--id", buildId, "--channel", channelName);
+    }
+
+    protected static IDisposable ChangeDirectory(string directory)
+    {
+        string old = Directory.GetCurrentDirectory();
+        TestContext.WriteLine($"Switching to directory {directory}");
+        Directory.SetCurrentDirectory(directory);
+        return Disposable.Create(() =>
+        {
+            TestContext.WriteLine($"Switching back to directory {old}");
+            Directory.SetCurrentDirectory(old);
+        });
+    }
+
+    protected Task<TemporaryDirectory> CloneRepositoryAsync(string repository)
+    {
+        return CloneRepositoryAsync(_parameters.GitHubTestOrg, repository);
+    }
+
+    protected async Task<TemporaryDirectory> CloneRepositoryAsync(string org, string repository)
+    {
+        using var shareable = Shareable.Create(TemporaryDirectory.Get());
+        string directory = shareable.Peek()!.Directory;
+
+        string fetchUrl = GetRepoFetchUrl(org, repository);
+        await RunGitAsync("clone", "--quiet", fetchUrl, directory);
+
+        using (ChangeDirectory(directory))
+        {
+            await RunGitAsync("config", "user.email", $"{_parameters.GitHubUser}@test.com");
+            await RunGitAsync("config", "user.name", _parameters.GitHubUser);
+            await RunGitAsync("config", "gc.auto", "0");
+            await RunGitAsync("config", "advice.detachedHead", "false");
+            await RunGitAsync("config", "color.ui", "false");
         }
 
-        public async Task<Build> CreateBuildAsync(string repositoryUrl, string branch, string commit, string buildNumber, IImmutableList<AssetData> assets, IImmutableList<BuildRef> dependencies)
+        return shareable.TryTake()!;
+    }
+
+    protected string GetAzDoRepoAuthUrl(string repoName)
+    {
+        return $"https://{_parameters.GitHubUser}:{_parameters.AzDoToken}@dev.azure.com/{_parameters.AzureDevOpsAccount}/{_parameters.AzureDevOpsProject}/_git/{repoName}";
+    }
+
+    protected async Task<TemporaryDirectory> CloneAzDoRepositoryAsync(string repoName, string targetBranch)
+    {
+        using var shareable = Shareable.Create(TemporaryDirectory.Get());
+        string directory = shareable.Peek()!.Directory;
+
+        string authUrl = GetAzDoRepoAuthUrl(repoName);
+        await RunGitAsync("clone", "--quiet", authUrl, directory);
+
+        using (ChangeDirectory(directory))
         {
-            Build build = await MaestroApi.Builds.CreateAsync(new BuildData(
-                commit: commit,
-                azureDevOpsAccount: _parameters.AzureDevOpsAccount,
-                azureDevOpsProject: _parameters.AzureDevOpsProject,
-                azureDevOpsBuildNumber: buildNumber,
-                azureDevOpsRepository: repositoryUrl,
-                azureDevOpsBranch: branch,
-                released: false,
-                stable: false)
+            // The GitHubUser and AzDoUser have the same user name so this uses the existing parameter
+            await RunGitAsync("config", "user.email", $"{_parameters.GitHubUser}@test.com");
+            await RunGitAsync("config", "user.name", _parameters.GitHubUser);
+        }
+
+
+        return shareable.TryTake()!;
+    }
+
+    protected async Task<TemporaryDirectory> CloneRepositoryWithDarc(string repoName, string version, string reposToIgnore, bool includeToolset, int depth)
+    {
+        string sourceRepoUri = GetRepoUrl("dotnet", repoName);
+
+        using var shareable = Shareable.Create(TemporaryDirectory.Get());
+        string directory = shareable.Peek().Directory;
+
+        string reposFolder = Path.Join(directory, "cloned-repos");
+        string gitDirFolder = Path.Join(directory, "git-dirs");
+
+        // Clone repo
+        await RunDarcAsync("clone", "--repo", sourceRepoUri, "--version", version, "--git-dir-folder", gitDirFolder, "--ignore-repos", reposToIgnore, "--repos-folder", reposFolder, "--depth", depth.ToString(), includeToolset ? "--include-toolset" : "");
+
+        return shareable.TryTake()!;
+    }
+
+    protected async Task CheckoutRemoteRefAsync(string commit)
+    {
+        await RunGitAsync("fetch", "origin", commit);
+        await RunGitAsync("checkout", commit);
+    }
+
+    protected async Task CheckoutRemoteBranchAsync(string branchName)
+    {
+        await RunGitAsync("fetch", "origin", branchName);
+        await RunGitAsync("checkout", branchName);
+    }
+
+    protected async Task<IAsyncDisposable> CheckoutBranchAsync(string branchName)
+    {
+        await RunGitAsync("fetch", "origin");
+        await RunGitAsync("checkout", "-b", branchName);
+
+        return AsyncDisposable.Create(async () =>
+        {
+            TestContext.WriteLine($"Deleting remote branch {branchName}");
+            try
             {
-                AzureDevOpsBuildId = _parameters.AzureDevOpsBuildId,
-                AzureDevOpsBuildDefinitionId = _parameters.AzureDevOpsBuildDefinitionId,
-                GitHubRepository = repositoryUrl,
-                GitHubBranch = branch,
-                Assets = assets,
-                Dependencies = dependencies,
-            });
-
-            return build;
-        }
-
-        public async Task<string> GetDarcBuildAsync(int buildId)
-        {
-            string buildString = await RunDarcAsync("get-build", "--id", buildId.ToString());
-            return buildString;
-        }
-
-        public async Task<string> UpdateBuildAsync(int buildId, string updateParams)
-        {
-            string buildString = await RunDarcAsync("update-build", "--id", buildId.ToString(), updateParams);
-            return buildString;
-        }
-
-        public async Task AddDependenciesToLocalRepo(string repoPath, List<AssetData> dependencies, string repoUri, string coherentParent = "")
-        {
-            using (ChangeDirectory(repoPath))
+                await DeleteBranchAsync(branchName);
+            }
+            catch
             {
-                foreach (AssetData asset in dependencies)
+                // If this throws it means that it was cleaned up by a different clean up method first
+            }
+        });
+    }
+
+    protected async Task DeleteBranchAsync(string branchName)
+    {
+        await RunGitAsync("push", "origin", "--delete", branchName);
+    }
+
+    protected IImmutableList<AssetData> GetAssetData(string asset1Name, string asset1Version, string asset2Name, string asset2Version)
+    {
+        string location = @"https://pkgs.dev.azure.com/dnceng/public/_packaging/NotARealFeed/nuget/v3/index.json";
+        LocationType locationType = LocationType.NugetFeed;
+
+        AssetData asset1 = GetAssetDataWithLocations(asset1Name, asset1Version, location, locationType);
+
+        AssetData asset2 = GetAssetDataWithLocations(asset2Name, asset2Version, location, locationType);
+
+        return ImmutableList.Create(asset1, asset2);
+    }
+
+    protected static AssetData GetAssetDataWithLocations(
+        string assetName,
+        string assetVersion,
+        string assetLocation1,
+        LocationType assetLocationType1,
+        string assetLocation2 = null,
+        LocationType assetLocationType2 = LocationType.None)
+    {
+        var locationsListBuilder = ImmutableList.CreateBuilder<AssetLocationData>();
+
+        AssetLocationData location1 = new AssetLocationData(assetLocationType1)
+        { Location = assetLocation1 };
+        locationsListBuilder.Add(location1);
+
+        if (assetLocation2 != null && assetLocationType2 != LocationType.None)
+        {
+            AssetLocationData location2 = new AssetLocationData(assetLocationType2)
+            { Location = assetLocation2 };
+            locationsListBuilder.Add(location2);
+        }
+
+        AssetData asset = new AssetData(false)
+        {
+            Name = assetName,
+            Version = assetVersion,
+            Locations = locationsListBuilder.ToImmutable()
+        };
+
+        return asset;
+    }
+
+    protected static IImmutableList<AssetData> GetSingleAssetData(string assetName, string assetVersion)
+    {
+        AssetData asset = new AssetData(false)
+        {
+            Name = assetName,
+            Version = assetVersion,
+            Locations = ImmutableList.Create(new AssetLocationData(LocationType.NugetFeed)
+            { Location = @"https://pkgs.dev.azure.com/dnceng/public/_packaging/NotARealFeed/nuget/v3/index.json" })
+        };
+
+        return ImmutableList.Create(asset);
+    }
+
+    protected async Task SetRepositoryPolicies(string repoUri, string branchName, string[] policyParams = null)
+    {
+        string[] commandParams = { "set-repository-policies", "-q", "--repo", repoUri, "--branch", branchName };
+
+        if (policyParams != null)
+        {
+            commandParams = commandParams.Concat(policyParams).ToArray();
+        }
+
+        await RunDarcAsync(commandParams);
+    }
+
+    protected async Task<string> GetRepositoryPolicies(string repoUri, string branchName)
+    {
+        return await RunDarcAsync("get-repository-policies", "--all", "--repo", repoUri, "--branch", branchName);
+    }
+
+    protected async Task WaitForMergedPullRequestAsync(string targetRepo, string targetBranch, PullRequest pr, Repository repo, int attempts = 7)
+    {
+        while (attempts-- > 0)
+        {
+            TestContext.WriteLine($"Starting check for merge, attempts remaining {attempts}");
+            pr = await GitHubApi.PullRequest.Get(repo.Id, pr.Number);
+
+            if (pr.State == ItemState.Closed)
+            {
+                return;
+            }
+
+            await Task.Delay(60 * 1000);
+        }
+
+        throw new MaestroTestException($"The created pull request for {targetRepo} targeting {targetBranch} was not merged within {attempts} minutes");
+    }
+
+    protected async Task<bool> CheckGithubPullRequestChecks(string targetRepoName, string targetBranch)
+    {
+        TestContext.WriteLine($"Checking opened PR in {targetBranch} {targetRepoName}");
+        PullRequest pullRequest = await WaitForPullRequestAsync(targetRepoName, targetBranch);
+        Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepoName);
+
+        return await ValidateGithubMaestroCheckRunsSuccessful(targetRepoName, targetBranch, pullRequest, repo);
+    }
+
+    protected async Task<bool> ValidateGithubMaestroCheckRunsSuccessful(string targetRepoName, string targetBranch, PullRequest pullRequest, Repository repo)
+    {
+        // Waiting 5 minutes for maestro to add the checks to the PR
+        await Task.Delay(TimeSpan.FromMinutes(5));
+        TestContext.WriteLine($"Checking maestro merge policies check in {targetBranch} {targetRepoName}");
+        CheckRunsResponse existingCheckRuns = await GitHubApi.Check.Run.GetAllForReference(repo.Id, pullRequest.Head.Sha);
+        int cnt = 0;
+        foreach (var checkRun in existingCheckRuns.CheckRuns)
+        {
+            if (checkRun.ExternalId.StartsWith(MergePolicyConstants.MaestroMergePolicyCheckRunPrefix))
+            {
+                cnt++;
+                if (checkRun.Status != "completed" && !checkRun.Output.Title.Contains("Waiting for checks."))
                 {
-                    List<string> parameters = new List<string>() { "add-dependency", "--name", asset.Name, "--type", "product", "--repo", repoUri };
-
-                    if (!String.IsNullOrEmpty(coherentParent))
-                    {
-                        parameters.Add("--coherent-parent");
-                        parameters.Add(coherentParent);
-                    }
-                    string[] parameterArr = parameters.ToArray();
-
-                    await RunDarcAsync(parameterArr);
+                    return false;
                 }
             }
         }
-
-        public async Task<string> GatherDrop(int buildId, string outputDir, bool includeReleased, string extraAssetsRegex)
-        {
-            string[] args = new[] { "gather-drop", "--id", buildId.ToString(), "--dry-run", "--output-dir", outputDir };
-
-            if (includeReleased)
-            {
-                args = args.Append("--include-released").ToArray();
-            }
-
-            if (!string.IsNullOrEmpty(extraAssetsRegex))
-            {
-                args = args.Append($"--always-download-asset-filters").Append(extraAssetsRegex).ToArray();
-            }
-
-            return await RunDarcAsync(args);
-        }
-
-        public async Task TriggerSubscriptionAsync(string subscriptionId)
-        {
-            await MaestroApi.Subscriptions.TriggerSubscriptionAsync(Guid.Parse(subscriptionId));
-        }
-
-        public async Task<IAsyncDisposable> AddBuildToChannelAsync(int buildId, string channelName)
-        {
-            await RunDarcAsync("add-build-to-channel", "--id", buildId.ToString(), "--channel", channelName, "--skip-assets-publishing");
-            return AsyncDisposable.Create(async () =>
-            {
-                TestContext.WriteLine($"Removing build {buildId} from channel {channelName}");
-                await RunDarcAsync("delete-build-from-channel", "--id", buildId.ToString(), "--channel", channelName);
-            });
-        }
-
-        public async Task DeleteBuildFromChannelAsync(string buildId, string channelName)
-        {
-            await RunDarcAsync("delete-build-from-channel", "--id", buildId, "--channel", channelName);
-        }
-
-        public IDisposable ChangeDirectory(string directory)
-        {
-            string old = Directory.GetCurrentDirectory();
-            TestContext.WriteLine($"Switching to directory {directory}");
-            Directory.SetCurrentDirectory(directory);
-            return Disposable.Create(() =>
-            {
-                TestContext.WriteLine($"Switching back to directory {old}");
-                Directory.SetCurrentDirectory(old);
-            });
-        }
-
-        public Task<TemporaryDirectory> CloneRepositoryAsync(string repository)
-        {
-            return CloneRepositoryAsync(_parameters.GitHubTestOrg, repository);
-        }
-
-        public async Task<TemporaryDirectory> CloneRepositoryAsync(string org, string repository)
-        {
-            using var shareable = Shareable.Create(TemporaryDirectory.Get());
-            string directory = shareable.Peek()!.Directory;
-
-            string fetchUrl = GetRepoFetchUrl(org, repository);
-            await RunGitAsync("clone", "--quiet", fetchUrl, directory).ConfigureAwait(false);
-
-            using (ChangeDirectory(directory))
-            {
-                await RunGitAsync("config", "user.email", $"{_parameters.GitHubUser}@test.com").ConfigureAwait(false);
-                await RunGitAsync("config", "user.name", _parameters.GitHubUser).ConfigureAwait(false);
-                await RunGitAsync("config", "gc.auto", "0").ConfigureAwait(false);
-                await RunGitAsync("config", "advice.detachedHead", "false").ConfigureAwait(false);
-                await RunGitAsync("config", "color.ui", "false").ConfigureAwait(false);
-            }
-
-            return shareable.TryTake()!;
-        }
-
-        public string GetAzDoRepoAuthUrl(string repoName)
-        {
-            return $"https://{_parameters.GitHubUser}:{_parameters.AzDoToken}@dev.azure.com/{_parameters.AzureDevOpsAccount}/{_parameters.AzureDevOpsProject}/_git/{repoName}";
-        }
-
-        public async Task<TemporaryDirectory> CloneAzDoRepositoryAsync(string repoName, string targetBranch)
-        {
-            using var shareable = Shareable.Create(TemporaryDirectory.Get());
-            string directory = shareable.Peek()!.Directory;
-
-            string authUrl = GetAzDoRepoAuthUrl(repoName);
-            await RunGitAsync("clone", "--quiet", authUrl, directory).ConfigureAwait(false);
-
-            using (ChangeDirectory(directory))
-            {
-                // The GitHubUser and AzDoUser have the same user name so this uses the existing parameter
-                await RunGitAsync("config", "user.email", $"{_parameters.GitHubUser}@test.com").ConfigureAwait(false);
-                await RunGitAsync("config", "user.name", _parameters.GitHubUser).ConfigureAwait(false);
-            }
-
-
-            return shareable.TryTake()!;
-        }
-
-        public async Task<TemporaryDirectory> CloneRepositoryWithDarc(string repoName, string version, string reposToIgnore, bool includeToolset, int depth)
-        {
-            string sourceRepoUri = GetRepoUrl("dotnet", repoName);
-
-            using var shareable = Shareable.Create(TemporaryDirectory.Get());
-            string directory = shareable.Peek().Directory;
-
-            string reposFolder = Path.Join(directory, "cloned-repos");
-            string gitDirFolder = Path.Join(directory, "git-dirs");
-
-            // Clone repo
-            await RunDarcAsync("clone", "--repo", sourceRepoUri, "--version", version, "--git-dir-folder", gitDirFolder, "--ignore-repos", reposToIgnore, "--repos-folder", reposFolder, "--depth", depth.ToString(), includeToolset ? "--include-toolset" : "");
-
-            return shareable.TryTake()!;
-        }
-
-        public async Task CheckoutRemoteRefAsync(string commit)
-        {
-            await RunGitAsync("fetch", "origin", commit);
-            await RunGitAsync("checkout", commit);
-        }
-
-        public async Task CheckoutRemoteBranchAsync(string branchName)
-        {
-            await RunGitAsync("fetch", "origin", branchName);
-            await RunGitAsync("checkout", branchName);
-        }
-
-        public async Task<IAsyncDisposable> CheckoutBranchAsync(string branchName)
-        {
-            await RunGitAsync("fetch", "origin");
-            await RunGitAsync("checkout", "-b", branchName);
-
-            return AsyncDisposable.Create(async () =>
-            {
-                TestContext.WriteLine($"Deleting remote branch {branchName}");
-                try
-                {
-                    await DeleteBranchAsync(branchName);
-                }
-                catch
-                {
-                    // If this throws it means that it was cleaned up by a different clean up method first
-                }
-            });
-        }
-
-        public async Task DeleteBranchAsync(string branchName)
-        {
-            await RunGitAsync("push", "origin", "--delete", branchName);
-        }
-
-        internal IImmutableList<AssetData> GetAssetData(string asset1Name, string asset1Version, string asset2Name, string asset2Version)
-        {
-            string location = @"https://pkgs.dev.azure.com/dnceng/public/_packaging/NotARealFeed/nuget/v3/index.json";
-            LocationType locationType = LocationType.NugetFeed;
-
-            AssetData asset1 = GetAssetDataWithLocations(asset1Name, asset1Version, location, locationType);
-
-            AssetData asset2 = GetAssetDataWithLocations(asset2Name, asset2Version, location, locationType);
-
-            return ImmutableList.Create(asset1, asset2);
-        }
-
-        internal AssetData GetAssetDataWithLocations(
-            string assetName,
-            string assetVersion,
-            string assetLocation1,
-            LocationType assetLocationType1,
-            string assetLocation2 = null,
-            LocationType assetLocationType2 = LocationType.None)
-        {
-            var locationsListBuilder = ImmutableList.CreateBuilder<AssetLocationData>();
-
-            AssetLocationData location1 = new AssetLocationData(assetLocationType1)
-            { Location = assetLocation1 };
-            locationsListBuilder.Add(location1);
-
-            if (assetLocation2 != null && assetLocationType2 != LocationType.None)
-            {
-                AssetLocationData location2 = new AssetLocationData(assetLocationType2)
-                { Location = assetLocation2 };
-                locationsListBuilder.Add(location2);
-            }
-
-            AssetData asset = new AssetData(false)
-            {
-                Name = assetName,
-                Version = assetVersion,
-                Locations = locationsListBuilder.ToImmutable()
-            };
-
-            return asset;
-        }
-
-        internal IImmutableList<AssetData> GetSingleAssetData(string assetName, string assetVersion)
-        {
-            AssetData asset = new AssetData(false)
-            {
-                Name = assetName,
-                Version = assetVersion,
-                Locations = ImmutableList.Create(new AssetLocationData(LocationType.NugetFeed)
-                { Location = @"https://pkgs.dev.azure.com/dnceng/public/_packaging/NotARealFeed/nuget/v3/index.json" })
-            };
-
-            return ImmutableList.Create(asset);
-        }
-
-        public async Task SetRepositoryPolicies(string repoUri, string branchName, string[] policyParams = null)
-        {
-            string[] commandParams = { "set-repository-policies", "-q", "--repo", repoUri, "--branch", branchName };
-
-            if (policyParams != null)
-            {
-                commandParams = commandParams.Concat(policyParams).ToArray();
-            }
-
-            await RunDarcAsync(commandParams);
-        }
-
-        public async Task<string> GetRepositoryPolicies(string repoUri, string branchName)
-        {
-            return await RunDarcAsync("get-repository-policies", "--all", "--repo", repoUri, "--branch", branchName);
-        }
-
-        public async Task WaitForMergedPullRequestAsync(string targetRepo, string targetBranch, PullRequest pr, Repository repo, int attempts = 7)
-        {
-            while (attempts-- > 0)
-            {
-                TestContext.WriteLine($"Starting check for merge, attempts remaining {attempts}");
-                pr = await GitHubApi.PullRequest.Get(repo.Id, pr.Number);
-
-                if (pr.State == ItemState.Closed)
-                {
-                    return;
-                }
-
-                await Task.Delay(60 * 1000).ConfigureAwait(false);
-            }
-
-            throw new MaestroTestException($"The created pull request for {targetRepo} targeting {targetBranch} was not merged within {attempts} minutes");
-        }
-
-        public async Task<bool> CheckGithubPullRequestChecks(string targetRepoName, string targetBranch)
-        {
-            TestContext.WriteLine($"Checking opened PR in {targetBranch} {targetRepoName}");
-            PullRequest pullRequest = await WaitForPullRequestAsync(targetRepoName, targetBranch);
-            Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepoName).ConfigureAwait(false);
-
-            return await ValidateGithubMaestroCheckRunsSuccessful(targetRepoName, targetBranch, pullRequest, repo);
-        }
-
-        public async Task<bool> ValidateGithubMaestroCheckRunsSuccessful(string targetRepoName, string targetBranch, PullRequest pullRequest, Repository repo)
-        {
-            // Waiting 5 minutes for maestro to add the checks to the PR
-            await Task.Delay(TimeSpan.FromMinutes(5));
-            TestContext.WriteLine($"Checking maestro merge policies check in {targetBranch} {targetRepoName}");
-            CheckRunsResponse existingCheckRuns = await GitHubApi.Check.Run.GetAllForReference(repo.Id, pullRequest.Head.Sha);
-            int cnt = 0;
-            foreach (var checkRun in existingCheckRuns.CheckRuns)
-            {
-                if (checkRun.ExternalId.StartsWith(MergePolicyConstants.MaestroMergePolicyCheckRunPrefix))
-                {
-                    cnt++;
-                    if (checkRun.Status != "completed" && !checkRun.Output.Title.Contains("Waiting for checks."))
-                    {
-                        return false;
-                    }
-                }
-            }
-            return cnt >= 1;
-        }
+        return cnt >= 1;
     }
 }

--- a/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
+++ b/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
@@ -285,7 +285,8 @@ internal class MaestroScenarioTestBase
         string[]? notExpectedFeeds = null)
     {
         var expectedPRTitle = $"[{targetBranch}] Update dependencies from {_parameters.AzureDevOpsAccount}/{_parameters.AzureDevOpsProject}/{sourceRepoName}";
-        await CheckAzDoPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedDependencies, repoDirectory, isCompleted, isUpdated, expectedFeeds, notExpectedFeeds);
+        // TODO (https://github.com/dotnet/arcade-services/issues/3149): I noticed we are not passing isCompleted further down - when I put it there the tests started failing - but we should fix this
+        await CheckAzDoPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedDependencies, repoDirectory, false, isUpdated, expectedFeeds, notExpectedFeeds);
     }
 
     private async Task CheckAzDoPullRequest(

--- a/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
+++ b/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
@@ -748,7 +748,7 @@ internal class MaestroScenarioTestBase
         var directory = shareable.Peek()!.Directory;
 
         var authUrl = GetAzDoRepoAuthUrl(repoName);
-        await RunGitAsync("clone", "-b", targetBranch, "--quiet", authUrl, directory);
+        await RunGitAsync("clone", "--quiet", authUrl, directory);
 
         using (ChangeDirectory(directory))
         {

--- a/test/Maestro.ScenarioTests/ObjectHelpers/BuildRefComparer.cs
+++ b/test/Maestro.ScenarioTests/ObjectHelpers/BuildRefComparer.cs
@@ -10,11 +10,6 @@ namespace Maestro.ScenarioTests.ObjectHelpers;
 
 public class BuildRefComparer : IEqualityComparer<BuildRef>, IComparer
 {
-    public int Compare(BuildRef x, BuildRef y)
-    {
-        return x.BuildId.CompareTo(y.BuildId);
-    }
-
     public int Compare(object x, object y)
     {
         return ((BuildRef)x).BuildId.CompareTo(((BuildRef)y).BuildId);

--- a/test/Maestro.ScenarioTests/ObjectHelpers/BuildRefComparer.cs
+++ b/test/Maestro.ScenarioTests/ObjectHelpers/BuildRefComparer.cs
@@ -6,30 +6,29 @@ using System.Collections;
 using System.Collections.Generic;
 using Microsoft.DotNet.Maestro.Client.Models;
 
-namespace Maestro.ScenarioTests.ObjectHelpers
+namespace Maestro.ScenarioTests.ObjectHelpers;
+
+public class BuildRefComparer : IEqualityComparer<BuildRef>, IComparer
 {
-    public class BuildRefComparer : IEqualityComparer<BuildRef>, IComparer
+    public int Compare(BuildRef x, BuildRef y)
     {
-        public int Compare(BuildRef x, BuildRef y)
-        {
-            return x.BuildId.CompareTo(y.BuildId);
-        }
+        return x.BuildId.CompareTo(y.BuildId);
+    }
 
-        public int Compare(object x, object y)
-        {
-            return ((BuildRef)x).BuildId.CompareTo(((BuildRef)y).BuildId);
-        }
+    public int Compare(object x, object y)
+    {
+        return ((BuildRef)x).BuildId.CompareTo(((BuildRef)y).BuildId);
+    }
 
-        public bool Equals(BuildRef x, BuildRef y)
-        {
-            return x.BuildId == y.BuildId &&
-                x.IsProduct == y.IsProduct &&
-                x.TimeToInclusionInMinutes == y.TimeToInclusionInMinutes;
-        }
+    public bool Equals(BuildRef x, BuildRef y)
+    {
+        return x.BuildId == y.BuildId &&
+            x.IsProduct == y.IsProduct &&
+            x.TimeToInclusionInMinutes == y.TimeToInclusionInMinutes;
+    }
 
-        public int GetHashCode(BuildRef obj)
-        {
-            return HashCode.Combine(obj.BuildId, obj.IsProduct, obj.TimeToInclusionInMinutes);
-        }
+    public int GetHashCode(BuildRef obj)
+    {
+        return HashCode.Combine(obj.BuildId, obj.IsProduct, obj.TimeToInclusionInMinutes);
     }
 }

--- a/test/Maestro.ScenarioTests/ObjectHelpers/DependencyCollectionStringBuilder.cs
+++ b/test/Maestro.ScenarioTests/ObjectHelpers/DependencyCollectionStringBuilder.cs
@@ -6,20 +6,19 @@ using System.Text;
 using Microsoft.DotNet.Darc;
 using Microsoft.DotNet.DarcLib;
 
-namespace Maestro.ScenarioTests.ObjectHelpers
+namespace Maestro.ScenarioTests.ObjectHelpers;
+
+public class DependencyCollectionStringBuilder
 {
-    public class DependencyCollectionStringBuilder
+    internal static string GetString(List<DependencyDetail> expectedDependencies)
     {
-        internal static string GetString(List<DependencyDetail> expectedDependencies)
+        StringBuilder stringBuilder = new StringBuilder();
+
+        foreach(DependencyDetail dependency in expectedDependencies)
         {
-            StringBuilder stringBuilder = new StringBuilder();
-
-            foreach(DependencyDetail dependency in expectedDependencies)
-            {
-                stringBuilder.AppendLine(UxHelpers.DependencyToString(dependency));
-            }
-
-            return stringBuilder.ToString();
+            stringBuilder.AppendLine(UxHelpers.DependencyToString(dependency));
         }
+
+        return stringBuilder.ToString();
     }
 }

--- a/test/Maestro.ScenarioTests/ObjectHelpers/SubscriptionBuilder.cs
+++ b/test/Maestro.ScenarioTests/ObjectHelpers/SubscriptionBuilder.cs
@@ -6,73 +6,71 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Maestro.MergePolicyEvaluation;
-using Microsoft.DotNet.Darc;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Newtonsoft.Json.Linq;
 
-namespace Maestro.ScenarioTests.ObjectHelpers
+namespace Maestro.ScenarioTests.ObjectHelpers;
+
+public class SubscriptionBuilder
 {
-    public class SubscriptionBuilder
+    /// <summary>
+    /// Creates a subscription object based on a standard set of test inputs
+    /// </summary>
+    public static Subscription BuildSubscription(string repo1Uri, string repo2Uri, string targetBranch, string channelName, string subscriptionId,
+        UpdateFrequency updateFrequency, bool batchable, List<string> mergePolicyNames = null, List<string> ignoreChecks = null,
+        string failureNotificationTags = null)
     {
-        /// <summary>
-        /// Creates a subscription object based on a standard set of test inputs
-        /// </summary>
-        public static Subscription BuildSubscription(string repo1Uri, string repo2Uri, string targetBranch, string channelName, string subscriptionId,
-            UpdateFrequency updateFrequency, bool batchable, List<string> mergePolicyNames = null, List<string> ignoreChecks = null,
-            string failureNotificationTags = null)
+        Subscription expectedSubscription = new Subscription(Guid.Parse(subscriptionId), true, repo1Uri, repo2Uri, targetBranch, failureNotificationTags);
+        expectedSubscription.Channel = new Channel(42, channelName, "test");
+        expectedSubscription.Policy = new SubscriptionPolicy(batchable, updateFrequency);
+
+        List<MergePolicy> mergePolicies = [];
+
+        if (mergePolicyNames == null)
         {
-            Subscription expectedSubscription = new Subscription(Guid.Parse(subscriptionId), true, repo1Uri, repo2Uri, targetBranch, failureNotificationTags);
-            expectedSubscription.Channel = new Channel(42, channelName, "test");
-            expectedSubscription.Policy = new SubscriptionPolicy(batchable, updateFrequency);
-
-            List<MergePolicy> mergePolicies = new List<MergePolicy>();
-
-            if (mergePolicyNames == null)
-            {
-                expectedSubscription.Policy.MergePolicies = mergePolicies.ToImmutableList<MergePolicy>();
-                return expectedSubscription;
-            }
-
-            if (mergePolicyNames.Contains(MergePolicyConstants.StandardMergePolicyName))
-            {
-                mergePolicies.Add(new MergePolicy
-                {
-                    Name = MergePolicyConstants.StandardMergePolicyName
-                });
-            }
-
-            if (mergePolicyNames.Contains(MergePolicyConstants.AllCheckSuccessfulMergePolicyName) && ignoreChecks.Any())
-            {
-                mergePolicies.Add(
-                    new MergePolicy
-                    {
-                        Name = MergePolicyConstants.AllCheckSuccessfulMergePolicyName,
-                        Properties = ImmutableDictionary.Create<string, JToken>()
-                            .Add(MergePolicyConstants.IgnoreChecksMergePolicyPropertyName, JToken.FromObject(ignoreChecks))
-                    });
-            }
-
-            if (mergePolicyNames.Contains(MergePolicyConstants.NoRequestedChangesMergePolicyName))
-            {
-                mergePolicies.Add(
-                    new MergePolicy
-                    {
-                        Name = MergePolicyConstants.NoRequestedChangesMergePolicyName,
-                        Properties = ImmutableDictionary.Create<string, JToken>()
-                    });
-            }
-
-            if (mergePolicyNames.Contains(MergePolicyConstants.ValidateCoherencyMergePolicyName))
-            {
-                mergePolicies.Add(
-                    new MergePolicy {
-                        Name = MergePolicyConstants.ValidateCoherencyMergePolicyName,
-                        Properties = ImmutableDictionary.Create<string, JToken>()
-                    });
-            }
-
             expectedSubscription.Policy.MergePolicies = mergePolicies.ToImmutableList<MergePolicy>();
             return expectedSubscription;
         }
+
+        if (mergePolicyNames.Contains(MergePolicyConstants.StandardMergePolicyName))
+        {
+            mergePolicies.Add(new MergePolicy
+            {
+                Name = MergePolicyConstants.StandardMergePolicyName
+            });
+        }
+
+        if (mergePolicyNames.Contains(MergePolicyConstants.AllCheckSuccessfulMergePolicyName) && ignoreChecks.Any())
+        {
+            mergePolicies.Add(
+                new MergePolicy
+                {
+                    Name = MergePolicyConstants.AllCheckSuccessfulMergePolicyName,
+                    Properties = ImmutableDictionary.Create<string, JToken>()
+                        .Add(MergePolicyConstants.IgnoreChecksMergePolicyPropertyName, JToken.FromObject(ignoreChecks))
+                });
+        }
+
+        if (mergePolicyNames.Contains(MergePolicyConstants.NoRequestedChangesMergePolicyName))
+        {
+            mergePolicies.Add(
+                new MergePolicy
+                {
+                    Name = MergePolicyConstants.NoRequestedChangesMergePolicyName,
+                    Properties = ImmutableDictionary.Create<string, JToken>()
+                });
+        }
+
+        if (mergePolicyNames.Contains(MergePolicyConstants.ValidateCoherencyMergePolicyName))
+        {
+            mergePolicies.Add(
+                new MergePolicy {
+                    Name = MergePolicyConstants.ValidateCoherencyMergePolicyName,
+                    Properties = ImmutableDictionary.Create<string, JToken>()
+                });
+        }
+
+        expectedSubscription.Policy.MergePolicies = mergePolicies.ToImmutableList<MergePolicy>();
+        return expectedSubscription;
     }
 }

--- a/test/Maestro.ScenarioTests/ObjectHelpers/SubscriptionBuilder.cs
+++ b/test/Maestro.ScenarioTests/ObjectHelpers/SubscriptionBuilder.cs
@@ -20,9 +20,11 @@ public class SubscriptionBuilder
         UpdateFrequency updateFrequency, bool batchable, List<string> mergePolicyNames = null, List<string> ignoreChecks = null,
         string failureNotificationTags = null)
     {
-        Subscription expectedSubscription = new Subscription(Guid.Parse(subscriptionId), true, repo1Uri, repo2Uri, targetBranch, failureNotificationTags);
-        expectedSubscription.Channel = new Channel(42, channelName, "test");
-        expectedSubscription.Policy = new SubscriptionPolicy(batchable, updateFrequency);
+        var expectedSubscription = new Subscription(Guid.Parse(subscriptionId), true, repo1Uri, repo2Uri, targetBranch, failureNotificationTags)
+        {
+            Channel = new Channel(42, channelName, "test"),
+            Policy = new SubscriptionPolicy(batchable, updateFrequency)
+        };
 
         List<MergePolicy> mergePolicies = [];
 

--- a/test/Maestro.ScenarioTests/ScenarioTests_AzDoFlow.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_AzDoFlow.cs
@@ -10,29 +10,32 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client.Models;
 using NUnit.Framework;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+[TestFixture]
+[NonParallelizable]
+[Category("PostDeployment")]
+class ScenarioTests_AzDoFlow : MaestroScenarioTestBase
 {
-    [TestFixture]
-    [NonParallelizable]
-    [Category("PostDeployment")]
-    class ScenarioTests_AzDoFlow : MaestroScenarioTestBase
+    private readonly IImmutableList<AssetData> source1Assets;
+    private readonly IImmutableList<AssetData> source2Assets;
+    private readonly IImmutableList<AssetData> source1AssetsUpdated;
+    private readonly List<DependencyDetail> expectedAzDoDependenciesSource1;
+    private readonly List<DependencyDetail> expectedAzDoDependenciesSource2;
+    private readonly List<DependencyDetail> expectedAzDoDependenciesSource1Updated;
+
+    public ScenarioTests_AzDoFlow()
     {
-        private readonly IImmutableList<AssetData> source1Assets;
-        private readonly IImmutableList<AssetData> source2Assets;
-        private readonly IImmutableList<AssetData> source1AssetsUpdated;
-        private readonly List<DependencyDetail> expectedAzDoDependenciesSource1;
-        private readonly List<DependencyDetail> expectedAzDoDependenciesSource2;
-        private readonly List<DependencyDetail> expectedAzDoDependenciesSource1Updated;
+        source1Assets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
+        source2Assets = GetAssetData("Pizza", "3.1.0", "Hamburger", "4.1.0");
+        source1AssetsUpdated = GetAssetData("Foo", "1.17.0", "Bar", "2.17.0");
 
-        public ScenarioTests_AzDoFlow()
-        {
-            source1Assets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
-            source2Assets = GetAssetData("Pizza", "3.1.0", "Hamburger", "4.1.0");
-            source1AssetsUpdated = GetAssetData("Foo", "1.17.0", "Bar", "2.17.0");
+        var sourceRepoUri = GetAzDoRepoUrl(TestRepository.TestRepo1Name);
+        var source2RepoUri = GetAzDoRepoUrl(TestRepository.TestRepo3Name);
 
-            expectedAzDoDependenciesSource1 = new List<DependencyDetail>();
-            string sourceRepoUri = GetAzDoRepoUrl(TestRepository.TestRepo1Name);
-            DependencyDetail foo = new DependencyDetail
+        expectedAzDoDependenciesSource1 =
+        [
+            new DependencyDetail
             {
                 Name = "Foo",
                 Version = "1.1.0",
@@ -40,10 +43,8 @@ namespace Maestro.ScenarioTests
                 Commit = TestRepository.CoherencyTestRepo1Commit,
                 Type = DependencyType.Product,
                 Pinned = false
-            };
-            expectedAzDoDependenciesSource1.Add(foo);
-
-            DependencyDetail bar = new DependencyDetail
+            },
+            new DependencyDetail
             {
                 Name = "Bar",
                 Version = "2.1.0",
@@ -51,12 +52,12 @@ namespace Maestro.ScenarioTests
                 Commit = TestRepository.CoherencyTestRepo1Commit,
                 Type = DependencyType.Product,
                 Pinned = false
-            };
-            expectedAzDoDependenciesSource1.Add(bar);
+            },
+        ];
 
-            expectedAzDoDependenciesSource2 = new List<DependencyDetail>();
-            string source2RepoUri = GetAzDoRepoUrl(TestRepository.TestRepo3Name);
-            DependencyDetail pizza = new DependencyDetail
+        expectedAzDoDependenciesSource2 =
+        [
+            new DependencyDetail
             {
                 Name = "Pizza",
                 Version = "3.1.0",
@@ -64,10 +65,8 @@ namespace Maestro.ScenarioTests
                 Commit = TestRepository.CoherencyTestRepo1Commit,
                 Type = DependencyType.Product,
                 Pinned = false
-            };
-            expectedAzDoDependenciesSource2.Add(pizza);
-
-            DependencyDetail hamburger = new DependencyDetail
+            },
+            new DependencyDetail
             {
                 Name = "Hamburger",
                 Version = "4.1.0",
@@ -75,11 +74,12 @@ namespace Maestro.ScenarioTests
                 Commit = TestRepository.CoherencyTestRepo1Commit,
                 Type = DependencyType.Product,
                 Pinned = false
-            };
-            expectedAzDoDependenciesSource2.Add(hamburger);
+            },
+        ];
 
-            expectedAzDoDependenciesSource1Updated = new List<DependencyDetail>();
-            DependencyDetail fooUpdated = new DependencyDetail
+        expectedAzDoDependenciesSource1Updated =
+        [
+            new DependencyDetail
             {
                 Name = "Foo",
                 Version = "1.1.0",
@@ -87,10 +87,8 @@ namespace Maestro.ScenarioTests
                 Commit = TestRepository.CoherencyTestRepo1Commit,
                 Type = DependencyType.Product,
                 Pinned = false
-            };
-            expectedAzDoDependenciesSource1Updated.Add(fooUpdated);
-
-            DependencyDetail barUpdated = new DependencyDetail
+            },
+            new DependencyDetail
             {
                 Name = "Bar",
                 Version = "2.1.0",
@@ -98,171 +96,170 @@ namespace Maestro.ScenarioTests
                 Commit = TestRepository.CoherencyTestRepo1Commit,
                 Type = DependencyType.Product,
                 Pinned = false
-            };
-            expectedAzDoDependenciesSource1Updated.Add(barUpdated);
-        }
+            },
+        ];
+    }
 
-        [Test]
-        public async Task Darc_AzDoFlow_Batched()
+    [Test]
+    public async Task Darc_AzDoFlow_Batched()
+    {
+        TestContext.WriteLine("Azure DevOps Dependency Flow, batched");
+
+        TestParameters parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
+        SetTestParameters(parameters);
+        var testLogic = new EndToEndFlowLogic(parameters);
+        var expectedDependencies = expectedAzDoDependenciesSource1.Concat(expectedAzDoDependenciesSource2).ToList();
+
+        await testLogic.DarcBatchedFlowTestBase(
+            $"AzDo_BatchedTestBranch_{Environment.MachineName}",
+            $"AzDo Batched Channel {Environment.MachineName}",
+            source1Assets,
+            source2Assets,
+            expectedDependencies,
+            true);
+    }
+
+    [Test]
+    public async Task Darc_AzDoFlow_NonBatched_AllChecksSuccessful()
+    {
+        TestContext.WriteLine("AzDo Dependency Flow, non-batched, all checks successful");
+
+        TestParameters parameters = await TestParameters.GetAsync();
+        SetTestParameters(parameters);
+        var testLogic = new EndToEndFlowLogic(parameters);
+
+        await testLogic.NonBatchedAzDoFlowTestBase(
+            $"AzDo_NonBatchedTestBranch_AllChecks_{Environment.MachineName}",
+            $"AzDo Non-Batched All Checks Channel {Environment.MachineName}",
+            source1Assets,
+            expectedAzDoDependenciesSource1,
+            allChecks: true).ConfigureAwait(true);
+    }
+
+    [Test]
+    public async Task Darc_AzDoFlow_NonBatched()
+    {
+        TestContext.WriteLine("AzDo Dependency Flow, non-batched");
+
+        TestParameters parameters = await TestParameters.GetAsync();
+        SetTestParameters(parameters);
+        var testLogic = new EndToEndFlowLogic(parameters);
+
+        await testLogic.NonBatchedUpdatingAzDoFlowTestBase(
+            $"AzDo_NonBatchedTestBranch_{Environment.MachineName}",
+            $"AzDo Non-Batched Channel {Environment.MachineName}",
+            source1Assets,
+            source1AssetsUpdated,
+            expectedAzDoDependenciesSource1,
+            expectedAzDoDependenciesSource1Updated).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task Darc_AzDoFlow_FeedFlow()
+    {
+        TestContext.WriteLine("AzDo Dependency Feed Flow, non-batched");
+
+        // Feed flow test strings
+        var proxyFeed = "https://some-proxy.azurewebsites.net/container/some-container/sig/somesig/se/2020-02-02/darc-int-maestro-test1-bababababab-1/index.json";
+        var azdoFeed1 = "https://some_org.pkgs.visualstudio.com/_packaging/darc-int-maestro-test1-aaabaababababe-1/nuget/v3/index.json";
+        var azdoFeed2 = "https://some_org.pkgs.visualstudio.com/_packaging/darc-int-maestro-test1-bbbbaababababd-1/nuget/v3/index.json";
+        var azdoFeed3 = "https://some_org.pkgs.visualstudio.com/_packaging/darc-int-maestro-test1-cccbaababababf-1/nuget/v3/index.json";
+        var regularFeed = "https://dotnetfeed.blob.core.windows.net/maestro-test1/index.json";
+        var buildContainer = "https://dev.azure.com/dnceng/internal/_apis/build/builds/9999999/artifacts";
+        string[] expectedFeeds = [proxyFeed, azdoFeed1, azdoFeed3];
+        string[] notExpectedFeeds = [regularFeed, azdoFeed2, buildContainer];
+
+        IImmutableList<AssetData> feedFlowSourceAssets = ImmutableList.Create(
+                GetAssetDataWithLocations(
+                    "Foo",
+                    "1.1.0",
+                    proxyFeed,
+                    LocationType.NugetFeed
+                    ),
+                GetAssetDataWithLocations(
+                    "Bar",
+                    "2.1.0",
+                    azdoFeed1,
+                    LocationType.NugetFeed),
+                GetAssetDataWithLocations(
+                    "Pizza",
+                    "3.1.0",
+                    azdoFeed2,
+                    LocationType.NugetFeed,
+                    regularFeed,
+                    LocationType.NugetFeed
+                    ),
+                GetAssetDataWithLocations(
+                    "Hamburger",
+                    "4.1.0",
+                    azdoFeed3,
+                    LocationType.NugetFeed,
+                    buildContainer,
+                    LocationType.Container)
+                );
+
+        TestContext.WriteLine("Azure DevOps Internal feed flow");
+        TestParameters parameters = await TestParameters.GetAsync();
+        SetTestParameters(parameters);
+
+        var testLogic = new EndToEndFlowLogic(parameters);
+
+        var expectedAzDoFeedFlowDependencies = new List<DependencyDetail>();
+
+        var feedFoo = new DependencyDetail
         {
-            TestContext.WriteLine("Azure DevOps Dependency Flow, batched");
+            Name = "Foo",
+            Version = "1.1.0",
+            RepoUri = GetAzDoRepoUrl(TestRepository.TestRepo1Name),
+            Commit = TestRepository.CoherencyTestRepo1Commit,
+            Type = DependencyType.Product,
+            Pinned = false,
+            Locations = new List<string> { proxyFeed }
+        };
+        expectedAzDoFeedFlowDependencies.Add(feedFoo);
 
-            TestParameters parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
-            SetTestParameters(parameters);
-            EndToEndFlowLogic testLogic = new EndToEndFlowLogic(parameters);
-            List<DependencyDetail> expectedDependencies = expectedAzDoDependenciesSource1.Concat(expectedAzDoDependenciesSource2).ToList();
-
-            await testLogic.DarcBatchedFlowTestBase(
-                $"AzDo_BatchedTestBranch_{Environment.MachineName}",
-                $"AzDo Batched Channel {Environment.MachineName}",
-                source1Assets,
-                source2Assets,
-                expectedDependencies,
-                true);
-        }
-
-        [Test]
-        public async Task Darc_AzDoFlow_NonBatched_AllChecksSuccessful()
+        var feedBar = new DependencyDetail
         {
-            TestContext.WriteLine("AzDo Dependency Flow, non-batched, all checks successful");
+            Name = "Bar",
+            Version = "2.1.0",
+            RepoUri = GetAzDoRepoUrl(TestRepository.TestRepo1Name),
+            Commit = TestRepository.CoherencyTestRepo1Commit,
+            Type = DependencyType.Product,
+            Pinned = false,
+            Locations = new List<string> { azdoFeed1 }
+        };
+        expectedAzDoFeedFlowDependencies.Add(feedBar);
 
-            TestParameters parameters = await TestParameters.GetAsync();
-            SetTestParameters(parameters);
-            EndToEndFlowLogic testLogic = new EndToEndFlowLogic(parameters);
-
-            await testLogic.NonBatchedAzDoFlowTestBase(
-                $"AzDo_NonBatchedTestBranch_AllChecks_{Environment.MachineName}",
-                $"AzDo Non-Batched All Checks Channel {Environment.MachineName}",
-                source1Assets,
-                expectedAzDoDependenciesSource1,
-                allChecks: true).ConfigureAwait(true);
-        }
-
-        [Test]
-        public async Task Darc_AzDoFlow_NonBatched()
+        var feedPizza = new DependencyDetail
         {
-            TestContext.WriteLine("AzDo Dependency Flow, non-batched");
+            Name = "Pizza",
+            Version = "3.1.0",
+            RepoUri = GetAzDoRepoUrl(TestRepository.TestRepo1Name),
+            Commit = TestRepository.CoherencyTestRepo1Commit,
+            Type = DependencyType.Product,
+            Pinned = false,
+            Locations = new List<string> { azdoFeed2, regularFeed }
+        };
+        expectedAzDoFeedFlowDependencies.Add(feedPizza);
 
-            TestParameters parameters = await TestParameters.GetAsync();
-            SetTestParameters(parameters);
-            EndToEndFlowLogic testLogic = new EndToEndFlowLogic(parameters);
-
-            await testLogic.NonBatchedUpdatingAzDoFlowTestBase(
-                $"AzDo_NonBatchedTestBranch_{Environment.MachineName}",
-                $"AzDo Non-Batched Channel {Environment.MachineName}",
-                source1Assets,
-                source1AssetsUpdated,
-                expectedAzDoDependenciesSource1,
-                expectedAzDoDependenciesSource1Updated).ConfigureAwait(false);
-        }
-
-        [Test]
-        public async Task Darc_AzDoFlow_FeedFlow()
+        var feedHamburger = new DependencyDetail
         {
-            TestContext.WriteLine("AzDo Dependency Feed Flow, non-batched");
-
-            // Feed flow test strings
-            string proxyFeed = "https://some-proxy.azurewebsites.net/container/some-container/sig/somesig/se/2020-02-02/darc-int-maestro-test1-bababababab-1/index.json";
-            string azdoFeed1 = "https://some_org.pkgs.visualstudio.com/_packaging/darc-int-maestro-test1-aaabaababababe-1/nuget/v3/index.json";
-            string azdoFeed2 = "https://some_org.pkgs.visualstudio.com/_packaging/darc-int-maestro-test1-bbbbaababababd-1/nuget/v3/index.json";
-            string azdoFeed3 = "https://some_org.pkgs.visualstudio.com/_packaging/darc-int-maestro-test1-cccbaababababf-1/nuget/v3/index.json";
-            string regularFeed = "https://dotnetfeed.blob.core.windows.net/maestro-test1/index.json";
-            string buildContainer = "https://dev.azure.com/dnceng/internal/_apis/build/builds/9999999/artifacts";
-            string[] expectedFeeds = { proxyFeed, azdoFeed1, azdoFeed3 };
-            string[] notExpectedFeeds = { regularFeed, azdoFeed2, buildContainer };
-
-            IImmutableList<AssetData> feedFlowSourceAssets = ImmutableList.Create(
-                    GetAssetDataWithLocations(
-                        "Foo",
-                        "1.1.0",
-                        proxyFeed,
-                        LocationType.NugetFeed
-                        ),
-                    GetAssetDataWithLocations(
-                        "Bar",
-                        "2.1.0",
-                        azdoFeed1,
-                        LocationType.NugetFeed),
-                    GetAssetDataWithLocations(
-                        "Pizza",
-                        "3.1.0",
-                        azdoFeed2,
-                        LocationType.NugetFeed,
-                        regularFeed,
-                        LocationType.NugetFeed
-                        ),
-                    GetAssetDataWithLocations(
-                        "Hamburger",
-                        "4.1.0",
-                        azdoFeed3,
-                        LocationType.NugetFeed,
-                        buildContainer,
-                        LocationType.Container)
-                    );
-
-            TestContext.WriteLine("Azure DevOps Internal feed flow");
-            TestParameters parameters = await TestParameters.GetAsync();
-            SetTestParameters(parameters);
-
-            EndToEndFlowLogic testLogic = new EndToEndFlowLogic(parameters);
-
-            List<DependencyDetail> expectedAzDoFeedFlowDependencies = new List<DependencyDetail>();
-
-            DependencyDetail feedFoo = new DependencyDetail
-            {
-                Name = "Foo",
-                Version = "1.1.0",
-                RepoUri = GetAzDoRepoUrl(TestRepository.TestRepo1Name),
-                Commit = TestRepository.CoherencyTestRepo1Commit,
-                Type = DependencyType.Product,
-                Pinned = false,
-                Locations = new List<string> { proxyFeed }
-            };
-            expectedAzDoFeedFlowDependencies.Add(feedFoo);
-
-            DependencyDetail feedBar = new DependencyDetail
-            {
-                Name = "Bar",
-                Version = "2.1.0",
-                RepoUri = GetAzDoRepoUrl(TestRepository.TestRepo1Name),
-                Commit = TestRepository.CoherencyTestRepo1Commit,
-                Type = DependencyType.Product,
-                Pinned = false,
-                Locations = new List<string> { azdoFeed1 }
-            };
-            expectedAzDoFeedFlowDependencies.Add(feedBar);
-
-            DependencyDetail feedPizza = new DependencyDetail
-            {
-                Name = "Pizza",
-                Version = "3.1.0",
-                RepoUri = GetAzDoRepoUrl(TestRepository.TestRepo1Name),
-                Commit = TestRepository.CoherencyTestRepo1Commit,
-                Type = DependencyType.Product,
-                Pinned = false,
-                Locations = new List<string> { azdoFeed2, regularFeed }
-            };
-            expectedAzDoFeedFlowDependencies.Add(feedPizza);
-
-            DependencyDetail feedHamburger = new DependencyDetail
-            {
-                Name = "Hamburger",
-                Version = "4.1.0",
-                RepoUri = GetAzDoRepoUrl(TestRepository.TestRepo1Name),
-                Commit = TestRepository.CoherencyTestRepo1Commit,
-                Type = DependencyType.Product,
-                Pinned = false,
-                Locations = new List<string> { azdoFeed3, buildContainer }
-            };
-            expectedAzDoFeedFlowDependencies.Add(feedHamburger);
-            await testLogic.NonBatchedAzDoFlowTestBase(
-                $"AzDo_FeedFlowBranch_{Environment.MachineName}",
-                $"AzDo_FeedFlowChannel_{Environment.MachineName}",
-                feedFlowSourceAssets,
-                expectedAzDoFeedFlowDependencies,
-                isFeedTest: true,
-                expectedFeeds: expectedFeeds,
-                notExpectedFeeds: notExpectedFeeds).ConfigureAwait(false);
-        }
+            Name = "Hamburger",
+            Version = "4.1.0",
+            RepoUri = GetAzDoRepoUrl(TestRepository.TestRepo1Name),
+            Commit = TestRepository.CoherencyTestRepo1Commit,
+            Type = DependencyType.Product,
+            Pinned = false,
+            Locations = new List<string> { azdoFeed3, buildContainer }
+        };
+        expectedAzDoFeedFlowDependencies.Add(feedHamburger);
+        await testLogic.NonBatchedAzDoFlowTestBase(
+            $"AzDo_FeedFlowBranch_{Environment.MachineName}",
+            $"AzDo_FeedFlowChannel_{Environment.MachineName}",
+            feedFlowSourceAssets,
+            expectedAzDoFeedFlowDependencies,
+            isFeedTest: true,
+            expectedFeeds: expectedFeeds,
+            notExpectedFeeds: notExpectedFeeds).ConfigureAwait(false);
     }
 }

--- a/test/Maestro.ScenarioTests/ScenarioTests_Builds.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Builds.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
@@ -9,100 +8,99 @@ using Microsoft.DotNet.Maestro.Client.Models;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+[TestFixture]
+[Category("PostDeployment")]
+internal class ScenarioTests_Builds : MaestroScenarioTestBase
 {
-    [TestFixture]
-    [Category("PostDeployment")]
-    public class ScenarioTests_Builds : MaestroScenarioTestBase
+    private string repoUrl;
+    private readonly string repoName = TestRepository.TestRepo1Name;
+    private const string SourceBuildNumber = "654321";
+    private const string SourceCommit = "123456";
+    private const string SourceBranch = "master";
+
+    private readonly IImmutableList<AssetData> sourceAssets;
+    private TestParameters _parameters;
+
+    public ScenarioTests_Builds()
     {
-        private string repoUrl;
-        private readonly string repoName = TestRepository.TestRepo1Name;
-        private readonly string sourceBuildNumber = "654321";
-        private readonly string sourceCommit = "123456";
-        private readonly string sourceBranch = "master";
+        sourceAssets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
+    }
 
-        private readonly IImmutableList<AssetData> sourceAssets;
-        private TestParameters _parameters;
+    [SetUp]
+    public async Task InitializeAsync()
+    {
+        _parameters = await TestParameters.GetAsync();
+        SetTestParameters(_parameters);
+    }
 
-        public ScenarioTests_Builds()
-        {
-            sourceAssets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
-        }
+    [TearDown]
+    public Task DisposeAsync()
+    {
+        _parameters.Dispose();
+        return Task.CompletedTask;
+    }
 
-        [SetUp]
-        public async Task InitializeAsync()
-        {
-            _parameters = await TestParameters.GetAsync();
-            SetTestParameters(_parameters);
-        }
+    // Create a new build and check some of the metadata. Then mark as released and check again
+    [Test]
+    public async Task ArcadeBuilds_EndToEnd()
+    {
+        TestContext.WriteLine("Darc/Maestro build-handling tests");
+        string scenarioDirectory = _parameters._dir.Directory;
 
-        [TearDown]
-        public Task DisposeAsync()
-        {
-            _parameters.Dispose();
-            return Task.CompletedTask;
-        }
+        repoUrl = GetGitHubRepoUrl(repoName);
 
-        // Create a new build and check some of the metadata. Then mark as released and check again
-        [Test]
-        public async Task ArcadeBuilds_EndToEnd()
-        {
-            TestContext.WriteLine("Darc/Maestro build-handling tests");
-            string scenarioDirectory = _parameters._dir.Directory;
+        // Create a build for the source repo
+        Build build = await CreateBuildAsync(repoUrl, SourceBranch, SourceCommit, SourceBuildNumber, sourceAssets);
+        Build retrievedBuild = await MaestroApi.Builds.GetBuildAsync(build.Id);
+        Assert.IsFalse(retrievedBuild.Released, "Retrieved build has Released set to true when it should be false");
 
-            repoUrl = GetRepoUrl(repoName);
+        // Release the build; gather-drop does not fetch anything unless the flag '--include-released' is included in its arguments (which the next operation does set)
+        Build updatedBuild = await MaestroApi.Builds.UpdateAsync(new BuildUpdate() { Released = true }, build.Id);
+        Assert.IsTrue(updatedBuild.Released, "Retrieved build has Released set to false when it should be true");
 
-            // Create a build for the source repo
-            Build build = await CreateBuildAsync(repoUrl, sourceBranch, sourceCommit, sourceBuildNumber, sourceAssets);
-            Build retrievedBuild = await MaestroApi.Builds.GetBuildAsync(build.Id);
-            Assert.IsFalse(retrievedBuild.Released, "Retrieved build has Released set to true when it should be false");
+        // Gather a drop with release included
+        string gatherWithReleasedDir = Path.Combine(scenarioDirectory, "gather-with-released");
+        string gatherDropOutput = "";
 
-            // Release the build; gather-drop does not fetch anything unless the flag '--include-released' is included in its arguments (which the next operation does set)
-            Build updatedBuild = await MaestroApi.Builds.UpdateAsync(new BuildUpdate() { Released = true }, build.Id);
-            Assert.IsTrue(updatedBuild.Released, "Retrieved build has Released set to false when it should be true");
+        TestContext.WriteLine("Starting 'Gather with released, where build has been set to released' using folder " + gatherWithReleasedDir);
 
-            // Gather a drop with release included
-            string gatherWithReleasedDir = Path.Combine(scenarioDirectory, "gather-with-released");
-            string gatherDropOutput = "";
+        gatherDropOutput = await GatherDrop(build.Id, gatherWithReleasedDir, true, string.Empty);
 
-            TestContext.WriteLine("Starting 'Gather with released, where build has been set to released' using folder " + gatherWithReleasedDir);
+        StringAssert.Contains($"Gathering drop for build {SourceBuildNumber}", gatherDropOutput, "Gather with released 1");
+        StringAssert.Contains("Downloading asset Bar@2.1.0", gatherDropOutput, "Gather with released 1");
+        StringAssert.Contains("Downloading asset Foo@1.1.0", gatherDropOutput, "Gather with released 1");
+        StringAssert.DoesNotContain("always-download assets in build", gatherDropOutput, "Gather with released 1");
 
-            gatherDropOutput = await GatherDrop(build.Id, gatherWithReleasedDir, true, string.Empty);
+        // Gather with release excluded (default behavior). Gather-drop should throw an error.
+        TestContext.WriteLine("Starting 'Gather with release excluded' - gather-drop should throw an error.");
 
-            StringAssert.Contains($"Gathering drop for build {sourceBuildNumber}", gatherDropOutput, "Gather with released 1");
-            StringAssert.Contains("Downloading asset Bar@2.1.0", gatherDropOutput, "Gather with released 1");
-            StringAssert.Contains("Downloading asset Foo@1.1.0", gatherDropOutput, "Gather with released 1");
-            StringAssert.DoesNotContain("always-download assets in build", gatherDropOutput, "Gather with released 1");
+        string gatherWithNoReleasedDir = Path.Combine(scenarioDirectory, "gather-no-released");
+        Assert.ThrowsAsync<MaestroTestException>(async () => await GatherDrop(build.Id, gatherWithNoReleasedDir, false, string.Empty), "Gather with release excluded");
 
-            // Gather with release excluded (default behavior). Gather-drop should throw an error.
-            TestContext.WriteLine("Starting 'Gather with release excluded' - gather-drop should throw an error.");
+        // Unrelease the build
+        Build unreleaseBuild = await MaestroApi.Builds.UpdateAsync(new BuildUpdate() { Released = false }, build.Id);
+        Assert.IsFalse(unreleaseBuild.Released);
 
-            string gatherWithNoReleasedDir = Path.Combine(scenarioDirectory, "gather-no-released");
-            Assert.ThrowsAsync<MaestroTestException>(async () => await GatherDrop(build.Id, gatherWithNoReleasedDir, false, string.Empty), "Gather with release excluded");
+        // Gather with release excluded again (default behavior)
+        string gatherWithNoReleased2Dir = Path.Combine(scenarioDirectory, "gather-no-released-2");
+        TestContext.WriteLine("Starting 'Gather unreleased with release excluded' using folder " + gatherWithNoReleased2Dir);
+        gatherDropOutput = await GatherDrop(build.Id, gatherWithNoReleased2Dir, false, string.Empty);
 
-            // Unrelease the build
-            Build unreleaseBuild = await MaestroApi.Builds.UpdateAsync(new BuildUpdate() { Released = false }, build.Id);
-            Assert.IsFalse(unreleaseBuild.Released);
+        StringAssert.Contains($"Gathering drop for build {SourceBuildNumber}", gatherDropOutput, "Gather unreleased with release excluded");
+        StringAssert.Contains("Downloading asset Bar@2.1.0", gatherDropOutput, "Gather unreleased with release excluded");
+        StringAssert.Contains("Downloading asset Foo@1.1.0", gatherDropOutput, "Gather unreleased with release excluded");
+        StringAssert.DoesNotContain("always-download assets in build", gatherDropOutput, "Gather unreleased with release excluded");
 
-            // Gather with release excluded again (default behavior)
-            string gatherWithNoReleased2Dir = Path.Combine(scenarioDirectory, "gather-no-released-2");
-            TestContext.WriteLine("Starting 'Gather unreleased with release excluded' using folder " + gatherWithNoReleased2Dir);
-            gatherDropOutput = await GatherDrop(build.Id, gatherWithNoReleased2Dir, false, string.Empty);
+        // Gather with release excluded again, but specify --always-download-asset-filters
+        string gatherWithNoReleased3Dir = Path.Combine(scenarioDirectory, "gather-no-released-3");
+        TestContext.WriteLine("Starting 'Gather unreleased with release excluded' using folder " + gatherWithNoReleased3Dir);
+        gatherDropOutput = await GatherDrop(build.Id, gatherWithNoReleased3Dir, false, $"B.*r$");
 
-            StringAssert.Contains($"Gathering drop for build {sourceBuildNumber}", gatherDropOutput, "Gather unreleased with release excluded");
-            StringAssert.Contains("Downloading asset Bar@2.1.0", gatherDropOutput, "Gather unreleased with release excluded");
-            StringAssert.Contains("Downloading asset Foo@1.1.0", gatherDropOutput, "Gather unreleased with release excluded");
-            StringAssert.DoesNotContain("always-download assets in build", gatherDropOutput, "Gather unreleased with release excluded");
-
-            // Gather with release excluded again, but specify --always-download-asset-filters
-            string gatherWithNoReleased3Dir = Path.Combine(scenarioDirectory, "gather-no-released-3");
-            TestContext.WriteLine("Starting 'Gather unreleased with release excluded' using folder " + gatherWithNoReleased3Dir);
-            gatherDropOutput = await GatherDrop(build.Id, gatherWithNoReleased3Dir, false, $"B.*r$");
-
-            StringAssert.Contains($"Gathering drop for build {sourceBuildNumber}", gatherDropOutput, "Gather unreleased with release excluded");
-            StringAssert.Contains("Downloading asset Bar@2.1.0", gatherDropOutput, "Gather unreleased with release excluded");
-            StringAssert.Contains("Downloading asset Foo@1.1.0", gatherDropOutput, "Gather unreleased with release excluded");
-            StringAssert.Contains("Found 1 always-download asset(s) in build", gatherDropOutput, "Gather unreleased with release excluded");
-        }
+        StringAssert.Contains($"Gathering drop for build {SourceBuildNumber}", gatherDropOutput, "Gather unreleased with release excluded");
+        StringAssert.Contains("Downloading asset Bar@2.1.0", gatherDropOutput, "Gather unreleased with release excluded");
+        StringAssert.Contains("Downloading asset Foo@1.1.0", gatherDropOutput, "Gather unreleased with release excluded");
+        StringAssert.Contains("Found 1 always-download asset(s) in build", gatherDropOutput, "Gather unreleased with release excluded");
     }
 }

--- a/test/Maestro.ScenarioTests/ScenarioTests_Channels.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Channels.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Maestro.ScenarioTests;
@@ -33,14 +34,14 @@ internal class ScenarioTests_Channels : MaestroScenarioTestBase
         {
             // Get the channel and make sure it's there
             string returnedChannel = await GetTestChannelsAsync().ConfigureAwait(false);
-            StringAssert.Contains(testChannelName, returnedChannel, "Channel was not created or could not be retrieved");
+            returnedChannel.Should().Contain(testChannelName, "Channel was not created or could not be retrieved");
 
             // Delete the channel
             await DeleteTestChannelAsync(testChannelName).ConfigureAwait(false);
 
             // Get the channel and make sure it was deleted
             string returnedChannel2 = await GetTestChannelsAsync().ConfigureAwait(false);
-            StringAssert.DoesNotContain(testChannelName, returnedChannel2, "Channel was not deleted");
+            returnedChannel2.Should().NotContain(testChannelName, "Channel was not deleted");
         }
     }
 }

--- a/test/Maestro.ScenarioTests/ScenarioTests_Channels.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Channels.cs
@@ -5,43 +5,42 @@ using System;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+[TestFixture]
+[Category("PostDeployment")]
+internal class ScenarioTests_Channels : MaestroScenarioTestBase
 {
-    [TestFixture]
-    [Category("PostDeployment")]
-    public class ScenarioTests_Channels : MaestroScenarioTestBase
+    private TestParameters _parameters;
+
+    [TearDown]
+    public Task DisposeAsync()
     {
-        private TestParameters _parameters;
+        _parameters.Dispose();
+        return Task.CompletedTask;
+    }
 
-        [TearDown]
-        public Task DisposeAsync()
+    [Test]
+    public async Task ArcadeChannels_EndToEnd()
+    {
+        _parameters = await TestParameters.GetAsync();
+        SetTestParameters(_parameters);
+
+        // Create a new channel
+        string testChannelName = $"Test Channel End to End {Environment.MachineName}";
+
+        await using (AsyncDisposableValue<string> channel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false))
         {
-            _parameters.Dispose();
-            return Task.CompletedTask;
-        }
+            // Get the channel and make sure it's there
+            string returnedChannel = await GetTestChannelsAsync().ConfigureAwait(false);
+            StringAssert.Contains(testChannelName, returnedChannel, "Channel was not created or could not be retrieved");
 
-        [Test]
-        public async Task ArcadeChannels_EndToEnd()
-        {
-            _parameters = await TestParameters.GetAsync();
-            SetTestParameters(_parameters);
+            // Delete the channel
+            await DeleteTestChannelAsync(testChannelName).ConfigureAwait(false);
 
-            // Create a new channel
-            string testChannelName = $"Test Channel End to End {Environment.MachineName}";
-
-            await using (AsyncDisposableValue<string> channel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false))
-            {
-                // Get the channel and make sure it's there
-                string returnedChannel = await GetTestChannelsAsync().ConfigureAwait(false);
-                StringAssert.Contains(testChannelName, returnedChannel, "Channel was not created or could not be retrieved");
-
-                // Delete the channel
-                await DeleteTestChannelAsync(testChannelName).ConfigureAwait(false);
-
-                // Get the channel and make sure it was deleted
-                string returnedChannel2 = await GetTestChannelsAsync().ConfigureAwait(false);
-                StringAssert.DoesNotContain(testChannelName, returnedChannel2, "Channel was not deleted");
-            }
+            // Get the channel and make sure it was deleted
+            string returnedChannel2 = await GetTestChannelsAsync().ConfigureAwait(false);
+            StringAssert.DoesNotContain(testChannelName, returnedChannel2, "Channel was not deleted");
         }
     }
 }

--- a/test/Maestro.ScenarioTests/ScenarioTests_Clone.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Clone.cs
@@ -26,7 +26,7 @@ namespace Maestro.ScenarioTests
 
             string sourceRepoName = "core-sdk";
             string sourceRepoVersion = "v3.0.100-preview4-011223";
-            string sourceRepoUri = GetRepoUrl(sourceRepoName);
+            string sourceRepoUri = GetGitHubRepoUrl(sourceRepoName);
 
             // these repos are not currently clonable for us due to auth
             string reposToIgnore = "https://dev.azure.com/dnceng/internal/_git/dotnet-optimization;https://dev.azure.com/devdiv/DevDiv/_git/DotNet-Trusted;https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Trusted";

--- a/test/Maestro.ScenarioTests/ScenarioTests_Clone.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Clone.cs
@@ -9,197 +9,196 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+[TestFixture]
+[NonParallelizable]
+[Category("PostDeployment")]
+class ScenarioTests_Clone : MaestroScenarioTestBase
 {
-    [TestFixture]
-    [NonParallelizable]
-    [Category("PostDeployment")]
-    class ScenarioTests_Clone : MaestroScenarioTestBase
+    [Test]
+    public async Task Darc_CloneRepo()
     {
-        [Test]
-        public async Task Darc_CloneRepo()
+        TestContext.WriteLine("Darc-Clone repo end to end test");
+
+        TestParameters parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
+        SetTestParameters(parameters);
+
+        var sourceRepoName = "core-sdk";
+        var sourceRepoVersion = "v3.0.100-preview4-011223";
+        var sourceRepoUri = GetGitHubRepoUrl(sourceRepoName);
+
+        // these repos are not currently clonable for us due to auth
+        var reposToIgnore = "https://dev.azure.com/dnceng/internal/_git/dotnet-optimization;https://dev.azure.com/devdiv/DevDiv/_git/DotNet-Trusted;https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Trusted";
+
+        // these repos have file names that are too long on Windows for the temp folder
+        reposToIgnore += ";https://github.com/aspnet/AspNetCore;https://github.com/aspnet/AspNetCore-Tooling;https://github.com/dotnet/core-setup;https://github.com/dotnet/templating;" +
+            "https://github.com/dotnet/sdk;https://github.com/Microsoft/visualfsharp;https://github.com/dotnet/roslyn;https://github.com/NuGet/NuGet.Client;https://github.com/dotnet/corefx";
+
+        var expectedRepos1 = new Dictionary<string, string>
         {
-            TestContext.WriteLine("Darc-Clone repo end to end test");
+            { "cli.204f425b6f061d0b8a01faf46f762ecf71436f68",                     "BB7B735A345157E1CB90E4E03340FD202C798B06E5EA089C2F0191562D9DF1B4" },
+            { "cliCommandLineParser.0e89c2116ad28e404ba56c14d1c3f938caa25a01",    "CCA267C3FB69E8AADFA6CEE474249ACB84829D9CCFE7F9F5D7F17EFA87A26739" },
+            { "core-sdk.v3.0.100-preview4-011223",                                "BBAE24214F40518798126A2F4729C38B6C3B67886DCDE0C2D64BBE203D4ACFBB" },
+            { "msbuild.d004974104fde202e633b3c97e0ece3287aa62f9",                 "FD4F85D3FB60B5EBC105647E290924071A240A0C6FD49E3D44A2BC38A797946C" },
+            { "standard.8ef5ada20b5343b0cb9e7fd577341426dab76cd8",                "FA876A709FDB0CD3D864431B2887D2BC9ACBFC313E8C452A8636EE7FAE4E5D02" },
+            { "toolset.3165b2579582b6b44aef768c01c3cc9ff4f0bc17",                 "D483493BF79129FD2DADC39C51FACB5FA363CEB03E54ECD180720DE2D95EDED9" },
+            { "websdk.b55d4f4cf22bee7ec9a2ca5f49d54ebf6ee67e83",                  "A51DEB15209039D17FC0D781BFC445F8C5CDC1D51673AC4C0929FBEE8C1E4D21" },
+            { "winforms.b1ee29b8b8e14c1200adff02847391dde471d0d2",                "1288479D12130F9AEF56137DCC655B5B59277F5153172B30DC419456AF9CA011" },
+            { "wpf.d378b1ec6b8555c52b7da1c40ffc0784cb0f5cad",                     "CFE5E19366FD5A90101A8F369CFC70611F9B1439A0720D435EE34872AF55A40A" }
+        };
 
-            TestParameters parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
-            SetTestParameters(parameters);
+        string[] expectedMasterRepos1 =
+        [
+            "cli",
+            "cliCommandLineParser",
+            "core-sdk",
+            "msbuild",
+            "standard",
+            "toolset",
+            "websdk",
+            "winforms",
+            "wpf"
+        ];
 
-            string sourceRepoName = "core-sdk";
-            string sourceRepoVersion = "v3.0.100-preview4-011223";
-            string sourceRepoUri = GetGitHubRepoUrl(sourceRepoName);
+        string[] expectedGitDirs1 =
+        [
+            "cli.git",
+            "cliCommandLineParser.git",
+            "core-sdk.git",
+            "msbuild.git",
+            "standard.git",
+            "toolset.git",
+            "websdk.git",
+            "winforms.git",
+            "wpf.git"
+        ];
 
-            // these repos are not currently clonable for us due to auth
-            string reposToIgnore = "https://dev.azure.com/dnceng/internal/_git/dotnet-optimization;https://dev.azure.com/devdiv/DevDiv/_git/DotNet-Trusted;https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Trusted";
+        TestContext.WriteLine($"parameters: sourceRepoName={sourceRepoName}, sourceRepoVersion={sourceRepoVersion}, reposToIgnore='{reposToIgnore}'");
+        TestContext.WriteLine($"Cloning repo {sourceRepoUri} at {sourceRepoVersion} with depth 2 and include - toolset = false");
+        TemporaryDirectory reposFolder = await CloneRepositoryWithDarc(sourceRepoName, sourceRepoVersion, reposToIgnore, false, 2);
+        CheckExpectedClonedRepos(expectedRepos1, expectedMasterRepos1, expectedGitDirs1, reposFolder);
 
-            // these repos have file names that are too long on Windows for the temp folder
-            reposToIgnore += ";https://github.com/aspnet/AspNetCore;https://github.com/aspnet/AspNetCore-Tooling;https://github.com/dotnet/core-setup;https://github.com/dotnet/templating;" +
-                "https://github.com/dotnet/sdk;https://github.com/Microsoft/visualfsharp;https://github.com/dotnet/roslyn;https://github.com/NuGet/NuGet.Client;https://github.com/dotnet/corefx";
-
-            Dictionary<string, string> expectedRepos1 = new Dictionary<string, string>
-            {
-                { "cli.204f425b6f061d0b8a01faf46f762ecf71436f68",                     "BB7B735A345157E1CB90E4E03340FD202C798B06E5EA089C2F0191562D9DF1B4" },
-                { "cliCommandLineParser.0e89c2116ad28e404ba56c14d1c3f938caa25a01",    "CCA267C3FB69E8AADFA6CEE474249ACB84829D9CCFE7F9F5D7F17EFA87A26739" },
-                { "core-sdk.v3.0.100-preview4-011223",                                "BBAE24214F40518798126A2F4729C38B6C3B67886DCDE0C2D64BBE203D4ACFBB" },
-                { "msbuild.d004974104fde202e633b3c97e0ece3287aa62f9",                 "FD4F85D3FB60B5EBC105647E290924071A240A0C6FD49E3D44A2BC38A797946C" },
-                { "standard.8ef5ada20b5343b0cb9e7fd577341426dab76cd8",                "FA876A709FDB0CD3D864431B2887D2BC9ACBFC313E8C452A8636EE7FAE4E5D02" },
-                { "toolset.3165b2579582b6b44aef768c01c3cc9ff4f0bc17",                 "D483493BF79129FD2DADC39C51FACB5FA363CEB03E54ECD180720DE2D95EDED9" },
-                { "websdk.b55d4f4cf22bee7ec9a2ca5f49d54ebf6ee67e83",                  "A51DEB15209039D17FC0D781BFC445F8C5CDC1D51673AC4C0929FBEE8C1E4D21" },
-                { "winforms.b1ee29b8b8e14c1200adff02847391dde471d0d2",                "1288479D12130F9AEF56137DCC655B5B59277F5153172B30DC419456AF9CA011" },
-                { "wpf.d378b1ec6b8555c52b7da1c40ffc0784cb0f5cad",                     "CFE5E19366FD5A90101A8F369CFC70611F9B1439A0720D435EE34872AF55A40A" }
-            };
-
-            string[] expectedMasterRepos1 = new string[]
-            {
-                "cli",
-                "cliCommandLineParser",
-                "core-sdk",
-                "msbuild",
-                "standard",
-                "toolset",
-                "websdk",
-                "winforms",
-                "wpf"
-            };
-
-            string[] expectedGitDirs1 = new string[]
-            {
-                "cli.git",
-                "cliCommandLineParser.git",
-                "core-sdk.git",
-                "msbuild.git",
-                "standard.git",
-                "toolset.git",
-                "websdk.git",
-                "winforms.git",
-                "wpf.git"
-            };
-
-            TestContext.WriteLine($"parameters: sourceRepoName={sourceRepoName}, sourceRepoVersion={sourceRepoVersion}, reposToIgnore='{reposToIgnore}'");
-            TestContext.WriteLine($"Cloning repo {sourceRepoUri} at {sourceRepoVersion} with depth 2 and include - toolset = false");
-            TemporaryDirectory reposFolder = await CloneRepositoryWithDarc(sourceRepoName, sourceRepoVersion, reposToIgnore, false, 2);
-            CheckExpectedClonedRepos(expectedRepos1, expectedMasterRepos1, expectedGitDirs1, reposFolder);
-
-            Dictionary<string, string> expectedRepos2 = new Dictionary<string, string>
-            {
-                { "cli.204f425b6f061d0b8a01faf46f762ecf71436f68",                     "BB7B735A345157E1CB90E4E03340FD202C798B06E5EA089C2F0191562D9DF1B4" },
-                { "cliCommandLineParser.0e89c2116ad28e404ba56c14d1c3f938caa25a01",    "CCA267C3FB69E8AADFA6CEE474249ACB84829D9CCFE7F9F5D7F17EFA87A26739" },
-                { "core-sdk.v3.0.100-preview4-011223",                                "BBAE24214F40518798126A2F4729C38B6C3B67886DCDE0C2D64BBE203D4ACFBB" },
-                { "coreclr.d833cacabd67150fe3a2405845429a0ba1b72c12",                 "5A69F61C354C1DE9B839D6922CE866AB0B760BCCBC919EE4C408D44B6A40084C" },
-                { "msbuild.d004974104fde202e633b3c97e0ece3287aa62f9",                 "FD4F85D3FB60B5EBC105647E290924071A240A0C6FD49E3D44A2BC38A797946C" },
-                { "standard.8ef5ada20b5343b0cb9e7fd577341426dab76cd8",                "FA876A709FDB0CD3D864431B2887D2BC9ACBFC313E8C452A8636EE7FAE4E5D02" },
-                { "toolset.3165b2579582b6b44aef768c01c3cc9ff4f0bc17",                 "D483493BF79129FD2DADC39C51FACB5FA363CEB03E54ECD180720DE2D95EDED9" },
-                { "websdk.b55d4f4cf22bee7ec9a2ca5f49d54ebf6ee67e83",                  "A51DEB15209039D17FC0D781BFC445F8C5CDC1D51673AC4C0929FBEE8C1E4D21" },
-                { "winforms.b1ee29b8b8e14c1200adff02847391dde471d0d2",                "1288479D12130F9AEF56137DCC655B5B59277F5153172B30DC419456AF9CA011" },
-                {"wpf.d378b1ec6b8555c52b7da1c40ffc0784cb0f5cad",                      "CFE5E19366FD5A90101A8F369CFC70611F9B1439A0720D435EE34872AF55A40A" }
-            };
-
-            string[] expectedMasterRepos2 = new string[]
-            {
-                "cli",
-                "cliCommandLineParser",
-                "core-sdk",
-                "coreclr",
-                "msbuild",
-                "standard",
-                "toolset",
-                "websdk",
-                "winforms",
-                "wpf"
-            };
-
-            string[] expectedGitDirs2 = new string[]
-            {
-                "cli.git",
-                "cliCommandLineParser.git",
-                "core-sdk.git",
-                "coreclr.git",
-                "msbuild.git",
-                "standard.git",
-                "toolset.git",
-                "websdk.git",
-                "winforms.git",
-                "wpf.git"
-            };
-
-            reposToIgnore += ";https://github.com/dotnet/arcade";
-            TestContext.WriteLine($"Cloning repo {sourceRepoUri} at {sourceRepoVersion} with depth 4 and include-toolset=true");
-            reposFolder = await CloneRepositoryWithDarc(sourceRepoName, sourceRepoVersion, reposToIgnore, true, 4);
-            CheckExpectedClonedRepos(expectedRepos2, expectedMasterRepos2, expectedGitDirs2, reposFolder);
-        }
-
-        private void CheckExpectedClonedRepos(Dictionary<string, string> expectedRepos, string[] expectedMasterRepos, string[] expectedGitDirs, TemporaryDirectory reposFolder)
+        var expectedRepos2 = new Dictionary<string, string>
         {
-            using (ChangeDirectory(reposFolder.Directory))
+            { "cli.204f425b6f061d0b8a01faf46f762ecf71436f68",                     "BB7B735A345157E1CB90E4E03340FD202C798B06E5EA089C2F0191562D9DF1B4" },
+            { "cliCommandLineParser.0e89c2116ad28e404ba56c14d1c3f938caa25a01",    "CCA267C3FB69E8AADFA6CEE474249ACB84829D9CCFE7F9F5D7F17EFA87A26739" },
+            { "core-sdk.v3.0.100-preview4-011223",                                "BBAE24214F40518798126A2F4729C38B6C3B67886DCDE0C2D64BBE203D4ACFBB" },
+            { "coreclr.d833cacabd67150fe3a2405845429a0ba1b72c12",                 "5A69F61C354C1DE9B839D6922CE866AB0B760BCCBC919EE4C408D44B6A40084C" },
+            { "msbuild.d004974104fde202e633b3c97e0ece3287aa62f9",                 "FD4F85D3FB60B5EBC105647E290924071A240A0C6FD49E3D44A2BC38A797946C" },
+            { "standard.8ef5ada20b5343b0cb9e7fd577341426dab76cd8",                "FA876A709FDB0CD3D864431B2887D2BC9ACBFC313E8C452A8636EE7FAE4E5D02" },
+            { "toolset.3165b2579582b6b44aef768c01c3cc9ff4f0bc17",                 "D483493BF79129FD2DADC39C51FACB5FA363CEB03E54ECD180720DE2D95EDED9" },
+            { "websdk.b55d4f4cf22bee7ec9a2ca5f49d54ebf6ee67e83",                  "A51DEB15209039D17FC0D781BFC445F8C5CDC1D51673AC4C0929FBEE8C1E4D21" },
+            { "winforms.b1ee29b8b8e14c1200adff02847391dde471d0d2",                "1288479D12130F9AEF56137DCC655B5B59277F5153172B30DC419456AF9CA011" },
+            {"wpf.d378b1ec6b8555c52b7da1c40ffc0784cb0f5cad",                      "CFE5E19366FD5A90101A8F369CFC70611F9B1439A0720D435EE34872AF55A40A" }
+        };
+
+        string[] expectedMasterRepos2 =
+        [
+            "cli",
+            "cliCommandLineParser",
+            "core-sdk",
+            "coreclr",
+            "msbuild",
+            "standard",
+            "toolset",
+            "websdk",
+            "winforms",
+            "wpf"
+        ];
+
+        string[] expectedGitDirs2 =
+        [
+            "cli.git",
+            "cliCommandLineParser.git",
+            "core-sdk.git",
+            "coreclr.git",
+            "msbuild.git",
+            "standard.git",
+            "toolset.git",
+            "websdk.git",
+            "winforms.git",
+            "wpf.git"
+        ];
+
+        reposToIgnore += ";https://github.com/dotnet/arcade";
+        TestContext.WriteLine($"Cloning repo {sourceRepoUri} at {sourceRepoVersion} with depth 4 and include-toolset=true");
+        reposFolder = await CloneRepositoryWithDarc(sourceRepoName, sourceRepoVersion, reposToIgnore, true, 4);
+        CheckExpectedClonedRepos(expectedRepos2, expectedMasterRepos2, expectedGitDirs2, reposFolder);
+    }
+
+    private void CheckExpectedClonedRepos(Dictionary<string, string> expectedRepos, string[] expectedMasterRepos, string[] expectedGitDirs, TemporaryDirectory reposFolder)
+    {
+        using (ChangeDirectory(reposFolder.Directory))
+        {
+            var clonedReposFolder = Path.Join(reposFolder.Directory, "cloned-repos");
+            var gitDirFolder = Path.Join(reposFolder.Directory, "git-dirs");
+
+            TestContext.WriteLine("Validate the hash of the Version.Details.xml matches expected");
+            foreach (var name in expectedRepos.Keys)
             {
-                string clonedReposFolder = Path.Join(reposFolder.Directory, "cloned-repos");
-                string gitDirFolder = Path.Join(reposFolder.Directory, "git-dirs");
+                var path = Path.Join(clonedReposFolder, name);
+                DirectoryAssert.Exists(path, $"Expected cloned repo '{name}' but not found at {path}");
 
-                TestContext.WriteLine("Validate the hash of the Version.Details.xml matches expected");
-                foreach (string name in expectedRepos.Keys)
+                var versionPath = Path.Join(path, "eng", "Version.Details.xml");
+                FileAssert.Exists(versionPath, $"Expected a file at {versionPath}");
+
+                using (FileStream stream = File.OpenRead(versionPath))
                 {
-                    string path = Path.Join(clonedReposFolder, name);
-                    DirectoryAssert.Exists(path, $"Expected cloned repo '{name}' but not found at {path}");
-
-                    string versionPath = Path.Join(path, "eng", "Version.Details.xml");
-                    FileAssert.Exists(versionPath, $"Expected a file at {versionPath}");
-
-                    using (FileStream stream = File.OpenRead(versionPath))
-                    {
-                        using SHA256 hashGenerator = SHA256.Create();
-                        byte[] fileHash = hashGenerator.ComputeHash(stream);
-                        string fileHashInHex = BitConverter.ToString(fileHash).Replace("-", "");
-                        Assert.AreEqual(expectedRepos[name], fileHashInHex, $"Expected {versionPath} to have hash '{expectedRepos[name]}', actual hash '{fileHash}'");
-                    }
+                    using var hashGenerator = SHA256.Create();
+                    var fileHash = hashGenerator.ComputeHash(stream);
+                    var fileHashInHex = BitConverter.ToString(fileHash).Replace("-", "");
+                    Assert.AreEqual(expectedRepos[name], fileHashInHex, $"Expected {versionPath} to have hash '{expectedRepos[name]}', actual hash '{fileHash}'");
                 }
+            }
 
-                TestContext.WriteLine("Ensure the presence of the git directories");
-                foreach (string repo in expectedMasterRepos)
-                {
-                    string path = Path.Join(clonedReposFolder, repo);
-                    DirectoryAssert.Exists(path, $"Expected cloned master repo {repo} but it is missing");
+            TestContext.WriteLine("Ensure the presence of the git directories");
+            foreach (var repo in expectedMasterRepos)
+            {
+                var path = Path.Join(clonedReposFolder, repo);
+                DirectoryAssert.Exists(path, $"Expected cloned master repo {repo} but it is missing");
 
-                    string gitRedirectPath = Path.Join(path, ".git");
-                    string expectedGitDir = Path.Join(gitDirFolder, repo);
-                    string expectedRedirect = $"gitdir: {expectedGitDir}.git";
-                    string actualRedirect = File.ReadAllText(gitRedirectPath);
-                    Assert.AreEqual(expectedRedirect, actualRedirect, $"Expected {path} to have .gitdir redirect of {expectedRedirect}, actual {actualRedirect}");
-                }
+                var gitRedirectPath = Path.Join(path, ".git");
+                var expectedGitDir = Path.Join(gitDirFolder, repo);
+                var expectedRedirect = $"gitdir: {expectedGitDir}.git";
+                var actualRedirect = File.ReadAllText(gitRedirectPath);
+                Assert.AreEqual(expectedRedirect, actualRedirect, $"Expected {path} to have .gitdir redirect of {expectedRedirect}, actual {actualRedirect}");
+            }
 
-                TestContext.WriteLine("Ensure the presence of the cloned repo directories");
-                string[] allRepos = Directory.GetDirectories(clonedReposFolder);
-                IEnumerable<string> reposFolderNames = allRepos.Select(d => Path.GetFileName(d));
-                List<string> actualRepos = reposFolderNames.Where(fn => fn.Contains(".")).ToList();
-                List<string> actualMasterRepos = reposFolderNames.Where(fn => !fn.Contains(".")).ToList();
+            TestContext.WriteLine("Ensure the presence of the cloned repo directories");
+            var allRepos = Directory.GetDirectories(clonedReposFolder);
+            IEnumerable<string> reposFolderNames = allRepos.Select(d => Path.GetFileName(d));
+            var actualRepos = reposFolderNames.Where(fn => fn.Contains(".")).ToList();
+            var actualMasterRepos = reposFolderNames.Where(fn => !fn.Contains(".")).ToList();
 
-                Assert.AreEqual(expectedRepos.Count, actualRepos.Count);
-                Assert.AreEqual(expectedRepos.Keys, actualRepos);
+            Assert.AreEqual(expectedRepos.Count, actualRepos.Count);
+            Assert.AreEqual(expectedRepos.Keys, actualRepos);
 
-                Assert.AreEqual(expectedMasterRepos.Length, actualMasterRepos.Count);
-                Assert.AreEqual(expectedMasterRepos, actualMasterRepos);
+            Assert.AreEqual(expectedMasterRepos.Length, actualMasterRepos.Count);
+            Assert.AreEqual(expectedMasterRepos, actualMasterRepos);
 
-                TestContext.WriteLine("Validating the existence and content of the git directories");
-                foreach (string dir in expectedGitDirs)
-                {
-                    string path = Path.Join(gitDirFolder, dir);
-                    DirectoryAssert.Exists(path, $"Expected a .gitdir for '{dir}', but not found at {path}");
-                }
+            TestContext.WriteLine("Validating the existence and content of the git directories");
+            foreach (var dir in expectedGitDirs)
+            {
+                var path = Path.Join(gitDirFolder, dir);
+                DirectoryAssert.Exists(path, $"Expected a .gitdir for '{dir}', but not found at {path}");
+            }
 
-                string[] actualGitDirs = Directory.GetDirectories(gitDirFolder);
-                List<string> actualGitDirNames = actualGitDirs.Select(d => Path.GetFileName(d)).ToList();
-                Assert.AreEqual(expectedGitDirs, actualGitDirNames);
+            var actualGitDirs = Directory.GetDirectories(gitDirFolder);
+            var actualGitDirNames = actualGitDirs.Select(d => Path.GetFileName(d)).ToList();
+            Assert.AreEqual(expectedGitDirs, actualGitDirNames);
 
-                foreach (string gitDirectory in actualGitDirs)
-                {
-                    TestContext.WriteLine($"Checking content of {gitDirectory}");
-                    string[] expectedFolders = { "hooks", "info", "logs", "objects", "refs" };
-                    string[] actualFolders = Directory.GetDirectories(gitDirectory);
-                    List<string> actualFolderNames = actualFolders.Select(d => Path.GetFileName(d)).ToList();
-                    Assert.AreEqual(expectedFolders, actualFolderNames);
+            foreach (var gitDirectory in actualGitDirs)
+            {
+                TestContext.WriteLine($"Checking content of {gitDirectory}");
+                string[] expectedFolders = ["hooks", "info", "logs", "objects", "refs"];
+                var actualFolders = Directory.GetDirectories(gitDirectory);
+                var actualFolderNames = actualFolders.Select(d => Path.GetFileName(d)).ToList();
+                Assert.AreEqual(expectedFolders, actualFolderNames);
 
-                    string[] expectedFiles = { "config", "description", "FETCH_HEAD", "HEAD", "index" };
-                    string[] actualFiles = Directory.GetFiles(gitDirectory).Select(p => Path.GetFileName(p)).ToArray();
-                    Assert.AreEqual(expectedFiles, actualFiles);
-                }
+                string[] expectedFiles = ["config", "description", "FETCH_HEAD", "HEAD", "index"];
+                var actualFiles = Directory.GetFiles(gitDirectory).Select(p => Path.GetFileName(p)).ToArray();
+                Assert.AreEqual(expectedFiles, actualFiles);
             }
         }
     }

--- a/test/Maestro.ScenarioTests/ScenarioTests_Clone.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Clone.cs
@@ -175,7 +175,7 @@ class ScenarioTests_Clone : MaestroScenarioTestBase
             actualRepos.Should().HaveCount(expectedRepos.Count);
             actualRepos.Should().BeEquivalentTo(expectedRepos.Keys);
 
-            actualMasterRepos.Count.Should().Be(expectedMasterRepos.Length);
+            actualMasterRepos.Should().HaveCount(expectedMasterRepos.Length);
             actualMasterRepos.Should().BeEquivalentTo(expectedMasterRepos);
 
             TestContext.WriteLine("Validating the existence and content of the git directories");

--- a/test/Maestro.ScenarioTests/ScenarioTests_Clone.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Clone.cs
@@ -169,8 +169,8 @@ class ScenarioTests_Clone : MaestroScenarioTestBase
             TestContext.WriteLine("Ensure the presence of the cloned repo directories");
             var allRepos = Directory.GetDirectories(clonedReposFolder);
             IEnumerable<string> reposFolderNames = allRepos.Select(Path.GetFileName);
-            var actualRepos = reposFolderNames.Where(fn => fn.Contains(".")).ToList();
-            var actualMasterRepos = reposFolderNames.Where(fn => !fn.Contains(".")).ToList();
+            var actualRepos = reposFolderNames.Where(fn => fn.Contains('.')).ToList();
+            var actualMasterRepos = reposFolderNames.Where(fn => !fn.Contains('.')).ToList();
 
             actualRepos.Should().HaveCount(expectedRepos.Count);
             actualRepos.Should().BeEquivalentTo(expectedRepos.Keys);

--- a/test/Maestro.ScenarioTests/ScenarioTests_DefaultChannels.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_DefaultChannels.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Maestro.ScenarioTests;
@@ -44,23 +45,23 @@ internal class ScenarioTests_DefaultChannels : MaestroScenarioTestBase
         string testChannelName1 = $"TestChannelDefault1_{Environment.MachineName}";
         string testChannelName2 = $"TestChannelDefault2_{Environment.MachineName}";
 
-        await using (AsyncDisposableValue<string> channel1 = await CreateTestChannelAsync(testChannelName1).ConfigureAwait(false))
+        await using (AsyncDisposableValue<string> channel1 = await CreateTestChannelAsync(testChannelName1))
         {
-            await using (AsyncDisposableValue<string> channel2 = await CreateTestChannelAsync(testChannelName2).ConfigureAwait(false))
+            await using (AsyncDisposableValue<string> channel2 = await CreateTestChannelAsync(testChannelName2))
             {
-                await AddDefaultTestChannelAsync(testChannelName1, repoUrl, branchNameWithRefsHeads).ConfigureAwait(false);
-                await AddDefaultTestChannelAsync(testChannelName2, repoUrl, branchNameWithRefsHeads).ConfigureAwait(false);
+                await AddDefaultTestChannelAsync(testChannelName1, repoUrl, branchNameWithRefsHeads);
+                await AddDefaultTestChannelAsync(testChannelName2, repoUrl, branchNameWithRefsHeads);
 
-                string defaultChannels = await GetDefaultTestChannelsAsync(repoUrl, branchName).ConfigureAwait(false);
-                StringAssert.Contains(testChannelName1, defaultChannels, $"{testChannelName1} is not a default channel");
-                StringAssert.Contains(testChannelName2, defaultChannels, $"{testChannelName2} is not a default channel");
+                string defaultChannels = await GetDefaultTestChannelsAsync(repoUrl, branchName);
+                defaultChannels.Should().Contain(testChannelName1, $"{testChannelName1} is not a default channel");
+                defaultChannels.Should().Contain(testChannelName2, $"{testChannelName2} is not a default channel");
 
                 await DeleteDefaultTestChannelAsync(testChannelName1, repoUrl, branchName);
                 await DeleteDefaultTestChannelAsync(testChannelName2, repoUrl, branchName);
 
-                defaultChannels = await GetDefaultTestChannelsAsync(repoUrl, branchName).ConfigureAwait(false);
-                StringAssert.DoesNotContain(testChannelName1, defaultChannels, $"{testChannelName1} was not deleted from default channels");
-                StringAssert.DoesNotContain(testChannelName2, defaultChannels, $"{testChannelName2} was not deleted from default channels");
+                defaultChannels = await GetDefaultTestChannelsAsync(repoUrl, branchName);
+                defaultChannels.Should().NotContain(testChannelName1, $"{testChannelName1} was not deleted from default channels");
+                defaultChannels.Should().NotContain(testChannelName2, $"{testChannelName2} was not deleted from default channels");
             }
         }
     }

--- a/test/Maestro.ScenarioTests/ScenarioTests_DefaultChannels.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_DefaultChannels.cs
@@ -5,63 +5,62 @@ using System;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+[TestFixture]
+[Category("PostDeployment")]
+internal class ScenarioTests_DefaultChannels : MaestroScenarioTestBase
 {
-    [TestFixture]
-    [Category("PostDeployment")]
-    public class ScenarioTests_DefaultChannels : MaestroScenarioTestBase
+    private readonly string repoName = TestRepository.TestRepo1Name;
+    private readonly string branchName;
+    private readonly string branchNameWithRefsHeads;
+    private TestParameters _parameters;
+
+    public ScenarioTests_DefaultChannels()
     {
-        private readonly string repoName = TestRepository.TestRepo1Name;
-        private readonly string branchName;
-        private readonly string branchNameWithRefsHeads;
-        private TestParameters _parameters;
+        branchName = $"ChannelTestBranch_{Environment.MachineName}";
+        branchNameWithRefsHeads = $"refs/heads/{branchName}";
+    }
 
-        public ScenarioTests_DefaultChannels()
+    [SetUp]
+    public async Task InitializeAsync()
+    {
+        _parameters = await TestParameters.GetAsync();
+        SetTestParameters(_parameters);
+    }
+
+    [TearDown]
+    public Task DisposeAsync()
+    {
+        _parameters.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task ArcadeChannels_DefaultChannels()
+    {
+        string repoUrl = GetGitHubRepoUrl(repoName);
+
+        string testChannelName1 = $"TestChannelDefault1_{Environment.MachineName}";
+        string testChannelName2 = $"TestChannelDefault2_{Environment.MachineName}";
+
+        await using (AsyncDisposableValue<string> channel1 = await CreateTestChannelAsync(testChannelName1).ConfigureAwait(false))
         {
-            branchName = $"ChannelTestBranch_{Environment.MachineName}";
-            branchNameWithRefsHeads = $"refs/heads/{branchName}";
-        }
-
-        [SetUp]
-        public async Task InitializeAsync()
-        {
-            _parameters = await TestParameters.GetAsync();
-            SetTestParameters(_parameters);
-        }
-
-        [TearDown]
-        public Task DisposeAsync()
-        {
-            _parameters.Dispose();
-            return Task.CompletedTask;
-        }
-
-        [Test]
-        public async Task ArcadeChannels_DefaultChannels()
-        {
-            string repoUrl = GetRepoUrl(repoName);
-
-            string testChannelName1 = $"TestChannelDefault1_{Environment.MachineName}";
-            string testChannelName2 = $"TestChannelDefault2_{Environment.MachineName}";
-
-            await using (AsyncDisposableValue<string> channel1 = await CreateTestChannelAsync(testChannelName1).ConfigureAwait(false))
+            await using (AsyncDisposableValue<string> channel2 = await CreateTestChannelAsync(testChannelName2).ConfigureAwait(false))
             {
-                await using (AsyncDisposableValue<string> channel2 = await CreateTestChannelAsync(testChannelName2).ConfigureAwait(false))
-                {
-                    await AddDefaultTestChannelAsync(testChannelName1, repoUrl, branchNameWithRefsHeads).ConfigureAwait(false);
-                    await AddDefaultTestChannelAsync(testChannelName2, repoUrl, branchNameWithRefsHeads).ConfigureAwait(false);
+                await AddDefaultTestChannelAsync(testChannelName1, repoUrl, branchNameWithRefsHeads).ConfigureAwait(false);
+                await AddDefaultTestChannelAsync(testChannelName2, repoUrl, branchNameWithRefsHeads).ConfigureAwait(false);
 
-                    string defaultChannels = await GetDefaultTestChannelsAsync(repoUrl, branchName).ConfigureAwait(false);
-                    StringAssert.Contains(testChannelName1, defaultChannels, $"{testChannelName1} is not a default channel");
-                    StringAssert.Contains(testChannelName2, defaultChannels, $"{testChannelName2} is not a default channel");
+                string defaultChannels = await GetDefaultTestChannelsAsync(repoUrl, branchName).ConfigureAwait(false);
+                StringAssert.Contains(testChannelName1, defaultChannels, $"{testChannelName1} is not a default channel");
+                StringAssert.Contains(testChannelName2, defaultChannels, $"{testChannelName2} is not a default channel");
 
-                    await DeleteDefaultTestChannelAsync(testChannelName1, repoUrl, branchName);
-                    await DeleteDefaultTestChannelAsync(testChannelName2, repoUrl, branchName);
+                await DeleteDefaultTestChannelAsync(testChannelName1, repoUrl, branchName);
+                await DeleteDefaultTestChannelAsync(testChannelName2, repoUrl, branchName);
 
-                    defaultChannels = await GetDefaultTestChannelsAsync(repoUrl, branchName).ConfigureAwait(false);
-                    StringAssert.DoesNotContain(testChannelName1, defaultChannels, $"{testChannelName1} was not deleted from default channels");
-                    StringAssert.DoesNotContain(testChannelName2, defaultChannels, $"{testChannelName2} was not deleted from default channels");
-                }
+                defaultChannels = await GetDefaultTestChannelsAsync(repoUrl, branchName).ConfigureAwait(false);
+                StringAssert.DoesNotContain(testChannelName1, defaultChannels, $"{testChannelName1} was not deleted from default channels");
+                StringAssert.DoesNotContain(testChannelName2, defaultChannels, $"{testChannelName2} was not deleted from default channels");
             }
         }
     }

--- a/test/Maestro.ScenarioTests/ScenarioTests_Dependencies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Dependencies.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Maestro.ScenarioTests.ObjectHelpers;
 using Microsoft.DotNet.Maestro.Client.Models;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using NUnit.Framework.Legacy;
 
 namespace Maestro.ScenarioTests;
 
@@ -83,8 +85,8 @@ internal class ScenarioTests_Dependencies : MaestroScenarioTestBase
         Build retrievedBuild1 = await MaestroApi.Builds.GetBuildAsync(targetBuild1.Id);
         Build retrievedBuild2 = await MaestroApi.Builds.GetBuildAsync(targetBuild2.Id);
 
-        Assert.AreEqual(newTargetBuild1.Dependencies.Count, retrievedBuild1.Dependencies.Count);
-        Assert.AreEqual(newTargetBuild2.Dependencies.Count, retrievedBuild2.Dependencies.Count);
+        retrievedBuild1.Dependencies.Should().HaveCount(newTargetBuild1.Dependencies.Count);
+        retrievedBuild2.Dependencies.Should().HaveCount(newTargetBuild2.Dependencies.Count);
 
         var buildRefComparer = new BuildRefComparer();
 

--- a/test/Maestro.ScenarioTests/ScenarioTests_Dependencies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Dependencies.cs
@@ -9,87 +9,86 @@ using Microsoft.DotNet.Maestro.Client.Models;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+[TestFixture]
+[Category("PostDeployment")]
+internal class ScenarioTests_Dependencies : MaestroScenarioTestBase
 {
-    [TestFixture]
-    [Category("PostDeployment")]
-    public class ScenarioTests_Dependencies : MaestroScenarioTestBase
+
+    private TestParameters _parameters;
+
+    [TearDown]
+    public Task DisposeAsync()
     {
+        _parameters.Dispose();
+        return Task.CompletedTask;
+    }
 
-        private TestParameters _parameters;
+    [Test]
+    public async Task ArcadeDependencies_EndToEnd()
+    {
+        _parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
+        SetTestParameters(_parameters);
 
-        [TearDown]
-        public Task DisposeAsync()
-        {
-            _parameters.Dispose();
-            return Task.CompletedTask;
-        }
+        var source1RepoName = TestRepository.TestRepo1Name;
+        var source2RepoName = TestRepository.TestRepo3Name;
+        var targetRepoName = TestRepository.TestRepo2Name;
+        var target1BuildNumber = "098765";
+        var target2BuildNumber = "987654";
+        var sourceBuildNumber = "654321";
+        var sourceCommit = "SourceCommitVar";
+        var targetCommit = "TargetCommitVar";
+        var sourceBranch = $"DependenciesSourceBranch_{Environment.MachineName}";
+        var targetBranch = $"DependenciesTargetBranch_{Environment.MachineName}";
+        var testChannelName = $"TestChannel_Dependencies_{Environment.MachineName}";
 
-        [Test]
-        public async Task ArcadeDependencies_EndToEnd()
-        {
-            _parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
-            SetTestParameters(_parameters);
+        IImmutableList<AssetData> source1Assets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
+        IImmutableList<AssetData> source2Assets = GetAssetData("Pizza", "3.1.0", "Hamburger", "4.1.0");
+        IImmutableList<AssetData> targetAssets = GetAssetData("Source1", "3.1.0", "Source2", "4.1.0");
+        var source1RepoUri = GetGitHubRepoUrl(source1RepoName);
+        var source2RepoUri = GetGitHubRepoUrl(source2RepoName);
+        var targetRepoUri = GetGitHubRepoUrl(targetRepoName);
 
-            string source1RepoName = TestRepository.TestRepo1Name;
-            string source2RepoName = TestRepository.TestRepo3Name;
-            string targetRepoName = TestRepository.TestRepo2Name;
-            string target1BuildNumber = "098765";
-            string target2BuildNumber = "987654";
-            string sourceBuildNumber = "654321";
-            string sourceCommit = "SourceCommitVar";
-            string targetCommit = "TargetCommitVar";
-            string sourceBranch = $"DependenciesSourceBranch_{Environment.MachineName}";
-            string targetBranch = $"DependenciesTargetBranch_{Environment.MachineName}";
-            string testChannelName = $"TestChannel_Dependencies_{Environment.MachineName}";
+        TestContext.WriteLine($"Creating test channel {testChannelName}");
+        await CreateTestChannelAsync(testChannelName);
 
-            IImmutableList<AssetData> source1Assets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
-            IImmutableList<AssetData> source2Assets = GetAssetData("Pizza", "3.1.0", "Hamburger", "4.1.0");
-            IImmutableList<AssetData> targetAssets = GetAssetData("Source1", "3.1.0", "Source2", "4.1.0");
-            string source1RepoUri = GetRepoUrl(source1RepoName);
-            string source2RepoUri = GetRepoUrl(source2RepoName);
-            string targetRepoUri = GetRepoUrl(targetRepoName);
+        TestContext.WriteLine("Set up build1 for intake into target repository");
+        Build build1 = await CreateBuildAsync(source1RepoUri, sourceBranch, sourceCommit, sourceBuildNumber, source1Assets);
+        await AddBuildToChannelAsync(build1.Id, testChannelName);
 
-            TestContext.WriteLine($"Creating test channel {testChannelName}");
-            await CreateTestChannelAsync(testChannelName);
+        TestContext.WriteLine("Set up build2 for intake into target repository");
+        Build build2 = await CreateBuildAsync(source2RepoUri, sourceBranch, sourceCommit, sourceBuildNumber, source2Assets);
+        await AddBuildToChannelAsync(build2.Id, testChannelName);
 
-            TestContext.WriteLine("Set up build1 for intake into target repository");
-            Build build1 = await CreateBuildAsync(source1RepoUri, sourceBranch, sourceCommit, sourceBuildNumber, source1Assets);
-            await AddBuildToChannelAsync(build1.Id, testChannelName);
+        ImmutableList<BuildRef> dependencies = ImmutableList<BuildRef>.Empty;
+        var buildRef1 = new BuildRef(build1.Id, true, 1);
+        dependencies = dependencies.Add(buildRef1);
+        var buildRef2 = new BuildRef(build2.Id, true, 2);
+        dependencies = dependencies.Add(buildRef2);
 
-            TestContext.WriteLine("Set up build2 for intake into target repository");
-            Build build2 = await CreateBuildAsync(source2RepoUri, sourceBranch, sourceCommit, sourceBuildNumber, source2Assets);
-            await AddBuildToChannelAsync(build2.Id, testChannelName);
+        // Add the target build once, should populate the BuildDependencies table and calculate TimeToInclusion
+        TestContext.WriteLine("Set up targetBuild in target repository");
+        Build targetBuild1 = await CreateBuildAsync(targetRepoUri, targetBranch, targetCommit, target1BuildNumber, targetAssets, dependencies);
+        await AddBuildToChannelAsync(targetBuild1.Id, testChannelName);
+        var newTargetBuild1 = new Build(targetBuild1.Id, targetBuild1.DateProduced, targetBuild1.Staleness, targetBuild1.Released,
+            targetBuild1.Stable, targetBuild1.Commit, targetBuild1.Channels, targetBuild1.Assets, dependencies, incoherencies: null);
 
-            ImmutableList<BuildRef> dependencies = ImmutableList<BuildRef>.Empty;
-            BuildRef buildRef1 = new BuildRef(build1.Id, true, 1);
-            dependencies = dependencies.Add(buildRef1);
-            BuildRef buildRef2 = new BuildRef(build2.Id, true, 2);
-            dependencies = dependencies.Add(buildRef2);
+        // Add the target build a second time, should populate the BuildDependencies table and use the previous TimeToInclusion
+        Build targetBuild2 = await CreateBuildAsync(targetRepoUri, targetBranch, targetCommit, target2BuildNumber, targetAssets, dependencies);
+        await AddBuildToChannelAsync(targetBuild2.Id, testChannelName);
+        var newTargetBuild2 = new Build(targetBuild2.Id, targetBuild2.DateProduced, targetBuild2.Staleness, targetBuild2.Released,
+            targetBuild2.Stable, targetBuild2.Commit, targetBuild2.Channels, targetBuild2.Assets, dependencies, incoherencies: null);
 
-            // Add the target build once, should populate the BuildDependencies table and calculate TimeToInclusion
-            TestContext.WriteLine("Set up targetBuild in target repository");
-            Build targetBuild1 = await CreateBuildAsync(targetRepoUri, targetBranch, targetCommit, target1BuildNumber, targetAssets, dependencies);
-            await AddBuildToChannelAsync(targetBuild1.Id, testChannelName);
-            Build newTargetBuild1 = new Build(targetBuild1.Id, targetBuild1.DateProduced, targetBuild1.Staleness, targetBuild1.Released,
-                targetBuild1.Stable, targetBuild1.Commit, targetBuild1.Channels, targetBuild1.Assets, dependencies, incoherencies: null);
+        Build retrievedBuild1 = await MaestroApi.Builds.GetBuildAsync(targetBuild1.Id);
+        Build retrievedBuild2 = await MaestroApi.Builds.GetBuildAsync(targetBuild2.Id);
 
-            // Add the target build a second time, should populate the BuildDependencies table and use the previous TimeToInclusion
-            Build targetBuild2 = await CreateBuildAsync(targetRepoUri, targetBranch, targetCommit, target2BuildNumber, targetAssets, dependencies);
-            await AddBuildToChannelAsync(targetBuild2.Id, testChannelName);
-            Build newTargetBuild2 = new Build(targetBuild2.Id, targetBuild2.DateProduced, targetBuild2.Staleness, targetBuild2.Released,
-                targetBuild2.Stable, targetBuild2.Commit, targetBuild2.Channels, targetBuild2.Assets, dependencies, incoherencies: null);
+        Assert.AreEqual(newTargetBuild1.Dependencies.Count, retrievedBuild1.Dependencies.Count);
+        Assert.AreEqual(newTargetBuild2.Dependencies.Count, retrievedBuild2.Dependencies.Count);
 
-            Build retrievedBuild1 = await MaestroApi.Builds.GetBuildAsync(targetBuild1.Id);
-            Build retrievedBuild2 = await MaestroApi.Builds.GetBuildAsync(targetBuild2.Id);
+        var buildRefComparer = new BuildRefComparer();
 
-            Assert.AreEqual(newTargetBuild1.Dependencies.Count, retrievedBuild1.Dependencies.Count);
-            Assert.AreEqual(newTargetBuild2.Dependencies.Count, retrievedBuild2.Dependencies.Count);
-
-            BuildRefComparer buildRefComparer = new BuildRefComparer();
-
-            CollectionAssert.AreEqual(retrievedBuild1.Dependencies, newTargetBuild1.Dependencies, buildRefComparer);
-            CollectionAssert.AreEqual(retrievedBuild2.Dependencies, newTargetBuild2.Dependencies, buildRefComparer);
-        }
+        CollectionAssert.AreEqual(retrievedBuild1.Dependencies, newTargetBuild1.Dependencies, buildRefComparer);
+        CollectionAssert.AreEqual(retrievedBuild2.Dependencies, newTargetBuild2.Dependencies, buildRefComparer);
     }
 }

--- a/test/Maestro.ScenarioTests/ScenarioTests_GitHubFlow.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_GitHubFlow.cs
@@ -11,32 +11,35 @@ using Microsoft.DotNet.Maestro.Client.Models;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+[TestFixture]
+[NonParallelizable]
+[Category("PostDeployment")]
+internal class ScenarioTests_GitHubFlow : MaestroScenarioTestBase
 {
-    [TestFixture]
-    [NonParallelizable]
-    [Category("PostDeployment")]
-    public class ScenarioTests_GitHubFlow : MaestroScenarioTestBase
+    private readonly IImmutableList<AssetData> source1Assets;
+    private readonly IImmutableList<AssetData> source2Assets;
+    private readonly IImmutableList<AssetData> source1AssetsUpdated;
+    private readonly List<DependencyDetail> expectedDependenciesSource1;
+    private readonly List<DependencyDetail> expectedDependenciesSource2;
+    private readonly List<DependencyDetail> expectedDependenciesSource1Updated;
+
+    public ScenarioTests_GitHubFlow()
     {
-        private readonly IImmutableList<AssetData> source1Assets;
-        private readonly IImmutableList<AssetData> source2Assets;
-        private readonly IImmutableList<AssetData> source1AssetsUpdated;
-        private readonly List<DependencyDetail> expectedDependenciesSource1;
-        private readonly List<DependencyDetail> expectedDependenciesSource2;
-        private readonly List<DependencyDetail> expectedDependenciesSource1Updated;
+        using TestParameters parameters = TestParameters.GetAsync().Result;
+        SetTestParameters(parameters);
 
-        public ScenarioTests_GitHubFlow()
-        {
-            using TestParameters parameters = TestParameters.GetAsync().Result;
-            SetTestParameters(parameters);
+        source1Assets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
+        source2Assets = GetAssetData("Pizza", "3.1.0", "Hamburger", "4.1.0");
+        source1AssetsUpdated = GetAssetData("Foo", "1.17.0", "Bar", "2.17.0");
 
-            source1Assets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
-            source2Assets = GetAssetData("Pizza", "3.1.0", "Hamburger", "4.1.0");
-            source1AssetsUpdated = GetAssetData("Foo", "1.17.0", "Bar", "2.17.0");
+        var sourceRepoUri = GetGitHubRepoUrl(TestRepository.TestRepo1Name);
+        var source2RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo3Name);
 
-            expectedDependenciesSource1 = new List<DependencyDetail>();
-            string sourceRepoUri = GetRepoUrl(TestRepository.TestRepo1Name);
-            DependencyDetail foo = new DependencyDetail
+        expectedDependenciesSource1 =
+        [
+            new DependencyDetail
             {
                 Name = "Foo",
                 Version = "1.1.0",
@@ -44,10 +47,8 @@ namespace Maestro.ScenarioTests
                 Commit = TestRepository.CoherencyTestRepo1Commit,
                 Type = DependencyType.Product,
                 Pinned = false
-            };
-            expectedDependenciesSource1.Add(foo);
-
-            DependencyDetail bar = new DependencyDetail
+            },
+            new DependencyDetail
             {
                 Name = "Bar",
                 Version = "2.1.0",
@@ -55,12 +56,12 @@ namespace Maestro.ScenarioTests
                 Commit = TestRepository.CoherencyTestRepo1Commit,
                 Type = DependencyType.Product,
                 Pinned = false
-            };
-            expectedDependenciesSource1.Add(bar);
+            }
+        ];
 
-            expectedDependenciesSource2 = new List<DependencyDetail>();
-            string source2RepoUri = GetRepoUrl(TestRepository.TestRepo3Name);
-            DependencyDetail pizza = new DependencyDetail
+        expectedDependenciesSource2 =
+        [
+            new DependencyDetail
             {
                 Name = "Pizza",
                 Version = "3.1.0",
@@ -68,10 +69,8 @@ namespace Maestro.ScenarioTests
                 Commit = TestRepository.CoherencyTestRepo1Commit,
                 Type = DependencyType.Product,
                 Pinned = false
-            };
-            expectedDependenciesSource2.Add(pizza);
-
-            DependencyDetail hamburger = new DependencyDetail
+            },
+            new DependencyDetail
             {
                 Name = "Hamburger",
                 Version = "4.1.0",
@@ -79,11 +78,12 @@ namespace Maestro.ScenarioTests
                 Commit = TestRepository.CoherencyTestRepo1Commit,
                 Type = DependencyType.Product,
                 Pinned = false
-            };
-            expectedDependenciesSource2.Add(hamburger);
+            }
+        ];
 
-            expectedDependenciesSource1Updated = new List<DependencyDetail>();
-            DependencyDetail fooUpdated = new DependencyDetail
+        expectedDependenciesSource1Updated =
+        [
+            new DependencyDetail
             {
                 Name = "Foo",
                 Version = "1.1.0",
@@ -91,10 +91,8 @@ namespace Maestro.ScenarioTests
                 Commit = TestRepository.CoherencyTestRepo1Commit,
                 Type = DependencyType.Product,
                 Pinned = false
-            };
-            expectedDependenciesSource1Updated.Add(fooUpdated);
-
-            DependencyDetail barUpdated = new DependencyDetail
+            },
+            new DependencyDetail
             {
                 Name = "Bar",
                 Version = "2.1.0",
@@ -102,223 +100,222 @@ namespace Maestro.ScenarioTests
                 Commit = TestRepository.CoherencyTestRepo1Commit,
                 Type = DependencyType.Product,
                 Pinned = false
-            };
-            expectedDependenciesSource1Updated.Add(barUpdated);
-        }
+            }
+        ];
+    }
 
-        [Test]
-        public async Task Darc_GitHubFlow_Batched()
-        {
-            TestContext.WriteLine("Github Dependency Flow, batched");
+    [Test]
+    public async Task Darc_GitHubFlow_Batched()
+    {
+        TestContext.WriteLine("Github Dependency Flow, batched");
 
-            using TestParameters parameters = await TestParameters.GetAsync();
-            EndToEndFlowLogic testLogic = new EndToEndFlowLogic(parameters);
-            List<DependencyDetail> expectedDependencies = expectedDependenciesSource1.Concat(expectedDependenciesSource2).ToList();
+        using TestParameters parameters = await TestParameters.GetAsync();
+        var testLogic = new EndToEndFlowLogic(parameters);
+        var expectedDependencies = expectedDependenciesSource1.Concat(expectedDependenciesSource2).ToList();
 
-            await testLogic.DarcBatchedFlowTestBase(
-                $"GitHub_BatchedTestBranch_{Environment.MachineName}",
-                $"GitHub Batched Channel {Environment.MachineName}",
-                source1Assets,
-                source2Assets,
-                expectedDependencies,
-                false).ConfigureAwait(false);
-        }
+        await testLogic.DarcBatchedFlowTestBase(
+            $"GitHub_BatchedTestBranch_{Environment.MachineName}",
+            $"GitHub Batched Channel {Environment.MachineName}",
+            source1Assets,
+            source2Assets,
+            expectedDependencies,
+            false).ConfigureAwait(false);
+    }
 
-        [Test]
-        public async Task Darc_GitHubFlow_NonBatched()
-        {
-            TestContext.WriteLine("GitHub Dependency Flow, non-batched");
+    [Test]
+    public async Task Darc_GitHubFlow_NonBatched()
+    {
+        TestContext.WriteLine("GitHub Dependency Flow, non-batched");
 
-            using TestParameters parameters = await TestParameters.GetAsync();
-            EndToEndFlowLogic testLogic = new EndToEndFlowLogic(parameters);
+        using TestParameters parameters = await TestParameters.GetAsync();
+        var testLogic = new EndToEndFlowLogic(parameters);
 
-            await testLogic.NonBatchedUpdatingGitHubFlowTestBase(
-                $"GitHub_NonBatchedTestBranch_{Environment.MachineName}",
-                $"GitHub Non-Batched Channel {Environment.MachineName}",
-                source1Assets,
-                source1AssetsUpdated,
-                expectedDependenciesSource1,
-                expectedDependenciesSource1Updated).ConfigureAwait(false);
-        }
+        await testLogic.NonBatchedUpdatingGitHubFlowTestBase(
+            $"GitHub_NonBatchedTestBranch_{Environment.MachineName}",
+            $"GitHub Non-Batched Channel {Environment.MachineName}",
+            source1Assets,
+            source1AssetsUpdated,
+            expectedDependenciesSource1,
+            expectedDependenciesSource1Updated).ConfigureAwait(false);
+    }
 
-        [Test]
-        public async Task Darc_GitHubFlow_NonBatched_StrictCoherency()
-        {
-            TestContext.WriteLine("GitHub Dependency Flow, non-batched");
+    [Test]
+    public async Task Darc_GitHubFlow_NonBatched_StrictCoherency()
+    {
+        TestContext.WriteLine("GitHub Dependency Flow, non-batched");
 
-            using TestParameters parameters = await TestParameters.GetAsync();
-            EndToEndFlowLogic testLogic = new EndToEndFlowLogic(parameters);
+        using TestParameters parameters = await TestParameters.GetAsync();
+        var testLogic = new EndToEndFlowLogic(parameters);
 
-            List<DependencyDetail> expectedCoherencyDependencies = new List<DependencyDetail>
+        List<DependencyDetail> expectedCoherencyDependencies =
+        [
+            new DependencyDetail
             {
-                new DependencyDetail
-                {
-                    Name = "Foo",
-                    Version = "1.1.0",
-                    RepoUri = GetRepoUrl(TestRepository.TestRepo1Name),
-                    Commit = TestRepository.CoherencyTestRepo1Commit,
-                    Type = DependencyType.Product,
-                    Pinned = false
-                },
-                new DependencyDetail
-                {
-                    Name = "Bar",
-                    Version = "2.1.0",
-                    RepoUri = GetRepoUrl(TestRepository.TestRepo1Name),
-                    Commit = TestRepository.CoherencyTestRepo1Commit,
-                    Type = DependencyType.Product,
-                    Pinned = false
-                }
-            };
-
-            IImmutableList<AssetData> sourceAssets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
-
-            await testLogic.NonBatchedGitHubFlowTestBase(
-                $"GitHub_NonBatchedTestBranch_{Environment.MachineName}",
-                $"GitHub Non-Batched Channel {Environment.MachineName}",
-                sourceAssets,
-                expectedCoherencyDependencies,
-                allChecks: true).ConfigureAwait(false);
-        }
-
-        [Test]
-        public async Task Darc_GitHubFlow_NonBatched_FailingCoherencyUpdate()
-        {
-            using TestParameters parameters = await TestParameters.GetAsync();
-            EndToEndFlowLogic testLogic = new EndToEndFlowLogic(parameters);
-
-            List<DependencyDetail> expectedCoherencyDependencies = new List<DependencyDetail>
+                Name = "Foo",
+                Version = "1.1.0",
+                RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo1Name),
+                Commit = TestRepository.CoherencyTestRepo1Commit,
+                Type = DependencyType.Product,
+                Pinned = false
+            },
+            new DependencyDetail
             {
-                new DependencyDetail
-                {
-                    Name = "Foo",
-                    Version = "1.1.0",
-                    RepoUri = GetRepoUrl(TestRepository.TestRepo2Name),
-                    Commit = TestRepository.CoherencyTestRepo1Commit,
-                    Type = DependencyType.Product,
-                    Pinned = false
-                },
-                new DependencyDetail
-                {
-                    Name = "Bar",
-                    Version = "2.1.0",
-                    RepoUri = GetRepoUrl(TestRepository.TestRepo2Name),
-                    Commit = TestRepository.CoherencyTestRepo1Commit,
-                    Type = DependencyType.Product,
-                    Pinned = false
-                },
-                new DependencyDetail
-                {
-                    Name = "Fzz",
-                    Version = "",
-                    RepoUri = GetRepoUrl(TestRepository.TestRepo1Name),
-                    Commit = "",
-                    Type = DependencyType.Product,
-                    CoherentParentDependencyName = "Foo"
-                },
-                new DependencyDetail
-                {
-                    Name = "ASD",
-                    Version = "",
-                    RepoUri = GetRepoUrl(TestRepository.TestRepo1Name),
-                    Commit = "",
-                    Type = DependencyType.Product,
-                    CoherentParentDependencyName = "Foo"
-                },
-            };
+                Name = "Bar",
+                Version = "2.1.0",
+                RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo1Name),
+                Commit = TestRepository.CoherencyTestRepo1Commit,
+                Type = DependencyType.Product,
+                Pinned = false
+            }
+        ];
 
-            IImmutableList<AssetData> sourceAssets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
-            IImmutableList<AssetData> childSourceAssets = GetAssetData("Fzz", "1.1.0", "ASD", "1.1.1");
+        IImmutableList<AssetData> sourceAssets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
 
-            await testLogic.NonBatchedGitHubFlowCoherencyTestBase(
-                $"GitHub_NonBatchedTestBranch_FailingCoherencyUpdate_{Environment.MachineName}",
-                $"GitHub Non-Batched Channel FailingCoherencyUpdate {Environment.MachineName}",
-                sourceAssets,
-                childSourceAssets,
-                expectedCoherencyDependencies,
-                coherentParent: "Foo",
-                allChecks: false).ConfigureAwait(false);
-        }
+        await testLogic.NonBatchedGitHubFlowTestBase(
+            $"GitHub_NonBatchedTestBranch_{Environment.MachineName}",
+            $"GitHub Non-Batched Channel {Environment.MachineName}",
+            sourceAssets,
+            expectedCoherencyDependencies,
+            allChecks: true).ConfigureAwait(false);
+    }
 
-        [Test]
-        public async Task Darc_GitHubFlow_NonBatched_FailingCoherentOnlyUpdate()
-        {
-            using TestParameters parameters = await TestParameters.GetAsync();
-            EndToEndFlowLogic testLogic = new EndToEndFlowLogic(parameters);
+    [Test]
+    public async Task Darc_GitHubFlow_NonBatched_FailingCoherencyUpdate()
+    {
+        using TestParameters parameters = await TestParameters.GetAsync();
+        var testLogic = new EndToEndFlowLogic(parameters);
 
-            List<DependencyDetail> expectedNonCoherencyDependencies = new List<DependencyDetail>
+        List<DependencyDetail> expectedCoherencyDependencies =
+        [
+            new DependencyDetail
             {
-                new DependencyDetail
-                {
-                    Name = "A1",
-                    Version = "1.1.0",
-                    RepoUri = GetRepoUrl(TestRepository.TestRepo2Name),
-                    Commit = TestRepository.CoherencyTestRepo1Commit,
-                    Type = DependencyType.Product,
-                    Pinned = false
-                },
-                new DependencyDetail
-                {
-                    Name = "A2",
-                    Version = "1.1.0",
-                    RepoUri = GetRepoUrl(TestRepository.TestRepo2Name),
-                    Commit = TestRepository.CoherencyTestRepo1Commit,
-                    Type = DependencyType.Product,
-                    Pinned = false
-                }
-            };
-
-            List<DependencyDetail> expectedCoherencyDependencies = new List<DependencyDetail>
+                Name = "Foo",
+                Version = "1.1.0",
+                RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo2Name),
+                Commit = TestRepository.CoherencyTestRepo1Commit,
+                Type = DependencyType.Product,
+                Pinned = false
+            },
+            new DependencyDetail
             {
-                new DependencyDetail
-                {
-                    Name = "A1",
-                    Version = "1.1.0",
-                    RepoUri = GetRepoUrl(TestRepository.TestRepo2Name),
-                    Commit = TestRepository.CoherencyTestRepo1Commit,
-                    Type = DependencyType.Product,
-                    Pinned = false
-                },
-                new DependencyDetail
-                {
-                    Name = "A2",
-                    Version = "1.1.0",
-                    RepoUri = GetRepoUrl(TestRepository.TestRepo2Name),
-                    Commit = TestRepository.CoherencyTestRepo1Commit,
-                    Type = DependencyType.Product,
-                    Pinned = false
-                },
-                new DependencyDetail
-                {
-                    Name = "B1",
-                    Version = "",
-                    RepoUri = GetRepoUrl(TestRepository.TestRepo1Name),
-                    Commit = "",
-                    Type = DependencyType.Product,
-                    CoherentParentDependencyName = "A1"
-                },
-                new DependencyDetail
-                {
-                    Name = "B2",
-                    Version = "",
-                    RepoUri = GetRepoUrl(TestRepository.TestRepo1Name),
-                    Commit = "",
-                    Type = DependencyType.Product,
-                    CoherentParentDependencyName = "A1"
-                },
-            };
+                Name = "Bar",
+                Version = "2.1.0",
+                RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo2Name),
+                Commit = TestRepository.CoherencyTestRepo1Commit,
+                Type = DependencyType.Product,
+                Pinned = false
+            },
+            new DependencyDetail
+            {
+                Name = "Fzz",
+                Version = "",
+                RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo1Name),
+                Commit = "",
+                Type = DependencyType.Product,
+                CoherentParentDependencyName = "Foo"
+            },
+            new DependencyDetail
+            {
+                Name = "ASD",
+                Version = "",
+                RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo1Name),
+                Commit = "",
+                Type = DependencyType.Product,
+                CoherentParentDependencyName = "Foo"
+            },
+        ];
 
-            IImmutableList<AssetData> sourceAssets = GetAssetData("A1", "1.1.0", "A2", "1.1.0");
-            IImmutableList<AssetData> childSourceAssets = GetAssetData("B1", "2.1.0", "B2", "2.1.0");
+        IImmutableList<AssetData> sourceAssets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
+        IImmutableList<AssetData> childSourceAssets = GetAssetData("Fzz", "1.1.0", "ASD", "1.1.1");
 
-            await testLogic.NonBatchedGitHubFlowCoherencyOnlyTestBase(
-                $"GitHub_NonBatchedTestBranch_FailingCoherencyOnlyUpdate_{Environment.MachineName}",
-                $"GitHub Non-Batched Channel FailingCoherencyOnlyUpdate {Environment.MachineName}",
-                sourceAssets,
-                childSourceAssets,
-                expectedNonCoherencyDependencies,
-                expectedCoherencyDependencies,
-                coherentParent: "A1").ConfigureAwait(false);
-        }
+        await testLogic.NonBatchedGitHubFlowCoherencyTestBase(
+            $"GitHub_NonBatchedTestBranch_FailingCoherencyUpdate_{Environment.MachineName}",
+            $"GitHub Non-Batched Channel FailingCoherencyUpdate {Environment.MachineName}",
+            sourceAssets,
+            childSourceAssets,
+            expectedCoherencyDependencies,
+            coherentParent: "Foo",
+            allChecks: false).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task Darc_GitHubFlow_NonBatched_FailingCoherentOnlyUpdate()
+    {
+        using TestParameters parameters = await TestParameters.GetAsync();
+        var testLogic = new EndToEndFlowLogic(parameters);
+
+        List<DependencyDetail> expectedNonCoherencyDependencies =
+        [
+            new DependencyDetail
+            {
+                Name = "A1",
+                Version = "1.1.0",
+                RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo2Name),
+                Commit = TestRepository.CoherencyTestRepo1Commit,
+                Type = DependencyType.Product,
+                Pinned = false
+            },
+            new DependencyDetail
+            {
+                Name = "A2",
+                Version = "1.1.0",
+                RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo2Name),
+                Commit = TestRepository.CoherencyTestRepo1Commit,
+                Type = DependencyType.Product,
+                Pinned = false
+            }
+        ];
+
+        List<DependencyDetail> expectedCoherencyDependencies =
+        [
+            new DependencyDetail
+            {
+                Name = "A1",
+                Version = "1.1.0",
+                RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo2Name),
+                Commit = TestRepository.CoherencyTestRepo1Commit,
+                Type = DependencyType.Product,
+                Pinned = false
+            },
+            new DependencyDetail
+            {
+                Name = "A2",
+                Version = "1.1.0",
+                RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo2Name),
+                Commit = TestRepository.CoherencyTestRepo1Commit,
+                Type = DependencyType.Product,
+                Pinned = false
+            },
+            new DependencyDetail
+            {
+                Name = "B1",
+                Version = "",
+                RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo1Name),
+                Commit = "",
+                Type = DependencyType.Product,
+                CoherentParentDependencyName = "A1"
+            },
+            new DependencyDetail
+            {
+                Name = "B2",
+                Version = "",
+                RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo1Name),
+                Commit = "",
+                Type = DependencyType.Product,
+                CoherentParentDependencyName = "A1"
+            },
+        ];
+
+        IImmutableList<AssetData> sourceAssets = GetAssetData("A1", "1.1.0", "A2", "1.1.0");
+        IImmutableList<AssetData> childSourceAssets = GetAssetData("B1", "2.1.0", "B2", "2.1.0");
+
+        await testLogic.NonBatchedGitHubFlowCoherencyOnlyTestBase(
+            $"GitHub_NonBatchedTestBranch_FailingCoherencyOnlyUpdate_{Environment.MachineName}",
+            $"GitHub Non-Batched Channel FailingCoherencyOnlyUpdate {Environment.MachineName}",
+            sourceAssets,
+            childSourceAssets,
+            expectedNonCoherencyDependencies,
+            expectedCoherencyDependencies,
+            coherentParent: "A1").ConfigureAwait(false);
     }
 }

--- a/test/Maestro.ScenarioTests/ScenarioTests_GitHubFlow.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_GitHubFlow.cs
@@ -18,26 +18,26 @@ namespace Maestro.ScenarioTests;
 [Category("PostDeployment")]
 internal class ScenarioTests_GitHubFlow : MaestroScenarioTestBase
 {
-    private readonly IImmutableList<AssetData> source1Assets;
-    private readonly IImmutableList<AssetData> source2Assets;
-    private readonly IImmutableList<AssetData> source1AssetsUpdated;
-    private readonly List<DependencyDetail> expectedDependenciesSource1;
-    private readonly List<DependencyDetail> expectedDependenciesSource2;
-    private readonly List<DependencyDetail> expectedDependenciesSource1Updated;
+    private readonly IImmutableList<AssetData> _source1Assets;
+    private readonly IImmutableList<AssetData> _source2Assets;
+    private readonly IImmutableList<AssetData> _source1AssetsUpdated;
+    private readonly List<DependencyDetail> _expectedDependenciesSource1;
+    private readonly List<DependencyDetail> _expectedDependenciesSource2;
+    private readonly List<DependencyDetail> _expectedDependenciesSource1Updated;
 
     public ScenarioTests_GitHubFlow()
     {
         using TestParameters parameters = TestParameters.GetAsync().Result;
         SetTestParameters(parameters);
 
-        source1Assets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
-        source2Assets = GetAssetData("Pizza", "3.1.0", "Hamburger", "4.1.0");
-        source1AssetsUpdated = GetAssetData("Foo", "1.17.0", "Bar", "2.17.0");
+        _source1Assets = GetAssetData("Foo", "1.1.0", "Bar", "2.1.0");
+        _source2Assets = GetAssetData("Pizza", "3.1.0", "Hamburger", "4.1.0");
+        _source1AssetsUpdated = GetAssetData("Foo", "1.17.0", "Bar", "2.17.0");
 
         var sourceRepoUri = GetGitHubRepoUrl(TestRepository.TestRepo1Name);
         var source2RepoUri = GetGitHubRepoUrl(TestRepository.TestRepo3Name);
 
-        expectedDependenciesSource1 =
+        _expectedDependenciesSource1 =
         [
             new DependencyDetail
             {
@@ -59,7 +59,7 @@ internal class ScenarioTests_GitHubFlow : MaestroScenarioTestBase
             }
         ];
 
-        expectedDependenciesSource2 =
+        _expectedDependenciesSource2 =
         [
             new DependencyDetail
             {
@@ -81,7 +81,7 @@ internal class ScenarioTests_GitHubFlow : MaestroScenarioTestBase
             }
         ];
 
-        expectedDependenciesSource1Updated =
+        _expectedDependenciesSource1Updated =
         [
             new DependencyDetail
             {
@@ -111,13 +111,13 @@ internal class ScenarioTests_GitHubFlow : MaestroScenarioTestBase
 
         using TestParameters parameters = await TestParameters.GetAsync();
         var testLogic = new EndToEndFlowLogic(parameters);
-        var expectedDependencies = expectedDependenciesSource1.Concat(expectedDependenciesSource2).ToList();
+        var expectedDependencies = _expectedDependenciesSource1.Concat(_expectedDependenciesSource2).ToList();
 
         await testLogic.DarcBatchedFlowTestBase(
             $"GitHub_BatchedTestBranch_{Environment.MachineName}",
             $"GitHub Batched Channel {Environment.MachineName}",
-            source1Assets,
-            source2Assets,
+            _source1Assets,
+            _source2Assets,
             expectedDependencies,
             false).ConfigureAwait(false);
     }
@@ -133,10 +133,10 @@ internal class ScenarioTests_GitHubFlow : MaestroScenarioTestBase
         await testLogic.NonBatchedUpdatingGitHubFlowTestBase(
             $"GitHub_NonBatchedTestBranch_{Environment.MachineName}",
             $"GitHub Non-Batched Channel {Environment.MachineName}",
-            source1Assets,
-            source1AssetsUpdated,
-            expectedDependenciesSource1,
-            expectedDependenciesSource1Updated).ConfigureAwait(false);
+            _source1Assets,
+            _source1AssetsUpdated,
+            _expectedDependenciesSource1,
+            _expectedDependenciesSource1Updated).ConfigureAwait(false);
     }
 
     [Test]

--- a/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
@@ -50,7 +50,7 @@ internal class ScenarioTests_MergePolicies : MaestroScenarioTestBase
         string testChannelName = GetTestChannelName();
         var targetBranch = GetTargetBranch();
 
-        await AutoMergeFlowTestBase(TargetRepo, SourceRepo, targetBranch, testChannelName, new List<string> {"--all-checks-passed" });
+        await AutoMergeFlowTestBase(TargetRepo, SourceRepo, targetBranch, testChannelName, ["--all-checks-passed"]);
     }
 
     [Test]
@@ -58,7 +58,7 @@ internal class ScenarioTests_MergePolicies : MaestroScenarioTestBase
         string testChannelName = GetTestChannelName();
         var targetBranch = GetTargetBranch();
 
-        await AutoMergeFlowTestBase(TargetRepo, SourceRepo, targetBranch, testChannelName, new List<string> { "--validate-coherency" });
+        await AutoMergeFlowTestBase(TargetRepo, SourceRepo, targetBranch, testChannelName, ["--validate-coherency"]);
     }
 
     [Test]
@@ -67,7 +67,7 @@ internal class ScenarioTests_MergePolicies : MaestroScenarioTestBase
         string testChannelName = GetTestChannelName();
         var targetBranch = GetTargetBranch();
 
-        await AutoMergeFlowTestBase(TargetRepo, SourceRepo, targetBranch, testChannelName, new List<string> { "--standard-automerge"});
+        await AutoMergeFlowTestBase(TargetRepo, SourceRepo, targetBranch, testChannelName, ["--standard-automerge"]);
     }
 
     [Test]
@@ -76,7 +76,7 @@ internal class ScenarioTests_MergePolicies : MaestroScenarioTestBase
         string testChannelName = GetTestChannelName();
         var targetBranch = GetTargetBranch();
 
-        await AutoMergeFlowTestBase(TargetRepo, SourceRepo, targetBranch, testChannelName, new List<string> { "--no-requested-changes" });
+        await AutoMergeFlowTestBase(TargetRepo, SourceRepo, targetBranch, testChannelName, ["--no-requested-changes"]);
     }
 
     public async Task AutoMergeFlowTestBase(string targetRepo, string sourceRepo, string targetBranch, string testChannelName, List<string> args)

--- a/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.DotNet.Maestro.Client.Models;
 using NUnit.Framework;
 using Build = Microsoft.DotNet.Maestro.Client.Models.Build;
@@ -125,7 +126,7 @@ internal class ScenarioTests_MergePolicies : MaestroScenarioTestBase
 
             TestContext.WriteLine($"Waiting on PR to be opened in ${targetRepoUri}");
             bool testResult = await CheckGithubPullRequestChecks(targetRepo, targetBranch);
-            Assert.IsTrue(testResult);
+            testResult.Should().BeTrue();
         }
     }
 }

--- a/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
@@ -9,124 +9,123 @@ using Microsoft.DotNet.Maestro.Client.Models;
 using NUnit.Framework;
 using Build = Microsoft.DotNet.Maestro.Client.Models.Build;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+[TestFixture]
+[Category("PostDeployment")]
+internal class ScenarioTests_MergePolicies : MaestroScenarioTestBase
 {
-    [TestFixture]
-    [Category("PostDeployment")]
-    public class ScenarioTests_MergePolicies : MaestroScenarioTestBase
+    private TestParameters _parameters;
+    private readonly Random _random = new();
+    private const string SourceRepo = "maestro-test1";
+    private const string TargetRepo = "maestro-test2";
+
+    [SetUp]
+    public async Task InitializeAsync()
     {
-        private TestParameters _parameters;
-        private readonly Random _random = new Random();
-        private readonly string sourceRepo = "maestro-test1";
-        private readonly string targetRepo = "maestro-test2";
+        _parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
+        SetTestParameters(_parameters);
+    }
 
-        [SetUp]
-        public async Task InitializeAsync()
-        {
-            _parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
-            SetTestParameters(_parameters);
-        }
+    [TearDown]
+    public Task DisposeAsync()
+    {
+        _parameters.Dispose();
+        return Task.CompletedTask;
+    }
 
-        [TearDown]
-        public Task DisposeAsync()
-        {
-            _parameters.Dispose();
-            return Task.CompletedTask;
-        }
+    private string GetTestChannelName()
+    {
+        return "Test Channel " + _random.Next(int.MaxValue);
+    }
 
-        private string GetTestChannelName()
-        {
-            return "Test Channel " + _random.Next(int.MaxValue);
-        }
+    private string GetTargetBranch()
+    {
+        return _random.Next(int.MaxValue).ToString();
+    }
 
-        private string GetTargetBranch()
-        {
-            return _random.Next(int.MaxValue).ToString();
-        }
+    [Test]
+    public async Task Darc_GitHubFlow_AutoMerge_GithubChecks_AllChecksSuccessful()
+    {
+        string testChannelName = GetTestChannelName();
+        var targetBranch = GetTargetBranch();
 
-        [Test]
-        public async Task Darc_GitHubFlow_AutoMerge_GithubChecks_AllChecksSuccessful()
-        {
-            string testChannelName = GetTestChannelName();
-            var targetBranch = GetTargetBranch();
+        await AutoMergeFlowTestBase(TargetRepo, SourceRepo, targetBranch, testChannelName, new List<string> {"--all-checks-passed" });
+    }
 
-            await AutoMergeFlowTestBase(targetRepo, sourceRepo, targetBranch, testChannelName, new List<string> {"--all-checks-passed" });
-        }
+    [Test]
+    public async Task Darc_GitHubFlow_AutoMerge_GithubChecks_ValidateCoherencyCheck() {
+        string testChannelName = GetTestChannelName();
+        var targetBranch = GetTargetBranch();
 
-        [Test]
-        public async Task Darc_GitHubFlow_AutoMerge_GithubChecks_ValidateCoherencyCheck() {
-            string testChannelName = GetTestChannelName();
-            var targetBranch = GetTargetBranch();
+        await AutoMergeFlowTestBase(TargetRepo, SourceRepo, targetBranch, testChannelName, new List<string> { "--validate-coherency" });
+    }
 
-            await AutoMergeFlowTestBase(targetRepo, sourceRepo, targetBranch, testChannelName, new List<string> { "--validate-coherency" });
-        }
+    [Test]
+    public async Task Darc_GitHubFlow_AutoMerge_GithubChecks_Standard()
+    {
+        string testChannelName = GetTestChannelName();
+        var targetBranch = GetTargetBranch();
 
-        [Test]
-        public async Task Darc_GitHubFlow_AutoMerge_GithubChecks_Standard()
-        {
-            string testChannelName = GetTestChannelName();
-            var targetBranch = GetTargetBranch();
+        await AutoMergeFlowTestBase(TargetRepo, SourceRepo, targetBranch, testChannelName, new List<string> { "--standard-automerge"});
+    }
 
-            await AutoMergeFlowTestBase(targetRepo, sourceRepo, targetBranch, testChannelName, new List<string> { "--standard-automerge"});
-        }
+    [Test]
+    public async Task Darc_GitHubFlow_AutoMerge_GithubChecks_NoRequestedChanges()
+    {
+        string testChannelName = GetTestChannelName();
+        var targetBranch = GetTargetBranch();
 
-        [Test]
-        public async Task Darc_GitHubFlow_AutoMerge_GithubChecks_NoRequestedChanges()
-        {
-            string testChannelName = GetTestChannelName();
-            var targetBranch = GetTargetBranch();
+        await AutoMergeFlowTestBase(TargetRepo, SourceRepo, targetBranch, testChannelName, new List<string> { "--no-requested-changes" });
+    }
 
-            await AutoMergeFlowTestBase(targetRepo, sourceRepo, targetBranch, testChannelName, new List<string> { "--no-requested-changes" });
-        }
-
-        public async Task AutoMergeFlowTestBase(string targetRepo, string sourceRepo, string targetBranch, string testChannelName, List<string> args)
-        {
-            string targetRepoUri = GetRepoUrl(targetRepo);
-            var sourceRepoUri = GetRepoUrl(sourceRepo);
-            var sourceBranch = "dependencyflow-tests";
-            var sourceCommit = "0b36b99e29b1751403e23cfad0a7dff585818051";
-            var sourceBuildNumber = _random.Next(int.MaxValue).ToString();
-            ImmutableList<AssetData> sourceAssets = ImmutableList.Create<AssetData>()
-                .Add(new AssetData(true)
-                {
-                    Name = "Foo",
-                    Version = "1.1.0",
-                })
-                .Add(new AssetData(true)
-                {
-                    Name = "Bar",
-                    Version = "2.1.0",
-                });
-
-            TestContext.WriteLine($"Creating test channel {testChannelName}");
-            await using AsyncDisposableValue<string> channel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
-
-            TestContext.WriteLine($"Adding a subscription from ${sourceRepo} to ${targetRepo}");
-            await using AsyncDisposableValue<string> sub = await CreateSubscriptionAsync(testChannelName, sourceRepo, targetRepo, targetBranch, "none","maestro-auth-test", additionalOptions: args);
-            
-            TestContext.WriteLine("Set up build for intake into target repository");
-            Build build = await CreateBuildAsync(sourceRepoUri, sourceBranch, sourceCommit, sourceBuildNumber, sourceAssets);
-            await using IAsyncDisposable _ = await AddBuildToChannelAsync(build.Id, testChannelName);
-
-            TestContext.WriteLine("Cloning target repo to prepare the target branch");
-            using TemporaryDirectory repo = await CloneRepositoryAsync(targetRepo);
-            using (ChangeDirectory(repo.Directory))
+    public async Task AutoMergeFlowTestBase(string targetRepo, string sourceRepo, string targetBranch, string testChannelName, List<string> args)
+    {
+        string targetRepoUri = GetGitHubRepoUrl(targetRepo);
+        var sourceRepoUri = GetGitHubRepoUrl(sourceRepo);
+        var sourceBranch = "dependencyflow-tests";
+        var sourceCommit = "0b36b99e29b1751403e23cfad0a7dff585818051";
+        var sourceBuildNumber = _random.Next(int.MaxValue).ToString();
+        ImmutableList<AssetData> sourceAssets = ImmutableList.Create<AssetData>()
+            .Add(new AssetData(true)
             {
-                await RunGitAsync("checkout", "-b", targetBranch).ConfigureAwait(false);
-                TestContext.WriteLine("Adding dependencies to target repo");
-                await AddDependenciesToLocalRepo(repo.Directory, "Foo", sourceRepoUri);
-                await AddDependenciesToLocalRepo(repo.Directory, "Bar", sourceRepoUri);
+                Name = "Foo",
+                Version = "1.1.0",
+            })
+            .Add(new AssetData(true)
+            {
+                Name = "Bar",
+                Version = "2.1.0",
+            });
 
-                TestContext.WriteLine("Pushing branch to remote");
-                await RunGitAsync("commit", "-am", "Add dependencies.");
-                await using IAsyncDisposable ___ = await PushGitBranchAsync("origin", targetBranch);
-                
-                await TriggerSubscriptionAsync(sub.Value);
+        TestContext.WriteLine($"Creating test channel {testChannelName}");
+        await using AsyncDisposableValue<string> channel = await CreateTestChannelAsync(testChannelName);
 
-                TestContext.WriteLine($"Waiting on PR to be opened in ${targetRepoUri}");
-                bool testResult = await CheckGithubPullRequestChecks(targetRepo, targetBranch);
-                Assert.IsTrue(testResult);
-            }
+        TestContext.WriteLine($"Adding a subscription from ${sourceRepo} to ${targetRepo}");
+        await using AsyncDisposableValue<string> sub = await CreateSubscriptionAsync(testChannelName, sourceRepo, targetRepo, targetBranch, "none","maestro-auth-test", additionalOptions: args);
+        
+        TestContext.WriteLine("Set up build for intake into target repository");
+        Build build = await CreateBuildAsync(sourceRepoUri, sourceBranch, sourceCommit, sourceBuildNumber, sourceAssets);
+        await using IAsyncDisposable _ = await AddBuildToChannelAsync(build.Id, testChannelName);
+
+        TestContext.WriteLine("Cloning target repo to prepare the target branch");
+        using TemporaryDirectory repo = await CloneRepositoryAsync(targetRepo);
+        using (ChangeDirectory(repo.Directory))
+        {
+            await RunGitAsync("checkout", "-b", targetBranch);
+            TestContext.WriteLine("Adding dependencies to target repo");
+            await AddDependenciesToLocalRepo(repo.Directory, "Foo", sourceRepoUri);
+            await AddDependenciesToLocalRepo(repo.Directory, "Bar", sourceRepoUri);
+
+            TestContext.WriteLine("Pushing branch to remote");
+            await RunGitAsync("commit", "-am", "Add dependencies.");
+            await using IAsyncDisposable ___ = await PushGitBranchAsync("origin", targetBranch);
+            
+            await TriggerSubscriptionAsync(sub.Value);
+
+            TestContext.WriteLine($"Waiting on PR to be opened in ${targetRepoUri}");
+            bool testResult = await CheckGithubPullRequestChecks(targetRepo, targetBranch);
+            Assert.IsTrue(testResult);
         }
     }
 }

--- a/test/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
@@ -43,13 +43,13 @@ internal class ScenarioTests_RepoPolicies : MaestroScenarioTestBase
         StringAssert.AreEqualIgnoringCase(expectedEmpty, emptyPolicies, "Repository merge policy is not empty");
 
         TestContext.WriteLine("Setting repository merge policy to standard");
-        await SetRepositoryPolicies(repoUrl, branchName, new string[] { "--standard-automerge" });
+        await SetRepositoryPolicies(repoUrl, branchName, ["--standard-automerge"]);
         string standardPolicies = await GetRepositoryPolicies(repoUrl, branchName);
         string expectedStandard = $"{repoUrl} @ {branchName}\r\n- Merge Policies:\r\n  Standard\r\n";
         StringAssert.AreEqualIgnoringCase(expectedStandard, standardPolicies, "Repository policy not set to standard");
 
         TestContext.WriteLine("Setting repository merge policy to all checks successful");
-        await SetRepositoryPolicies(repoUrl, branchName, new string[] { "--all-checks-passed", "--ignore-checks", "A,B" });
+        await SetRepositoryPolicies(repoUrl, branchName, ["--all-checks-passed", "--ignore-checks", "A,B"]);
         string allChecksPolicies = await GetRepositoryPolicies(repoUrl, branchName);
         string expectedAllChecksPolicies = $"{repoUrl} @ {branchName}\r\n- Merge Policies:\r\n  AllChecksSuccessful\r\n    ignoreChecks = \r\n" +
             "                   [\r\n" +

--- a/test/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
@@ -40,13 +41,13 @@ internal class ScenarioTests_RepoPolicies : MaestroScenarioTestBase
         await SetRepositoryPolicies(repoUrl, branchName);
         string emptyPolicies = await GetRepositoryPolicies(repoUrl, branchName);
         string expectedEmpty = $"{repoUrl} @ {branchName}\r\n- Merge Policies: []\r\n";
-        StringAssert.AreEqualIgnoringCase(expectedEmpty, emptyPolicies, "Repository merge policy is not empty");
+        emptyPolicies.Should().BeEquivalentTo(expectedEmpty, "Repository merge policy is not empty");
 
         TestContext.WriteLine("Setting repository merge policy to standard");
         await SetRepositoryPolicies(repoUrl, branchName, ["--standard-automerge"]);
         string standardPolicies = await GetRepositoryPolicies(repoUrl, branchName);
         string expectedStandard = $"{repoUrl} @ {branchName}\r\n- Merge Policies:\r\n  Standard\r\n";
-        StringAssert.AreEqualIgnoringCase(expectedStandard, standardPolicies, "Repository policy not set to standard");
+        standardPolicies.Should().BeEquivalentTo(expectedStandard, "Repository policy not set to standard");
 
         TestContext.WriteLine("Setting repository merge policy to all checks successful");
         await SetRepositoryPolicies(repoUrl, branchName, ["--all-checks-passed", "--ignore-checks", "A,B"]);
@@ -56,6 +57,6 @@ internal class ScenarioTests_RepoPolicies : MaestroScenarioTestBase
             "                     \"A\",\r\n" +
             "                     \"B\"\r\n" +
             "                   ]\r\n";
-        StringAssert.AreEqualIgnoringCase(expectedAllChecksPolicies, allChecksPolicies, "Repository policy is incorrect for all checks successful case");
+        allChecksPolicies.Should().BeEquivalentTo(expectedAllChecksPolicies, "Repository policy is incorrect for all checks successful case");
     }
 }

--- a/test/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
@@ -6,57 +6,56 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+[TestFixture]
+[Category("PostDeployment")]
+internal class ScenarioTests_RepoPolicies : MaestroScenarioTestBase
 {
-    [TestFixture]
-    [Category("PostDeployment")]
-    public class ScenarioTests_RepoPolicies : MaestroScenarioTestBase
+    // The RepoPolicies logic does a partial string match for the branch name in the base,
+    // so it's important that this branch name not be a substring or superstring of another branch name
+    private readonly string branchName = $"MaestroRepoPoliciesTestBranch_{Environment.MachineName}";
+    private readonly string repoName = TestRepository.TestRepo1Name;
+    private TestParameters _parameters;
+
+    [TearDown]
+    public Task DisposeAsync()
     {
-        // The RepoPolicies logic does a partial string match for the branch name in the base,
-        // so it's important that this branch name not be a substring or superstring of another branch name
-        private readonly string branchName = $"MaestroRepoPoliciesTestBranch_{Environment.MachineName}";
-        private readonly string repoName = TestRepository.TestRepo1Name;
-        private TestParameters _parameters;
+        _parameters.Dispose();
+        return Task.CompletedTask;
+    }
 
-        [TearDown]
-        public Task DisposeAsync()
-        {
-            _parameters.Dispose();
-            return Task.CompletedTask;
-        }
+    [Test]
+    public async Task ArcadeRepoPolicies_EndToEnd()
+    {
+        TestContext.WriteLine("Repository merge policy handling");
+        TestContext.WriteLine("Running tests...");
 
-        [Test]
-        public async Task ArcadeRepoPolicies_EndToEnd()
-        {
-            TestContext.WriteLine("Repository merge policy handling");
-            TestContext.WriteLine("Running tests...");
+        _parameters = await TestParameters.GetAsync();
+        SetTestParameters(_parameters);
 
-            _parameters = await TestParameters.GetAsync();
-            SetTestParameters(_parameters);
+        string repoUrl = GetGitHubRepoUrl(repoName);
 
-            string repoUrl = GetRepoUrl(repoName);
+        TestContext.WriteLine("Setting repository merge policy to empty");
+        await SetRepositoryPolicies(repoUrl, branchName);
+        string emptyPolicies = await GetRepositoryPolicies(repoUrl, branchName);
+        string expectedEmpty = $"{repoUrl} @ {branchName}\r\n- Merge Policies: []\r\n";
+        StringAssert.AreEqualIgnoringCase(expectedEmpty, emptyPolicies, "Repository merge policy is not empty");
 
-            TestContext.WriteLine("Setting repository merge policy to empty");
-            await SetRepositoryPolicies(repoUrl, branchName);
-            string emptyPolicies = await GetRepositoryPolicies(repoUrl, branchName);
-            string expectedEmpty = $"{repoUrl} @ {branchName}\r\n- Merge Policies: []\r\n";
-            StringAssert.AreEqualIgnoringCase(expectedEmpty, emptyPolicies, "Repository merge policy is not empty");
+        TestContext.WriteLine("Setting repository merge policy to standard");
+        await SetRepositoryPolicies(repoUrl, branchName, new string[] { "--standard-automerge" });
+        string standardPolicies = await GetRepositoryPolicies(repoUrl, branchName);
+        string expectedStandard = $"{repoUrl} @ {branchName}\r\n- Merge Policies:\r\n  Standard\r\n";
+        StringAssert.AreEqualIgnoringCase(expectedStandard, standardPolicies, "Repository policy not set to standard");
 
-            TestContext.WriteLine("Setting repository merge policy to standard");
-            await SetRepositoryPolicies(repoUrl, branchName, new string[] { "--standard-automerge" });
-            string standardPolicies = await GetRepositoryPolicies(repoUrl, branchName);
-            string expectedStandard = $"{repoUrl} @ {branchName}\r\n- Merge Policies:\r\n  Standard\r\n";
-            StringAssert.AreEqualIgnoringCase(expectedStandard, standardPolicies, "Repository policy not set to standard");
-
-            TestContext.WriteLine("Setting repository merge policy to all checks successful");
-            await SetRepositoryPolicies(repoUrl, branchName, new string[] { "--all-checks-passed", "--ignore-checks", "A,B" });
-            string allChecksPolicies = await GetRepositoryPolicies(repoUrl, branchName);
-            string expectedAllChecksPolicies = $"{repoUrl} @ {branchName}\r\n- Merge Policies:\r\n  AllChecksSuccessful\r\n    ignoreChecks = \r\n" +
-                "                   [\r\n" +
-                "                     \"A\",\r\n" +
-                "                     \"B\"\r\n" +
-                "                   ]\r\n";
-            StringAssert.AreEqualIgnoringCase(expectedAllChecksPolicies, allChecksPolicies, "Repository policy is incorrect for all checks successful case");
-        }
+        TestContext.WriteLine("Setting repository merge policy to all checks successful");
+        await SetRepositoryPolicies(repoUrl, branchName, new string[] { "--all-checks-passed", "--ignore-checks", "A,B" });
+        string allChecksPolicies = await GetRepositoryPolicies(repoUrl, branchName);
+        string expectedAllChecksPolicies = $"{repoUrl} @ {branchName}\r\n- Merge Policies:\r\n  AllChecksSuccessful\r\n    ignoreChecks = \r\n" +
+            "                   [\r\n" +
+            "                     \"A\",\r\n" +
+            "                     \"B\"\r\n" +
+            "                   ]\r\n";
+        StringAssert.AreEqualIgnoringCase(expectedAllChecksPolicies, allChecksPolicies, "Repository policy is incorrect for all checks successful case");
     }
 }

--- a/test/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
@@ -10,95 +10,94 @@ using Microsoft.DotNet.Maestro.Client.Models;
 using NUnit.Framework;
 using Octokit;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+[TestFixture]
+[Category("PostDeployment")]
+internal class ScenarioTests_SdkUpdate : MaestroScenarioTestBase
 {
-    [TestFixture]
-    [Category("PostDeployment")]
-    public class ScenarioTests_SdkUpdate : MaestroScenarioTestBase
+    private TestParameters _parameters;
+    private readonly Random _random = new();
+
+    [TearDown]
+    public Task DisposeAsync()
     {
-        private TestParameters _parameters;
-        private Random _random = new Random();
+        _parameters.Dispose();
+        return Task.CompletedTask;
+    }
 
-        [TearDown]
-        public Task DisposeAsync()
-        {
-            _parameters.Dispose();
-            return Task.CompletedTask;
-        }
+    [Test]
+    public async Task ArcadeSdkUpdate()
+    {
+        _parameters = await TestParameters.GetAsync();
+        SetTestParameters(_parameters);
 
-        [Test]
-        public async Task ArcadeSdkUpdate()
-        {
-            _parameters = await TestParameters.GetAsync();
-            SetTestParameters(_parameters);
-
-            string testChannelName = "Test Channel " + _random.Next(int.MaxValue);
-            var sourceRepo = "arcade";
-            var sourceRepoUri = "https://github.com/dotnet/arcade";
-            var sourceBranch = "dependencyflow-tests";
-            var sourceCommit = "0b36b99e29b1751403e23cfad0a7dff585818051";
-            var sourceBuildNumber = _random.Next(int.MaxValue).ToString();
-            ImmutableList<AssetData> sourceAssets = ImmutableList.Create<AssetData>()
-                .Add(new AssetData(true)
-                {
-                    Name = "Microsoft.DotNet.Arcade.Sdk",
-                    Version = "2.1.0",
-                });
-            var targetRepo = "maestro-test2";
-            var targetBranch = _random.Next(int.MaxValue).ToString();
-            await using AsyncDisposableValue<string> channel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
-            await using AsyncDisposableValue<string> sub = await CreateSubscriptionAsync(testChannelName, sourceRepo, targetRepo, targetBranch, "none");
-            Build build = await CreateBuildAsync(GetRepoUrl("dotnet", sourceRepo), sourceBranch, sourceCommit, sourceBuildNumber, sourceAssets);
-            await using IAsyncDisposable _ = await AddBuildToChannelAsync(build.Id, testChannelName);
-
-            using TemporaryDirectory repo = await CloneRepositoryAsync(targetRepo);
-            using (ChangeDirectory(repo.Directory))
+        string testChannelName = "Test Channel " + _random.Next(int.MaxValue);
+        var sourceRepo = "arcade";
+        var sourceRepoUri = "https://github.com/dotnet/arcade";
+        var sourceBranch = "dependencyflow-tests";
+        var sourceCommit = "0b36b99e29b1751403e23cfad0a7dff585818051";
+        var sourceBuildNumber = _random.Next(int.MaxValue).ToString();
+        ImmutableList<AssetData> sourceAssets = ImmutableList.Create<AssetData>()
+            .Add(new AssetData(true)
             {
-                await RunGitAsync("checkout", "-b", targetBranch).ConfigureAwait(false);
-                await RunDarcAsync("add-dependency",
-                    "--name", "Microsoft.DotNet.Arcade.Sdk",
-                    "--type", "toolset",
-                    "--repo", sourceRepoUri);
-                await RunGitAsync("commit", "-am", "Add dependencies.");
-                await using IAsyncDisposable ___ = await PushGitBranchAsync("origin", targetBranch);
-                await TriggerSubscriptionAsync(sub.Value);
+                Name = "Microsoft.DotNet.Arcade.Sdk",
+                Version = "2.1.0",
+            });
+        var targetRepo = "maestro-test2";
+        var targetBranch = _random.Next(int.MaxValue).ToString();
+        await using AsyncDisposableValue<string> channel = await CreateTestChannelAsync(testChannelName).ConfigureAwait(false);
+        await using AsyncDisposableValue<string> sub = await CreateSubscriptionAsync(testChannelName, sourceRepo, targetRepo, targetBranch, "none");
+        Build build = await CreateBuildAsync(GetRepoUrl("dotnet", sourceRepo), sourceBranch, sourceCommit, sourceBuildNumber, sourceAssets);
+        await using IAsyncDisposable _ = await AddBuildToChannelAsync(build.Id, testChannelName);
 
-                PullRequest pr = await WaitForPullRequestAsync(targetRepo, targetBranch);
+        using TemporaryDirectory repo = await CloneRepositoryAsync(targetRepo);
+        using (ChangeDirectory(repo.Directory))
+        {
+            await RunGitAsync("checkout", "-b", targetBranch).ConfigureAwait(false);
+            await RunDarcAsync("add-dependency",
+                "--name", "Microsoft.DotNet.Arcade.Sdk",
+                "--type", "toolset",
+                "--repo", sourceRepoUri);
+            await RunGitAsync("commit", "-am", "Add dependencies.");
+            await using IAsyncDisposable ___ = await PushGitBranchAsync("origin", targetBranch);
+            await TriggerSubscriptionAsync(sub.Value);
 
-                StringAssert.AreEqualIgnoringCase($"[{targetBranch}] Update dependencies from dotnet/arcade", pr.Title);
+            PullRequest pr = await WaitForPullRequestAsync(targetRepo, targetBranch);
 
-                await CheckoutRemoteRefAsync(pr.MergeCommitSha);
+            StringAssert.AreEqualIgnoringCase($"[{targetBranch}] Update dependencies from dotnet/arcade", pr.Title);
 
-                string dependencies = await RunDarcAsync("get-dependencies");
-                string[] dependencyLines = dependencies.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
-                Assert.AreEqual(new[]
-                {
-                    "Name:             Microsoft.DotNet.Arcade.Sdk",
-                    "Version:          2.1.0",
-                    $"Repo:             {sourceRepoUri}",
-                    $"Commit:           {sourceCommit}",
-                    "Type:             Toolset",
-                    "Pinned:           False",
-                }, dependencyLines);
+            await CheckoutRemoteRefAsync(pr.MergeCommitSha);
 
-                using TemporaryDirectory arcadeRepo = await CloneRepositoryAsync("dotnet", sourceRepo);
-                using (ChangeDirectory(arcadeRepo.Directory))
-                {
-                    await CheckoutRemoteRefAsync(sourceCommit);
-                }
+            string dependencies = await RunDarcAsync("get-dependencies");
+            string[] dependencyLines = dependencies.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.AreEqual(new[]
+            {
+                "Name:             Microsoft.DotNet.Arcade.Sdk",
+                "Version:          2.1.0",
+                $"Repo:             {sourceRepoUri}",
+                $"Commit:           {sourceCommit}",
+                "Type:             Toolset",
+                "Pinned:           False",
+            }, dependencyLines);
 
-                var arcadeFiles = Directory.EnumerateFileSystemEntries(Path.Join(arcadeRepo.Directory, "eng", "common"),
-                        "*", SearchOption.AllDirectories)
-                    .Select(s => s.Substring(arcadeRepo.Directory.Length))
-                    .ToHashSet();
-                var repoFiles = Directory.EnumerateFileSystemEntries(Path.Join(repo.Directory, "eng", "common"), "*",
-                        SearchOption.AllDirectories)
-                    .Select(s => s.Substring(repo.Directory.Length))
-                    .ToHashSet();
-
-                Assert.IsEmpty(arcadeFiles.Except(repoFiles));
-                Assert.IsEmpty(repoFiles.Except(arcadeFiles));
+            using TemporaryDirectory arcadeRepo = await CloneRepositoryAsync("dotnet", sourceRepo);
+            using (ChangeDirectory(arcadeRepo.Directory))
+            {
+                await CheckoutRemoteRefAsync(sourceCommit);
             }
+
+            var arcadeFiles = Directory.EnumerateFileSystemEntries(Path.Join(arcadeRepo.Directory, "eng", "common"),
+                    "*", SearchOption.AllDirectories)
+                .Select(s => s.Substring(arcadeRepo.Directory.Length))
+                .ToHashSet();
+            var repoFiles = Directory.EnumerateFileSystemEntries(Path.Join(repo.Directory, "eng", "common"), "*",
+                    SearchOption.AllDirectories)
+                .Select(s => s.Substring(repo.Directory.Length))
+                .ToHashSet();
+
+            Assert.IsEmpty(arcadeFiles.Except(repoFiles));
+            Assert.IsEmpty(repoFiles.Except(arcadeFiles));
         }
     }
 }

--- a/test/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
@@ -97,7 +97,7 @@ internal class ScenarioTests_SdkUpdate : MaestroScenarioTestBase
                 .Select(s => s.Substring(repo.Directory.Length))
                 .ToHashSet();
 
-            arcadeFiles.Except(repoFiles).Should().BeEmpty();
+            arcadeFiles.Should().BeEquivalentTo(repoFiles);
         }
     }
 }

--- a/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
@@ -11,156 +11,154 @@ using Microsoft.DotNet.Maestro.Client.Models;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+[TestFixture]
+[Category("PostDeployment")]
+internal class ScenarioTests_Subscriptions : MaestroScenarioTestBase
 {
-    [TestFixture]
-    [Category("PostDeployment")]
-    public class ScenarioTests_Subscriptions : MaestroScenarioTestBase
+    private TestParameters _parameters;
+
+    [TearDown]
+    public Task DisposeAsync()
     {
-        private TestParameters _parameters;
+        _parameters.Dispose();
+        return Task.CompletedTask;
+    }
 
-        [TearDown]
-        public Task DisposeAsync()
+    [Test]
+    public async Task Subscriptions_EndToEnd()
+    {
+        TestContext.WriteLine("Subscription management tests...");
+        string repo1Name = TestRepository.TestRepo1Name;
+        string repo2Name = TestRepository.TestRepo2Name;
+        string channel1Name = $"SubscriptionEndToEnd_TestChannel1_{Environment.MachineName}";
+        string channel2Name = $"SubscriptionEndToEnd_TestChannel2_{Environment.MachineName}";
+
+        _parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
+        SetTestParameters(_parameters);
+
+        string repo1Uri = GetGitHubRepoUrl(repo1Name);
+        string repo2Uri = GetGitHubRepoUrl(repo2Name);
+        string repo1AzDoUri = GetAzDoRepoUrl(repo1Name);
+        string targetBranch = $"SubscriptionEndToEnd_TargetBranch_{Environment.MachineName}";
+
+        TestContext.WriteLine($"Creating channels {channel1Name} and {channel2Name}");
+        await using (AsyncDisposableValue<string> channel1 = await CreateTestChannelAsync(channel1Name).ConfigureAwait(false))
         {
-            _parameters.Dispose();
-            return Task.CompletedTask;
-        }
-
-        [Test]
-        public async Task Subscriptions_EndToEnd()
-        {
-            TestContext.WriteLine("Subscription management tests...");
-            string repo1Name = TestRepository.TestRepo1Name;
-            string repo2Name = TestRepository.TestRepo2Name;
-            string channel1Name = $"SubscriptionEndToEnd_TestChannel1_{Environment.MachineName}";
-            string channel2Name = $"SubscriptionEndToEnd_TestChannel2_{Environment.MachineName}";
-
-            _parameters = await TestParameters.GetAsync(useNonPrimaryEndpoint: true);
-            SetTestParameters(_parameters);
-
-            string repo1Uri = GetRepoUrl(repo1Name);
-            string repo2Uri = GetRepoUrl(repo2Name);
-            string repo1AzDoUri = GetAzDoRepoUrl(repo1Name);
-            string targetBranch = $"SubscriptionEndToEnd_TargetBranch_{Environment.MachineName}";
-
-            TestContext.WriteLine($"Creating channels {channel1Name} and {channel2Name}");
-            await using (AsyncDisposableValue<string> channel1 = await CreateTestChannelAsync(channel1Name).ConfigureAwait(false))
+            await using (AsyncDisposableValue<string> channel2 = await CreateTestChannelAsync(channel2Name).ConfigureAwait(false))
             {
-                await using (AsyncDisposableValue<string> channel2 = await CreateTestChannelAsync(channel2Name).ConfigureAwait(false))
-                {
 
-                    TestContext.WriteLine("Testing various command line parameters of add-subscription");
-                    await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionAsync(
-                        channel1Name, repo1Name, repo2Name, targetBranch, "everyWeek", "maestro-auth-test");
+                TestContext.WriteLine("Testing various command line parameters of add-subscription");
+                await using AsyncDisposableValue<string> subscription1Id = await CreateSubscriptionAsync(
+                    channel1Name, repo1Name, repo2Name, targetBranch, "everyWeek", "maestro-auth-test");
 
-                    Subscription expectedSubscription1 = SubscriptionBuilder.BuildSubscription(
-                        repo1Uri, 
-                        repo2Uri, 
-                        targetBranch, 
-                        channel1Name, 
-                        subscription1Id.Value, 
-                        UpdateFrequency.EveryWeek, 
-                        false);
+                Subscription expectedSubscription1 = SubscriptionBuilder.BuildSubscription(
+                    repo1Uri, 
+                    repo2Uri, 
+                    targetBranch, 
+                    channel1Name, 
+                    subscription1Id.Value, 
+                    UpdateFrequency.EveryWeek, 
+                    false);
 
-                    string expectedSubscription1Info = UxHelpers.GetTextSubscriptionDescription(expectedSubscription1, null);
+                string expectedSubscription1Info = UxHelpers.GetTextSubscriptionDescription(expectedSubscription1, null);
 
-                    await ValidateSubscriptionInfo(subscription1Id.Value, expectedSubscription1Info);
+                await ValidateSubscriptionInfo(subscription1Id.Value, expectedSubscription1Info);
 
-                    await using AsyncDisposableValue<string> subscription2Id = await CreateSubscriptionAsync(
-                        channel1Name, repo1Name, repo1Name, targetBranch, "none", "maestro-auth-test",
-                        new List<string>
-                        { "--all-checks-passed", "--no-requested-changes", "--ignore-checks", "WIP,license/cla" }, targetIsAzDo: true);
+                await using AsyncDisposableValue<string> subscription2Id = await CreateSubscriptionAsync(
+                    channel1Name, repo1Name, repo1Name, targetBranch, "none", "maestro-auth-test",
+                    ["--all-checks-passed", "--no-requested-changes", "--ignore-checks", "WIP,license/cla"], targetIsAzDo: true);
 
-                    Subscription expectedSubscription2 = SubscriptionBuilder.BuildSubscription(
-                        repo1Uri,
-                        repo1AzDoUri,
-                        targetBranch,
-                        channel1Name,
-                        subscription2Id.Value,
-                        UpdateFrequency.None,
-                        false,
-                        new List<string> { MergePolicyConstants.AllCheckSuccessfulMergePolicyName, MergePolicyConstants.NoRequestedChangesMergePolicyName },
-                        new List<string> { "WIP", "license/cla" });
+                Subscription expectedSubscription2 = SubscriptionBuilder.BuildSubscription(
+                    repo1Uri,
+                    repo1AzDoUri,
+                    targetBranch,
+                    channel1Name,
+                    subscription2Id.Value,
+                    UpdateFrequency.None,
+                    false,
+                    [MergePolicyConstants.AllCheckSuccessfulMergePolicyName, MergePolicyConstants.NoRequestedChangesMergePolicyName],
+                    ["WIP", "license/cla"]);
 
-                    string expectedSubscription2Info = UxHelpers.GetTextSubscriptionDescription(expectedSubscription2, null);
+                string expectedSubscription2Info = UxHelpers.GetTextSubscriptionDescription(expectedSubscription2, null);
 
-                    await ValidateSubscriptionInfo(subscription2Id.Value, expectedSubscription2Info);
+                await ValidateSubscriptionInfo(subscription2Id.Value, expectedSubscription2Info);
 
-                    await using AsyncDisposableValue<string> subscription3Id = await CreateSubscriptionAsync(
-                        channel2Name, repo1Name, repo2Name, targetBranch, "none", "maestro-auth-test",
-                        new List<string>
-                        { "--all-checks-passed", "--no-requested-changes", "--ignore-checks", "WIP,license/cla" });
+                await using AsyncDisposableValue<string> subscription3Id = await CreateSubscriptionAsync(
+                    channel2Name, repo1Name, repo2Name, targetBranch, "none", "maestro-auth-test",
+                    ["--all-checks-passed", "--no-requested-changes", "--ignore-checks", "WIP,license/cla"]);
 
-                    Subscription expectedSubscription3 = SubscriptionBuilder.BuildSubscription(
-                        repo1Uri,
-                        repo2Uri,
-                        targetBranch,
-                        channel2Name,
-                        subscription3Id.Value,
-                        UpdateFrequency.None,
-                        false,
-                        new List<string> { MergePolicyConstants.AllCheckSuccessfulMergePolicyName, MergePolicyConstants.NoRequestedChangesMergePolicyName },
-                        new List<string> { "WIP", "license/cla" });
+                Subscription expectedSubscription3 = SubscriptionBuilder.BuildSubscription(
+                    repo1Uri,
+                    repo2Uri,
+                    targetBranch,
+                    channel2Name,
+                    subscription3Id.Value,
+                    UpdateFrequency.None,
+                    false,
+                    [MergePolicyConstants.AllCheckSuccessfulMergePolicyName, MergePolicyConstants.NoRequestedChangesMergePolicyName],
+                    ["WIP", "license/cla"]);
 
-                    string expectedSubscription3Info = UxHelpers.GetTextSubscriptionDescription(expectedSubscription3, null);
+                string expectedSubscription3Info = UxHelpers.GetTextSubscriptionDescription(expectedSubscription3, null);
 
-                    await ValidateSubscriptionInfo(subscription3Id.Value, expectedSubscription3Info);
+                await ValidateSubscriptionInfo(subscription3Id.Value, expectedSubscription3Info);
 
-                    // Disable the first two subscriptions, but not the third.
-                    TestContext.WriteLine("Disable the subscriptions for test channel 1");
-                    await SetSubscriptionStatus(false, channelName: channel1Name);
+                // Disable the first two subscriptions, but not the third.
+                TestContext.WriteLine("Disable the subscriptions for test channel 1");
+                await SetSubscriptionStatus(false, channelName: channel1Name);
 
-                    // Disable one by id (classic usage) to make sure that works
-                    TestContext.WriteLine("Disable the third subscription by id");
-                    await SetSubscriptionStatus(false, subscriptionId: subscription3Id.Value);
+                // Disable one by id (classic usage) to make sure that works
+                TestContext.WriteLine("Disable the third subscription by id");
+                await SetSubscriptionStatus(false, subscriptionId: subscription3Id.Value);
 
-                    // Re-enable
-                    TestContext.WriteLine("Enable the third subscription by id");
-                    await SetSubscriptionStatus(true, subscriptionId: subscription3Id.Value);
-                    StringAssert.Contains("Enabled: True", await GetSubscriptionInfo(subscription3Id.Value), $"Expected subscription {subscription3Id} to be enabled");
+                // Re-enable
+                TestContext.WriteLine("Enable the third subscription by id");
+                await SetSubscriptionStatus(true, subscriptionId: subscription3Id.Value);
+                StringAssert.Contains("Enabled: True", await GetSubscriptionInfo(subscription3Id.Value), $"Expected subscription {subscription3Id} to be enabled");
 
-                    // Mass delete the subscriptions. Delete the first two but not the third.
-                    TestContext.WriteLine("Delete the subscriptions for test channel 1");
-                    string message = await DeleteSubscriptionsForChannel(channel1Name);
+                // Mass delete the subscriptions. Delete the first two but not the third.
+                TestContext.WriteLine("Delete the subscriptions for test channel 1");
+                string message = await DeleteSubscriptionsForChannel(channel1Name);
 
-                    // Check that there are no subscriptions against channel1 now
-                    TestContext.WriteLine("Verify that there are no subscriptions in test channel 1");
-                    Assert.ThrowsAsync<MaestroTestException>(async () => await GetSubscriptions(channel1Name), "Subscriptions for channel 1 were not deleted.");
+                // Check that there are no subscriptions against channel1 now
+                TestContext.WriteLine("Verify that there are no subscriptions in test channel 1");
+                Assert.ThrowsAsync<MaestroTestException>(async () => await GetSubscriptions(channel1Name), "Subscriptions for channel 1 were not deleted.");
 
-                    // Validate the third subscription, which should still exist
-                    TestContext.WriteLine("Verify that the third subscription still exists, then delete it");
-                    await ValidateSubscriptionInfo(subscription3Id.Value, expectedSubscription3Info);
-                    string message2 = await DeleteSubscriptionById(subscription3Id.Value);
+                // Validate the third subscription, which should still exist
+                TestContext.WriteLine("Verify that the third subscription still exists, then delete it");
+                await ValidateSubscriptionInfo(subscription3Id.Value, expectedSubscription3Info);
+                string message2 = await DeleteSubscriptionById(subscription3Id.Value);
 
-                    // Attempt to create a batchable subscription with merge policies.
-                    // Should fail, merge policies are set separately for batched subs
-                    TestContext.WriteLine("Attempt to create a batchable subscription with merge policies");
-                    Assert.ThrowsAsync<MaestroTestException>(async () =>
-                        await CreateSubscriptionAsync(channel1Name, repo1Name, repo2Name, targetBranch, "none", additionalOptions: new List<string> { "--standard-automerge", "--batchable" }),
-                        "Attempt to create a batchable subscription with merge policies");
+                // Attempt to create a batchable subscription with merge policies.
+                // Should fail, merge policies are set separately for batched subs
+                TestContext.WriteLine("Attempt to create a batchable subscription with merge policies");
+                Assert.ThrowsAsync<MaestroTestException>(async () =>
+                    await CreateSubscriptionAsync(channel1Name, repo1Name, repo2Name, targetBranch, "none", additionalOptions: ["--standard-automerge", "--batchable"]),
+                    "Attempt to create a batchable subscription with merge policies");
 
-                    // Create a batchable subscription
-                    TestContext.WriteLine("Create a batchable subscription");
-                    await using AsyncDisposableValue<string> batchSubscriptionId = await CreateSubscriptionAsync(
-                        channel1Name, repo1Name, repo2Name, targetBranch, "everyWeek", "maestro-auth-test", additionalOptions: new List<string> { "--batchable" });
+                // Create a batchable subscription
+                TestContext.WriteLine("Create a batchable subscription");
+                await using AsyncDisposableValue<string> batchSubscriptionId = await CreateSubscriptionAsync(
+                    channel1Name, repo1Name, repo2Name, targetBranch, "everyWeek", "maestro-auth-test", additionalOptions: ["--batchable"]);
 
-                    Subscription expectedBatchedSubscription = SubscriptionBuilder.BuildSubscription(
-                        repo1Uri, 
-                        repo2Uri, 
-                        targetBranch, 
-                        channel1Name, 
-                        batchSubscriptionId.Value, 
-                        UpdateFrequency.EveryWeek, 
-                        true);
+                Subscription expectedBatchedSubscription = SubscriptionBuilder.BuildSubscription(
+                    repo1Uri, 
+                    repo2Uri, 
+                    targetBranch, 
+                    channel1Name, 
+                    batchSubscriptionId.Value, 
+                    UpdateFrequency.EveryWeek, 
+                    true);
 
-                    string expectedBatchedSubscriptionInfo = UxHelpers.GetTextSubscriptionDescription(expectedBatchedSubscription, null);
+                string expectedBatchedSubscriptionInfo = UxHelpers.GetTextSubscriptionDescription(expectedBatchedSubscription, null);
 
-                    await ValidateSubscriptionInfo(batchSubscriptionId.Value, expectedBatchedSubscriptionInfo);
-                    await DeleteSubscriptionById(batchSubscriptionId.Value);
+                await ValidateSubscriptionInfo(batchSubscriptionId.Value, expectedBatchedSubscriptionInfo);
+                await DeleteSubscriptionById(batchSubscriptionId.Value);
 
-                    TestContext.WriteLine("Testing YAML for darc add-subscription");
+                TestContext.WriteLine("Testing YAML for darc add-subscription");
 
-                    string yamlDefinition = $@"
+                string yamlDefinition = $@"
                     Channel: {channel1Name}
                     Source Repository URL: {repo1Uri}
                     Target Repository URL: {repo2Uri}
@@ -171,26 +169,26 @@ namespace Maestro.ScenarioTests
                     - Name: Standard
                     ";
 
-                    await using AsyncDisposableValue<string> yamlSubscriptionId = await CreateSubscriptionAsync(yamlDefinition);
+                await using AsyncDisposableValue<string> yamlSubscriptionId = await CreateSubscriptionAsync(yamlDefinition);
 
-                    Subscription expectedYamlSubscription = SubscriptionBuilder.BuildSubscription(
-                        repo1Uri, 
-                        repo2Uri, 
-                        targetBranch, 
-                        channel1Name, 
-                        yamlSubscriptionId.Value, 
-                        UpdateFrequency.EveryWeek, 
-                        false, 
-                        new List<string> { MergePolicyConstants.StandardMergePolicyName });
+                Subscription expectedYamlSubscription = SubscriptionBuilder.BuildSubscription(
+                    repo1Uri, 
+                    repo2Uri, 
+                    targetBranch, 
+                    channel1Name, 
+                    yamlSubscriptionId.Value, 
+                    UpdateFrequency.EveryWeek, 
+                    false, 
+                    [MergePolicyConstants.StandardMergePolicyName]);
 
-                    string expectedYamlSubscriptionInfo = UxHelpers.GetTextSubscriptionDescription(expectedYamlSubscription, null);
+                string expectedYamlSubscriptionInfo = UxHelpers.GetTextSubscriptionDescription(expectedYamlSubscription, null);
 
-                    await ValidateSubscriptionInfo(yamlSubscriptionId.Value, expectedYamlSubscriptionInfo);
-                    await DeleteSubscriptionById(yamlSubscriptionId.Value);
+                await ValidateSubscriptionInfo(yamlSubscriptionId.Value, expectedYamlSubscriptionInfo);
+                await DeleteSubscriptionById(yamlSubscriptionId.Value);
 
-                    TestContext.WriteLine("Change casing of the various properties. Expecting no changes.");
+                TestContext.WriteLine("Change casing of the various properties. Expecting no changes.");
 
-                    string yamlDefinition2 = $@"
+                string yamlDefinition2 = $@"
                     Channel: {channel1Name}
                     Source Repository URL: {repo1Uri}
                     Target Repository URL: {repo2Uri}
@@ -201,25 +199,25 @@ namespace Maestro.ScenarioTests
                     - Name: standard
                     ";
 
-                    await using AsyncDisposableValue<string> yamlSubscription2Id = await CreateSubscriptionAsync(yamlDefinition2);
+                await using AsyncDisposableValue<string> yamlSubscription2Id = await CreateSubscriptionAsync(yamlDefinition2);
 
-                    Subscription expectedYamlSubscription2 = SubscriptionBuilder.BuildSubscription(
-                        repo1Uri, 
-                        repo2Uri,
-                        targetBranch, 
-                        channel1Name, 
-                        yamlSubscription2Id.Value, 
-                        UpdateFrequency.EveryWeek, false, 
-                        new List<string> { MergePolicyConstants.StandardMergePolicyName });
+                Subscription expectedYamlSubscription2 = SubscriptionBuilder.BuildSubscription(
+                    repo1Uri, 
+                    repo2Uri,
+                    targetBranch, 
+                    channel1Name, 
+                    yamlSubscription2Id.Value, 
+                    UpdateFrequency.EveryWeek, false, 
+                    [MergePolicyConstants.StandardMergePolicyName]);
 
-                    string expectedYamlSubscriptionInfo2 = UxHelpers.GetTextSubscriptionDescription(expectedYamlSubscription2, null);
+                string expectedYamlSubscriptionInfo2 = UxHelpers.GetTextSubscriptionDescription(expectedYamlSubscription2, null);
 
-                    await ValidateSubscriptionInfo(yamlSubscription2Id.Value, expectedYamlSubscriptionInfo2);
-                    await DeleteSubscriptionById(yamlSubscription2Id.Value);
+                await ValidateSubscriptionInfo(yamlSubscription2Id.Value, expectedYamlSubscriptionInfo2);
+                await DeleteSubscriptionById(yamlSubscription2Id.Value);
 
-                    TestContext.WriteLine("Attempt to add multiple of the same merge policy checks. Should fail.");
+                TestContext.WriteLine("Attempt to add multiple of the same merge policy checks. Should fail.");
 
-                    string yamlDefinition3 = $@"
+                string yamlDefinition3 = $"""
                     Channel: {channel1Name}
                     Source Repository URL: {repo1Uri}
                     Target Repository URL: {repo2Uri}
@@ -236,26 +234,26 @@ namespace Maestro.ScenarioTests
                       Properties:
                         ignoreChecks:
                         - WIP
-                        - MySpecialCheck";
+                        - MySpecialCheck
+                    """;
 
-                    Assert.ThrowsAsync<MaestroTestException>(async () =>
-                        await CreateSubscriptionAsync(yamlDefinition3), "Attempt to create a subscription with multiples of the same merge policy.");
+                Assert.ThrowsAsync<MaestroTestException>(async () =>
+                    await CreateSubscriptionAsync(yamlDefinition3), "Attempt to create a subscription with multiples of the same merge policy.");
 
-                    TestContext.WriteLine("Testing duplicate subscription handling...");
-                    AsyncDisposableValue<string> yamlSubscription3Id = await CreateSubscriptionAsync(channel1Name, repo1Name, repo2Name, targetBranch, "everyWeek", "maestro-auth-test");
+                TestContext.WriteLine("Testing duplicate subscription handling...");
+                AsyncDisposableValue<string> yamlSubscription3Id = await CreateSubscriptionAsync(channel1Name, repo1Name, repo2Name, targetBranch, "everyWeek", "maestro-auth-test");
 
-                    Assert.ThrowsAsync<MaestroTestException>(async () =>
-                        await CreateSubscriptionAsync(channel1Name, repo1Name, repo2Name, targetBranch, "everyWeek", "maestro-auth-test"),
-                        "Attempt to create a subscription with the same values as an existing subscription.");
+                Assert.ThrowsAsync<MaestroTestException>(async () =>
+                    await CreateSubscriptionAsync(channel1Name, repo1Name, repo2Name, targetBranch, "everyWeek", "maestro-auth-test"),
+                    "Attempt to create a subscription with the same values as an existing subscription.");
 
-                    Assert.ThrowsAsync<MaestroTestException>(async () =>
-                        await CreateSubscriptionAsync(channel1Name, repo1Name, repo2Name, targetBranch, "everyweek", "maestro-auth-test"),
-                        "Attempt to create a subscription with the same values as an existing subscription (except for the casing of one parameter.");
+                Assert.ThrowsAsync<MaestroTestException>(async () =>
+                    await CreateSubscriptionAsync(channel1Name, repo1Name, repo2Name, targetBranch, "everyweek", "maestro-auth-test"),
+                    "Attempt to create a subscription with the same values as an existing subscription (except for the casing of one parameter.");
 
-                    await DeleteSubscriptionById(yamlSubscription3Id.Value);
+                await DeleteSubscriptionById(yamlSubscription3Id.Value);
 
-                    TestContext.WriteLine("End of test case. Starting clean up.");
-                }
+                TestContext.WriteLine("End of test case. Starting clean up.");
             }
         }
     }

--- a/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.Darc;
 using Microsoft.DotNet.Maestro.Client.Models;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using NUnit.Framework.Legacy;
 
 namespace Maestro.ScenarioTests;
 
@@ -116,7 +117,8 @@ internal class ScenarioTests_Subscriptions : MaestroScenarioTestBase
                 // Re-enable
                 TestContext.WriteLine("Enable the third subscription by id");
                 await SetSubscriptionStatusById(true, subscription3Id.Value);
-                (await GetSubscriptionInfo(subscription3Id.Value)).Should().Be("Enabled: True", $"Expected subscription {subscription3Id} to be enabled");
+
+                (await GetSubscriptionInfo(subscription3Id.Value)).Should().Contain("Enabled: True", $"Expected subscription {subscription3Id} to be enabled");
 
                 // Mass delete the subscriptions. Delete the first two but not the third.
                 TestContext.WriteLine("Delete the subscriptions for test channel 1");

--- a/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Maestro.MergePolicyEvaluation;
 using Maestro.ScenarioTests.ObjectHelpers;
 using Microsoft.DotNet.Darc;
@@ -115,7 +116,7 @@ internal class ScenarioTests_Subscriptions : MaestroScenarioTestBase
                 // Re-enable
                 TestContext.WriteLine("Enable the third subscription by id");
                 await SetSubscriptionStatusById(true, subscription3Id.Value);
-                StringAssert.Contains("Enabled: True", await GetSubscriptionInfo(subscription3Id.Value), $"Expected subscription {subscription3Id} to be enabled");
+                (await GetSubscriptionInfo(subscription3Id.Value)).Should().Be("Enabled: True", $"Expected subscription {subscription3Id} to be enabled");
 
                 // Mass delete the subscriptions. Delete the first two but not the third.
                 TestContext.WriteLine("Delete the subscriptions for test channel 1");
@@ -261,6 +262,6 @@ internal class ScenarioTests_Subscriptions : MaestroScenarioTestBase
     private async Task ValidateSubscriptionInfo(string subscriptionId, string expectedSubscriptionInfo)
     {
         var subscriptionInfo = await GetSubscriptionInfo(subscriptionId);
-        StringAssert.AreEqualIgnoringCase(expectedSubscriptionInfo, subscriptionInfo);
+        subscriptionInfo.Should().BeEquivalentTo(expectedSubscriptionInfo);
     }
 }

--- a/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
@@ -106,15 +106,15 @@ internal class ScenarioTests_Subscriptions : MaestroScenarioTestBase
 
                 // Disable the first two subscriptions, but not the third.
                 TestContext.WriteLine("Disable the subscriptions for test channel 1");
-                await SetSubscriptionStatus(false, channelName: channel1Name);
+                await SetSubscriptionStatusByChannel(false, channel1Name);
 
                 // Disable one by id (classic usage) to make sure that works
                 TestContext.WriteLine("Disable the third subscription by id");
-                await SetSubscriptionStatus(false, subscriptionId: subscription3Id.Value);
+                await SetSubscriptionStatusById(false, subscription3Id.Value);
 
                 // Re-enable
                 TestContext.WriteLine("Enable the third subscription by id");
-                await SetSubscriptionStatus(true, subscriptionId: subscription3Id.Value);
+                await SetSubscriptionStatusById(true, subscription3Id.Value);
                 StringAssert.Contains("Enabled: True", await GetSubscriptionInfo(subscription3Id.Value), $"Expected subscription {subscription3Id} to be enabled");
 
                 // Mass delete the subscriptions. Delete the first two but not the third.
@@ -256,5 +256,11 @@ internal class ScenarioTests_Subscriptions : MaestroScenarioTestBase
                 TestContext.WriteLine("End of test case. Starting clean up.");
             }
         }
+    }
+
+    private async Task ValidateSubscriptionInfo(string subscriptionId, string expectedSubscriptionInfo)
+    {
+        var subscriptionInfo = await GetSubscriptionInfo(subscriptionId);
+        StringAssert.AreEqualIgnoringCase(expectedSubscriptionInfo, subscriptionInfo);
     }
 }

--- a/test/Maestro.ScenarioTests/Shareable.cs
+++ b/test/Maestro.ScenarioTests/Shareable.cs
@@ -4,42 +4,41 @@
 using System;
 using System.Threading;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+public sealed class Shareable<T> : IDisposable where T : class, IDisposable
 {
-    public sealed class Shareable<T> : IDisposable where T : class, IDisposable
+    private T _inner;
+
+    internal Shareable(T inner)
     {
-        private T _inner;
-
-        internal Shareable(T inner)
-        {
-            _inner = inner;
-        }
-
-        public void Dispose()
-        {
-            _inner?.Dispose();
-        }
-
-        public T TryTake()
-        {
-            return Interlocked.Exchange(ref _inner, null);
-        }
-
-        public T Peek()
-        {
-            if (_inner == null)
-            {
-                throw new InvalidOperationException("Peek() called on null Shareable.");
-            }
-            return _inner;
-        }
+        _inner = inner;
     }
 
-    public static class Shareable
+    public void Dispose()
     {
-        public static Shareable<T> Create<T>(T target) where T : class, IDisposable
+        _inner?.Dispose();
+    }
+
+    public T TryTake()
+    {
+        return Interlocked.Exchange(ref _inner, null);
+    }
+
+    public T Peek()
+    {
+        if (_inner == null)
         {
-            return new Shareable<T>(target);
+            throw new InvalidOperationException("Peek() called on null Shareable.");
         }
+        return _inner;
+    }
+}
+
+public static class Shareable
+{
+    public static Shareable<T> Create<T>(T target) where T : class, IDisposable
+    {
+        return new Shareable<T>(target);
     }
 }

--- a/test/Maestro.ScenarioTests/TemporaryDirectory.cs
+++ b/test/Maestro.ScenarioTests/TemporaryDirectory.cs
@@ -5,41 +5,40 @@ using System;
 using System.IO;
 using System.Threading;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+public class TemporaryDirectory : IDisposable
 {
-    public class TemporaryDirectory : IDisposable
+    public static TemporaryDirectory Get()
     {
-        public static TemporaryDirectory Get()
+        string dir = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+        System.IO.Directory.CreateDirectory(dir);
+        return new TemporaryDirectory(dir);
+    }
+
+    public string Directory { get; }
+
+    private TemporaryDirectory(string dir)
+    {
+        Directory = dir;
+    }
+
+    public void Dispose()
+    {
+        try
         {
-            string dir = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
-            System.IO.Directory.CreateDirectory(dir);
-            return new TemporaryDirectory(dir);
+            System.IO.Directory.Delete(Directory, true);
         }
-
-        public string Directory { get; }
-
-        private TemporaryDirectory(string dir)
+        catch (UnauthorizedAccessException)
         {
-            Directory = dir;
-        }
-
-        public void Dispose()
-        {
+            Thread.Sleep(5000);
             try
             {
                 System.IO.Directory.Delete(Directory, true);
             }
             catch (UnauthorizedAccessException)
             {
-                Thread.Sleep(5000);
-                try
-                {
-                    System.IO.Directory.Delete(Directory, true);
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    // We tried, don't fail the test.
-                }
+                // We tried, don't fail the test.
             }
         }
     }

--- a/test/Maestro.ScenarioTests/TestHelpers.cs
+++ b/test/Maestro.ScenarioTests/TestHelpers.cs
@@ -10,159 +10,157 @@ using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+public static class TestHelpers
 {
-    public static class TestHelpers
+    public static async Task<string> RunExecutableAsync(string executable, params string[] args)
     {
-        public static async Task<string> RunExecutableAsync(string executable, params string[] args)
-        {
-            return await RunExecutableAsyncWithInput(executable, "", args);
-        }
-
-        public static async Task<string> RunExecutableAsyncWithInput(string executable, string input, params string[] args)
-        {
-            TestContext.WriteLine(FormatExecutableCall(executable, args));
-            var output = new StringBuilder();
-
-            void WriteOutput(string message)
-            {
-                if (message != null)
-                {
-                    Debug.WriteLine(message);
-                    output.AppendLine(message);
-                    TestContext.WriteLine(message);
-                }
-            }
-
-            var psi = new ProcessStartInfo(executable)
-            {
-                RedirectStandardError = true,
-                RedirectStandardOutput = true,
-                RedirectStandardInput = true,
-                UseShellExecute = false
-            };
-
-            foreach (string arg in args)
-            {
-                // The string append used by Process will accept null params 
-                // and then throw without identifying the param, so we need to handle it here to get logging
-                if (arg != null)
-                {
-                    psi.ArgumentList.Add(arg);
-                }
-                else
-                {
-                    WriteOutput("Null parameter encountered while constructing command string.");
-                }
-            }
-
-            using var process = new Process
-            {
-                StartInfo = psi
-            };
-
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            process.EnableRaisingEvents = true;
-            process.Exited += (s, e) => { tcs.TrySetResult(true); };
-            process.Start();
-
-            Task<bool> exitTask = tcs.Task;
-            Task stdin = Task.Run(() => { process.StandardInput.Write(input); process.StandardInput.Close(); });
-            Task<string> stdout = process.StandardOutput.ReadLineAsync();
-            Task<string> stderr = process.StandardError.ReadLineAsync();
-            var list = new List<Task> { exitTask, stdout, stderr, stdin };
-            while (list.Count != 0)
-            {
-                var done = await Task.WhenAny(list);
-                list.Remove(done);
-                if (done == exitTask)
-                {
-                    continue;
-                }
-
-                if (done == stdout)
-                {
-                    var data = await stdout;
-                    WriteOutput(data);
-                    if (data != null)
-                    {
-                        list.Add(stdout = process.StandardOutput.ReadLineAsync());
-                    }
-                    continue;
-                }
-
-                if (done == stderr)
-                {
-                    var data = await stderr;
-                    WriteOutput(data);
-                    if (data != null)
-                    {
-                        list.Add(stderr = process.StandardError.ReadLineAsync());
-                    }
-                    continue;
-                }
-
-                if (done == stdin)
-                {
-                    await stdin;
-                    continue;
-                }
-
-                throw new InvalidOperationException("Unexpected Task completed.");
-            }
-
-            if (process.ExitCode != 0)
-            {
-                MaestroTestException exceptionWithConsoleLog = new MaestroTestException($"{executable} exited with code {process.ExitCode}");
-                exceptionWithConsoleLog.Data.Add("ConsoleOutput", output.ToString());
-                throw exceptionWithConsoleLog;
-            }
-
-            return output.ToString();
-        }
-
-        public static async Task<string> Which(string command)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                string cmd = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd";
-                return (await RunExecutableAsync(cmd, "/c", $"where {command}")).Trim()
-                       // get the first line of where's output
-                       .Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? "";
-            }
-
-            return (await RunExecutableAsync("/bin/sh", "-c", $"which {command}")).Trim();
-        }
-
-        internal static string FormatExecutableCall(string executable, params string[] args)
-        {
-            var output = new StringBuilder();
-            var secretArgNames = new[] { "-p", "--password", "--github-pat", "--azdev-pat" };
-
-            output.Append(executable);
-            for (var i = 0; i < args.Length; i++)
-            {
-                output.Append(' ');
-
-                if (i > 0 && secretArgNames.Contains(args[i - 1]))
-                {
-                    output.Append("\"***\"");
-                    continue;
-                }
-
-                output.Append($"\"{args[i]}\"");
-            }
-
-            return output.ToString();
-        }
+        return await RunExecutableAsyncWithInput(executable, "", args);
     }
 
-    public class MaestroTestException : Exception
+    public static async Task<string> RunExecutableAsyncWithInput(string executable, string input, params string[] args)
     {
-        public MaestroTestException(string message)
+        TestContext.WriteLine(FormatExecutableCall(executable, args));
+        var output = new StringBuilder();
+
+        void WriteOutput(string message)
         {
-            TestContext.WriteLine(message);
+            if (message != null)
+            {
+                Debug.WriteLine(message);
+                output.AppendLine(message);
+                TestContext.WriteLine(message);
+            }
         }
+
+        var psi = new ProcessStartInfo(executable)
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false
+        };
+
+        foreach (string arg in args)
+        {
+            // The string append used by Process will accept null params 
+            // and then throw without identifying the param, so we need to handle it here to get logging
+            if (arg != null)
+            {
+                psi.ArgumentList.Add(arg);
+            }
+            else
+            {
+                WriteOutput("Null parameter encountered while constructing command string.");
+            }
+        }
+
+        using var process = new Process
+        {
+            StartInfo = psi
+        };
+
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        process.EnableRaisingEvents = true;
+        process.Exited += (s, e) => { tcs.TrySetResult(true); };
+        process.Start();
+
+        Task<bool> exitTask = tcs.Task;
+        Task stdin = Task.Run(() => { process.StandardInput.Write(input); process.StandardInput.Close(); });
+        Task<string> stdout = process.StandardOutput.ReadLineAsync();
+        Task<string> stderr = process.StandardError.ReadLineAsync();
+        var list = new List<Task> { exitTask, stdout, stderr, stdin };
+        while (list.Count != 0)
+        {
+            var done = await Task.WhenAny(list);
+            list.Remove(done);
+            if (done == exitTask)
+            {
+                continue;
+            }
+
+            if (done == stdout)
+            {
+                var data = await stdout;
+                WriteOutput(data);
+                if (data != null)
+                {
+                    list.Add(stdout = process.StandardOutput.ReadLineAsync());
+                }
+                continue;
+            }
+
+            if (done == stderr)
+            {
+                var data = await stderr;
+                WriteOutput(data);
+                if (data != null)
+                {
+                    list.Add(stderr = process.StandardError.ReadLineAsync());
+                }
+                continue;
+            }
+
+            if (done == stdin)
+            {
+                await stdin;
+                continue;
+            }
+
+            throw new InvalidOperationException("Unexpected Task completed.");
+        }
+
+        if (process.ExitCode != 0)
+        {
+            MaestroTestException exceptionWithConsoleLog = new MaestroTestException($"{executable} exited with code {process.ExitCode}");
+            exceptionWithConsoleLog.Data.Add("ConsoleOutput", output.ToString());
+            throw exceptionWithConsoleLog;
+        }
+
+        return output.ToString();
     }
 
+    public static async Task<string> Which(string command)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            string cmd = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd";
+            return (await RunExecutableAsync(cmd, "/c", $"where {command}")).Trim()
+                   // get the first line of where's output
+                   .Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? "";
+        }
+
+        return (await RunExecutableAsync("/bin/sh", "-c", $"which {command}")).Trim();
+    }
+
+    internal static string FormatExecutableCall(string executable, params string[] args)
+    {
+        var output = new StringBuilder();
+        var secretArgNames = new[] { "-p", "--password", "--github-pat", "--azdev-pat" };
+
+        output.Append(executable);
+        for (var i = 0; i < args.Length; i++)
+        {
+            output.Append(' ');
+
+            if (i > 0 && secretArgNames.Contains(args[i - 1]))
+            {
+                output.Append("\"***\"");
+                continue;
+            }
+
+            output.Append($"\"{args[i]}\"");
+        }
+
+        return output.ToString();
+    }
+}
+
+public class MaestroTestException : Exception
+{
+    public MaestroTestException(string message)
+    {
+        TestContext.WriteLine(message);
+    }
 }

--- a/test/Maestro.ScenarioTests/TestHelpersTest.cs
+++ b/test/Maestro.ScenarioTests/TestHelpersTest.cs
@@ -3,32 +3,31 @@
 
 using NUnit.Framework;
 
-namespace Maestro.ScenarioTests
+namespace Maestro.ScenarioTests;
+
+public class TestHelpersTests
 {
-    public class TestHelpersTests
+    [Test]
+    public void EmptyArguments()
     {
-        [Test]
-        public void EmptyArguments()
-        {
-            var formatted = TestHelpers.FormatExecutableCall("darc.exe");
+        var formatted = TestHelpers.FormatExecutableCall("darc.exe");
 
-            Assert.AreEqual("darc.exe", formatted);
-        }
+        Assert.AreEqual("darc.exe", formatted);
+    }
 
-        [Test]
-        public void HarmlessArguments()
-        {
-            var formatted = TestHelpers.FormatExecutableCall("darc.exe", new[] { "add-channel", "--name", "what-a-channel" });
+    [Test]
+    public void HarmlessArguments()
+    {
+        var formatted = TestHelpers.FormatExecutableCall("darc.exe", ["add-channel", "--name", "what-a-channel"]);
 
-            Assert.AreEqual("darc.exe \"add-channel\" \"--name\" \"what-a-channel\"", formatted);
-        }
+        Assert.AreEqual("darc.exe \"add-channel\" \"--name\" \"what-a-channel\"", formatted);
+    }
 
-        [Test]
-        public void ArgumentsWithSecretTokensInside()
-        {
-            var formatted = TestHelpers.FormatExecutableCall("darc.exe", new[] { "-p", "secret", "add-channel", "--github-pat", "another secret", "--name", "what-a-channel" });
+    [Test]
+    public void ArgumentsWithSecretTokensInside()
+    {
+        var formatted = TestHelpers.FormatExecutableCall("darc.exe", ["-p", "secret", "add-channel", "--github-pat", "another secret", "--name", "what-a-channel"]);
 
-            Assert.AreEqual("darc.exe \"-p\" \"***\" \"add-channel\" \"--github-pat\" \"***\" \"--name\" \"what-a-channel\"", formatted);
-        }
+        Assert.AreEqual("darc.exe \"-p\" \"***\" \"add-channel\" \"--github-pat\" \"***\" \"--name\" \"what-a-channel\"", formatted);
     }
 }

--- a/test/Maestro.ScenarioTests/TestHelpersTest.cs
+++ b/test/Maestro.ScenarioTests/TestHelpersTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Maestro.ScenarioTests;
@@ -12,7 +13,7 @@ public class TestHelpersTests
     {
         var formatted = TestHelpers.FormatExecutableCall("darc.exe");
 
-        Assert.AreEqual("darc.exe", formatted);
+        formatted.Should().Be("darc.exe");
     }
 
     [Test]
@@ -20,7 +21,7 @@ public class TestHelpersTests
     {
         var formatted = TestHelpers.FormatExecutableCall("darc.exe", ["add-channel", "--name", "what-a-channel"]);
 
-        Assert.AreEqual("darc.exe \"add-channel\" \"--name\" \"what-a-channel\"", formatted);
+        formatted.Should().Be("darc.exe \"add-channel\" \"--name\" \"what-a-channel\"");
     }
 
     [Test]
@@ -28,6 +29,6 @@ public class TestHelpersTests
     {
         var formatted = TestHelpers.FormatExecutableCall("darc.exe", ["-p", "secret", "add-channel", "--github-pat", "another secret", "--name", "what-a-channel"]);
 
-        Assert.AreEqual("darc.exe \"-p\" \"***\" \"add-channel\" \"--github-pat\" \"***\" \"--name\" \"what-a-channel\"", formatted);
+        formatted.Should().Be("darc.exe \"-p\" \"***\" \"add-channel\" \"--github-pat\" \"***\" \"--name\" \"what-a-channel\"");
     }
 }

--- a/test/Maestro.ScenarioTests/TestParameters.cs
+++ b/test/Maestro.ScenarioTests/TestParameters.cs
@@ -72,7 +72,7 @@ public class TestParameters : IDisposable
             toolInstallArgs.Add("--add-source");
             toolInstallArgs.Add(darcPackageSource);
         }
-        await TestHelpers.RunExecutableAsync(dotnetExe, toolInstallArgs.ToArray());
+        await TestHelpers.RunExecutableAsync(dotnetExe, [.. toolInstallArgs]);
 
         string darcExe = Path.Join(testDirSharedWrapper.Peek()!.Directory, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "darc.exe" : "darc");
 

--- a/test/Maestro.ScenarioTests/TestRepository.cs
+++ b/test/Maestro.ScenarioTests/TestRepository.cs
@@ -6,19 +6,18 @@ using System.Collections.Generic;
 using System.Reflection.Metadata.Ecma335;
 using System.Text;
 
-namespace Maestro.ScenarioTests
-{
-    internal class TestRepository
-    {
-        internal static string TestRepo1Name => "maestro-test1";
-        internal static string TestRepo2Name => "maestro-test2";
-        internal static string TestRepo3Name => "maestro-test3";
-        internal static string SourceBranch => "master";
+namespace Maestro.ScenarioTests;
 
-        // This branch and commit data is special for the coherency test
-        // It's required to make sure that the dependency tree is set up correctly in the repo without conflicting with other test cases
-        internal static string CoherencySourceBranch => "coherency-tree";
-        internal static string CoherencyTestRepo1Commit => "cc1a27107a1f4c4bc5e2f796c5ef346f60abb404";
-        internal static string CoherencyTestRepo2Commit => "8460158878d4b7568f55d27960d4453877523ea6";
-    }
+internal class TestRepository
+{
+    internal static string TestRepo1Name => "maestro-test1";
+    internal static string TestRepo2Name => "maestro-test2";
+    internal static string TestRepo3Name => "maestro-test3";
+    internal static string SourceBranch => "master";
+
+    // This branch and commit data is special for the coherency test
+    // It's required to make sure that the dependency tree is set up correctly in the repo without conflicting with other test cases
+    internal static string CoherencySourceBranch => "coherency-tree";
+    internal static string CoherencyTestRepo1Commit => "cc1a27107a1f4c4bc5e2f796c5ef346f60abb404";
+    internal static string CoherencyTestRepo2Commit => "8460158878d4b7568f55d27960d4453877523ea6";
 }

--- a/test/Microsoft.DotNet.DarcLib.Tests/GitHubClientTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/GitHubClientTests.cs
@@ -358,8 +358,8 @@ public class GitHubClientTests
     {
         var pullRequestReviewData = GetApprovingPullRequestData("githubclienttests", "getlatestreviews", 123, fakeUserCount, usersCommentAfterApprove);
         var reviews = await GetLatestReviewsForPullRequestWrapperAsync(pullRequestReviewData, pullRequestUrl);
-        Assert.AreEqual(reviews.Count, expectedReviewCount);
-        Assert.False(reviews.Any(r => r.Status == ReviewState.ChangesRequested || r.Status == ReviewState.Rejected));
+        reviews.Should().HaveCount(expectedReviewCount);
+        reviews.Any(r => r.Status == ReviewState.ChangesRequested || r.Status == ReviewState.Rejected).Should().BeFalse();
     }
 
     [TestCase("https://api.github.com/repos/githubclienttests/getlatestreviews/pulls/123", 0, 10)]
@@ -368,7 +368,7 @@ public class GitHubClientTests
     {
         var pullRequestReviewData = GetOnlyCommentsPullRequestData("githubclienttests", "getlatestreviews", 123, fakeUserCount);
         var reviews = await GetLatestReviewsForPullRequestWrapperAsync(pullRequestReviewData, pullRequestUrl);
-        Assert.AreEqual(reviews.Count, expectedReviewCount);
+        reviews.Should().HaveCount(expectedReviewCount);
     }
 
     [TestCase("https://api.github.com/repos/githubclienttests/getmixedreviews/pulls/456", 10, 10, false)] // Happy path: 10 approvals
@@ -379,16 +379,16 @@ public class GitHubClientTests
     {
         var pullRequestReviewData = GetMixedPullRequestData("githubclienttests", "getmixedreviews", 456, fakeUserCount, usersCommentAfterApprove);
         var reviews = await GetLatestReviewsForPullRequestWrapperAsync(pullRequestReviewData, pullRequestUrl);
-        Assert.AreEqual(reviews.Count, expectedReviewCount);
+        reviews.Should().HaveCount(expectedReviewCount);
 
         if (successExpected)
         {
-            Assert.False(reviews.Any(r => r.Status == ReviewState.ChangesRequested || r.Status == ReviewState.Rejected));
-            Assert.GreaterOrEqual(reviews.Count, 1);
+            reviews.Any(r => r.Status == ReviewState.ChangesRequested || r.Status == ReviewState.Rejected).Should().BeFalse();
+            reviews.Should().HaveCountGreaterThanOrEqualTo(1);
         }
         else if (reviews.Count > 0)
         {
-            Assert.True(reviews.Any(r => r.Status == ReviewState.ChangesRequested || r.Status == ReviewState.Rejected));
+            reviews.Any(r => r.Status == ReviewState.ChangesRequested || r.Status == ReviewState.Rejected).Should().BeTrue();
         }
     }
 
@@ -398,9 +398,9 @@ public class GitHubClientTests
 
         // Use Moq to put the return value 
         OctoKitPullRequestReviewsClient.Setup(x => x.GetAll(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
-            .Callback<string, string, int>((string x, string y, int z) =>
+            .Callback((string x, string y, int z) =>
             {
-                Tuple<string, string, int> theKey = new Tuple<string, string, int>(x, y, z);
+                var theKey = new Tuple<string, string, int>(x, y, z);
                 if (data.ContainsKey(theKey))
                 {
                     fakeReviews.AddRange(data[theKey]);

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
@@ -126,8 +126,8 @@ public class RepositoryCloneManagerTests
 
         void ResetCalls()
         {
-            _repoCloner.ResetCalls();
-            _localGitRepo.ResetCalls();
+            _repoCloner.Invocations.Clear();
+            _localGitRepo.Invocations.Clear();
         }
 
         // Clone for the first time

--- a/test/Microsoft.DotNet.Maestro.Tasks.Tests/MergedManifestTests.cs
+++ b/test/Microsoft.DotNet.Maestro.Tasks.Tests/MergedManifestTests.cs
@@ -202,7 +202,7 @@ internal class MergedManifestTests
         public void GetGithubRepoNameTest(string azdoRepoUrl, string expectedRepo)
         {
             string actualRepo = pushMetadata.GetGithubRepoName(azdoRepoUrl);
-            Assert.AreEqual(expectedRepo, actualRepo);
+            actualRepo.Should().Be(expectedRepo);
         }
 
         [Test]


### PR DESCRIPTION
This PR improves the work with the ScenarioTests project code:
- Ran analyzers and resolved compiler messages
- Bumped testing libraries
- Stopped using `NUnit.Assert` and started using `FluentAssertions` for better test failure messages
- Formatted code to match the rest of the repo
- Enabled nullability for some classes

There should be no functional changes, just re-formatting and adding nullability. Just errors from failed assertions should get better.

https://github.com/dotnet/arcade-services/issues/3031

This build verifies everything: https://dev.azure.com/dnceng/internal/_build/results?buildId=2340341&view=results

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Not release notes worthy