### PR TITLE
Lower logging level for no-op VMR sync

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -342,6 +342,10 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             {
                 if (update.Mapping == rootUpdate.Mapping)
                 {
+                    _logger.LogWarning(e.Message);
+                }
+                else
+                {
                     _logger.LogInformation(e.Message);
                 }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -338,6 +338,15 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                     discardPatches,
                     cancellationToken);
             }
+            catch (EmptySyncException e) when (e.Message.Contains("is already at"))
+            {
+                if (update.Mapping == rootUpdate.Mapping)
+                {
+                    _logger.LogInformation(e.Message);
+                }
+
+                continue;
+            }
             catch (EmptySyncException e)
             {
                 _logger.LogWarning(e.Message);


### PR DESCRIPTION
Fixes this log:
https://dev.azure.com/dnceng-public/public/_build/results?buildId=506596&view=logs&j=941f2e24-48a0-594a-6b1a-0e16aaeb8606&t=cffff4a5-f52c-50c6-45c9-52a0bd619b26&l=423

```
info: Recursively updating installer's dependency test-templates / 1e5f3603af2277910aad946736ee23283e7f3e16 → 1e5f3603af2277910aad946736ee23283e7f3e16
warn: Repository test-templates is already at 1e5f3603af2277910aad946736ee23283e7f3e16
info: Recursively updating installer's dependency fsharp / f41fe153f68dd6b20cf4f91de9ea1e55fc09bb20 → f41fe153f68dd6b20cf4f91de9ea1e55fc09bb20
warn: Repository fsharp is already at f41fe153f68dd6b20cf4f91de9ea1e55fc09bb20
info: Recursively updating installer's dependency vstest / ae25c3b96fe433c60af70e3991ace49fcbf7e970 → ae25c3b96fe433c60af70e3991ace49fcbf7e970
warn: Repository vstest is already at ae25c3b96fe433c60af70e3991ace49fcbf7e970
info: Recursively updating installer's dependency roslyn / f43cd10b737b6343956dee421cff8c50b602c788 → f43cd10b737b6343956dee421cff8c50b602c788
warn: Repository roslyn is already at f43cd10b737b6343956dee421cff8c50b602c788
info: Recursively updating installer's dependency nuget-client / 0dd5a1ea536201af94725353e4bc711d7560b246 → 0dd5a1ea536201af94725353e4bc711d7560b246
warn: Repository nuget-client is already at 0dd5a1ea536201af94725353e4bc711d7560b246
```

https://github.com/dotnet/arcade-services/issues/3148

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Not release notes worthy
