### PR TITLE
Enable the Product Construction Service to connect with KeyVaults

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
          See: https://github.com/dotnet/arcade/blob/main/eng/Versions.props -->
     <PackageVersion Include="Aspire.Hosting" Version="8.0.0-preview.2.23619.3" />
     <PackageVersion Include="Azure.Core" Version="1.36.0" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.1.0" />
     <PackageVersion Include="Azure.Identity" Version="1.10.3" />

--- a/eng/service-templates/ProductConstructionService/provision.bicep
+++ b/eng/service-templates/ProductConstructionService/provision.bicep
@@ -28,6 +28,9 @@ param applicationInsightsName string = 'product-construction-service-ai-int'
 @description('Key Vault name')
 param keyVaultName string = 'ProductConstructionInt'
 
+@description('Dev Key Vault name')
+param devKeyVaultName string = 'ProductConstructionDev'
+
 @description('Log analytics workspace name')
 param logAnalyticsName string = 'product-construction-service-workspace-int'
 
@@ -252,5 +255,22 @@ resource containerRegistryPasswordSecret 'Microsoft.KeyVault/vaults/secrets@2022
     name: 'container-registry-password'
     properties: {
         value: containerRegistry.listCredentials().passwords[0].value
+    }
+}
+
+// If we're creating the staging environment, also create a dev key vault
+resource devKeyVault 'Microsoft.KeyVault/vaults@2022-07-01' = if (aspnetcoreEnvironment == 'Staging') {
+    name: devKeyVaultName
+    location: location
+    properties: {
+        sku: {
+            name: 'standard'
+            family: 'A'
+        }
+        tenantId: subscription().tenantId
+        enableSoftDelete: true
+        softDeleteRetentionInDays: 90
+        accessPolicies: []
+        enableRbacAuthorization: true
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/ProductConstructionService.Api.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.Api/ProductConstructionService.Api.csproj
@@ -13,6 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ProductConstructionService/ProductConstructionService.Api/Program.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Program.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Azure.Identity;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
@@ -9,6 +11,10 @@ builder.AddServiceDefaults();
 
 builder.Services.AddControllers();
 builder.Services.AddSwaggerGen();
+
+builder.Configuration.AddAzureKeyVault(
+    new Uri($"https://{builder.Configuration["KeyVaultName"]}.vault.azure.net/"),
+    new DefaultAzureCredential());
 
 var app = builder.Build();
 

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Development.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Development.json
@@ -1,8 +1,9 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "KeyVaultName": "ProductConstructionDev"
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
@@ -1,0 +1,3 @@
+{
+    "KeyVaultName": "ProductConstructionInt"
+}

--- a/src/ProductConstructionService/Readme.md
+++ b/src/ProductConstructionService/Readme.md
@@ -2,7 +2,7 @@
 
 To run the Product Construction Service locally, set the `ProductConstructionService.AppHost` as Startup Project, and run with F5.
 
-When running locally, the service will attempt to read secrets from the `ProductConstructionDev` KeyVault, using your Microsoft credentials. If you're having some authentication double check the following:
+When running locally, the service will attempt to read secrets from the [`ProductConstructionDev`](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cab65fc3-d077-467d-931f-3932eabf36d3/resourceGroups/product-construction-service/providers/Microsoft.KeyVault/vaults/ProductConstructionDev/overview) KeyVault, using your Microsoft credentials. If you're having some authentication double check the following:
  - In VS, go to `Tools -> Options -> Azure Service Authentication -> Account Selection` and make sure your corp account is selected
  - Check your environmental variables, you might have `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` set, and the `DefaultAzureCredential` is attempting to use `EnvironmentalCredentials` for an app that doesn't have access to the dev KV.
 

--- a/src/ProductConstructionService/Readme.md
+++ b/src/ProductConstructionService/Readme.md
@@ -1,6 +1,10 @@
 # Starting the service locally
 
-To run the Product Construction Service locally, set the `ProductConstructionService.AppHost` as Startup Project, and run with F5
+To run the Product Construction Service locally, set the `ProductConstructionService.AppHost` as Startup Project, and run with F5.
+
+When running locally, the service will attempt to read secrets from the `ProductConstructionDev` KeyVault, using your Microsoft credentials. If you're having some authentication double check the following:
+ - In VS, go to `Tools -> Options -> Azure Service Authentication -> Account Selection` and make sure your corp account is selected
+ - Check your environmental variables, you might have `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` set, and the `DefaultAzureCredential` is attempting to use `EnvironmentalCredentials` for an app that doesn't have access to the dev KV.
 
 # Instructions for recreating the Product Construction Service
 Run the `provision.ps1` script by giving it the name of the subscription you want to create the service in. Note that keyvault and container registry names have to be unique on Azure, so you'll have to change these, or delete and purge the existing ones.


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/3163
Connects the Product Construction Service with it's environments Key Vault.
This allows us to use the secrets like `app.Configuration[<secret name>]`

In the staging environment, the service will authenticate using [Environmental Credentials](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet). I created a new `app registration`, `product-construction-service-int`, gave it permissions to read secrets from ProductConstructionInt KV and put it's details in the Container App resource. The `DefaultAzureCredentails` will pick these up and connect to the vault. This is only a temporary solution tho, this approach isn't ideal because of two reasons:
 - The App secret will expire and will require manual rotation
 - The environment has to be set up by hand, as biceps doesn't offer any support for Entra ID apps

Once https://github.com/dotnet/arcade-services/issues/3180 is resolved, we'll be able to use Managed Identities for authentication. Managed Identities resolve both of the issues above, they require no secret rotation, and they can be fully configured in the bicep.

For local development, the `DefaultAzureCredentials` will pick up your VS credential, and use that to authenticate. Also we will have a different KV for this, ProductConstructionDev.

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Enable the Product Construction Service to connect with KeyVaults