### PR TITLE
Start getting `IRemoteFactory` from DI

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
@@ -43,7 +43,7 @@ internal class LocalSettings
         return JsonConvert.DeserializeObject<LocalSettings>(settings);
     }
 
-    public static LocalSettings LoadSettingsFile(CommandLineOptions options)
+    public static LocalSettings LoadSettingsFile(ICommandLineOptions options)
     {
         try
         {
@@ -72,7 +72,7 @@ internal class LocalSettings
     /// <param name="options">Command line options</param>
     /// <returns>Darc settings for use in remote commands</returns>
     /// <remarks>The command line takes precedence over the darc settings file.</remarks>
-    public static DarcSettings GetDarcSettings(CommandLineOptions options, ILogger logger, string repoUri = null)
+    public static DarcSettings GetDarcSettings(ICommandLineOptions options, ILogger logger, string repoUri = null)
     {
         LocalSettings localSettings = null;
         DarcSettings darcSettings = new DarcSettings

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
@@ -1,25 +1,25 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
-using System.IO;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Helpers;
 
 internal class RemoteFactory : IRemoteFactory
 {
-    private readonly CommandLineOptions _options;
+    private readonly ICommandLineOptions _options;
 
-    public RemoteFactory(CommandLineOptions options)
+    public RemoteFactory(ICommandLineOptions options)
     {
         _options = options;
     }
 
-    public static IRemote GetRemote(CommandLineOptions options, string repoUrl, ILogger logger)
+    public static IRemote GetRemote(ICommandLineOptions options, string repoUrl, ILogger logger)
     {
         DarcSettings darcSettings = LocalSettings.GetDarcSettings(options, logger, repoUrl);
 
@@ -60,14 +60,15 @@ internal class RemoteFactory : IRemoteFactory
         return new Remote(gitClient, new VersionDetailsParser(), logger);
     }
 
-    public static IBarApiClient GetBarClient(CommandLineOptions options, ILogger logger)
+    public static IBarApiClient GetBarClient(ICommandLineOptions options, ILogger logger)
     {
         DarcSettings darcSettings = LocalSettings.GetDarcSettings(options, logger);
         IBarApiClient barClient = null;
         if (!string.IsNullOrEmpty(darcSettings.BuildAssetRegistryPassword))
         {
-            barClient = new BarApiClient(darcSettings.BuildAssetRegistryPassword,
-            darcSettings.BuildAssetRegistryBaseUri);
+            barClient = new BarApiClient(
+                darcSettings.BuildAssetRegistryPassword,
+                darcSettings.BuildAssetRegistryBaseUri);
         }
 
         return barClient;

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
@@ -1,19 +1,20 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Options;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.Maestro.Client;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.DotNet.Services.Utility;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Helpers;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.DotNet.Services.Utility;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -64,7 +65,7 @@ internal class AddBuildToChannelOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             Build build = await barClient.GetBuildAsync(_options.Id);
             if (build == null)
@@ -418,7 +419,7 @@ internal class AddBuildToChannelOperation : Operation
             build.GitHubRepository;
 
         IRemote repoRemote = RemoteFactory.GetRemote(_options, sourceBuildRepo, Logger);
-        IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+        IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
         IEnumerable<DependencyDetail> sourceBuildDependencies = await repoRemote.GetDependenciesAsync(sourceBuildRepo, build.Commit)
             .ConfigureAwait(false);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddChannelOperation.cs
@@ -1,16 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
+using System;
+using System.Net;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using System;
-using System.Net;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -31,7 +31,7 @@ internal class AddChannelOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             // If the user tried to mark as internal, indicate that this is currently
             // unsupported.

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddDefaultChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddDefaultChannelOperation.cs
@@ -1,14 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Services.Utility;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -27,7 +28,7 @@ internal class AddDefaultChannelOperation : Operation
         try
         {
             IRemote repoRemote = RemoteFactory.GetRemote(_options, _options.Repository, Logger);
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             // Users can ignore the flag and pass in -regex: but to prevent typos we'll avoid that.
             _options.Branch = _options.UseBranchAsRegex ? $"-regex:{_options.Branch}" : GitHelpers.NormalizeBranchName(_options.Branch);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
@@ -1,6 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
 using Maestro.MergePolicyEvaluation;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Models.PopUps;
@@ -9,13 +14,9 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.DotNet.Services.Utility;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -35,7 +36,7 @@ class AddSubscriptionOperation : Operation
     /// <param name="options"></param>
     public override async Task<int> ExecuteAsync()
     {
-        IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+        IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
         if (_options.IgnoreChecks.Any() && !_options.AllChecksSuccessfulMergePolicy)
         {

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/DefaultChannelStatusOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/DefaultChannelStatusOperation.cs
@@ -1,14 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
+using System;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -34,7 +34,7 @@ class DefaultChannelStatusOperation : UpdateDefaultChannelBaseOperation
             return Constants.ErrorCode;
         }
 
-        IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+        IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
         try
         {

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/DeleteBuildFromChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/DeleteBuildFromChannelOperation.cs
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
@@ -30,7 +30,7 @@ internal class DeleteBuildFromChannelOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             // Find the build to give someone info
             Build build = await barClient.GetBuildAsync(_options.Id);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/DeleteChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/DeleteChannelOperation.cs
@@ -1,15 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -30,7 +30,7 @@ internal class DeleteChannelOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             // Get the ID of the channel with the specified name.
             Channel existingChannel = (await barClient.GetChannelsAsync()).Where(channel => channel.Name.Equals(_options.Name, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/DeleteDefaultChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/DeleteDefaultChannelOperation.cs
@@ -1,14 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
+using System;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -25,7 +25,7 @@ internal class DeleteDefaultChannelOperation : UpdateDefaultChannelBaseOperation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             DefaultChannel resolvedChannel = await ResolveSingleChannel();
             if (resolvedChannel == null)

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/DeleteSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/DeleteSubscriptionsOperation.cs
@@ -1,17 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Options;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.Extensions.Logging;
 using System;
-using System.Net;
-using System.Threading.Tasks;
-using Microsoft.DotNet.Maestro.Client;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -28,7 +28,7 @@ internal class DeleteSubscriptionsOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             bool noConfirm = _options.NoConfirmation;
             List<Subscription> subscriptionsToDelete = [];

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GatherDropOperation.cs
@@ -1,17 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Options;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.DarcLib.Helpers;
-using Microsoft.DotNet.DarcLib.Models.Darc;
-using Microsoft.DotNet.Maestro.Client;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.DotNet.Services.Utility;
-using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.Services.Common;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -23,6 +12,18 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Helpers;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.Models.Darc;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.DotNet.Services.Utility;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.Services.Common;
+using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -209,7 +210,7 @@ internal class GatherDropOperation : Operation
             return null;
         }
 
-        IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+        IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
         string repoUri = _options.RepoUri;
 
@@ -688,7 +689,7 @@ internal class GatherDropOperation : Operation
             builds.Add(rootBuild);
         }
 
-        var remoteFactory = new RemoteFactory(_options);
+        var remoteFactory = Provider.GetRequiredService<IRemoteFactory>();
 
         // Flatten for convenience and remove dependencies of types that we don't want if need be.
         if (!_options.IncludeToolset)
@@ -711,7 +712,7 @@ internal class GatherDropOperation : Operation
             var rootBuildRepository = rootBuild.GitHubRepository ?? rootBuild.AzureDevOpsRepository;
             DependencyGraph graph = await DependencyGraph.BuildRemoteDependencyGraphAsync(
                 remoteFactory,
-                RemoteFactory.GetBarClient(_options, Logger),
+                Provider.GetRequiredService<IBarApiClient>(),
                 rootBuildRepository,
                 rootBuild.Commit,
                 buildOptions,
@@ -803,7 +804,7 @@ internal class GatherDropOperation : Operation
     /// <param name="rootOutputDirectory">Output directory. Must exist.</param>
     private async Task<DownloadedBuild> GatherDropForBuildAsync(Build build, string rootOutputDirectory)
     {
-        IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+        IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
         var success = true;
         var unifiedOutputDirectory = rootOutputDirectory;
         Directory.CreateDirectory(unifiedOutputDirectory);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetAssetOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetAssetOperation.cs
@@ -1,18 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Options;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.Maestro.Client;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -37,7 +37,7 @@ internal class GetAssetOperation : Operation
             return Constants.ErrorCode;
         }
 
-        IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+        IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
         try
         {

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetChannelsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetChannelsOperation.cs
@@ -1,17 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Options;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.Maestro.Client;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -33,7 +33,7 @@ internal class GetChannelsOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             var allChannels = await barClient.GetChannelsAsync();
             switch (_options.OutputFormat)

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetDefaultChannelsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetDefaultChannelsOperation.cs
@@ -1,16 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Options;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.Maestro.Client;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -35,7 +35,7 @@ internal class GetDefaultChannelsOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             IEnumerable<DefaultChannel> defaultChannels = (await barClient.GetDefaultChannelsAsync())
                 .Where(defaultChannel =>

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependencyFlowGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependencyFlowGraphOperation.cs
@@ -1,17 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Options;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.Maestro.Client;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -29,8 +29,8 @@ internal class GetDependencyFlowGraphOperation : Operation
     {
         try
         {
-            var remoteFactory = new RemoteFactory(_options);
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IRemoteFactory remoteFactory = Provider.GetRequiredService<IRemoteFactory>();
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             Channel targetChannel = null;
             if (!string.IsNullOrEmpty(_options.Channel))

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependencyGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependencyGraphOperation.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Darc.Operations;
@@ -35,7 +36,7 @@ internal class GetDependencyGraphOperation : Operation
         {
             IEnumerable<DependencyDetail> rootDependencies = null;
             DependencyGraph graph;
-            var remoteFactory = new RemoteFactory(_options);
+            IRemoteFactory remoteFactory = Provider.GetRequiredService<IRemoteFactory>();
 
             if (!_options.Local)
             {
@@ -115,7 +116,7 @@ internal class GetDependencyGraphOperation : Operation
                 // Build graph
                 graph = await DependencyGraph.BuildRemoteDependencyGraphAsync(
                     remoteFactory,
-                    RemoteFactory.GetBarClient(_options, Logger),
+                    Provider.GetRequiredService<IBarApiClient>(),
                     rootDependencies,
                     _options.RepoUri ?? await _gitClient.GetRootDirAsync(),
                     _options.Version ?? await _gitClient.GetGitCommitAsync(),

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetGoalOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetGoalOperation.cs
@@ -1,15 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
+using System;
+using System.Net;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Net;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -31,7 +31,7 @@ internal class GetGoalOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
             Goal goalInfo = await barClient.GetGoalAsync(_options.Channel, _options.DefinitionId);
             Console.Write(goalInfo.Minutes);
             return Constants.SuccessCode;

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetHealthOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetHealthOperation.cs
@@ -1,17 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.HealthMetrics;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -54,7 +55,7 @@ internal class GetHealthOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             IEnumerable<Subscription> subscriptions = await barClient.GetSubscriptionsAsync();
             IEnumerable<DefaultChannel> defaultChannels = await barClient.GetDefaultChannelsAsync();
@@ -204,8 +205,8 @@ internal class GetHealthOperation : Operation
         IEnumerable<Subscription> subscriptions,
         IEnumerable<DefaultChannel> defaultChannels)
     {
-        var remoteFactory = new RemoteFactory(_options);
-        var barClient = RemoteFactory.GetBarClient(_options, Logger);
+        var remoteFactory = Provider.GetRequiredService<IRemoteFactory>();
+        var barClient = Provider.GetRequiredService<IBarApiClient>();
 
         HashSet<(string repo, string branch)> repoBranchCombinations =
             GetRepositoryBranchCombinations(channelsToEvaluate, reposToEvaluate, subscriptions, defaultChannels);
@@ -279,8 +280,8 @@ internal class GetHealthOperation : Operation
         IEnumerable<Subscription> subscriptions,
         IEnumerable<DefaultChannel> defaultChannels)
     {
-        var remoteFactory = new RemoteFactory(_options);
-        var barClient = RemoteFactory.GetBarClient(_options, Logger);
+        var remoteFactory = Provider.GetRequiredService<IRemoteFactory>();
+        var barClient = Provider.GetRequiredService<IBarApiClient>();
 
         HashSet<(string repo, string branch)> repoBranchCombinations =
             GetRepositoryBranchCombinations(channelsToEvaluate, reposToEvaluate, subscriptions, defaultChannels);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetLatestBuildOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetLatestBuildOperation.cs
@@ -1,16 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Options;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.Maestro.Client;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -31,7 +31,7 @@ internal class GetLatestBuildOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             // Calculate out possible repos based on the input strings.
             // Today the DB has no way of searching for builds by substring, so for now

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetRepositoryMergePoliciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetRepositoryMergePoliciesOperation.cs
@@ -1,16 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Options;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.Maestro.Client;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -28,7 +28,7 @@ internal class GetRepositoryMergePoliciesOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             IEnumerable<RepositoryBranch> allRepositories = await barClient.GetRepositoriesAsync(null, null);
             IEnumerable<RepositoryBranch> filteredRepositories = allRepositories.Where(repositories =>

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetSubscriptionsOperation.cs
@@ -1,14 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
@@ -17,6 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
+#nullable enable
 namespace Microsoft.DotNet.Darc.Operations;
 
 /// <summary>
@@ -36,8 +34,7 @@ class GetSubscriptionsOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = Provider.GetService<IBarApiClient>()
-                ?? RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             IEnumerable<Subscription> subscriptions = await _options.FilterSubscriptions(barClient);
 

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 
@@ -47,9 +48,9 @@ public abstract class Operation : IDisposable
             .SetMinimumLevel(level));
             
         services.AddSingleton(options);
-        services.AddSingleton<IRemoteFactory, RemoteFactory>();
-        services.AddSingleton<IBarApiClient>(sp => RemoteFactory.GetBarClient(options, sp.GetRequiredService<ILogger<BarApiClient>>()));
-        services.AddSingleton<IBasicBarClient>(sp => sp.GetRequiredService<IBarApiClient>());
+        services.TryAddSingleton<IRemoteFactory, RemoteFactory>();
+        services.TryAddSingleton<IBarApiClient>(sp => RemoteFactory.GetBarClient(options, sp.GetRequiredService<ILogger<BarApiClient>>()));
+        services.TryAddSingleton<IBasicBarClient>(sp => sp.GetRequiredService<IBarApiClient>());
 
         Provider = services.BuildServiceProvider();
         Logger = Provider.GetRequiredService<ILogger<Operation>>();

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Arcade.Common;
-using Microsoft.DotNet.Darc.Options;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
+using Microsoft.Arcade.Common;
+using Microsoft.DotNet.Darc.Helpers;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 
 #nullable enable
@@ -45,6 +47,9 @@ public abstract class Operation : IDisposable
             .SetMinimumLevel(level));
             
         services.AddSingleton(options);
+        services.AddSingleton<IRemoteFactory, RemoteFactory>();
+        services.AddSingleton<IBarApiClient>(sp => RemoteFactory.GetBarClient(options, sp.GetRequiredService<ILogger<BarApiClient>>()));
+        services.AddSingleton<IBasicBarClient>(sp => sp.GetRequiredService<IBarApiClient>());
 
         Provider = services.BuildServiceProvider();
         Logger = Provider.GetRequiredService<ILogger<Operation>>();

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/SetGoalOperations.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/SetGoalOperations.cs
@@ -1,15 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
+using System;
+using System.Net;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Net;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -31,7 +31,7 @@ internal class SetGoalOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
             Goal goalInfo = await barClient.SetGoalAsync(_options.Channel, _options.DefinitionId, _options.Minutes);
             Console.Write(goalInfo.Minutes);
             return Constants.SuccessCode;

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
@@ -1,6 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
 using Maestro.MergePolicyEvaluation;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Models.PopUps;
@@ -8,13 +13,9 @@ using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -30,7 +31,7 @@ internal class SetRepositoryMergePoliciesOperation : Operation
 
     public override async Task<int> ExecuteAsync()
     {
-        IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+        IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
         if (_options.IgnoreChecks.Any() && !_options.AllChecksSuccessfulMergePolicy)
         {

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/SubscriptionsStatusOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/SubscriptionsStatusOperation.cs
@@ -1,17 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Options;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.Maestro.Client;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -44,10 +44,10 @@ class SubscriptionsStatusOperation : Operation
 
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             bool noConfirm = _options.NoConfirmation;
-            List<Subscription> subscriptionsToEnableDisable = new List<Subscription>();
+            List<Subscription> subscriptionsToEnableDisable = [];
 
             if (!string.IsNullOrEmpty(_options.Id))
             {

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/TriggerSubscriptionsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/TriggerSubscriptionsOperation.cs
@@ -1,17 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Options;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -32,7 +32,7 @@ internal class TriggerSubscriptionsOperation : Operation
     {
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             bool noConfirm = _options.NoConfirmation;
             List<Subscription> subscriptionsToTrigger = [];

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateBuildOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateBuildOperation.cs
@@ -1,14 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
+using System;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -31,7 +31,7 @@ internal class UpdateBuildOperation : Operation
 
         try
         {
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
             Build updatedBuild = await barClient.UpdateBuildAsync(_options.Id, new BuildUpdate { Released = _options.Released });
 

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDefaultChannelBaseOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDefaultChannelBaseOperation.cs
@@ -1,15 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Options;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.Maestro.Client.Models;
-using Microsoft.DotNet.Services.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.DotNet.Services.Utility;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -31,7 +31,7 @@ abstract class UpdateDefaultChannelBaseOperation : Operation
     /// <returns>Default channel or null</returns>
     protected async Task<DefaultChannel> ResolveSingleChannel()
     {
-        IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+        IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
         IEnumerable<DefaultChannel> potentialDefaultChannels = await barClient.GetDefaultChannelsAsync();
             

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NuGet.Packaging;
 
@@ -47,8 +48,8 @@ class UpdateDependenciesOperation : Operation
                 localSettings.GitHubToken :
                 _options.GitHubPat;
 
-            IRemoteFactory remoteFactory = new RemoteFactory(_options);
-            IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+            IRemoteFactory remoteFactory = Provider.GetRequiredService<IRemoteFactory>();
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
             var coherencyUpdateResolver = new CoherencyUpdateResolver(barClient, Logger);
 
             var local = new Local(_options.GetRemoteConfiguration(), Logger);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateSubscriptionOperation.cs
@@ -1,18 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Models.PopUps;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Darc.Operations;
 
@@ -31,7 +32,7 @@ class UpdateSubscriptionOperation : Operation
     /// </summary>
     public override async Task<int> ExecuteAsync()
     {
-        IBarApiClient barClient = RemoteFactory.GetBarClient(_options, Logger);
+        IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
 
         // First, try to get the subscription. If it doesn't exist the call will throw and the exception will be
         // caught by `RunOperation`


### PR DESCRIPTION
Another step of moving Darc to use DI more directly - we pull classes directly instead of newing classes.
I will utilize this later when I inject a different implementation.

https://github.com/dotnet/arcade-services/issues/2497

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes