### PR TITLE
Comment out the code that's breaking the CI

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.AppHost/Program.cs
+++ b/src/ProductConstructionService/ProductConstructionService.AppHost/Program.cs
@@ -7,6 +7,7 @@ var queues = builder.AddAzureStorage("storage")
     .UseEmulator()
     .AddQueues("queues");
 
+// TODO https://github.com/dotnet/arcade-services/issues/3242
 // builder.AddProject<Projects.ProductConstructionService_Api>("productConstructionService.api")
 //    .WithReference(queues);
 

--- a/src/ProductConstructionService/ProductConstructionService.AppHost/Program.cs
+++ b/src/ProductConstructionService/ProductConstructionService.AppHost/Program.cs
@@ -7,7 +7,7 @@ var queues = builder.AddAzureStorage("storage")
     .UseEmulator()
     .AddQueues("queues");
 
-builder.AddProject<Projects.ProductConstructionService_Api>("productConstructionService.api")
-    .WithReference(queues);
+// builder.AddProject<Projects.ProductConstructionService_Api>("productConstructionService.api")
+//    .WithReference(queues);
 
 builder.Build().Run();


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->


<!-- Potentially also include release notes in the PR directly -->
Aspire workloads got updated and broke our CI. This PR comments out the code that's failing for us, until we have a permanent solution. Since this code is used only for local development, it won't affect our Staging env.
https://github.com/dotnet/arcade-services/issues/3242

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Don't include in release notes