### PR TITLE
Eliminate the `useServicingBuildPool` parameter to promotion pipeline

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
@@ -266,12 +266,6 @@ internal class AddBuildToChannelOperation : Operation
             { "ArtifactsPublishingAdditionalParameters", _options.ArtifactPublishingAdditionalParameters }
         };
 
-        if ((build.GitHubBranch?.Contains("release/", StringComparison.InvariantCultureIgnoreCase)) == true ||
-            (build.AzureDevOpsBranch?.Contains("release/", StringComparison.InvariantCultureIgnoreCase) == true))
-        {
-            promotionPipelineVariables.Add("UseServicingBuildPool", true.ToString());
-        }
-
         if (_options.DoSDLValidation)
         {
             promotionPipelineVariables.Add("EnableSDLValidation", _options.DoSDLValidation.ToString());


### PR DESCRIPTION
- see https://github.com/dotnet/arcade-services/issues/3258
- see also https://github.com/dotnet/arcade/issues/14445 (the main driving force)
- see also https://github.com/dotnet/dnceng/issues/1145
- parameter is no longer needed and may cause errors if used