### PR TITLE
Extend the subscription model with VMR code flow metadata

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,12 +2,6 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "microsoft.dotnet.swaggergenerator.cmdline": {
-      "version": "5.0.0-beta.20215.1",
-      "commands": [
-        "dotnet-swaggergen"
-      ]
-    },
     "microsoft.dnceng.secretmanager": {
       "version": "1.1.0-beta.24074.1",
       "commands": [

--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -68,17 +68,17 @@ When debugging the tests, you can check this via the Immediate window, e.g. by r
 
 In case you need to change the database model (e.g. add a column to a table), follow the usual [EF Core code-first migration steps](https://learn.microsoft.com/en-us/ef/core/managing-schemas/migrations/?tabs=dotnet-core-cli#evolving-your-model).
 In practice this means the following:
-- Make the change to the model classes in the `Maestro.Data` project
-- Install the [EF Core CLI](https://docs.microsoft.com/en-us/ef/core/cli/dotnet)
+1. Make the change to the model classes in the `Maestro.Data` project
+1. Install the [EF Core CLI](https://docs.microsoft.com/en-us/ef/core/cli/dotnet)
   ```ps1
   dotnet tool install --global dotnet-ef
   ```
-- Go to the `src\Maestro\Maestro.Data` project directory and build the project
+1. Go to the `src\Maestro\Maestro.Data` project directory and build the project
   ```ps1
   cd src\Maestro\Maestro.Data
   dotnet build
   ```
-- Run the following command to create a new migration
+1. Run the following command to create a new migration
   ```ps1
   dotnet ef --msbuildprojectextensionspath <full path to obj dir for Maestro repo (e.g. "C:\arcade-services\artifacts\obj\Maestro.Data")> migrations add <migration name>
   ```
@@ -95,6 +95,21 @@ Build succeeded.
 Applying migration '20240201144006_<migration name>'.
 Done.
 ```
+
+If your change of the model changes the public API of the service, update also the `Maestro.Client`.
+
+## Changing the API / Updating `Maestro.Client`
+
+`Maestro.Client` is an auto-generated client library for the Maestro API. It is generated using Swagger Codegen which parses the `swagger.json` file.
+The `swagger.json` file is accessible at `/api/swagger.json` when the Maestro application is running.
+If you changed the API (e.g. changed an endpoint, model coming from the API, etc.), you need to regenerate the `Maestro.Client` library.
+
+If you need to update the client library, follow these steps:
+
+1. Change the model/endpoint/..
+1. Change `src\Maestro\Client\src\Microsoft.DotNet.Maestro.Client.csproj` and point the `SwaggerDocumentUri` to `http://127.0.0.1:8088/api/swagger.json`.
+1. Start the Maestro application locally, verify you can access the swagger.json file. You can now stop debugging, the local SF cluster will keep running.
+1. Run `src\Maestro\Client\src\generate-client.cmd` which will regenerate the C# classes.
 
 ## Troubleshooting
 

--- a/src/Maestro/Client/src/Generated/Assets.cs
+++ b/src/Maestro/Client/src/Generated/Assets.cs
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.Maestro.Client
                 "/api/assets/bulk-add-locations",
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -225,11 +225,11 @@ namespace Microsoft.DotNet.Maestro.Client
 
             if (!string.IsNullOrEmpty(name))
             {
-                _url.AppendQuery("name", MaestroApi.Serialize(name));
+                _url.AppendQuery("name", Client.Serialize(name));
             }
             if (!string.IsNullOrEmpty(version))
             {
-                _url.AppendQuery("version", MaestroApi.Serialize(version));
+                _url.AppendQuery("version", Client.Serialize(version));
             }
             if (buildId != default)
             {
@@ -251,7 +251,7 @@ namespace Microsoft.DotNet.Maestro.Client
             {
                 _url.AppendQuery("perPage", Client.Serialize(perPage));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -320,7 +320,7 @@ namespace Microsoft.DotNet.Maestro.Client
                 "/api/assets/darc-version",
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -387,10 +387,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/assets/{id}".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/assets/{id}".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -469,18 +469,18 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/assets/{assetId}/locations".Replace("{assetId}", Uri.EscapeDataString(MaestroApi.Serialize(assetId))),
+                "/api/assets/{assetId}/locations".Replace("{assetId}", Uri.EscapeDataString(Client.Serialize(assetId))),
                 false);
 
             if (!string.IsNullOrEmpty(location))
             {
-                _url.AppendQuery("location", MaestroApi.Serialize(location));
+                _url.AppendQuery("location", Client.Serialize(location));
             }
             if (assetLocationType != default)
             {
                 _url.AppendQuery("assetLocationType", Client.Serialize(assetLocationType));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -548,10 +548,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/assets/{assetId}/locations/{assetLocationId}".Replace("{assetId}", Uri.EscapeDataString(MaestroApi.Serialize(assetId))).Replace("{assetLocationId}", Uri.EscapeDataString(MaestroApi.Serialize(assetLocationId))),
+                "/api/assets/{assetId}/locations/{assetLocationId}".Replace("{assetId}", Uri.EscapeDataString(Client.Serialize(assetId))).Replace("{assetLocationId}", Uri.EscapeDataString(Client.Serialize(assetLocationId))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())

--- a/src/Maestro/Client/src/Generated/BuildTime.cs
+++ b/src/Maestro/Client/src/Generated/BuildTime.cs
@@ -48,14 +48,14 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/buildtime/{id}".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/buildtime/{id}".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
             if (days != default)
             {
-                _url.AppendQuery("days", MaestroApi.Serialize(days));
+                _url.AppendQuery("days", Client.Serialize(days));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())

--- a/src/Maestro/Client/src/Generated/Builds.cs
+++ b/src/Maestro/Client/src/Generated/Builds.cs
@@ -188,15 +188,15 @@ namespace Microsoft.DotNet.Maestro.Client
 
             if (!string.IsNullOrEmpty(repository))
             {
-                _url.AppendQuery("repository", MaestroApi.Serialize(repository));
+                _url.AppendQuery("repository", Client.Serialize(repository));
             }
             if (!string.IsNullOrEmpty(commit))
             {
-                _url.AppendQuery("commit", MaestroApi.Serialize(commit));
+                _url.AppendQuery("commit", Client.Serialize(commit));
             }
             if (!string.IsNullOrEmpty(buildNumber))
             {
-                _url.AppendQuery("buildNumber", MaestroApi.Serialize(buildNumber));
+                _url.AppendQuery("buildNumber", Client.Serialize(buildNumber));
             }
             if (azdoBuildId != default)
             {
@@ -204,11 +204,11 @@ namespace Microsoft.DotNet.Maestro.Client
             }
             if (!string.IsNullOrEmpty(azdoAccount))
             {
-                _url.AppendQuery("azdoAccount", MaestroApi.Serialize(azdoAccount));
+                _url.AppendQuery("azdoAccount", Client.Serialize(azdoAccount));
             }
             if (!string.IsNullOrEmpty(azdoProject))
             {
-                _url.AppendQuery("azdoProject", MaestroApi.Serialize(azdoProject));
+                _url.AppendQuery("azdoProject", Client.Serialize(azdoProject));
             }
             if (channelId != default)
             {
@@ -234,7 +234,7 @@ namespace Microsoft.DotNet.Maestro.Client
             {
                 _url.AppendQuery("perPage", Client.Serialize(perPage));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -314,7 +314,7 @@ namespace Microsoft.DotNet.Maestro.Client
                 "/api/builds",
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -387,10 +387,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/builds/{id}".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/builds/{id}".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -457,10 +457,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/builds/{id}/graph".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/builds/{id}/graph".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -538,15 +538,15 @@ namespace Microsoft.DotNet.Maestro.Client
 
             if (!string.IsNullOrEmpty(repository))
             {
-                _url.AppendQuery("repository", MaestroApi.Serialize(repository));
+                _url.AppendQuery("repository", Client.Serialize(repository));
             }
             if (!string.IsNullOrEmpty(commit))
             {
-                _url.AppendQuery("commit", MaestroApi.Serialize(commit));
+                _url.AppendQuery("commit", Client.Serialize(commit));
             }
             if (!string.IsNullOrEmpty(buildNumber))
             {
-                _url.AppendQuery("buildNumber", MaestroApi.Serialize(buildNumber));
+                _url.AppendQuery("buildNumber", Client.Serialize(buildNumber));
             }
             if (channelId != default)
             {
@@ -564,7 +564,7 @@ namespace Microsoft.DotNet.Maestro.Client
             {
                 _url.AppendQuery("loadCollections", Client.Serialize(loadCollections));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -631,10 +631,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/builds/{buildId}/commit".Replace("{buildId}", Uri.EscapeDataString(MaestroApi.Serialize(buildId))),
+                "/api/builds/{buildId}/commit".Replace("{buildId}", Uri.EscapeDataString(Client.Serialize(buildId))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -707,10 +707,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/builds/{buildId}".Replace("{buildId}", Uri.EscapeDataString(MaestroApi.Serialize(buildId))),
+                "/api/builds/{buildId}".Replace("{buildId}", Uri.EscapeDataString(Client.Serialize(buildId))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())

--- a/src/Maestro/Client/src/Generated/Channels.cs
+++ b/src/Maestro/Client/src/Generated/Channels.cs
@@ -28,6 +28,7 @@ namespace Microsoft.DotNet.Maestro.Client
 
         Task<IImmutableList<string>> ListRepositoriesAsync(
             int id,
+            int? withBuildsInDays = default,
             CancellationToken cancellationToken = default
         );
 
@@ -243,6 +244,7 @@ namespace Microsoft.DotNet.Maestro.Client
 
         public async Task<IImmutableList<string>> ListRepositoriesAsync(
             int id,
+            int? withBuildsInDays = default,
             CancellationToken cancellationToken = default
         )
         {
@@ -256,6 +258,10 @@ namespace Microsoft.DotNet.Maestro.Client
                 "/api/channels/{id}/repositories".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
                 false);
 
+            if (withBuildsInDays != default)
+            {
+                _url.AppendQuery("withBuildsInDays", MaestroApi.Serialize(withBuildsInDays));
+            }
             _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
 
 

--- a/src/Maestro/Client/src/Generated/Channels.cs
+++ b/src/Maestro/Client/src/Generated/Channels.cs
@@ -96,9 +96,9 @@ namespace Microsoft.DotNet.Maestro.Client
 
             if (!string.IsNullOrEmpty(classification))
             {
-                _url.AppendQuery("classification", MaestroApi.Serialize(classification));
+                _url.AppendQuery("classification", Client.Serialize(classification));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -181,13 +181,13 @@ namespace Microsoft.DotNet.Maestro.Client
 
             if (!string.IsNullOrEmpty(name))
             {
-                _url.AppendQuery("name", MaestroApi.Serialize(name));
+                _url.AppendQuery("name", Client.Serialize(name));
             }
             if (!string.IsNullOrEmpty(classification))
             {
-                _url.AppendQuery("classification", MaestroApi.Serialize(classification));
+                _url.AppendQuery("classification", Client.Serialize(classification));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -255,14 +255,14 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/channels/{id}/repositories".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/channels/{id}/repositories".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
             if (withBuildsInDays != default)
             {
                 _url.AppendQuery("withBuildsInDays", Client.Serialize(withBuildsInDays));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -329,10 +329,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/channels/{id}".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/channels/{id}".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -399,10 +399,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/channels/{id}".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/channels/{id}".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -470,10 +470,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/channels/{channelId}/builds/{buildId}".Replace("{channelId}", Uri.EscapeDataString(MaestroApi.Serialize(channelId))).Replace("{buildId}", Uri.EscapeDataString(MaestroApi.Serialize(buildId))),
+                "/api/channels/{channelId}/builds/{buildId}".Replace("{channelId}", Uri.EscapeDataString(Client.Serialize(channelId))).Replace("{buildId}", Uri.EscapeDataString(Client.Serialize(buildId))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -532,10 +532,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/channels/{channelId}/builds/{buildId}".Replace("{channelId}", Uri.EscapeDataString(MaestroApi.Serialize(channelId))).Replace("{buildId}", Uri.EscapeDataString(MaestroApi.Serialize(buildId))),
+                "/api/channels/{channelId}/builds/{buildId}".Replace("{channelId}", Uri.EscapeDataString(Client.Serialize(channelId))).Replace("{buildId}", Uri.EscapeDataString(Client.Serialize(buildId))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -598,33 +598,33 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/channels/{channelId}/graph".Replace("{channelId}", Uri.EscapeDataString(MaestroApi.Serialize(channelId))),
+                "/api/channels/{channelId}/graph".Replace("{channelId}", Uri.EscapeDataString(Client.Serialize(channelId))),
                 false);
 
             if (includeDisabledSubscriptions != default)
             {
-                _url.AppendQuery("includeDisabledSubscriptions", MaestroApi.Serialize(includeDisabledSubscriptions));
+                _url.AppendQuery("includeDisabledSubscriptions", Client.Serialize(includeDisabledSubscriptions));
             }
             if (includedFrequencies != default(IImmutableList<string>))
             {
                 foreach (var _item in includedFrequencies)
                 {
-                    _url.AppendQuery("includedFrequencies", MaestroApi.Serialize(_item));
+                    _url.AppendQuery("includedFrequencies", Client.Serialize(_item));
                 }
             }
             if (includeBuildTimes != default)
             {
-                _url.AppendQuery("includeBuildTimes", MaestroApi.Serialize(includeBuildTimes));
+                _url.AppendQuery("includeBuildTimes", Client.Serialize(includeBuildTimes));
             }
             if (days != default)
             {
-                _url.AppendQuery("days", MaestroApi.Serialize(days));
+                _url.AppendQuery("days", Client.Serialize(days));
             }
             if (includeArcade != default)
             {
-                _url.AppendQuery("includeArcade", MaestroApi.Serialize(includeArcade));
+                _url.AppendQuery("includeArcade", Client.Serialize(includeArcade));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())

--- a/src/Maestro/Client/src/Generated/Channels.cs
+++ b/src/Maestro/Client/src/Generated/Channels.cs
@@ -260,7 +260,7 @@ namespace Microsoft.DotNet.Maestro.Client
 
             if (withBuildsInDays != default)
             {
-                _url.AppendQuery("withBuildsInDays", MaestroApi.Serialize(withBuildsInDays));
+                _url.AppendQuery("withBuildsInDays", Client.Serialize(withBuildsInDays));
             }
             _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
 

--- a/src/Maestro/Client/src/Generated/DefaultChannels.cs
+++ b/src/Maestro/Client/src/Generated/DefaultChannels.cs
@@ -80,11 +80,11 @@ namespace Microsoft.DotNet.Maestro.Client
 
             if (!string.IsNullOrEmpty(repository))
             {
-                _url.AppendQuery("repository", MaestroApi.Serialize(repository));
+                _url.AppendQuery("repository", Client.Serialize(repository));
             }
             if (!string.IsNullOrEmpty(branch))
             {
-                _url.AppendQuery("branch", MaestroApi.Serialize(branch));
+                _url.AppendQuery("branch", Client.Serialize(branch));
             }
             if (channelId != default)
             {
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.Maestro.Client
             {
                 _url.AppendQuery("enabled", Client.Serialize(enabled));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -174,7 +174,7 @@ namespace Microsoft.DotNet.Maestro.Client
                 "/api/default-channels",
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -239,10 +239,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/default-channels/{id}".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/default-channels/{id}".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -315,10 +315,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/default-channels/{id}".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/default-channels/{id}".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -385,10 +385,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/default-channels/{id}".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/default-channels/{id}".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())

--- a/src/Maestro/Client/src/Generated/Goal.cs
+++ b/src/Maestro/Client/src/Generated/Goal.cs
@@ -67,10 +67,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/goals/channelName/{channelName}/definitionId/{definitionId}".Replace("{channelName}", Uri.EscapeDataString(MaestroApi.Serialize(channelName))).Replace("{definitionId}", Uri.EscapeDataString(MaestroApi.Serialize(definitionId))),
+                "/api/goals/channelName/{channelName}/definitionId/{definitionId}".Replace("{channelName}", Uri.EscapeDataString(Client.Serialize(channelName))).Replace("{definitionId}", Uri.EscapeDataString(Client.Serialize(definitionId))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -149,10 +149,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/goals/channelName/{channelName}/definitionId/{definitionId}".Replace("{definitionId}", Uri.EscapeDataString(MaestroApi.Serialize(definitionId))).Replace("{channelName}", Uri.EscapeDataString(MaestroApi.Serialize(channelName))),
+                "/api/goals/channelName/{channelName}/definitionId/{definitionId}".Replace("{definitionId}", Uri.EscapeDataString(Client.Serialize(definitionId))).Replace("{channelName}", Uri.EscapeDataString(Client.Serialize(channelName))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())

--- a/src/Maestro/Client/src/Generated/MaestroApi.cs
+++ b/src/Maestro/Client/src/Generated/MaestroApi.cs
@@ -169,43 +169,43 @@ namespace Microsoft.DotNet.Maestro.Client
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string Serialize(string value)
+        public string Serialize(string value)
         {
             return value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string Serialize(bool value)
+        public string Serialize(bool value)
         {
             return value ? "true" : "false";
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string Serialize(int value)
+        public string Serialize(int value)
         {
             return value.ToString(CultureInfo.InvariantCulture);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string Serialize(long value)
+        public string Serialize(long value)
         {
             return value.ToString(CultureInfo.InvariantCulture);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string Serialize(float value)
+        public string Serialize(float value)
         {
             return value.ToString(CultureInfo.InvariantCulture);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string Serialize(double value)
+        public string Serialize(double value)
         {
             return value.ToString(CultureInfo.InvariantCulture);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string Serialize(Guid value)
+        public string Serialize(Guid value)
         {
             return value.ToString("D", CultureInfo.InvariantCulture);
         }
@@ -409,10 +409,10 @@ namespace Microsoft.DotNet.Maestro.Client
             KeyValuePair<string, string> keyValuePair = this[index];
             if (index != 0)
             {
-                builder.Append('&');
+                builder.Append("&");
             }
             builder.Append(UrlEncoder.Default.Encode(keyValuePair.Key));
-            builder.Append('=');
+            builder.Append("=");
             builder.Append(UrlEncoder.Default.Encode(keyValuePair.Value));
           }
           return builder.ToString();

--- a/src/Maestro/Client/src/Generated/Models/Subscription.cs
+++ b/src/Maestro/Client/src/Generated/Models/Subscription.cs
@@ -2,20 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Immutable;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Maestro.Client.Models
 {
     public partial class Subscription
     {
-        public Subscription(Guid id, bool enabled, string sourceRepository, string targetRepository, string targetBranch, string pullRequestFailureNotificationTags)
+        public Subscription(Guid id, bool enabled, bool sourceEnabled, string sourceRepository, string targetRepository, string targetBranch, string pullRequestFailureNotificationTags, IImmutableList<string> excludedAssets)
         {
             Id = id;
             Enabled = enabled;
+            SourceEnabled = sourceEnabled;
             SourceRepository = sourceRepository;
             TargetRepository = targetRepository;
             TargetBranch = targetBranch;
             PullRequestFailureNotificationTags = pullRequestFailureNotificationTags;
+            ExcludedAssets = excludedAssets;
         }
 
         [JsonProperty("id")]
@@ -42,7 +45,13 @@ namespace Microsoft.DotNet.Maestro.Client.Models
         [JsonProperty("enabled")]
         public bool Enabled { get; }
 
+        [JsonProperty("sourceEnabled")]
+        public bool SourceEnabled { get; }
+
         [JsonProperty("pullRequestFailureNotificationTags")]
         public string PullRequestFailureNotificationTags { get; }
+
+        [JsonProperty("excludedAssets")]
+        public IImmutableList<string> ExcludedAssets { get; }
     }
 }

--- a/src/Maestro/Client/src/Generated/Models/SubscriptionData.cs
+++ b/src/Maestro/Client/src/Generated/Models/SubscriptionData.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Maestro.Client.Models
@@ -32,11 +33,17 @@ namespace Microsoft.DotNet.Maestro.Client.Models
         [JsonProperty("enabled")]
         public bool? Enabled { get; set; }
 
+        [JsonProperty("sourceEnabled")]
+        public bool? SourceEnabled { get; set; }
+
         [JsonProperty("policy")]
         public SubscriptionPolicy Policy { get; set; }
 
         [JsonProperty("pullRequestFailureNotificationTags")]
         public string PullRequestFailureNotificationTags { get; set; }
+
+        [JsonProperty("excludedAssets")]
+        public IImmutableList<string> ExcludedAssets { get; set; }
 
         [JsonIgnore]
         public bool IsValid

--- a/src/Maestro/Client/src/Generated/Models/SubscriptionUpdate.cs
+++ b/src/Maestro/Client/src/Generated/Models/SubscriptionUpdate.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Maestro.Client.Models
@@ -23,7 +24,13 @@ namespace Microsoft.DotNet.Maestro.Client.Models
         [JsonProperty("enabled")]
         public bool? Enabled { get; set; }
 
+        [JsonProperty("sourceEnabled")]
+        public bool? SourceEnabled { get; set; }
+
         [JsonProperty("pullRequestFailureNotificationTags")]
         public string PullRequestFailureNotificationTags { get; set; }
+
+        [JsonProperty("excludedAssets")]
+        public IImmutableList<string> ExcludedAssets { get; set; }
     }
 }

--- a/src/Maestro/Client/src/Generated/Repository.cs
+++ b/src/Maestro/Client/src/Generated/Repository.cs
@@ -90,13 +90,13 @@ namespace Microsoft.DotNet.Maestro.Client
 
             if (!string.IsNullOrEmpty(repository))
             {
-                _url.AppendQuery("repository", MaestroApi.Serialize(repository));
+                _url.AppendQuery("repository", Client.Serialize(repository));
             }
             if (!string.IsNullOrEmpty(branch))
             {
-                _url.AppendQuery("branch", MaestroApi.Serialize(branch));
+                _url.AppendQuery("branch", Client.Serialize(branch));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -179,13 +179,13 @@ namespace Microsoft.DotNet.Maestro.Client
 
             if (!string.IsNullOrEmpty(repository))
             {
-                _url.AppendQuery("repository", MaestroApi.Serialize(repository));
+                _url.AppendQuery("repository", Client.Serialize(repository));
             }
             if (!string.IsNullOrEmpty(branch))
             {
-                _url.AppendQuery("branch", MaestroApi.Serialize(branch));
+                _url.AppendQuery("branch", Client.Serialize(branch));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -269,13 +269,13 @@ namespace Microsoft.DotNet.Maestro.Client
 
             if (!string.IsNullOrEmpty(repository))
             {
-                _url.AppendQuery("repository", MaestroApi.Serialize(repository));
+                _url.AppendQuery("repository", Client.Serialize(repository));
             }
             if (!string.IsNullOrEmpty(branch))
             {
-                _url.AppendQuery("branch", MaestroApi.Serialize(branch));
+                _url.AppendQuery("branch", Client.Serialize(branch));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -392,11 +392,11 @@ namespace Microsoft.DotNet.Maestro.Client
 
             if (!string.IsNullOrEmpty(repository))
             {
-                _url.AppendQuery("repository", MaestroApi.Serialize(repository));
+                _url.AppendQuery("repository", Client.Serialize(repository));
             }
             if (!string.IsNullOrEmpty(branch))
             {
-                _url.AppendQuery("branch", MaestroApi.Serialize(branch));
+                _url.AppendQuery("branch", Client.Serialize(branch));
             }
             if (page != default)
             {
@@ -406,7 +406,7 @@ namespace Microsoft.DotNet.Maestro.Client
             {
                 _url.AppendQuery("perPage", Client.Serialize(perPage));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -485,18 +485,18 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/repo-config/retry/{timestamp}".Replace("{timestamp}", Uri.EscapeDataString(MaestroApi.Serialize(timestamp))),
+                "/api/repo-config/retry/{timestamp}".Replace("{timestamp}", Uri.EscapeDataString(Client.Serialize(timestamp))),
                 false);
 
             if (!string.IsNullOrEmpty(repository))
             {
-                _url.AppendQuery("repository", MaestroApi.Serialize(repository));
+                _url.AppendQuery("repository", Client.Serialize(repository));
             }
             if (!string.IsNullOrEmpty(branch))
             {
-                _url.AppendQuery("branch", MaestroApi.Serialize(branch));
+                _url.AppendQuery("branch", Client.Serialize(branch));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())

--- a/src/Maestro/Client/src/Generated/Subscriptions.cs
+++ b/src/Maestro/Client/src/Generated/Subscriptions.cs
@@ -18,8 +18,9 @@ namespace Microsoft.DotNet.Maestro.Client
     public partial interface ISubscriptions
     {
         Task<IImmutableList<Models.Subscription>> ListSubscriptionsAsync(
-            int? channelId = default,
             bool? enabled = default,
+            int? channelId = default,
+            bool? sourceEnabled = default,
             string sourceRepository = default,
             string targetRepository = default,
             CancellationToken cancellationToken = default
@@ -90,8 +91,9 @@ namespace Microsoft.DotNet.Maestro.Client
         partial void HandleFailedListSubscriptionsRequest(RestApiException ex);
 
         public async Task<IImmutableList<Models.Subscription>> ListSubscriptionsAsync(
-            int? channelId = default,
             bool? enabled = default,
+            int? channelId = default,
+            bool? sourceEnabled = default,
             string sourceRepository = default,
             string targetRepository = default,
             CancellationToken cancellationToken = default
@@ -109,11 +111,11 @@ namespace Microsoft.DotNet.Maestro.Client
 
             if (!string.IsNullOrEmpty(sourceRepository))
             {
-                _url.AppendQuery("sourceRepository", MaestroApi.Serialize(sourceRepository));
+                _url.AppendQuery("sourceRepository", Client.Serialize(sourceRepository));
             }
             if (!string.IsNullOrEmpty(targetRepository))
             {
-                _url.AppendQuery("targetRepository", MaestroApi.Serialize(targetRepository));
+                _url.AppendQuery("targetRepository", Client.Serialize(targetRepository));
             }
             if (channelId != default)
             {
@@ -123,7 +125,11 @@ namespace Microsoft.DotNet.Maestro.Client
             {
                 _url.AppendQuery("enabled", Client.Serialize(enabled));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            if (sourceEnabled != default)
+            {
+                _url.AppendQuery("sourceEnabled", Client.Serialize(sourceEnabled));
+            }
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -203,7 +209,7 @@ namespace Microsoft.DotNet.Maestro.Client
                 "/api/subscriptions",
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -276,10 +282,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/subscriptions/{id}".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/subscriptions/{id}".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -347,10 +353,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/subscriptions/{id}".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/subscriptions/{id}".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -423,10 +429,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/subscriptions/{id}".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/subscriptions/{id}".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -494,14 +500,14 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/subscriptions/{id}/trigger".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/subscriptions/{id}/trigger".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
             if (barBuildId != default)
             {
-                _url.AppendQuery("bar-build-id", MaestroApi.Serialize(barBuildId));
+                _url.AppendQuery("bar-build-id", Client.Serialize(barBuildId));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -570,7 +576,7 @@ namespace Microsoft.DotNet.Maestro.Client
                 "/api/subscriptions/triggerDaily",
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -673,7 +679,7 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/subscriptions/{id}/history".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))),
+                "/api/subscriptions/{id}/history".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))),
                 false);
 
             if (page != default)
@@ -684,7 +690,7 @@ namespace Microsoft.DotNet.Maestro.Client
             {
                 _url.AppendQuery("perPage", Client.Serialize(perPage));
             }
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())
@@ -752,10 +758,10 @@ namespace Microsoft.DotNet.Maestro.Client
             var _url = new RequestUriBuilder();
             _url.Reset(_baseUri);
             _url.AppendPath(
-                "/api/subscriptions/{id}/retry/{timestamp}".Replace("{id}", Uri.EscapeDataString(MaestroApi.Serialize(id))).Replace("{timestamp}", Uri.EscapeDataString(MaestroApi.Serialize(timestamp))),
+                "/api/subscriptions/{id}/retry/{timestamp}".Replace("{id}", Uri.EscapeDataString(Client.Serialize(id))).Replace("{timestamp}", Uri.EscapeDataString(Client.Serialize(timestamp))),
                 false);
 
-            _url.AppendQuery("api-version", MaestroApi.Serialize(apiVersion));
+            _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 
 
             using (var _req = Client.Pipeline.CreateRequest())

--- a/src/Maestro/Client/src/Generated/Subscriptions.cs
+++ b/src/Maestro/Client/src/Generated/Subscriptions.cs
@@ -18,8 +18,8 @@ namespace Microsoft.DotNet.Maestro.Client
     public partial interface ISubscriptions
     {
         Task<IImmutableList<Models.Subscription>> ListSubscriptionsAsync(
-            bool? enabled = default,
             int? channelId = default,
+            bool? enabled = default,
             bool? sourceEnabled = default,
             string sourceRepository = default,
             string targetRepository = default,
@@ -91,8 +91,8 @@ namespace Microsoft.DotNet.Maestro.Client
         partial void HandleFailedListSubscriptionsRequest(RestApiException ex);
 
         public async Task<IImmutableList<Models.Subscription>> ListSubscriptionsAsync(
-            bool? enabled = default,
             int? channelId = default,
+            bool? enabled = default,
             bool? sourceEnabled = default,
             string sourceRepository = default,
             string targetRepository = default,

--- a/src/Maestro/Maestro.Data/BuildAssetRegistryContext.cs
+++ b/src/Maestro/Maestro.Data/BuildAssetRegistryContext.cs
@@ -57,6 +57,7 @@ public class BuildAssetRegistryContext : IdentityDbContext<ApplicationUser, Iden
 
     public DbSet<Asset> Assets { get; set; }
     public DbSet<AssetLocation> AssetLocations { get; set; }
+    public DbSet<AssetFilter> AssetFilters { get; set; }
     public DbSet<Build> Builds { get; set; }
     public DbSet<BuildChannel> BuildChannels { get; set; }
     public DbSet<BuildDependency> BuildDependencies { get; set; }

--- a/src/Maestro/Maestro.Data/Migrations/20240202111944_CodeEnabledSubscriptions.Designer.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20240202111944_CodeEnabledSubscriptions.Designer.cs
@@ -4,6 +4,7 @@ using Maestro.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Maestro.Data.Migrations
 {
     [DbContext(typeof(BuildAssetRegistryContext))]
-    partial class BuildAssetRegistryContextModelSnapshot : ModelSnapshot
+    [Migration("20240202111944_CodeEnabledSubscriptions")]
+    partial class CodeEnabledSubscriptions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -253,24 +255,6 @@ namespace Maestro.Data.Migrations
                     b.ToTable("Builds");
                 });
 
-            modelBuilder.Entity("Maestro.Data.Models.BuildChannel", b =>
-                {
-                    b.Property<int>("BuildId")
-                        .HasColumnType("int");
-
-                    b.Property<int>("ChannelId")
-                        .HasColumnType("int");
-
-                    b.Property<DateTimeOffset>("DateTimeAdded")
-                        .HasColumnType("datetimeoffset");
-
-                    b.HasKey("BuildId", "ChannelId");
-
-                    b.HasIndex("ChannelId");
-
-                    b.ToTable("BuildChannels");
-                });
-
             modelBuilder.Entity("Maestro.Data.Models.BuildDependency", b =>
                 {
                     b.Property<int>("BuildId")
@@ -290,6 +274,24 @@ namespace Maestro.Data.Migrations
                     b.HasIndex("DependentBuildId");
 
                     b.ToTable("BuildDependencies");
+                });
+
+            modelBuilder.Entity("Maestro.Data.Models.BuildChannel", b =>
+                {
+                    b.Property<int>("BuildId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("ChannelId")
+                        .HasColumnType("int");
+
+                    b.Property<DateTimeOffset>("DateTimeAdded")
+                        .HasColumnType("datetimeoffset");
+
+                    b.HasKey("BuildId", "ChannelId");
+
+                    b.HasIndex("ChannelId");
+
+                    b.ToTable("BuildChannels");
                 });
 
             modelBuilder.Entity("Maestro.Data.Models.BuildIncoherence", b =>
@@ -320,30 +322,6 @@ namespace Maestro.Data.Migrations
                     b.HasIndex("BuildId");
 
                     b.ToTable("BuildIncoherencies");
-                });
-
-            modelBuilder.Entity("Maestro.Data.Models.Channel", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
-
-                    b.Property<string>("Classification")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(450)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("Name")
-                        .IsUnique();
-
-                    b.ToTable("Channels");
                 });
 
             modelBuilder.Entity("Maestro.Data.Models.DefaultChannel", b =>
@@ -440,6 +418,30 @@ namespace Maestro.Data.Migrations
                     b.HasIndex("ChannelId");
 
                     b.ToTable("GoalTime");
+                });
+
+            modelBuilder.Entity("Maestro.Data.Models.Channel", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+
+                    b.Property<string>("Classification")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(450)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Name")
+                        .IsUnique();
+
+                    b.ToTable("Channels");
                 });
 
             modelBuilder.Entity("Maestro.Data.Models.LongestBuildPath", b =>
@@ -891,25 +893,6 @@ namespace Maestro.Data.Migrations
                         .HasForeignKey("AssetId");
                 });
 
-            modelBuilder.Entity("Maestro.Data.Models.BuildChannel", b =>
-                {
-                    b.HasOne("Maestro.Data.Models.Build", "Build")
-                        .WithMany("BuildChannels")
-                        .HasForeignKey("BuildId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("Maestro.Data.Models.Channel", "Channel")
-                        .WithMany("BuildChannels")
-                        .HasForeignKey("ChannelId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Build");
-
-                    b.Navigation("Channel");
-                });
-
             modelBuilder.Entity("Maestro.Data.Models.BuildDependency", b =>
                 {
                     b.HasOne("Maestro.Data.Models.Build", "Build")
@@ -927,6 +910,25 @@ namespace Maestro.Data.Migrations
                     b.Navigation("Build");
 
                     b.Navigation("DependentBuild");
+                });
+
+            modelBuilder.Entity("Maestro.Data.Models.BuildChannel", b =>
+                {
+                    b.HasOne("Maestro.Data.Models.Build", "Build")
+                        .WithMany("BuildChannels")
+                        .HasForeignKey("BuildId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("Maestro.Data.Models.Channel", "Channel")
+                        .WithMany("BuildChannels")
+                        .HasForeignKey("ChannelId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Build");
+
+                    b.Navigation("Channel");
                 });
 
             modelBuilder.Entity("Maestro.Data.Models.BuildIncoherence", b =>

--- a/src/Maestro/Maestro.Data/Migrations/20240202111944_CodeEnabledSubscriptions.Designer.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20240202111944_CodeEnabledSubscriptions.Designer.cs
@@ -882,7 +882,7 @@ namespace Maestro.Data.Migrations
             modelBuilder.Entity("Maestro.Data.Models.AssetFilter", b =>
                 {
                     b.HasOne("Maestro.Data.Models.Subscription", null)
-                        .WithMany("ExcludedDependencies")
+                        .WithMany("ExcludedAssets")
                         .HasForeignKey("SubscriptionId");
                 });
 
@@ -1116,7 +1116,7 @@ namespace Maestro.Data.Migrations
 
             modelBuilder.Entity("Maestro.Data.Models.Subscription", b =>
                 {
-                    b.Navigation("ExcludedDependencies");
+                    b.Navigation("ExcludedAssets");
                 });
 #pragma warning restore 612, 618
         }

--- a/src/Maestro/Maestro.Data/Migrations/20240202111944_CodeEnabledSubscriptions.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20240202111944_CodeEnabledSubscriptions.cs
@@ -17,7 +17,7 @@ namespace Maestro.Data.Migrations
                 defaultValue: false);
 
             migrationBuilder.CreateTable(
-                name: "AssetFilter",
+                name: "AssetFilters",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
@@ -27,7 +27,7 @@ namespace Maestro.Data.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_AssetFilter", x => x.Id);
+                    table.PrimaryKey("PK_AssetFilters", x => x.Id);
                     table.ForeignKey(
                         name: "FK_AssetFilter_Subscriptions_SubscriptionId",
                         column: x => x.SubscriptionId,
@@ -37,14 +37,14 @@ namespace Maestro.Data.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_AssetFilter_SubscriptionId",
-                table: "AssetFilter",
+                table: "AssetFilters",
                 column: "SubscriptionId");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "AssetFilter");
+                name: "AssetFilters");
 
             migrationBuilder.DropColumn(
                 name: "SourceEnabled",

--- a/src/Maestro/Maestro.Data/Migrations/20240202111944_CodeEnabledSubscriptions.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20240202111944_CodeEnabledSubscriptions.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Maestro.Data.Migrations
+{
+    public partial class CodeEnabledSubscriptions : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "SourceEnabled",
+                table: "Subscriptions",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateTable(
+                name: "AssetFilter",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Filter = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    SubscriptionId = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AssetFilter", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AssetFilter_Subscriptions_SubscriptionId",
+                        column: x => x.SubscriptionId,
+                        principalTable: "Subscriptions",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AssetFilter_SubscriptionId",
+                table: "AssetFilter",
+                column: "SubscriptionId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AssetFilter");
+
+            migrationBuilder.DropColumn(
+                name: "SourceEnabled",
+                table: "Subscriptions");
+        }
+    }
+}

--- a/src/Maestro/Maestro.Data/Migrations/BuildAssetRegistryContextModelSnapshot.cs
+++ b/src/Maestro/Maestro.Data/Migrations/BuildAssetRegistryContextModelSnapshot.cs
@@ -880,7 +880,7 @@ namespace Maestro.Data.Migrations
             modelBuilder.Entity("Maestro.Data.Models.AssetFilter", b =>
                 {
                     b.HasOne("Maestro.Data.Models.Subscription", null)
-                        .WithMany("ExcludedDependencies")
+                        .WithMany("ExcludedAssets")
                         .HasForeignKey("SubscriptionId");
                 });
 
@@ -1114,7 +1114,7 @@ namespace Maestro.Data.Migrations
 
             modelBuilder.Entity("Maestro.Data.Models.Subscription", b =>
                 {
-                    b.Navigation("ExcludedDependencies");
+                    b.Navigation("ExcludedAssets");
                 });
 #pragma warning restore 612, 618
         }

--- a/src/Maestro/Maestro.Data/Models/AssetFilter.cs
+++ b/src/Maestro/Maestro.Data/Models/AssetFilter.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Maestro.Data.Models;
+
+public class AssetFilter
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Filter for assets to ignore, e.g. "Microsoft.AspNetCore.App", "Microsoft.NETCore.*", etc.
+    /// </summary>
+    public string Filter { get; set; }
+}

--- a/src/Maestro/Maestro.Data/Models/Subscription.cs
+++ b/src/Maestro/Maestro.Data/Models/Subscription.cs
@@ -77,7 +77,7 @@ public class Subscription
     /// <summary>
     /// Dependencies to ignore when synchronizing code of source-enabled subscriptions.
     /// </summary>
-    public List<AssetFilter> ExcludedDependencies { get; set; }
+    public List<AssetFilter> ExcludedAssets { get; set; }
 
     [NotMapped]
     public SubscriptionPolicy PolicyObject

--- a/src/Maestro/Maestro.Data/Models/Subscription.cs
+++ b/src/Maestro/Maestro.Data/Models/Subscription.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.DotNet.DarcLib;
@@ -67,6 +68,17 @@ public class Subscription
 
     public bool Enabled { get; set; } = true;
 
+    /// <summary>
+    /// Denotes whether sources are also synchronized.
+    /// Source or target repository must be a VMR.
+    /// </summary>
+    public bool SourceEnabled { get; set; }
+
+    /// <summary>
+    /// Dependencies to ignore when synchronizing code of source-enabled subscriptions.
+    /// </summary>
+    public List<AssetFilter> ExcludedDependencies { get; set; }
+
     [NotMapped]
     public SubscriptionPolicy PolicyObject
     {
@@ -79,69 +91,4 @@ public class Subscription
     public Build LastAppliedBuild { get; set; }
 
     public string PullRequestFailureNotificationTags { get; set; }
-}
-
-public class SubscriptionUpdate
-{
-    [Key]
-    public Guid SubscriptionId { get; set; }
-
-    public Subscription Subscription { get; set; }
-
-    /// <summary>
-    ///     **true** if the update succeeded; **false** otherwise.
-    /// </summary>
-    public bool Success { get; set; }
-
-    /// <summary>
-    ///     A message describing what the subscription was trying to do.
-    ///     e.g. 'Updating dependencies from dotnet/coreclr in dotnet/corefx'
-    /// </summary>
-    public string Action { get; set; }
-
-    /// <summary>
-    ///     The error that occured, if any.
-    /// </summary>
-    public string ErrorMessage { get; set; }
-
-    /// <summary>
-    ///     The method that was called.
-    /// </summary>
-    public string Method { get; set; }
-
-    /// <summary>
-    ///     The parameters to the called method.
-    /// </summary>
-    public string Arguments { get; set; }
-}
-
-public class SubscriptionUpdateHistory
-{
-    public Guid SubscriptionId { get; set; }
-
-    /// <summary>
-    ///     **true** if the update succeeded; **false** otherwise.
-    /// </summary>
-    public bool Success { get; set; }
-
-    /// <summary>
-    ///     A message describing what the subscription was trying to do.
-    ///     e.g. 'Updating dependencies from dotnet/coreclr in dotnet/corefx'
-    /// </summary>
-    public string Action { get; set; }
-
-    /// <summary>
-    ///     The error that occured, if any.
-    /// </summary>
-    public string ErrorMessage { get; set; }
-
-    /// <summary>
-    ///     The method that was called.
-    /// </summary>
-    public string Method { get; set; }
-
-    /// <summary>
-    ///     The parameters to the called method.
-    /// </summary>
-    public string Arguments { get; set; }
 }

--- a/src/Maestro/Maestro.Data/Models/SubscriptionUpdate.cs
+++ b/src/Maestro/Maestro.Data/Models/SubscriptionUpdate.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Maestro.Data.Models;
+
+public class SubscriptionUpdate
+{
+    [Key]
+    public Guid SubscriptionId { get; set; }
+
+    public Subscription Subscription { get; set; }
+
+    /// <summary>
+    ///     **true** if the update succeeded; **false** otherwise.
+    /// </summary>
+    public bool Success { get; set; }
+
+    /// <summary>
+    ///     A message describing what the subscription was trying to do.
+    ///     e.g. 'Updating dependencies from dotnet/coreclr in dotnet/corefx'
+    /// </summary>
+    public string Action { get; set; }
+
+    /// <summary>
+    ///     The error that occured, if any.
+    /// </summary>
+    public string ErrorMessage { get; set; }
+
+    /// <summary>
+    ///     The method that was called.
+    /// </summary>
+    public string Method { get; set; }
+
+    /// <summary>
+    ///     The parameters to the called method.
+    /// </summary>
+    public string Arguments { get; set; }
+}

--- a/src/Maestro/Maestro.Data/Models/SubscriptionUpdateHistory.cs
+++ b/src/Maestro/Maestro.Data/Models/SubscriptionUpdateHistory.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Maestro.Data.Models;
+
+public class SubscriptionUpdateHistory
+{
+    public Guid SubscriptionId { get; set; }
+
+    /// <summary>
+    ///     **true** if the update succeeded; **false** otherwise.
+    /// </summary>
+    public bool Success { get; set; }
+
+    /// <summary>
+    ///     A message describing what the subscription was trying to do.
+    ///     e.g. 'Updating dependencies from dotnet/coreclr in dotnet/corefx'
+    /// </summary>
+    public string Action { get; set; }
+
+    /// <summary>
+    ///     The error that occured, if any.
+    /// </summary>
+    public string ErrorMessage { get; set; }
+
+    /// <summary>
+    ///     The method that was called.
+    /// </summary>
+    public string Method { get; set; }
+
+    /// <summary>
+    ///     The parameters to the called method.
+    /// </summary>
+    public string Arguments { get; set; }
+}

--- a/src/Maestro/Maestro.DataProviders/SqlBarClient.cs
+++ b/src/Maestro/Maestro.DataProviders/SqlBarClient.cs
@@ -34,18 +34,24 @@ public class SqlBarClient : IBasicBarClient
 
     public async Task<Subscription> GetSubscriptionAsync(Guid subscriptionId)
     {
-        var subscriptionObject = await _context.Subscriptions.FirstOrDefaultAsync(s => s.Id.Equals(subscriptionId));
-        if (subscriptionObject != null)
+        var sub = await _context.Subscriptions
+            .Include(s => s.ExcludedAssets)
+            .FirstOrDefaultAsync(s => s.Id.Equals(subscriptionId));
+
+        if (sub == null)
         {
-            return new Subscription(
-                subscriptionObject.Id,
-                subscriptionObject.Enabled,
-                subscriptionObject.SourceRepository,
-                subscriptionObject.TargetRepository,
-                subscriptionObject.TargetBranch,
-                subscriptionObject.PullRequestFailureNotificationTags);
+            return null;
         }
-        return null;
+
+        return new Subscription(
+            sub.Id,
+            sub.Enabled,
+            //sub.SourceEnabled,
+            sub.SourceRepository,
+            sub.TargetRepository,
+            sub.TargetBranch,
+            sub.PullRequestFailureNotificationTags/*,
+            sub.ExcludedAssets.Select(s => s.Filter)*/);
     }
 
     public async Task<Subscription> GetSubscriptionAsync(string subscriptionId)

--- a/src/Maestro/Maestro.DataProviders/SqlBarClient.cs
+++ b/src/Maestro/Maestro.DataProviders/SqlBarClient.cs
@@ -46,12 +46,12 @@ public class SqlBarClient : IBasicBarClient
         return new Subscription(
             sub.Id,
             sub.Enabled,
-            //sub.SourceEnabled,
+            sub.SourceEnabled,
             sub.SourceRepository,
             sub.TargetRepository,
             sub.TargetBranch,
-            sub.PullRequestFailureNotificationTags/*,
-            sub.ExcludedAssets.Select(s => s.Filter)*/);
+            sub.PullRequestFailureNotificationTags,
+            sub.ExcludedAssets.Select(s => s.Filter).ToImmutableList());
     }
 
     public async Task<Subscription> GetSubscriptionAsync(string subscriptionId)
@@ -277,10 +277,12 @@ public class SqlBarClient : IBasicBarClient
         return new Subscription(
             other.Id,
             other.Enabled,
+            other.SourceEnabled,
             other.SourceRepository,
             other.TargetRepository,
             other.TargetBranch,
-            other.PullRequestFailureNotificationTags)
+            other.PullRequestFailureNotificationTags,
+            other.ExcludedAssets.Select(a => a.Filter).ToImmutableList())
         {
             Channel = ToClientModelChannel(other.Channel),
             Policy = ToClientModelSubscriptionPolicy(other.PolicyObject),

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
@@ -40,17 +40,28 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
         _gitHubClientFactory = gitHubClientFactory;
     }
 
+    [ApiRemoved]
+    public sealed override IActionResult ListSubscriptions(
+        string sourceRepository = null,
+        string targetRepository = null,
+        int? channelId = null,
+        bool? enabled = null)
+    {
+        throw new NotImplementedException();
+    }
+
     /// <summary>
     ///   Gets a list of all <see cref="Subscription"/>s that match the given search criteria.
     /// </summary>
     [HttpGet]
     [SwaggerApiResponse(HttpStatusCode.OK, Type = typeof(List<Subscription>), Description = "The list of Subscriptions")]
     [ValidateModelState]
-    public override IActionResult ListSubscriptions(
+    public IActionResult ListSubscriptions(
         string sourceRepository = null,
         string targetRepository = null,
         int? channelId = null,
-        bool? enabled = null)
+        bool? enabled = null,
+        bool? sourceEnabled = null)
     {
         IQueryable<Data.Models.Subscription> query = _context.Subscriptions
             .Include(s => s.Channel)
@@ -75,6 +86,11 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
         if (enabled.HasValue)
         {
             query = query.Where(sub => sub.Enabled == enabled.Value);
+        }
+
+        if (sourceEnabled.HasValue)
+        {
+            query = query.Where(sub => sub.SourceEnabled == sourceEnabled.Value);
         }
 
         List<Subscription> results = query.AsEnumerable().Select(sub => new Subscription(sub)).ToList();

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
@@ -1,6 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Kusto.Cloud.Platform.Utils;
 using Maestro.Data;
 using Maestro.Web.Api.v2020_02_20.Models;
 using Microsoft.AspNetCore.ApiVersioning;
@@ -8,12 +15,6 @@ using Microsoft.AspNetCore.ApiVersioning.Swashbuckle;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
 
 namespace Maestro.Web.Api.v2020_02_20.Controllers;
 
@@ -187,6 +188,20 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
         if (update.Enabled.HasValue)
         {
             subscription.Enabled = update.Enabled.Value;
+            doUpdate = true;
+        }
+
+        if (update.SourceEnabled.HasValue)
+        {
+            subscription.SourceEnabled = update.SourceEnabled.Value;
+            doUpdate = true;
+        }
+
+        update.ExcludedAssets = [.. (update.ExcludedAssets?.OrderBy(a => a).ToList() ?? [])];
+        var currentSubscriptions = subscription.ExcludedAssets.Select(a => a.Filter).OrderBy(a => a);
+        if (!currentSubscriptions.SequenceEqual(update.ExcludedAssets))
+        {
+            subscription.ExcludedAssets = update.ExcludedAssets.Select(asset => new Data.Models.AssetFilter() { Filter = asset }).ToList();
             doUpdate = true;
         }
 

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/Subscription.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/Subscription.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Maestro.Web.Api.v2020_02_20.Models;
 
@@ -18,8 +20,10 @@ public class Subscription
         TargetRepository = other.TargetRepository;
         TargetBranch = other.TargetBranch;
         Enabled = other.Enabled;
+        SourceEnabled = other.SourceEnabled;
         Policy = new v2018_07_16.Models.SubscriptionPolicy(other.PolicyObject);
         PullRequestFailureNotificationTags = other.PullRequestFailureNotificationTags;
+        ExcludedAssets = [..other.ExcludedAssets.Select(s => s.Filter)];
     }
 
     public Guid Id { get; }
@@ -38,5 +42,9 @@ public class Subscription
 
     public bool Enabled { get; }
 
+    public bool SourceEnabled { get; }
+
     public string PullRequestFailureNotificationTags { get; }
+
+    public IReadOnlyCollection<string> ExcludedAssets { get; }
 }

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/Subscription.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/Subscription.cs
@@ -23,7 +23,7 @@ public class Subscription
         SourceEnabled = other.SourceEnabled;
         Policy = new v2018_07_16.Models.SubscriptionPolicy(other.PolicyObject);
         PullRequestFailureNotificationTags = other.PullRequestFailureNotificationTags;
-        ExcludedAssets = [..other.ExcludedAssets.Select(s => s.Filter)];
+        ExcludedAssets = other.ExcludedAssets != null ? [..other.ExcludedAssets.Select(s => s.Filter)] : [];
     }
 
     public Guid Id { get; }

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/SubscriptionData.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/SubscriptionData.cs
@@ -42,6 +42,6 @@ public class SubscriptionData
         Enabled = Enabled ?? true,
         SourceEnabled = SourceEnabled ?? false,
         PullRequestFailureNotificationTags = PullRequestFailureNotificationTags,
-        ExcludedAssets = [..ExcludedAssets.Select(asset => new Data.Models.AssetFilter() { Filter = asset })],
+        ExcludedAssets = ExcludedAssets == null ? [] : [..ExcludedAssets.Select(asset => new Data.Models.AssetFilter() { Filter = asset })],
     };
 }

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/SubscriptionData.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/SubscriptionData.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 
 namespace Maestro.Web.Api.v2020_02_20.Models;
 
@@ -22,21 +24,24 @@ public class SubscriptionData
 
     public bool? Enabled { get; set; }
 
+    public bool? SourceEnabled { get; set; }
+
     [Required]
     public v2018_07_16.Models.SubscriptionPolicy Policy { get; set; }
 
     public string PullRequestFailureNotificationTags { get; set; }
 
-    public Data.Models.Subscription ToDb()
+    public IReadOnlyCollection<string> ExcludedAssets { get; set; }
+
+    public Data.Models.Subscription ToDb() => new()
     {
-        return new Data.Models.Subscription
-        {
-            SourceRepository = SourceRepository,
-            TargetRepository = TargetRepository,
-            TargetBranch = TargetBranch,
-            PolicyObject = Policy.ToDb(),
-            Enabled = Enabled ?? true,
-            PullRequestFailureNotificationTags = PullRequestFailureNotificationTags
-        };
-    }
+        SourceRepository = SourceRepository,
+        TargetRepository = TargetRepository,
+        TargetBranch = TargetBranch,
+        PolicyObject = Policy.ToDb(),
+        Enabled = Enabled ?? true,
+        SourceEnabled = SourceEnabled ?? false,
+        PullRequestFailureNotificationTags = PullRequestFailureNotificationTags,
+        ExcludedAssets = [..ExcludedAssets.Select(asset => new Data.Models.AssetFilter() { Filter = asset })],
+    };
 }

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/SubscriptionUpdate.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/SubscriptionUpdate.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+
 namespace Maestro.Web.Api.v2020_02_20.Models;
 
 public class SubscriptionUpdate
@@ -9,5 +11,7 @@ public class SubscriptionUpdate
     public string SourceRepository { get; set; }
     public v2018_07_16.Models.SubscriptionPolicy Policy { get; set; }
     public bool? Enabled { get; set; }
+    public bool? SourceEnabled { get; set; }
     public string PullRequestFailureNotificationTags { get; set; }
+    public IReadOnlyCollection<string> ExcludedAssets { get; set; }
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/SubscriptionsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/SubscriptionsCommandLineOptions.cs
@@ -46,6 +46,9 @@ internal abstract class SubscriptionsCommandLineOptions : CommandLineOptions
     [Option("enabled", HelpText = "Get only enabled subscriptions.")]
     public bool Enabled { get; set; }
 
+    [Option("source-enabled", HelpText = "Get only source-enabled (VMR code flow) subscriptions.")]
+    public bool? SourceEnabled { get; set; }
+
     [Option("batchable", HelpText = "Get only batchable subscriptions.")]
     public bool Batchable { get; set; }
 
@@ -71,6 +74,7 @@ internal abstract class SubscriptionsCommandLineOptions : CommandLineOptions
                SubscriptionParameterMatches(SourceRepository, subscription.SourceRepository) &&
                SubscriptionParameterMatches(Channel, subscription.Channel.Name) &&
                SubscriptionEnabledParameterMatches(subscription) &&
+               SubscriptionSourceEnabledParameterMatches(subscription) &&
                SubscriptionBatchableParameterMatches(subscription) &&
                SubscriptionIdsParameterMatches(subscription) &&
                SubscriptionFrequenciesParameterMatches(subscription) &&
@@ -82,6 +86,11 @@ internal abstract class SubscriptionsCommandLineOptions : CommandLineOptions
         return (Enabled && subscription.Enabled) ||
                (Disabled && !subscription.Enabled) ||
                (!Enabled && !Disabled);
+    }
+
+    public bool SubscriptionSourceEnabledParameterMatches(Subscription subscription)
+    {
+        return !SourceEnabled.HasValue || subscription.SourceEnabled == SourceEnabled;
     }
 
     public bool SubscriptionBatchableParameterMatches(Subscription subscription)
@@ -140,18 +149,17 @@ internal abstract class SubscriptionsCommandLineOptions : CommandLineOptions
     /// Determine whether the set of input options has any valid filters.
     /// </summary>
     /// <returns>True if there are valid filters, false otherwise.</returns>
-    public bool HasAnyFilters()
-    {
-        return !string.IsNullOrEmpty(TargetRepository) ||
-               !string.IsNullOrEmpty(TargetBranch) ||
-               !string.IsNullOrEmpty(SourceRepository) ||
-               !string.IsNullOrEmpty(Channel) ||
-               Frequencies.Any() ||
-               !string.IsNullOrEmpty(DefaultChannelTarget) ||
-               Disabled ||
-               Enabled ||
-               Batchable ||
-               NotBatchable ||
-               SubscriptionIds.Any();
-    }
+    public bool HasAnyFilters() =>
+        !string.IsNullOrEmpty(TargetRepository)
+        || !string.IsNullOrEmpty(TargetBranch)
+        || !string.IsNullOrEmpty(SourceRepository)
+        || !string.IsNullOrEmpty(Channel)
+        || Frequencies.Any()
+        || !string.IsNullOrEmpty(DefaultChannelTarget)
+        || Disabled
+        || Enabled
+        || SourceEnabled.HasValue
+        || Batchable
+        || NotBatchable
+        || SubscriptionIds.Any();
 }

--- a/test/Maestro.ScenarioTests/ObjectHelpers/SubscriptionBuilder.cs
+++ b/test/Maestro.ScenarioTests/ObjectHelpers/SubscriptionBuilder.cs
@@ -20,7 +20,7 @@ public class SubscriptionBuilder
         UpdateFrequency updateFrequency, bool batchable, List<string> mergePolicyNames = null, List<string> ignoreChecks = null,
         string failureNotificationTags = null)
     {
-        var expectedSubscription = new Subscription(Guid.Parse(subscriptionId), true, repo1Uri, repo2Uri, targetBranch, failureNotificationTags)
+        var expectedSubscription = new Subscription(Guid.Parse(subscriptionId), true, false, repo1Uri, repo2Uri, targetBranch, failureNotificationTags, ImmutableList<string>.Empty)
         {
             Channel = new Channel(42, channelName, "test"),
             Policy = new SubscriptionPolicy(batchable, updateFrequency)

--- a/test/Microsoft.DotNet.Darc.Tests/Operations/GetBuildOperationTests.cs
+++ b/test/Microsoft.DotNet.Darc.Tests/Operations/GetBuildOperationTests.cs
@@ -48,8 +48,8 @@ public class GetBuildOperationTests
         string sha = "50c88957fb93ccaa0040b5b28ff459a29ecf88c6";
         string internalRepo = $"internal-{repo}";
         string githubRepo = $"Github-{repo}";
-        Subscription subscription1 = new(Guid.Empty, true, internalRepo, "target", "test", string.Empty);
-        Subscription subscription2 = new(Guid.Empty, true, githubRepo, "target", "test", string.Empty);
+        Subscription subscription1 = new(Guid.Empty, true, false, internalRepo, "target", "test", string.Empty, ImmutableList<string>.Empty);
+        Subscription subscription2 = new(Guid.Empty, true, false, githubRepo, "target", "test", string.Empty, ImmutableList<string>.Empty);
 
         List<Subscription> subscriptions =
         [

--- a/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_json.verified.txt
+++ b/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_json.verified.txt
@@ -16,6 +16,11 @@
     },
     "lastAppliedBuild": null,
     "enabled": true,
-    "pullRequestFailureNotificationTags": ""
+    "sourceEnabled": false,
+    "pullRequestFailureNotificationTags": "",
+    "excludedAssets": [
+      "Foo.Bar",
+      "Bar.Xyz"
+    ]
   }
 ]

--- a/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.cs
+++ b/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.cs
@@ -98,7 +98,7 @@ public class GetSubscriptionsOperationTests
     [Test]
     public async Task GetSubscriptionsOperationTests_ExecuteAsync_returns_text()
     {
-        Subscription subscription = new(Guid.Empty, true, "source", "target", "test", string.Empty)
+        Subscription subscription = new(Guid.Empty, true, false, "source", "target", "test", string.Empty, ImmutableList<string>.Empty)
         {
             Channel = new(id: 1, name: "name", classification: "classification"),
             Policy = new(batchable: false, updateFrequency: UpdateFrequency.EveryDay)
@@ -130,7 +130,7 @@ public class GetSubscriptionsOperationTests
     [Test]
     public async Task GetSubscriptionsOperationTests_ExecuteAsync_returns_json()
     {
-        Subscription subscription = new(Guid.Empty, true, "source", "target", "test", string.Empty)
+        Subscription subscription = new(Guid.Empty, true, false, "source", "target", "test", string.Empty, ImmutableList<string>.Empty)
         {
             Channel = new(id: 1, name: "name", classification: "classification"),
             Policy = new(batchable: false, updateFrequency: UpdateFrequency.EveryDay)
@@ -161,7 +161,7 @@ public class GetSubscriptionsOperationTests
     [Test]
     public async Task GetSubscriptionsOperationTests_ExecuteAsync_returns_sorted_text()
     {
-        Subscription subscription1 = new(Guid.Empty, true, "source2", "target2", "test", string.Empty)
+        Subscription subscription1 = new(Guid.Empty, true, false, "source2", "target2", "test", string.Empty, ImmutableList<string>.Empty)
         {
             Channel = new(id: 1, name: "name", classification: "classification"),
             Policy = new(batchable: false, updateFrequency: UpdateFrequency.EveryDay)
@@ -170,7 +170,7 @@ public class GetSubscriptionsOperationTests
             }
         };
 
-        Subscription subscription2 = new(Guid.Empty, true, "source1", "target1", "test", string.Empty)
+        Subscription subscription2 = new(Guid.Empty, true, false, "source1", "target1", "test", string.Empty, ImmutableList<string>.Empty)
         {
             Channel = new(id: 1, name: "name", classification: "classification"),
             Policy = new(batchable: false, updateFrequency: UpdateFrequency.EveryDay)

--- a/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.cs
+++ b/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.cs
@@ -130,7 +130,7 @@ public class GetSubscriptionsOperationTests
     [Test]
     public async Task GetSubscriptionsOperationTests_ExecuteAsync_returns_json()
     {
-        Subscription subscription = new(Guid.Empty, true, false, "source", "target", "test", string.Empty, ImmutableList<string>.Empty)
+        Subscription subscription = new(Guid.Empty, true, false, "source", "target", "test", string.Empty, ImmutableList.Create("Foo.Bar", "Bar.Xyz"))
         {
             Channel = new(id: 1, name: "name", classification: "classification"),
             Policy = new(batchable: false, updateFrequency: UpdateFrequency.EveryDay)

--- a/test/Microsoft.DotNet.DarcLib.Tests/Models/Darc/DependencyFlowNodeTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Models/Darc/DependencyFlowNodeTests.cs
@@ -76,7 +76,7 @@ public class DependencyFlowNodeTests
             WorstCasePathTime = worstCasePathTime,
         };
 
-        var subscription = new Subscription(Guid.NewGuid(), true, "source", "target", "test", string.Empty)
+        var subscription = new Subscription(Guid.NewGuid(), true, false, "source", "target", "test", string.Empty, ImmutableList<string>.Empty)
         {
             LastAppliedBuild = new Build(
             id: 1,

--- a/test/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -246,24 +247,30 @@ public class PullRequestPolicyFailureNotifierTests
         new ClientModels.Subscription(
             new Guid("35684498-9C08-431F-8E66-8242D7C38598"),
             true,
+            false,
             $"https://github.com/{FakeOrgName}/source-repo1",
             $"https://github.com/{FakeOrgName}/dest-repo",
             "fakebranch",
-            "@notifiedUser1;@notifiedUser2;userWithoutAtSign;"),
+            "@notifiedUser1;@notifiedUser2;userWithoutAtSign;",
+            ImmutableList<string>.Empty),
         new ClientModels.Subscription(
             new Guid("80B3B6EE-4C9B-46AC-B275-E016E0D5AF41"),
             true,
+            false,
             $"https://github.com/{FakeOrgName}/source-repo2",
             $"https://github.com/{FakeOrgName}/dest-repo",
             "fakebranch",
-            "@notifiedUser3;@notifiedUser4"),
+            "@notifiedUser3;@notifiedUser4",
+            ImmutableList<string>.Empty),
         new ClientModels.Subscription(
             new Guid("1802E0D2-D6BF-4A14-BF4C-B2A292739E59"),
             true,
+            false,
             $"https://github.com/{FakeOrgName}/source-repo2",
             $"https://github.com/{FakeOrgName}/dest-repo",
             "fakebranch",
-            string.Empty)
+            string.Empty,
+            ImmutableList<string>.Empty)
     ];
 
     #endregion


### PR DESCRIPTION
- Adds a new column `SourceEnabled` to the `Subscriptions` table
- Adds a new table `AssetFilers` which we will use to define the list of excluded packages for the new VMR subscriptions
- Adds a possibility to filter subscriptions based on the `SourceEnabled` flag
- Adds DB migrations + Maestro API client updates
- Does not include yet darc CLI command extensions to add/change these new subscriptions

https://github.com/dotnet/arcade-services/issues/3254

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Added new metadata to subscriptions connected to the new VMR code flow