### PR TITLE
Don't run the scan on repos with no filters

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCloakedFileScanner.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCloakedFileScanner.cs
@@ -31,6 +31,11 @@ public class VmrCloakedFileScanner : VmrScanner
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        if (sourceMapping.Exclude.Count == 0)
+        {
+            return [];
+        }
+
         var args = new List<string>
         {
             "diff",

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrScanner.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrScanner.cs
@@ -45,7 +45,7 @@ public abstract class VmrScanner : IVmrScanner
 
         _logger.LogInformation("Scanning VMR repositories for {type} files", ScanType);
 
-        foreach (var sourceMapping in _dependencyTracker.Mappings)
+        foreach (var sourceMapping in _dependencyTracker.Mappings.Where(mapping => mapping.Exclude.Count > 0))
         {
             taskList.Add(ScanSubRepository(sourceMapping, baselineFilePath, cancellationToken));
         }


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade-services/issues/3282
This error happened because of the way we're building our git command.
We're going through the list of the cloaked filters, for example `src/arcade/**/*.dll` and appending them to the `git diff --names-only <zero commit sha>` command, so Git will only look for those files.
The config had default cloaked files, so this list was never empty.
The new VMR branch `main-ub` doesn't have any default cloaked files, so some repos are just running `git diff <zero commit sha>`, which is just displaying all of the files.

If a repo has no cloaked files, we should just skip scanning it

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Don't run the VMR Cloaked File Scan on repos with no excluded files