### PR TITLE
Fix `darc add-subscription` pop-up dialog values

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
@@ -23,8 +23,8 @@ public abstract class SubscriptionPopUp : EditorPopUp
     private const string MergePolicyElement = "Merge Policies";
     private const string BatchableElement = "Batchable";
     private const string FailureNotificationTagsElement = "Pull Request Failure Notification Tags";
-    private const string SourceEnabledElement = "SourceEnabled";
-    private const string ExcludedAssetsElement = "ExcludedAssets";
+    private const string SourceEnabledElement = "Source Enabled";
+    private const string ExcludedAssetsElement = "Excluded Assets";
 
     protected readonly SubscriptionData _data;
     private readonly IEnumerable<string> _suggestedChannels;

--- a/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
@@ -168,6 +168,8 @@ internal class ScenarioTests_Subscriptions : MaestroScenarioTestBase
                     Batchable: False
                     Merge Policies:
                     - Name: Standard
+                    Source Enabled: False
+                    Excluded Assets: []
                     ";
 
                 await using AsyncDisposableValue<string> yamlSubscriptionId = await CreateSubscriptionAsync(yamlDefinition);
@@ -198,6 +200,8 @@ internal class ScenarioTests_Subscriptions : MaestroScenarioTestBase
                     Batchable: False
                     Merge Policies:
                     - Name: standard
+                    Source Enabled: False
+                    Excluded Assets: []
                     ";
 
                 await using AsyncDisposableValue<string> yamlSubscription2Id = await CreateSubscriptionAsync(yamlDefinition2);
@@ -236,6 +240,8 @@ internal class ScenarioTests_Subscriptions : MaestroScenarioTestBase
                         ignoreChecks:
                         - WIP
                         - MySpecialCheck
+                    Source Enabled: False
+                    Excluded Assets: []
                     """;
 
                 Assert.ThrowsAsync<MaestroTestException>(async () =>


### PR DESCRIPTION
Fix for a bug introduced in https://github.com/dotnet/arcade-services/issues/3281 that is failing E2E tests



### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes