### PR TITLE
Fix null exception error in Subscriptions E2E test

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/EditorPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/EditorPopUp.cs
@@ -79,6 +79,12 @@ public abstract class EditorPopUp
     /// </returns>
     protected static string ParseSetting(string inputSetting, string originalSetting, bool isSecret)
     {
+        //if the setting is null, trimming will throw an exception
+        if (string.IsNullOrEmpty(inputSetting))
+        {
+            return inputSetting;
+        }
+
         string trimmedSetting = inputSetting.Trim();
         if (trimmedSetting.StartsWith('<') && trimmedSetting.EndsWith('>'))
         {


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

I think this will fix the NullReferenceException in https://dev.azure.com/dnceng/internal/_build/results?buildId=2376388&view=ms.vss-test-web.build-test-results-tab&runId=53057251&resultId=100006&paneView=debug

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes
