### PR TITLE
Fix `darc get-latest-build` when searching multiple channels

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
@@ -501,11 +501,19 @@ public class BarApiClient : IBarApiClient
     /// <returns>Latest build of <paramref name="repoUri"/> on channel <paramref name="channelId"/>,
     /// or null if there is no latest.</returns>
     /// <remarks>The build's assets are returned</remarks>
-    public Task<Build> GetLatestBuildAsync(string repoUri, int channelId)
+    public async Task<Build> GetLatestBuildAsync(string repoUri, int channelId)
     {
-        return _barClient.Builds.GetLatestAsync(repository: repoUri,
-            channelId: channelId,
-            loadCollections: true);
+        try
+        {
+            return await _barClient.Builds.GetLatestAsync(
+                repository: repoUri,
+                channelId: channelId,
+                loadCollections: true);
+        }
+        catch (RestApiException<ApiError> e) when (e.Message.Contains("404 Not Found"))
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/Microsoft.DotNet.Darc/DarcLib/HealthMetrics/SubscriptionHealthMetric.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/HealthMetrics/SubscriptionHealthMetric.cs
@@ -203,12 +203,8 @@ public class SubscriptionHealthMetric : HealthMetric
         foreach (Subscription subscription in Subscriptions)
         {
             // Look up the latest build and add it to the dictionary.
-            Build latestBuild = null;
-            try
-            {
-                latestBuild = await _barClient.GetLatestBuildAsync(subscription.SourceRepository, subscription.Channel.Id);
-            }
-            catch (Exception)
+            Build latestBuild = await _barClient.GetLatestBuildAsync(subscription.SourceRepository, subscription.Channel.Id);
+            if (latestBuild == null)
             {
                 continue;
             }


### PR DESCRIPTION
Fixes an uncaught exception where an API used to return `null` before

https://github.com/dotnet/arcade-services/issues/3284

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Fix `darc get-latest-build` when searching multiple channels