### PR TITLE
Extend the manifest.json file generation to contain the asset owner information.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -110,9 +110,9 @@
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.14" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NuGet.Configuration" Version="6.7.0" />
-    <PackageVersion Include="NuGet.Packaging" Version="6.7.0" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.7.0" />
+    <PackageVersion Include="NuGet.Configuration" Version="6.7.1" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.7.1" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.7.1" />
     <PackageVersion Include="NUnit" Version="4.0.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="Octokit" Version="0.49.0" />

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GatherDropOperation.cs
@@ -610,7 +610,8 @@ internal class GatherDropOperation : Operation
         var manifestJson = ManifestHelper.GenerateDarcAssetJsonManifest(downloadedBuilds,
             extraAssets,
             _options.OutputDirectory,
-            _options.UseRelativePathsInManifest);
+            _options.UseRelativePathsInManifest,
+            Logger);
 
         await File.WriteAllTextAsync(outputPath, JsonConvert.SerializeObject(manifestJson, Formatting.Indented));
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/ManifestHelper.cs
@@ -65,7 +65,7 @@ public class ManifestHelper
                         new
                         {
                             name = asset.Asset.Name,
-                            origin = assetOriginMap.ContainsKey(asset.Asset.Name) ? assetOriginMap[asset.Asset.Name] : null,
+                            origin = assetOriginMap.TryGetValue(asset.Asset.Name, out var origin) ? origin : null,
                             version = asset.Asset.Version,
                             nonShipping = asset.Asset.NonShipping,
                             source = asset.SourceLocation,
@@ -119,9 +119,8 @@ public class ManifestHelper
     private static List<DownloadedAsset> SelectMergedManifestAssets(IEnumerable<DownloadedBuild> downloadedBuilds)
     {
         return downloadedBuilds
-            .Select(build => build.DownloadedAssets
+            .SelectMany(build => build.DownloadedAssets
                 .Where(asset => asset.Asset.Name.EndsWith(MergedManifestFileName)))
-            .SelectMany(x => x)
             .ToList();
     }
 
@@ -148,7 +147,7 @@ public class ManifestHelper
             if (buildName == null)
                 continue;
 
-            string repoName = buildName.Replace("dotnet-", string.Empty);
+            string repoName = buildName.Replace("dotnet-", null);
 
             foreach (var asset in buildElement?.Elements() ?? [])
             {

--- a/test/Microsoft.DotNet.DarcLib.Tests/Helpers/DarcManifestHelperTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Helpers/DarcManifestHelperTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models.Darc;
 using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using System;
@@ -26,11 +27,13 @@ public class DarcManifestHelperTests
         JObject testManifest;
         if (includeExtraAssets)
         {
-            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), GetSomeExtraDownloadedAssets(), FakeOutputPath, false);
+            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), GetSomeExtraDownloadedAssets(),
+                FakeOutputPath, false, NullLogger.Instance);
         }
         else
         {
-            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), FakeOutputPath, false);
+            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(),
+                FakeOutputPath, false, NullLogger.Instance);
         }
 
         var builds = testManifest["builds"].ToList();
@@ -80,11 +83,13 @@ public class DarcManifestHelperTests
         JObject testManifest;
         if (includeExtraAssets)
         {
-            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), GetSomeExtraDownloadedAssets(), FakeOutputPath, true);
+            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), GetSomeExtraDownloadedAssets(),
+                FakeOutputPath, true, NullLogger.Instance);
         }
         else
         {
-            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(), FakeOutputPath, true);
+            testManifest = ManifestHelper.GenerateDarcAssetJsonManifest(GetSomeShippingAssetsBuilds(),
+                FakeOutputPath, true, NullLogger.Instance);
         }
 
         var builds = testManifest["builds"].ToList();
@@ -176,7 +181,8 @@ public class DarcManifestHelperTests
     public void NoDownloadedBuildsProvided()
     {
         List<DownloadedBuild> downloadedBuilds = [];
-        JObject emptyManifest = ManifestHelper.GenerateDarcAssetJsonManifest(downloadedBuilds, FakeOutputPath, false);
+        JObject emptyManifest = ManifestHelper.GenerateDarcAssetJsonManifest(downloadedBuilds,
+            FakeOutputPath, false, NullLogger.Instance);
         var builds = emptyManifest["builds"].ToList();
         builds.Count.Should().Be(0);
         emptyManifest["outputPath"].Value<string>().Should().Be(FakeOutputPath);


### PR DESCRIPTION

<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/release/issues/820

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [x]  Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Modify the gather-drop command to add the asset owner information to the manifest.json file generation. 