### PR TITLE
Add property to MergedManifest for packages published as part of .NET

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
         [XmlAttribute(AttributeName = "NonShipping")]
         public bool NonShipping { get; set; }
 
-        [XmlAttribute(AttributeName = "NetCoreOwned")]
+        [XmlAttribute(AttributeName = "NetCoreAsset")]
         public bool NetCoreAsset { get; set; }
     }
 

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
@@ -101,8 +101,8 @@ namespace Microsoft.DotNet.Maestro.Tasks
         [XmlAttribute(AttributeName = "NonShipping")]
         public bool NonShipping { get; set; }
 
-        [XmlAttribute(AttributeName = "NetCoreAsset")]
-        public bool NetCoreAsset { get; set; }
+        [XmlAttribute(AttributeName = "DotNetReleaseShipping")]
+        public bool DotNetReleaseShipping { get; set; }
     }
 
     [XmlRoot(ElementName = "Blob")]
@@ -116,6 +116,9 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
         [XmlAttribute(AttributeName = "Category")]
         public string Category { get; set; }
+
+        [XmlAttribute(AttributeName = "DotNetReleaseShipping")]
+        public bool DotNetReleaseShipping { get; set; }
     }
 
     [XmlRoot(ElementName = "SigningInformation")]

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
@@ -92,16 +92,19 @@ namespace Microsoft.DotNet.Maestro.Tasks
     [XmlRoot(ElementName = "Package")]
     public class Package
     {
+        public const string NonShippingAttributeName = "NonShipping";
+        public const string NetCoreAssetAttributeName = "NetCoreAsset";
+
         [XmlAttribute(AttributeName = "Id")]
         public string Id { get; set; }
 
         [XmlAttribute(AttributeName = "Version")]
         public string Version { get; set; }
 
-        [XmlAttribute(AttributeName = "NonShipping")]
+        [XmlAttribute(AttributeName = NetCoreAssetAttributeName)]
         public bool NonShipping { get; set; }
 
-        [XmlAttribute(AttributeName = "NetCoreAsset")]
+        [XmlAttribute(AttributeName = NetCoreAssetAttributeName)]
         public bool NetCoreAsset { get; set; }
     }
 

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
@@ -92,19 +92,16 @@ namespace Microsoft.DotNet.Maestro.Tasks
     [XmlRoot(ElementName = "Package")]
     public class Package
     {
-        public const string NonShippingAttributeName = "NonShipping";
-        public const string NetCoreAssetAttributeName = "NetCoreAsset";
-
         [XmlAttribute(AttributeName = "Id")]
         public string Id { get; set; }
 
         [XmlAttribute(AttributeName = "Version")]
         public string Version { get; set; }
 
-        [XmlAttribute(AttributeName = NetCoreAssetAttributeName)]
+        [XmlAttribute(AttributeName = "NonShipping")]
         public bool NonShipping { get; set; }
 
-        [XmlAttribute(AttributeName = NetCoreAssetAttributeName)]
+        [XmlAttribute(AttributeName = "NetCoreAsset")]
         public bool NetCoreAsset { get; set; }
     }
 

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
@@ -100,6 +100,9 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
         [XmlAttribute(AttributeName = "NonShipping")]
         public bool NonShipping { get; set; }
+
+        [XmlAttribute(AttributeName = "NetCoreOwned")]
+        public bool NetCoreAsset { get; set; }
     }
 
     [XmlRoot(ElementName = "Blob")]

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -45,9 +45,6 @@ namespace Microsoft.DotNet.Maestro.Tasks
         private const string SearchPattern = "*.xml";
         private const string MergedManifestFileName = "MergedManifest.xml";
         private const string NoCategory = "NONE";
-        private const string NonShippingAttributeName = "NonShipping";
-        private const string NetCoreAssetAttributeName = "NetCoreAsset";
-        private const string CategoryAttributeName = "Category";
         private readonly CancellationTokenSource _tokenSource = new CancellationTokenSource();
         private string _gitHubRepository = "";
         private string _gitHubBranch = "";
@@ -56,6 +53,9 @@ namespace Microsoft.DotNet.Maestro.Tasks
         internal IVersionIdentifierProxy _versionIdentifier = new VersionIdentifierProxy();
         internal IGetEnvProxy _getEnvProxy = new GetEnvProxy();
 
+        public const string NonShippingAttributeName = "NonShipping";
+        public const string NetCoreAssetAttributeName = "NetCoreAsset";
+        public const string CategoryAttributeName = "Category";
         public void Cancel()
         {
             _tokenSource.Cancel();

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
         internal IGetEnvProxy _getEnvProxy = new GetEnvProxy();
 
         public const string NonShippingAttributeName = "NonShipping";
-        public const string NetCoreAssetAttributeName = "NetCoreAsset";
+        public const string DotNetReleaseShippingAttributeName = "DotNetReleaseShipping";
         public const string CategoryAttributeName = "Category";
         public void Cancel()
         {
@@ -497,7 +497,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                     Attributes = new Dictionary<string, string>
                     {
                         { NonShippingAttributeName, package.NonShipping.ToString().ToLower() },
-                        { NetCoreAssetAttributeName, package.NetCoreAsset.ToString().ToLower() }
+                        { DotNetReleaseShippingAttributeName, package.DotNetReleaseShipping.ToString().ToLower() }
                     },
                     Id = package.Id,
                     Version = package.Version
@@ -516,7 +516,8 @@ namespace Microsoft.DotNet.Maestro.Tasks
                         {
                             CategoryAttributeName,
                             !string.IsNullOrEmpty(blob.Category) ? blob.Category.ToString().ToUpper() : NoCategory
-                        }
+                        },
+                        { DotNetReleaseShippingAttributeName, blob.DotNetReleaseShipping.ToString().ToLower() }
                     },
                     Id = blob.Id,
                 };

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -56,6 +56,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
         public const string NonShippingAttributeName = "NonShipping";
         public const string DotNetReleaseShippingAttributeName = "DotNetReleaseShipping";
         public const string CategoryAttributeName = "Category";
+
         public void Cancel()
         {
             _tokenSource.Cancel();

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -494,6 +494,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                     Attributes = new Dictionary<string, string>
                     {
                         { "NonShipping", package.NonShipping.ToString().ToLower() },
+                        { "NetCoreAsset", package.NetCoreAsset.ToString().ToLower() }
                     },
                     Id = package.Id,
                     Version = package.Version

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -45,6 +45,9 @@ namespace Microsoft.DotNet.Maestro.Tasks
         private const string SearchPattern = "*.xml";
         private const string MergedManifestFileName = "MergedManifest.xml";
         private const string NoCategory = "NONE";
+        private const string NonShippingAttributeName = "NonShipping";
+        private const string NetCoreAssetAttributeName = "NetCoreAsset";
+        private const string CategoryAttributeName = "Category";
         private readonly CancellationTokenSource _tokenSource = new CancellationTokenSource();
         private string _gitHubRepository = "";
         private string _gitHubBranch = "";
@@ -493,8 +496,8 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 {
                     Attributes = new Dictionary<string, string>
                     {
-                        { "NonShipping", package.NonShipping.ToString().ToLower() },
-                        { "NetCoreAsset", package.NetCoreAsset.ToString().ToLower() }
+                        { NonShippingAttributeName, package.NonShipping.ToString().ToLower() },
+                        { NetCoreAssetAttributeName, package.NetCoreAsset.ToString().ToLower() }
                     },
                     Id = package.Id,
                     Version = package.Version
@@ -509,9 +512,9 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 {
                     Attributes = new Dictionary<string, string>
                     {
-                        { "NonShipping", blob.NonShipping.ToString().ToLower() },
+                        { NonShippingAttributeName, blob.NonShipping.ToString().ToLower() },
                         {
-                            "Category",
+                            CategoryAttributeName,
                             !string.IsNullOrEmpty(blob.Category) ? blob.Category.ToString().ToUpper() : NoCategory
                         }
                     },
@@ -738,7 +741,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
             {
                 Attributes = new Dictionary<string, string>()
                 {
-                    { "NonShipping", "true" }
+                    { NonShippingAttributeName, "true" }
                 },
                 Id = $"{Id}"
             };

--- a/test/Microsoft.DotNet.Maestro.Tasks.Tests/CreateMergedManifestBuildModelTests.cs
+++ b/test/Microsoft.DotNet.Maestro.Tasks.Tests/CreateMergedManifestBuildModelTests.cs
@@ -38,7 +38,7 @@ internal class CreateMergedManifestBuildModelTests
     {
         Attributes = new Dictionary<string, string>
         {
-            { "NonShipping", "true" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" }
         },
         Id = "Microsoft.DotNet.ApiCompat",
         Version = Version
@@ -48,7 +48,7 @@ internal class CreateMergedManifestBuildModelTests
     {
         Attributes = new Dictionary<string, string>
         {
-            { "NonShipping", "true" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" }
         },
         Id = "Microsoft.Cci.Extensions",
         Version = Version
@@ -58,7 +58,7 @@ internal class CreateMergedManifestBuildModelTests
     {
         Attributes = new Dictionary<string, string>
         {
-            { "NonShipping", "true" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" }
         },
         Id = "Microsoft.Cci.Extensions",
         Version = null
@@ -68,7 +68,7 @@ internal class CreateMergedManifestBuildModelTests
     {
         Attributes = new Dictionary<string, string>
         {
-            { "NonShipping", "false" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "false" }
         },
         Id = "Microsoft.DotNet.ApiCompat",
         Version = Version
@@ -80,8 +80,8 @@ internal class CreateMergedManifestBuildModelTests
     {
         Attributes = new Dictionary<string, string>
         {
-            { "NonShipping", "true" },
-            { "Category", "other" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
+            { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "other" }
         },
         Id = "assets/symbols/Microsoft.Cci.Extensions.6.0.0-beta.20516.5.symbols.nupkg"
     };
@@ -90,7 +90,7 @@ internal class CreateMergedManifestBuildModelTests
     {
         Attributes = new Dictionary<string, string>
         {
-            { "NonShipping", "true" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" }
         },
         Id = $"assets/manifests/{BuildRepoName}/{Id}/{MergedManifestName}"
     };
@@ -99,8 +99,8 @@ internal class CreateMergedManifestBuildModelTests
     {
         Attributes = new Dictionary<string, string>
         {
-            { "NonShipping", "true" },
-            { "Category", "none" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
+            { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "none" }
         },
         Id = "assets/symbols/Microsoft.DotNet.ApiCompat.6.0.0-beta.20516.5.symbols.nupkg"
     };
@@ -109,8 +109,8 @@ internal class CreateMergedManifestBuildModelTests
     {
         Attributes = new Dictionary<string, string>
         {
-            { "NonShipping", "false" },
-            { "Category", "none" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "false" },
+            { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "none" }
         },
         Id = "assets/symbols/Microsoft.DotNet.Maestro.Client.6.0.0-beta.20516.5.symbols.nupkg"
     };

--- a/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
+++ b/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
@@ -108,7 +108,7 @@ public class ParseBuildManifestMetadataTests
         Id = "Microsoft.Cci.Extensions",
         NonShipping = true,
         Version = Version,
-        NetCoreAsset = true
+        DotNetReleaseShipping = true
     };
 
     private static readonly Package package2 = new()
@@ -123,7 +123,7 @@ public class ParseBuildManifestMetadataTests
         Attributes = new Dictionary<string, string>()
         {
             { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
-            { PushMetadataToBuildAssetRegistry.NetCoreAssetAttributeName, "true" }
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "true" }
         },
         Id = "Microsoft.Cci.Extensions",
         Version = Version
@@ -134,7 +134,7 @@ public class ParseBuildManifestMetadataTests
         Attributes = new Dictionary<string, string>()
         {
             { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
-            { PushMetadataToBuildAssetRegistry.NetCoreAssetAttributeName, "false" }
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" }
         },
         Id = "Microsoft.DotNet.ApiCompat",
         Version = Version
@@ -145,7 +145,7 @@ public class ParseBuildManifestMetadataTests
         Attributes = new Dictionary<string, string>()
         {
             { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
-            { PushMetadataToBuildAssetRegistry.NetCoreAssetAttributeName, "false" }
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" }
         },
         Id = "Microsoft.Cci.Extensions",
         Version = null
@@ -175,7 +175,8 @@ public class ParseBuildManifestMetadataTests
         Attributes = new Dictionary<string, string>()
         {
             { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
-            { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "NONE" }
+            { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "NONE" },
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" }
         },
         Id = "assets/manifests/dotnet-arcade/6.0.0-beta.20516.5/MergedManifest.xml"
     };
@@ -185,7 +186,8 @@ public class ParseBuildManifestMetadataTests
         Attributes = new Dictionary<string, string>()
         {
             { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
-            { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "OTHER" }
+            { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "OTHER" },
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" }
         },
         Id = "assets/symbols/Microsoft.Cci.Extensions.6.0.0-beta.20516.5.symbols.nupkg"
     };
@@ -195,7 +197,8 @@ public class ParseBuildManifestMetadataTests
         Attributes = new Dictionary<string, string>()
         {
             { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
-            { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "NONE" }
+            { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "NONE" },
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" }
         },
         Id = "assets/symbols/Microsoft.DotNet.Arcade.Sdk.6.0.0-beta.20516.5.symbols.nupkg"
     };

--- a/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
+++ b/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
@@ -122,8 +122,8 @@ public class ParseBuildManifestMetadataTests
     {
         Attributes = new Dictionary<string, string>()
         {
-            { "NonShipping", "true" },
-            { "NetCoreAsset", "true" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
+            { PushMetadataToBuildAssetRegistry.NetCoreAssetAttributeName, "true" }
         },
         Id = "Microsoft.Cci.Extensions",
         Version = Version
@@ -133,8 +133,8 @@ public class ParseBuildManifestMetadataTests
     {
         Attributes = new Dictionary<string, string>()
         {
-            { "NonShipping", "true" },
-            { "NetCoreAsset", "false" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
+            { PushMetadataToBuildAssetRegistry.NetCoreAssetAttributeName, "false" }
         },
         Id = "Microsoft.DotNet.ApiCompat",
         Version = Version
@@ -144,8 +144,8 @@ public class ParseBuildManifestMetadataTests
     {
         Attributes = new Dictionary<string, string>()
         {
-            { "NonShipping", "true" },
-            { "NetCoreAsset", "false" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
+            { PushMetadataToBuildAssetRegistry.NetCoreAssetAttributeName, "false" }
         },
         Id = "Microsoft.Cci.Extensions",
         Version = null
@@ -174,8 +174,8 @@ public class ParseBuildManifestMetadataTests
     {
         Attributes = new Dictionary<string, string>()
         {
-            { "NonShipping", "true" },
-            { "Category", "NONE" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
+            { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "NONE" }
         },
         Id = "assets/manifests/dotnet-arcade/6.0.0-beta.20516.5/MergedManifest.xml"
     };
@@ -184,8 +184,8 @@ public class ParseBuildManifestMetadataTests
     {
         Attributes = new Dictionary<string, string>()
         {
-            { "NonShipping", "true" },
-            { "Category", "OTHER" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
+            { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "OTHER" }
         },
         Id = "assets/symbols/Microsoft.Cci.Extensions.6.0.0-beta.20516.5.symbols.nupkg"
     };
@@ -194,8 +194,8 @@ public class ParseBuildManifestMetadataTests
     {
         Attributes = new Dictionary<string, string>()
         {
-            { "NonShipping", "true" },
-            { "Category", "NONE" }
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
+            { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "NONE" }
         },
         Id = "assets/symbols/Microsoft.DotNet.Arcade.Sdk.6.0.0-beta.20516.5.symbols.nupkg"
     };

--- a/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
+++ b/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
@@ -107,7 +107,8 @@ public class ParseBuildManifestMetadataTests
     {
         Id = "Microsoft.Cci.Extensions",
         NonShipping = true,
-        Version = Version
+        Version = Version,
+        NetCoreAsset = true
     };
 
     private static readonly Package package2 = new()
@@ -121,7 +122,8 @@ public class ParseBuildManifestMetadataTests
     {
         Attributes = new Dictionary<string, string>()
         {
-            { "NonShipping", "true" }
+            { "NonShipping", "true" },
+            { "NetCoreAsset", "true" }
         },
         Id = "Microsoft.Cci.Extensions",
         Version = Version
@@ -131,7 +133,8 @@ public class ParseBuildManifestMetadataTests
     {
         Attributes = new Dictionary<string, string>()
         {
-            { "NonShipping", "true" }
+            { "NonShipping", "true" },
+            { "NetCoreAsset", "false" }
         },
         Id = "Microsoft.DotNet.ApiCompat",
         Version = Version
@@ -141,7 +144,8 @@ public class ParseBuildManifestMetadataTests
     {
         Attributes = new Dictionary<string, string>()
         {
-            { "NonShipping", "true" }
+            { "NonShipping", "true" },
+            { "NetCoreAsset", "false" }
         },
         Id = "Microsoft.Cci.Extensions",
         Version = null


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

Issue: https://github.com/dotnet/arcade-services/issues/3308

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Add `DotNetReleaseShipping` property to assets in MergedManifest.xml
