### PR TITLE
Do not flow packages in forward code flow

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -108,7 +108,7 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
         var mapping = _dependencyTracker.Mappings.First(m => m.Name == mappingName);
         Codeflow lastFlow = await GetLastFlowAsync(mapping, sourceRepo, currentIsBackflow: false);
 
-        var branchName = await FlowCodeAsync(
+        return await FlowCodeAsync(
             lastFlow,
             new ForwardFlow(lastFlow.TargetSha, shaToFlow),
             sourceRepo,
@@ -116,13 +116,6 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             build,
             discardPatches,
             cancellationToken);
-
-        if (branchName != null)
-        {
-            await UpdateDependenciesAndToolset(repoPath, LocalVmr, build, shaToFlow, updateSourceElement: false, cancellationToken);
-        }
-
-        return branchName;
     }
 
     protected override async Task<string?> SameDirectionFlowAsync(

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeflowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeflowTest.cs
@@ -268,26 +268,6 @@ internal class VmrCodeflowTest :  VmrTestsBase
         await GitOperations.MergePrBranch(VmrPath, branch!);
 
         CheckFileContents(_productRepoVmrFilePath, "Change that will have a build");
-
-        // Verify that Version.Details.xml got updated with the new package "built" in the repo
-        Local local = GetLocal(VmrPath);
-        List<DependencyDetail> dependencies = await local.GetDependenciesAsync();
-
-        dependencies.Should().HaveCount(1);
-        dependencies.Should().Contain(dep =>
-            dep.Name == DependencyFileManager.ArcadeSdkPackageName
-            && dep.RepoUri == build.GitHubRepository
-            && dep.Commit == build.Commit
-            && dep.Version == newVersion);
-
-        // Verify that global.json got updated
-        DependencyFileManager dependencyFileManager = GetDependencyFileManager();
-        JObject globalJson = await dependencyFileManager.ReadGlobalJsonAsync(VmrPath, "main");
-        JToken? arcadeVersion = globalJson.SelectToken($"msbuild-sdks.['{DependencyFileManager.ArcadeSdkPackageName}']", true);
-        arcadeVersion?.ToString().Should().Be(newVersion);
-
-        var dotnetVersion = await dependencyFileManager.ReadToolsDotnetVersionAsync(VmrPath, "main");
-        dotnetVersion.ToString().Should().Be("9.0.200");
     }
 
     [Test]


### PR DESCRIPTION
We have decided to not flow packages for forward flow after all. I separated this removal into a dedicated PR because we might reconsider it in the future so it might be valuable to keep it as a separate commit.

https://github.com/dotnet/arcade-services/issues/3253


<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes