### PR TITLE
Allow code flow branch name customization

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
@@ -16,7 +16,7 @@ internal class BackflowOperation(BackflowCommandLineOptions options)
 {
     private readonly BackflowCommandLineOptions _options = options;
 
-    protected override async Task<string?> FlowAsync(
+    protected override async Task<bool> FlowAsync(
         string mappingName,
         NativePath targetDirectory,
         string? shaToFlow,
@@ -27,6 +27,7 @@ internal class BackflowOperation(BackflowCommandLineOptions options)
                 new NativePath(targetDirectory),
                 shaToFlow,
                 _options.Build,
+                _options.BranchName,
                 _options.DiscardPatches,
                 cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/CodeFlowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/CodeFlowOperation.cs
@@ -57,7 +57,7 @@ internal abstract class CodeFlowOperation : VmrOperationBase
             cancellationToken);
     }
 
-    protected abstract Task<string?> FlowAsync(
+    protected abstract Task<bool> FlowAsync(
         string mappingName,
         NativePath targetDirectory,
         string? shaToFlow,

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/ForwardFlowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/ForwardFlowOperation.cs
@@ -16,7 +16,7 @@ internal class ForwardFlowOperation(ForwardFlowCommandLineOptions options)
 {
     private readonly ForwardFlowCommandLineOptions _options = options;
 
-    protected override async Task<string?> FlowAsync(
+    protected override async Task<bool> FlowAsync(
         string mappingName,
         NativePath targetDirectory,
         string? shaToFlow,
@@ -27,6 +27,7 @@ internal class ForwardFlowOperation(ForwardFlowCommandLineOptions options)
                 new NativePath(targetDirectory),
                 shaToFlow,
                 _options.Build,
+                _options.BranchName,
                 _options.DiscardPatches,
                 cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/CodeFlowCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/CodeFlowCommandLineOptions.cs
@@ -17,15 +17,18 @@ internal abstract class CodeFlowCommandLineOptions : VmrCommandLineOptions, IBas
     public IEnumerable<string> AdditionalRemotes { get; set; }
 
     [Option("repository-dirs", Required = false, HelpText = "Path to where all repositories are checked out to (directory names must match mapping names). " +
-        "Substitutes the need to specify path for every backflown repository")]
+        "Substitutes the need to specify path for every backflown repository.")]
     public string RepositoryDirectory { get; set; }
 
     [Option("discard-patches", Required = false, HelpText = "Delete .patch files created during the sync.")]
     public bool DiscardPatches { get; set; } = false;
 
-    [Option("build", Required = false, HelpText = "If specified, flows the given build. Cannot be used with --ref")]
+    [Option("build", Required = false, HelpText = "If specified, flows the given build. Cannot be used with --ref.")]
     public int? Build { get; set; }
 
-    [Option("commit", Required = false, HelpText = "If specified, flows the given commit. Cannot be used with --build")]
+    [Option("commit", Required = false, HelpText = "If specified, flows the given commit. Cannot be used with --build.")]
     public string Commit { get; set; }
+
+    [Option("branch-name", Required = false, HelpText = "Name of the new branch that will be created in the target repository. Defaults to codeflow/backflow/SHA1-SHA2")]
+    public string BranchName { get; set; }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -71,20 +71,21 @@ internal abstract class VmrCodeFlower
     /// The algorithm is described in depth in the Unified Build documentation
     /// https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Full-Code-Flow.md#the-code-flow-algorithm
     /// </summary>
-    /// <returns>Name of the PR branch that was created for the changes</returns>
-    protected async Task<string?> FlowCodeAsync(
+    /// <returns>True if there were changes to flow</returns>
+    protected async Task<bool> FlowCodeAsync(
         Codeflow lastFlow,
         Codeflow currentFlow,
         ILocalGitRepo repo,
         SourceMapping mapping,
         Build? build,
+        string? branchName,
         bool discardPatches,
         CancellationToken cancellationToken = default)
     {
         if (lastFlow.SourceSha == currentFlow.TargetSha)
         {
             _logger.LogInformation("No new commits to flow from {sourceRepo}", currentFlow is Backflow ? "VMR" : mapping.Name);
-            return null;
+            return false;
         }
 
         _logger.LogInformation("Last flow was {type} flow: {sourceSha} -> {targetSha}",
@@ -92,38 +93,41 @@ internal abstract class VmrCodeFlower
             lastFlow.SourceSha,
             lastFlow.TargetSha);
 
-        string? branchName;
+        branchName ??= currentFlow.GetBranchName();
+
+        bool hasChanges;
         if (lastFlow.Name == currentFlow.Name)
         {
             _logger.LogInformation("Current flow is in the same direction");
-            branchName = await SameDirectionFlowAsync(mapping, lastFlow, currentFlow, repo, build, discardPatches, cancellationToken);
+            hasChanges = await SameDirectionFlowAsync(mapping, lastFlow, currentFlow, repo, build, branchName, discardPatches, cancellationToken);
         }
         else
         {
             _logger.LogInformation("Current flow is in the opposite direction");
-            branchName = await OppositeDirectionFlowAsync(mapping, lastFlow, currentFlow, repo, build, discardPatches, cancellationToken);
+            hasChanges = await OppositeDirectionFlowAsync(mapping, lastFlow, currentFlow, repo, build, branchName, discardPatches, cancellationToken);
         }
 
-        if (branchName is null)
+        if (!hasChanges)
         {
             // TODO: Clean up repos?
             _logger.LogInformation("Nothing to flow from {sourceRepo}", currentFlow is Backflow ? "VMR" : mapping.Name);
         }
 
-        return branchName;
+        return hasChanges;
     }
 
     /// <summary>
     /// Handles flowing changes that succeed a flow that was in the same direction (outgoing from the source repo).
     /// The changes that are flown are taken from a simple patch of changes that occurred since the last flow.
     /// </summary>
-    /// <returns>Name of the PR branch that was created for the changes</returns>
-    protected abstract Task<string?> SameDirectionFlowAsync(
+    /// <returns>True if there were changes to flow</returns>
+    protected abstract Task<bool> SameDirectionFlowAsync(
         SourceMapping mapping,
         Codeflow lastFlow,
         Codeflow currentFlow,
         ILocalGitRepo repo,
         Build? build,
+        string branchName,
         bool discardPatches,
         CancellationToken cancellationToken);
 
@@ -131,13 +135,14 @@ internal abstract class VmrCodeFlower
     /// Handles flowing changes that succeed a flow that was in the opposite direction (incoming in the source repo).
     /// The changes that are flown are taken from a diff of repo contents and the last sync point from the last flow.
     /// </summary>
-    /// <returns>Name of the PR branch that was created for the changes</returns>
-    protected abstract Task<string?> OppositeDirectionFlowAsync(
+    /// <returns>True if there were changes to flow</returns>
+    protected abstract Task<bool> OppositeDirectionFlowAsync(
         SourceMapping mapping,
         Codeflow lastFlow,
         Codeflow currentFlow,
         ILocalGitRepo repo,
         Build? build,
+        string branchName,
         bool discardPatches,
         CancellationToken cancellationToken);
 
@@ -375,7 +380,7 @@ internal abstract class VmrCodeFlower
 
         public abstract string VmrSha { get; init; }
 
-        public string GetBranchName() => $"codeflow/{Name}/{Commit.GetShortSha(SourceSha)}-{Commit.GetShortSha(TargetSha)}";
+        public string GetBranchName() => $"darc/{Name}/{Commit.GetShortSha(SourceSha)}-{Commit.GetShortSha(TargetSha)}";
 
         public abstract string Name { get; }
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/WorkBranchFactory.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/WorkBranchFactory.cs
@@ -32,7 +32,7 @@ public class WorkBranchFactory(ILogger<WorkBranch> logger) : IWorkBranchFactory
             throw new Exception(message);
         }
 
-        _logger.LogInformation("Creating a temporary work branch {branchName}", branchName);
+        _logger.LogInformation("Creating a branch {branchName}", branchName);
 
         await repo.CreateBranchAsync(branchName, overwriteExistingBranch: true);
 

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -176,16 +176,16 @@ internal abstract class VmrTestsBase
         await vmrUpdater.UpdateRepository(repository, commit, null, true, additionalRemotes, null, null, generateCodeowners, true, _cancellationToken.Token);
     }
 
-    protected async Task<string?> CallDarcBackflow(string mappingName, NativePath repoPath, string? shaToFlow = null, int? buildToFlow = null)
+    protected async Task<bool> CallDarcBackflow(string mappingName, NativePath repoPath, string branch, string? shaToFlow = null, int? buildToFlow = null)
     {
         var codeflower = _serviceProvider.Value.GetRequiredService<IVmrBackFlower>();
-        return await codeflower.FlowBackAsync(mappingName, repoPath, shaToFlow, buildToFlow, cancellationToken: _cancellationToken.Token);
+        return await codeflower.FlowBackAsync(mappingName, repoPath, shaToFlow, buildToFlow, branch, cancellationToken: _cancellationToken.Token);
     }
 
-    protected async Task<string?> CallDarcForwardflow(string mappingName, NativePath repoPath, string? shaToFlow = null, int? buildToFlow = null)
+    protected async Task<bool> CallDarcForwardflow(string mappingName, NativePath repoPath, string branch, string? shaToFlow = null, int? buildToFlow = null)
     {
         var codeflower = _serviceProvider.Value.GetRequiredService<IVmrForwardFlower>();
-        return await codeflower.FlowForwardAsync(mappingName, repoPath, shaToFlow, buildToFlow, cancellationToken: _cancellationToken.Token);
+        return await codeflower.FlowForwardAsync(mappingName, repoPath, shaToFlow, buildToFlow, branch, cancellationToken: _cancellationToken.Token);
     }
 
     protected async Task<List<string>> CallDarcCloakedFileScan(string baselinesFilePath)


### PR DESCRIPTION
This will allow us to be able to control the name of the PR branch from Maestro.
Before we used to signal with branch name or `null` whether a new branch was created but now we return a boolean.

https://github.com/dotnet/arcade-services/issues/3317


<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Made the VMR code flow branch name customizable
