### PR TITLE
Allow targeting a specific branch in VMR code flow

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitRepoUrlParser.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitRepoUrlParser.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.Helpers;
@@ -62,6 +65,9 @@ public static class GitRepoUrlParser
 
         return 1;
     }
+
+    public static IEnumerable<string> OrderRemotesByLocalPublicOther(this IEnumerable<string> uris)
+        => uris.OrderBy(ParseTypeFromUri, Comparer<GitRepoType>.Create(OrderByLocalPublicOther));
 
     public static (string RepoName, string Org) GetRepoNameAndOwner(string uri)
     {

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
@@ -141,7 +141,7 @@ public class SourceManifest : ISourceManifest
     {
         if (!File.Exists(path))
         {
-            return new SourceManifest(Array.Empty<RepositoryRecord>(), Array.Empty<SubmoduleRecord>());
+            return new SourceManifest([], []);
         }
 
         var options = new JsonSerializerOptions
@@ -176,7 +176,7 @@ public class SourceManifest : ISourceManifest
     /// </summary>
     private class SourceManifestWrapper
     {
-        public ICollection<RepositoryRecord> Repositories { get; init; } = Array.Empty<RepositoryRecord>();
-        public ICollection<SubmoduleRecord> Submodules { get; init; } = Array.Empty<SubmoduleRecord>();
+        public ICollection<RepositoryRecord> Repositories { get; init; } = [];
+        public ICollection<SubmoduleRecord> Submodules { get; init; } = [];
     }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
@@ -1,14 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
-using static Microsoft.VisualStudio.Services.Graph.GraphResourceIds.Users;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 #nullable enable
 namespace Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
@@ -24,8 +23,8 @@ public interface ISourceManifest
     void UpdateSubmodule(SubmoduleRecord submodule);
     void UpdateVersion(string repository, string uri, string sha, string? packageVersion);
     VmrDependencyVersion? GetVersion(string repository);
-    bool TryGetRepoVersion(string mappingName, [NotNullWhen(true)] out IVersionedSourceComponent? mapping);
-    IVersionedSourceComponent GetRepoVersion(string mappingName);
+    bool TryGetRepoVersion(string mappingName, [NotNullWhen(true)] out ISourceComponent? mapping);
+    ISourceComponent GetRepoVersion(string mappingName);
     void Refresh(string sourceManifestPath);
 }
 
@@ -126,13 +125,14 @@ public class SourceManifest : ISourceManifest
         _submodules = newManifst._submodules;
     }
 
-    public bool TryGetRepoVersion(string mappingName, [NotNullWhen(true)] out IVersionedSourceComponent? version)
+    public bool TryGetRepoVersion(string mappingName, [NotNullWhen(true)] out ISourceComponent? version)
     {
         version = Repositories.FirstOrDefault(m => m.Path.Equals(mappingName, StringComparison.InvariantCultureIgnoreCase));
+        version ??= Submodules.FirstOrDefault(m => m.Path.Equals(mappingName, StringComparison.InvariantCultureIgnoreCase));
         return version != null;
     }
 
-    public IVersionedSourceComponent GetRepoVersion(string mappingName)
+    public ISourceComponent GetRepoVersion(string mappingName)
         => TryGetRepoVersion(mappingName, out var version)
             ? version
             : throw new Exception($"No manifest record named {mappingName} found");
@@ -164,7 +164,7 @@ public class SourceManifest : ISourceManifest
         if (repositoryRecord != null)
         {
             return new(repositoryRecord.CommitSha, repositoryRecord.PackageVersion);
-        } 
+        }
         else
         {
             return null;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -127,7 +127,7 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             await CheckOutVmr(shaToFlow);
         }
 
-        var mapping = _dependencyTracker.Mappings.First(m => m.Name == mappingName);
+        var mapping = _dependencyTracker.GetMapping(mappingName);
         Codeflow lastFlow = await GetLastFlowAsync(mapping, targetRepo, currentIsBackflow: true);
 
         var hasChanges = await FlowCodeAsync(

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -16,6 +16,17 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IVmrBackFlower
 {
+    /// <summary>
+    /// Flows backward the code from the VMR to the target branch of a product repo.
+    /// This overload is used in the context of the darc CLI.
+    /// </summary>
+    /// <param name="mapping">Mapping to flow</param>
+    /// <param name="targetRepo">Local checkout of the repository</param>
+    /// <param name="shaToFlow">SHA to flow</param>
+    /// <param name="buildToFlow">Build to flow</param>
+    /// <param name="branchName">New branch name</param>
+    /// <param name="targetBranch">Target branch to create the PR branch on top of</param>
+    /// <param name="discardPatches">Keep patch files?</param>
     Task<bool> FlowBackAsync(
         string mapping,
         NativePath targetRepo,
@@ -25,6 +36,17 @@ public interface IVmrBackFlower
         bool discardPatches = false,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Flows backward the code from the VMR to the target branch of a product repo.
+    /// This overload is used in the context of the darc CLI.
+    /// </summary>
+    /// <param name="mapping">Mapping to flow</param>
+    /// <param name="targetRepo">Local checkout of the repository</param>
+    /// <param name="shaToFlow">SHA to flow</param>
+    /// <param name="buildToFlow">Build to flow</param>
+    /// <param name="branchName">New branch name</param>
+    /// <param name="targetBranch">Target branch to create the PR branch on top of</param>
+    /// <param name="discardPatches">Keep patch files?</param>
     Task<bool> FlowBackAsync(
         string mapping,
         ILocalGitRepo targetRepo,
@@ -33,26 +55,30 @@ public interface IVmrBackFlower
         string? branchName,
         bool discardPatches = false,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Flows backward the code from the VMR to the target branch of a product repo.
+    /// This overload is used in the context of the PCS.
+    /// </summary>
+    /// <param name="mappingName">Mapping to flow</param>
+    /// <param name="build">Build to flow</param>
+    /// <param name="branchName">New branch name</param>
+    /// <param name="targetBranch">Target branch to create the PR branch on top of</param>
+    /// <returns>True when there were changes to be flown</returns>
+    Task<bool> FlowBackAsync(
+        string mappingName,
+        Build build,
+        string branchName,
+        string targetBranch,
+        CancellationToken cancellationToken = default);
 }
 
-internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
-{
-    private readonly IVmrInfo _vmrInfo;
-    private readonly ISourceManifest _sourceManifest;
-    private readonly IVmrDependencyTracker _dependencyTracker;
-    private readonly ILocalGitClient _localGitClient;
-    private readonly ILocalGitRepoFactory _localGitRepoFactory;
-    private readonly IVmrPatchHandler _vmrPatchHandler;
-    private readonly IWorkBranchFactory _workBranchFactory;
-    private readonly IBasicBarClient _barClient;
-    private readonly IFileSystem _fileSystem;
-    private readonly ILogger<VmrCodeFlower> _logger;
-
-    public VmrBackFlower(
+internal class VmrBackFlower(
         IVmrInfo vmrInfo,
         ISourceManifest sourceManifest,
         IVmrDependencyTracker dependencyTracker,
         IDependencyFileManager dependencyFileManager,
+        IRepositoryCloneManager repositoryCloneManager,
         ILocalGitClient localGitClient,
         ILocalGitRepoFactory localGitRepoFactory,
         IVersionDetailsParser versionDetailsParser,
@@ -64,31 +90,20 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         IAssetLocationResolver assetLocationResolver,
         IFileSystem fileSystem,
         ILogger<VmrCodeFlower> logger)
-        : base(
-            vmrInfo,
-            sourceManifest,
-            dependencyTracker,
-            localGitClient,
-            libGit2Client,
-            localGitRepoFactory,
-            versionDetailsParser,
-            dependencyFileManager,
-            coherencyUpdateResolver,
-            assetLocationResolver,
-            fileSystem,
-            logger)
-    {
-        _vmrInfo = vmrInfo;
-        _sourceManifest = sourceManifest;
-        _dependencyTracker = dependencyTracker;
-        _localGitClient = localGitClient;
-        _localGitRepoFactory = localGitRepoFactory;
-        _vmrPatchHandler = vmrPatchHandler;
-        _workBranchFactory = workBranchFactory;
-        _barClient = basicBarClient;
-        _fileSystem = fileSystem;
-        _logger = logger;
-    }
+    : VmrCodeFlower(vmrInfo, sourceManifest, dependencyTracker, repositoryCloneManager, localGitClient, libGit2Client, localGitRepoFactory, versionDetailsParser, dependencyFileManager, coherencyUpdateResolver, assetLocationResolver, fileSystem, logger),
+    IVmrBackFlower
+{
+    private readonly IVmrInfo _vmrInfo = vmrInfo;
+    private readonly ISourceManifest _sourceManifest = sourceManifest;
+    private readonly IVmrDependencyTracker _dependencyTracker = dependencyTracker;
+    private readonly IRepositoryCloneManager _repositoryCloneManager = repositoryCloneManager;
+    private readonly ILocalGitClient _localGitClient = localGitClient;
+    private readonly ILocalGitRepoFactory _localGitRepoFactory = localGitRepoFactory;
+    private readonly IVmrPatchHandler _vmrPatchHandler = vmrPatchHandler;
+    private readonly IWorkBranchFactory _workBranchFactory = workBranchFactory;
+    private readonly IBasicBarClient _barClient = basicBarClient;
+    private readonly IFileSystem _fileSystem = fileSystem;
+    private readonly ILogger<VmrCodeFlower> _logger = logger;
 
     public Task<bool> FlowBackAsync(
         string mapping,
@@ -98,7 +113,36 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         string? branchName,
         bool discardPatches = false,
         CancellationToken cancellationToken = default)
-        => FlowBackAsync(mapping, _localGitRepoFactory.Create(targetRepoPath), shaToFlow, buildToFlow, branchName, discardPatches, cancellationToken);
+        => FlowBackAsync(
+            mapping,
+            _localGitRepoFactory.Create(targetRepoPath),
+            shaToFlow,
+            buildToFlow,
+            branchName,
+            discardPatches,
+    cancellationToken);
+
+    public async Task<bool> FlowBackAsync(
+        string mappingName,
+        Build build,
+        string branchName,
+        string targetBranch,
+        CancellationToken cancellationToken = default)
+    {
+        SourceMapping mapping = _dependencyTracker.GetMapping(mappingName);
+        ILocalGitRepo targetRepo = await PrepareRepoAndVmr(mapping, targetBranch, build.Commit, cancellationToken);
+        Codeflow lastFlow = await GetLastFlowAsync(mapping, targetRepo, currentIsBackflow: true);
+
+        return await FlowBackAsync(
+            mapping,
+            targetRepo,
+            lastFlow,
+            build.Commit,
+            build,
+            branchName,
+            true,
+            cancellationToken);
+    }
 
     public async Task<bool> FlowBackAsync(
         string mappingName,
@@ -129,7 +173,27 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
 
         var mapping = _dependencyTracker.GetMapping(mappingName);
         Codeflow lastFlow = await GetLastFlowAsync(mapping, targetRepo, currentIsBackflow: true);
+        return await FlowBackAsync(
+            mapping,
+            targetRepo,
+            lastFlow,
+            shaToFlow,
+            build,
+            branchName,
+            discardPatches,
+            cancellationToken);
+    }
 
+    private async Task<bool> FlowBackAsync(
+        SourceMapping mapping,
+        ILocalGitRepo targetRepo,
+        Codeflow lastFlow,
+        string shaToFlow,
+        Build? build,
+        string? branchName,
+        bool discardPatches,
+        CancellationToken cancellationToken)
+    {
         var hasChanges = await FlowCodeAsync(
             lastFlow,
             new Backflow(lastFlow.TargetSha, shaToFlow),

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -96,7 +96,6 @@ internal class VmrBackFlower(
     private readonly IVmrInfo _vmrInfo = vmrInfo;
     private readonly ISourceManifest _sourceManifest = sourceManifest;
     private readonly IVmrDependencyTracker _dependencyTracker = dependencyTracker;
-    private readonly IRepositoryCloneManager _repositoryCloneManager = repositoryCloneManager;
     private readonly ILocalGitClient _localGitClient = localGitClient;
     private readonly ILocalGitRepoFactory _localGitRepoFactory = localGitRepoFactory;
     private readonly IVmrPatchHandler _vmrPatchHandler = vmrPatchHandler;
@@ -120,7 +119,7 @@ internal class VmrBackFlower(
             buildToFlow,
             branchName,
             discardPatches,
-    cancellationToken);
+            cancellationToken);
 
     public async Task<bool> FlowBackAsync(
         string mappingName,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -385,7 +385,7 @@ internal abstract class VmrCodeFlower
             .OrderRemotesByLocalPublicOther();
 
         ILocalGitRepo repo = await _repositoryCloneManager.PrepareCloneAsync(
-        mapping,
+            mapping,
             [.. remotes],
             repoRef,
             cancellationToken);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -76,10 +76,8 @@ internal class VmrForwardFlower(
     IVmrForwardFlower
 {
     private readonly IVmrInfo _vmrInfo = vmrInfo;
-    private readonly ISourceManifest _sourceManifest = sourceManifest;
     private readonly IVmrUpdater _vmrUpdater = vmrUpdater;
     private readonly IVmrDependencyTracker _dependencyTracker = dependencyTracker;
-    private readonly IRepositoryCloneManager _repositoryCloneManager = repositoryCloneManager;
     private readonly IBasicBarClient _barClient = basicBarClient;
     private readonly ILocalGitRepoFactory _localGitRepoFactory = localGitRepoFactory;
     private readonly IProcessManager _processManager = processManager;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -107,7 +107,7 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             await sourceRepo.CheckoutAsync(shaToFlow);
         }
 
-        var mapping = _dependencyTracker.Mappings.First(m => m.Name == mappingName);
+        var mapping = _dependencyTracker.GetMapping(mappingName);
         Codeflow lastFlow = await GetLastFlowAsync(mapping, sourceRepo, currentIsBackflow: false);
 
         return await FlowCodeAsync(

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -16,6 +16,18 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public interface IVmrForwardFlower
 {
+    /// <summary>
+    /// Flows forward the code from the source repo to the target branch of the VMR.
+    /// This overload is used in the context of the darc CLI.
+    /// </summary>
+    /// <param name="mapping">Mapping to flow</param>
+    /// <param name="sourceRepo">Local checkout of the repository</param>
+    /// <param name="shaToFlow">SHA to flow</param>
+    /// <param name="buildToFlow">Build to flow</param>
+    /// <param name="branchName">New branch name</param>
+    /// <param name="targetBranch">Target branch to create the PR branch on top of</param>
+    /// <param name="discardPatches">Keep patch files?</param>
+    /// <returns>True when there were changes to be flown</returns>
     Task<bool> FlowForwardAsync(
         string mapping,
         NativePath sourceRepo,
@@ -24,25 +36,31 @@ public interface IVmrForwardFlower
         string branchName,
         bool discardPatches = false,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Flows forward the code from the source repo to the target branch of the VMR.
+    /// This overload is used in the context of the PCS.
+    /// </summary>
+    /// <param name="mappingName">Mapping to flow</param>
+    /// <param name="build">Build to flow</param>
+    /// <param name="branchName">New branch name</param>
+    /// <param name="targetBranch">Target branch to create the PR branch on top of</param>
+    /// <returns>True when there were changes to be flown</returns>
+    Task<bool> FlowForwardAsync(
+        string mappingName,
+        Build build,
+        string branchName,
+        string targetBranch,
+        CancellationToken cancellationToken = default);
 }
 
-internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
-{
-    private readonly IVmrInfo _vmrInfo;
-    private readonly IVmrUpdater _vmrUpdater;
-    private readonly IVmrDependencyTracker _dependencyTracker;
-    private readonly IBasicBarClient _barClient;
-    private readonly ILocalGitRepoFactory _localGitRepoFactory;
-    private readonly IProcessManager _processManager;
-    private readonly IWorkBranchFactory _workBranchFactory;
-    private readonly ILogger<VmrCodeFlower> _logger;
-
-    public VmrForwardFlower(
+internal class VmrForwardFlower(
         IVmrInfo vmrInfo,
         ISourceManifest sourceManifest,
         IVmrUpdater vmrUpdater,
         IVmrDependencyTracker dependencyTracker,
         IDependencyFileManager dependencyFileManager,
+        IRepositoryCloneManager repositoryCloneManager,
         ILocalGitClient localGitClient,
         ILocalLibGit2Client libGit2Client,
         IBasicBarClient basicBarClient,
@@ -54,28 +72,40 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
         IAssetLocationResolver assetLocationResolver,
         IFileSystem fileSystem,
         ILogger<VmrCodeFlower> logger)
-        : base(
-            vmrInfo,
-            sourceManifest,
-            dependencyTracker,
-            localGitClient,
-            libGit2Client,
-            localGitRepoFactory,
-            versionDetailsParser,
-            dependencyFileManager,
-            coherencyUpdateResolver,
-            assetLocationResolver,
-            fileSystem,
-            logger)
+    : VmrCodeFlower(vmrInfo, sourceManifest, dependencyTracker, repositoryCloneManager, localGitClient, libGit2Client, localGitRepoFactory, versionDetailsParser, dependencyFileManager, coherencyUpdateResolver, assetLocationResolver, fileSystem, logger),
+    IVmrForwardFlower
+{
+    private readonly IVmrInfo _vmrInfo = vmrInfo;
+    private readonly ISourceManifest _sourceManifest = sourceManifest;
+    private readonly IVmrUpdater _vmrUpdater = vmrUpdater;
+    private readonly IVmrDependencyTracker _dependencyTracker = dependencyTracker;
+    private readonly IRepositoryCloneManager _repositoryCloneManager = repositoryCloneManager;
+    private readonly IBasicBarClient _barClient = basicBarClient;
+    private readonly ILocalGitRepoFactory _localGitRepoFactory = localGitRepoFactory;
+    private readonly IProcessManager _processManager = processManager;
+    private readonly IWorkBranchFactory _workBranchFactory = workBranchFactory;
+    private readonly ILogger<VmrCodeFlower> _logger = logger;
+
+    public async Task<bool> FlowForwardAsync(
+        string mappingName,
+        Build build,
+        string branchName,
+        string targetBranch,
+        CancellationToken cancellationToken = default)
     {
-        _vmrInfo = vmrInfo;
-        _vmrUpdater = vmrUpdater;
-        _dependencyTracker = dependencyTracker;
-        _barClient = basicBarClient;
-        _localGitRepoFactory = localGitRepoFactory;
-        _processManager = processManager;
-        _workBranchFactory = workBranchFactory;
-        _logger = logger;
+        SourceMapping mapping = _dependencyTracker.GetMapping(mappingName);
+        ILocalGitRepo sourceRepo = await PrepareRepoAndVmr(mapping, build.Commit, targetBranch, cancellationToken);
+        Codeflow lastFlow = await GetLastFlowAsync(mapping, sourceRepo, currentIsBackflow: false);
+
+        return await FlowCodeAsync(
+            lastFlow,
+            new ForwardFlow(lastFlow.TargetSha, build.Commit),
+            sourceRepo,
+            mapping,
+            build,
+            branchName,
+            discardPatches: true,
+            cancellationToken);
     }
 
     public async Task<bool> FlowForwardAsync(

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -89,8 +89,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
     {
         await _dependencyTracker.InitializeSourceMappings(sourceMappingsPath);
 
-        var mapping = _dependencyTracker.Mappings.FirstOrDefault(m => m.Name == mappingName)
-            ?? throw new Exception($"No repository mapping named `{mappingName}` found!");
+        var mapping = _dependencyTracker.GetMapping(mappingName);
 
         if (_dependencyTracker.GetDependencyVersion(mapping) is not null)
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -224,7 +224,7 @@ public abstract class VmrManagerBase
                 .Append(repo.RemoteUri)
                 .Prepend(repo.Mapping.DefaultRemote)
                 .Distinct()
-                .OrderBy(GitRepoUrlParser.ParseTypeFromUri, Comparer<GitRepoType>.Create(GitRepoUrlParser.OrderByLocalPublicOther));
+                .OrderRemotesByLocalPublicOther();
 
             IEnumerable<DependencyDetail>? repoDependencies = null;
             foreach (var remoteUri in remotes)

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -256,10 +256,12 @@ public abstract class VmrManagerBase
 
             foreach (var dependency in repoDependencies)
             {
-                var mapping = _dependencyInfo.Mappings.FirstOrDefault(m => m.Name == dependency.SourceBuild.RepoName)
-                    ?? throw new InvalidOperationException(
+                if (!_dependencyInfo.TryGetMapping(dependency.SourceBuild.RepoName, out var mapping))
+                {
+                    throw new InvalidOperationException(
                         $"No source mapping named '{dependency.SourceBuild.RepoName}' found " +
                         $"for a {VersionFiles.VersionDetailsXml} dependency of {dependency.Name}");
+                }
 
                 var update = new VmrDependencyUpdate(
                     mapping,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRepoVersionResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRepoVersionResolver.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 
@@ -31,8 +30,7 @@ internal class VmrRepoVersionResolver : IVmrRepoVersionResolver
     {
         await _dependencyTracker.InitializeSourceMappings();
 
-        SourceMapping mapping = _dependencyTracker.Mappings.FirstOrDefault(m => m.Name == mappingName)
-            ?? throw new ArgumentException($"No mapping named {mappingName} found");
+        SourceMapping mapping = _dependencyTracker.GetMapping(mappingName);
 
         return _dependencyTracker.GetDependencyVersion(mapping)?.Sha
             ?? throw new Exception($"Mapping {mappingName} has not been initialized yet");

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -208,7 +208,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             .Prepend(update.Mapping.DefaultRemote)
             .Distinct()
             // Prefer local git repos, then GitHub, then AzDO
-            .OrderBy(GitRepoUrlParser.ParseTypeFromUri, Comparer<GitRepoType>.Create(GitRepoUrlParser.OrderByLocalPublicOther))
+            .OrderRemotesByLocalPublicOther()
             .ToArray();
 
         ILocalGitRepo clone = await _cloneManager.PrepareCloneAsync(
@@ -535,7 +535,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                     .Prepend(sourceMapping.DefaultRemote)
                     .Append(source.RemoteUri)
                     .Distinct()
-                    .OrderBy(GitRepoUrlParser.ParseTypeFromUri, Comparer<GitRepoType>.Create(GitRepoUrlParser.OrderByLocalPublicOther))
+                    .OrderRemotesByLocalPublicOther()
                     .ToList();
 
                 clone = await _cloneManager.PrepareCloneAsync(sourceMapping, remotes, new[] { source.CommitSha }, source.CommitSha, cancellationToken);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -202,7 +202,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             .Where(r => r.Mapping == update.Mapping.Name)
             .Select(r => r.RemoteUri)
             // Add remotes for where we synced last from and where we are syncing to (e.g. github.com -> dev.azure.com)
-            .Append(_sourceManifest.Repositories.First(r => r.Path == update.Mapping.Name).RemoteUri)
+            .Append(_sourceManifest.GetRepoVersion(update.Mapping.Name).RemoteUri)
             .Append(update.RemoteUri)
             // Add the default remote
             .Prepend(update.Mapping.DefaultRemote)
@@ -732,7 +732,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             TargetRevision: targetRevision,
             TargetVersion: targetVersion,
             Parent: null,
-            RemoteUri: _sourceManifest.Repositories.First(r => r.Path == mapping.Name).RemoteUri));
+            RemoteUri: _sourceManifest.GetRepoVersion(mapping.Name).RemoteUri));
 
         var filesToAdd = new List<string>
         {


### PR DESCRIPTION
This PR adds a different way of executing the VMR code flow that is more suitable for using inside of PCS (the current APIs are used in `darc`).
The new API in `VmrForwardFlower` and `VmrBackFlower` also allows targeting a given branch of the VMR/repo that we want to synchronized to.
Eventually, the target branch of the subscription will be used there.

Later, we will use these new APIs as part of https://github.com/dotnet/arcade-services/issues/3316.
Tests will be added once we have an E2E flow in place.

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes