### PR TITLE
[main] Bump us to Octokit v10.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -116,7 +116,7 @@
     <PackageVersion Include="NuGet.Protocol" Version="6.7.1" />
     <PackageVersion Include="NUnit" Version="4.0.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageVersion Include="Octokit" Version="0.49.0" />
+    <PackageVersion Include="Octokit" Version="10.0.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/Microsoft.DotNet.Maestro.Tasks.csproj
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/Microsoft.DotNet.Maestro.Tasks.csproj
@@ -5,8 +5,6 @@
     <Description>This package include tasks involving Maestro++ and the Build Asset Registry.</Description>
     <DevelopmentDependency>true</DevelopmentDependency>
     <PackageType>MSBuildSdk</PackageType>
-    <!-- Octokit is not strong named yet (https://github.com/octokit/octokit.net/blob/master/docs/strong-naming.md) -->
-    <SignAssembly>false</SignAssembly>
     <!-- Build Tasks should not include any dependencies -->
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <LangVersion>8.0</LangVersion>


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

- see https://github.com/dotnet/dnceng/issues/2065
- assembly is now (since v4.0.0) strong named

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description

Bumped our Octokit version to get `int` overflow fix.