### PR TITLE
Improve PCS configuration, add `CodeFlowJob`

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Api/Controllers/CodeFlowController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Controllers/CodeFlowController.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client.Models;
+using ProductConstructionService.Api.Queue;
+using ProductConstructionService.Api.Queue.Jobs;
+
+namespace ProductConstructionService.Api.Controllers;
+
+[Route("codeflow")]
+public class CodeFlowController(
+        IBasicBarClient barClient,
+        JobProducerFactory jobProducerFactory)
+    : Controller
+{
+    private readonly IBasicBarClient _barClient = barClient;
+    private readonly JobProducerFactory _jobProducerFactory = jobProducerFactory;
+
+    [HttpPost("create-branch")]
+    public async Task<IActionResult> CreateBranch(string subscriptionId, int buildId)
+    {
+        if (!Guid.TryParse(subscriptionId, out Guid subId))
+        {
+            return BadRequest("Provided subscription ID is not a GUID");
+        }
+
+        Subscription subscription = await _barClient.GetSubscriptionAsync(subId);
+        if (subscription == null)
+        {
+            return NotFound($"Subscription {subscriptionId} not found");
+        }
+
+        Build build = await _barClient.GetBuildAsync(buildId);
+        if (build == null)
+        {
+            return NotFound($"Build {buildId} not found");
+        }
+
+        await _jobProducerFactory.Create<CodeFlowJob>().ProduceJobAsync(new()
+        {
+            BuildId = buildId,
+            SubscriptionId = subscriptionId,
+        });
+
+        return Ok();
+    }
+}

--- a/src/ProductConstructionService/ProductConstructionService.Api/Controllers/StatusController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Controllers/StatusController.cs
@@ -9,9 +9,9 @@ using ProductConstructionService.Api.Queue;
 namespace ProductConstructionService.Api.Controllers;
 
 [Route("status")]
-public class StatusController(JobProcessorScopeManager jobProcessorScopeManager) : Controller
+public class StatusController(JobScopeManager jobProcessorScopeManager) : Controller
 {
-    private readonly JobProcessorScopeManager _jobProcessorScopeManager = jobProcessorScopeManager;
+    private readonly JobScopeManager _jobProcessorScopeManager = jobProcessorScopeManager;
 
     [HttpPut("stop")]
     public IActionResult StopPcsJobProcessor()

--- a/src/ProductConstructionService/ProductConstructionService.Api/DatabaseConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/DatabaseConfiguration.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Maestro.Data;
+using Maestro.DataProviders;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace ProductConstructionService.Api;
+
+internal static class DatabaseConfiguration
+{
+    public static void AddBuildAssetRegistry(this WebApplicationBuilder builder, string connectionString)
+    {
+        builder.Services.TryAddTransient<IBasicBarClient, SqlBarClient>();
+        builder.Services.AddDbContext<BuildAssetRegistryContext>(options =>
+        {
+            options.UseSqlServer(connectionString, sqlOptions =>
+            {
+                sqlOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SingleQuery);
+            });
+        });
+    }
+}

--- a/src/ProductConstructionService/ProductConstructionService.Api/InitializationBackgroundService.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/InitializationBackgroundService.cs
@@ -8,10 +8,12 @@ using ProductConstructionService.Api.Telemetry;
 
 namespace ProductConstructionService.Api;
 
-public class InitializationBackgroundService(IRepositoryCloneManager repositoryCloneManager,
-    ITelemetryRecorder telemetryRecorder,
-    InitializationBackgroundServiceOptions options,
-    JobProcessorScopeManager jobProcessorScopeManager) : BackgroundService
+public class InitializationBackgroundService(
+        IRepositoryCloneManager repositoryCloneManager,
+        ITelemetryRecorder telemetryRecorder,
+        InitializationBackgroundServiceOptions options,
+        JobScopeManager jobScopeManager)
+    : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -24,7 +26,7 @@ public class InitializationBackgroundService(IRepositoryCloneManager repositoryC
             linkedTokenSource.Token.ThrowIfCancellationRequested();
 
             scope.SetSuccess();
-            jobProcessorScopeManager.InitializingDone();
+            jobScopeManager.InitializingDone();
         }
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/InitializationHealthCheck.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/InitializationHealthCheck.cs
@@ -6,7 +6,7 @@ using ProductConstructionService.Api.Queue;
 
 namespace ProductConstructionService.Api;
 
-public class InitializationHealthCheck(JobProcessorScopeManager jobProcessorScopeManager) : IHealthCheck
+public class InitializationHealthCheck(JobScopeManager jobProcessorScopeManager) : IHealthCheck
 {
     public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {

--- a/src/ProductConstructionService/ProductConstructionService.Api/PcsConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/PcsConfiguration.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+internal static class PcsConfiguration
+{
+    public const string DatabaseConnectionString = "build-asset-registry-sql-connection-string";
+    public const string ManagedIdentityId = "ManagedIdentityClientId";
+    public const string KeyVaultName = "KeyVaultName";
+    public const string GitHubToken = "BotAccount-dotnet-bot-repo-PAT";
+    public const string AzDOToken = "dn-bot-all-orgs-code-r";
+
+    public static string GetRequiredValue(this IConfiguration configuration, string key)
+        => configuration[key] ?? throw new ArgumentException($"{key} missing from the configuration / environment settings");
+}

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobConsumer.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobConsumer.cs
@@ -21,6 +21,8 @@ public class JobConsumer(
 
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
+        Thread.Yield();
+
         QueueClient queueClient = queueServiceClient.GetQueueClient(_options.Value.JobQueueName);
         _logger.LogInformation("Starting to process PCS jobs {queueName}", _options.Value.JobQueueName);
         while (!cancellationToken.IsCancellationRequested)

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobConsumer.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobConsumer.cs
@@ -21,7 +21,9 @@ public class JobConsumer(
 
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        Thread.Yield();
+        // We yield so that the rest of the service can progress initialization
+        // Otherwise, the service will be stuck here
+        await Task.Yield();
 
         QueueClient queueClient = queueServiceClient.GetQueueClient(_options.Value.JobQueueName);
         _logger.LogInformation("Starting to process PCS jobs {queueName}", _options.Value.JobQueueName);

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobConsumerOptions.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobConsumerOptions.cs
@@ -3,9 +3,9 @@
 
 namespace ProductConstructionService.Api.Queue;
 
-public class JobProcessorOptions
+public class JobConsumerOptions
 {
-    public const string ConfigurationKey = "JobProcessorOptions";
+    public const string ConfigurationKey = "JobConsumerOptions";
 
     public required TimeSpan QueuePollTimeout { get; init; }
     public required string JobQueueName { get; init; }

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobProcessors/CodeFlowJobProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobProcessors/CodeFlowJobProcessor.cs
@@ -79,7 +79,7 @@ public class CodeFlowJobProcessor(
             return;
         }
 
-        if (hadUpdates)
+        if (!hadUpdates)
         {
             _logger.LogInformation("There were no code-flow updates for subscription {subscriptionId}",
                 subscription.Id);

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobProcessors/CodeFlowJobProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobProcessors/CodeFlowJobProcessor.cs
@@ -37,7 +37,9 @@ public class CodeFlowJobProcessor(
         Build build = await _barClient.GetBuildAsync(codeflowJob.BuildId)
             ?? throw new Exception($"Build {codeflowJob.BuildId} not found");
 
-        var isForwardFlow = build.GitHubRepository != _vmrInfo.VmrUri && build.AzureDevOpsRepository != _vmrInfo.VmrUri;
+        var isForwardFlow = build.GitHubRepository != _vmrInfo.VmrUri
+            && build.AzureDevOpsRepository != _vmrInfo.VmrUri;
+
         var branchName = $"darc-{subscription.TargetBranch}-{Guid.NewGuid()}";
 
         _logger.LogInformation("{direction}-flowing build {buildId} for subscription {subscriptionId} targeting {repo} / {targetBranch} to new branch {newBranch}",

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobProcessors/CodeFlowJobProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobProcessors/CodeFlowJobProcessor.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using Microsoft.DotNet.Maestro.Client.Models;
+using ProductConstructionService.Api.Queue.Jobs;
+
+namespace ProductConstructionService.Api.Queue.JobProcessors;
+
+public class CodeFlowJobProcessor(
+        IVmrInfo vmrInfo,
+        IBasicBarClient barClient,
+        IVmrBackFlower vmrBackFlower,
+        IVmrForwardFlower vmrForwardFlower,
+        ILogger<CodeFlowJobProcessor> logger)
+    : IJobProcessor
+{
+    private readonly IVmrInfo _vmrInfo = vmrInfo;
+    private readonly IBasicBarClient _barClient = barClient;
+    private readonly IVmrBackFlower _vmrBackFlower = vmrBackFlower;
+    private readonly IVmrForwardFlower _vmrForwardFlower = vmrForwardFlower;
+    private readonly ILogger<CodeFlowJobProcessor> _logger = logger;
+
+    public async Task ProcessJobAsync(Job job, CancellationToken cancellationToken)
+    {
+        var codeflowJob = (CodeFlowJob)job;
+
+        Subscription subscription = await _barClient.GetSubscriptionAsync(codeflowJob.SubscriptionId)
+            ?? throw new Exception($"Subscription {codeflowJob.SubscriptionId} not found");
+
+        if (!subscription.SourceEnabled || subscription.SourceDirectory == null)
+        {
+            throw new Exception($"Subscription {codeflowJob.SubscriptionId} is not source enabled or source directory is not set");
+        }
+
+        Build build = await _barClient.GetBuildAsync(codeflowJob.BuildId)
+            ?? throw new Exception($"Build {codeflowJob.BuildId} not found");
+
+        var isForwardFlow = build.GitHubRepository != _vmrInfo.VmrUri && build.AzureDevOpsRepository != _vmrInfo.VmrUri;
+        var branchName = $"darc-{subscription.TargetBranch}-{Guid.NewGuid()}";
+
+        _logger.LogInformation("{direction}-flowing build {buildId} for subscription {subscriptionId} targeting {repo} / {targetBranch} to new branch {newBranch}",
+            isForwardFlow ? "Forward" : "Back",
+            build.Id,
+            subscription.Id,
+            subscription.TargetRepository,
+            subscription.TargetBranch,
+            branchName);
+
+        bool hadUpdates;
+
+        try
+        {
+            if (isForwardFlow)
+            {
+                hadUpdates = await _vmrForwardFlower.FlowForwardAsync(
+                    subscription.SourceDirectory,
+                    build,
+                    branchName,
+                    subscription.TargetBranch,
+                    cancellationToken);
+            }
+            else
+            {
+                hadUpdates = await _vmrBackFlower.FlowBackAsync(
+                    subscription.SourceDirectory,
+                    build,
+                    branchName,
+                    subscription.TargetBranch,
+                    cancellationToken);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to flow changes for build {buildId} in subscription {subscriptionId}",
+                build.Id,
+                subscription.Id);
+            return;
+        }
+
+        if (hadUpdates)
+        {
+            _logger.LogInformation("There were no code-flow updates for subscription {subscriptionId}",
+                subscription.Id);
+        }
+        else
+        {
+            _logger.LogInformation("Code changes for {subscriptionId} ready in branch {branch} {targetRepository}",
+                subscription.Id,
+                subscription.TargetBranch,
+                subscription.TargetRepository);
+        }
+    }
+}

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobProcessors/IJobProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobProcessors/IJobProcessor.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using ProductConstructionService.Api.Queue.Jobs;
+
+namespace ProductConstructionService.Api.Queue.JobProcessors;
+
+public interface IJobProcessor
+{
+    Task ProcessJobAsync(Job job, CancellationToken cancellationToken);
+}

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobProcessors/TextJobProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobProcessors/TextJobProcessor.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using ProductConstructionService.Api.Queue.Jobs;
+
+namespace ProductConstructionService.Api.Queue.JobProcessors;
+
+public class TextJobProcessor(ILogger<TextJobProcessor> logger) : IJobProcessor
+{
+    private readonly ILogger<TextJobProcessor> _logger = logger;
+
+    public Task ProcessJobAsync(Job job, CancellationToken cancellationToken)
+    {
+        var textJob = (TextJob)job;
+        _logger.LogInformation("Processed text job. Message: {message}", textJob.Text);
+        return Task.CompletedTask;
+    }
+}

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobScope.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobScope.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using ProductConstructionService.Api.Queue.JobRunners;
+using ProductConstructionService.Api.Queue.JobProcessors;
 using ProductConstructionService.Api.Queue.Jobs;
 using ProductConstructionService.Api.Telemetry;
 
@@ -34,11 +34,11 @@ public class JobScope(
             throw new Exception($"{nameof(JobScope)} not initialized! Call InitializeScope before calling {nameof(RunJobAsync)}");
         }
 
-        var jobRunner = _serviceScope.ServiceProvider.GetRequiredKeyedService<IJobRunner>(_job.Type);
+        var jobRunner = _serviceScope.ServiceProvider.GetRequiredKeyedService<IJobProcessor>(_job.Type);
 
-        using (ITelemetryScope telemetryScope  = _telemetryRecorder.RecordJob(_job))
+        using (ITelemetryScope telemetryScope = _telemetryRecorder.RecordJob(_job))
         {
-            await jobRunner.RunAsync(_job, cancellationToken);
+            await jobRunner.ProcessJobAsync(_job, cancellationToken);
             telemetryScope.SetSuccess();
         }
     }

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobScopeManager.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobScopeManager.cs
@@ -3,21 +3,9 @@
 
 namespace ProductConstructionService.Api.Queue;
 
-public enum JobsProcessorState
+public class JobScopeManager
 {
-    // The JobsProcessor will keep taking and processing new jobs
-    Working,
-    // The JobsProcessor isn't doing anything
-    Stopped,
-    // The JobsProcessor will finish its current job and stop
-    Stopping,
-    // The JobsProcessor is waiting for service to fully initialize
-    Initializing
-}
-
-public class JobProcessorScopeManager
-{
-    public JobProcessorScopeManager(bool initializingOnStartup, IServiceProvider serviceProvider)
+    public JobScopeManager(bool initializingOnStartup, IServiceProvider serviceProvider)
     {
         _autoResetEvent = new AutoResetEvent(!initializingOnStartup);
         State = initializingOnStartup ? JobsProcessorState.Initializing : JobsProcessorState.Working;

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/Jobs/CodeFlowJob.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/Jobs/CodeFlowJob.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace ProductConstructionService.Api.Queue.Jobs;
+
+public class CodeFlowJob : Job
+{
+    public required string SubscriptionId { get; init; }
+    public required int BuildId { get; init; }
+    public override string Type => nameof(CodeFlowJob);
+}

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/Jobs/Job.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/Jobs/Job.cs
@@ -6,8 +6,9 @@ using System.Text.Json.Serialization;
 namespace ProductConstructionService.Api.Queue.Jobs;
 
 [JsonDerivedType(typeof(TextJob), typeDiscriminator: nameof(TextJob))]
+[JsonDerivedType(typeof(CodeFlowJob), typeDiscriminator: nameof(CodeFlowJob))]
 public abstract class Job
 {
-    public required Guid Id { get; init; }
+    public Guid Id { get; } = Guid.NewGuid();
     public abstract string Type { get; }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobsProcessorState.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/JobsProcessorState.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace ProductConstructionService.Api.Queue;
+
+public enum JobsProcessorState
+{
+    /// <summary>
+    /// The JobsProcessor is waiting for service to fully initialize
+    /// </summary>
+    Initializing,
+
+    /// <summary>
+    /// The JobsProcessor will keep taking and processing new jobs
+    /// </summary>
+    Working,
+
+    /// <summary>
+    /// The JobsProcessor isn't doing anything
+    /// </summary>
+    Stopped,
+
+    /// <summary>
+    /// The JobsProcessor will finish its current job and stop
+    /// </summary>
+    Stopping,
+}

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/QueueConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/QueueConfiguration.cs
@@ -2,35 +2,40 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Azure.Identity;
-using ProductConstructionService.Api.Queue.JobRunners;
+using ProductConstructionService.Api.Queue.JobProcessors;
 using ProductConstructionService.Api.Queue.Jobs;
 
 namespace ProductConstructionService.Api.Queue;
 
 public static class QueueConfiguration
 {
-    public const string JobQueueConfigurationKey = $"{JobProcessorOptions.ConfigurationKey}:JobQueueName";
+    public const string JobQueueNameConfigurationKey = $"{JobConsumerOptions.ConfigurationKey}:JobQueueName";
 
     public static void AddWorkitemQueues(this WebApplicationBuilder builder, DefaultAzureCredential credential)
     {
         builder.AddAzureQueueService("queues", (settings) => { settings.Credential = credential; });
 
-        var queueName = builder.Configuration[JobQueueConfigurationKey] ??
-            throw new ArgumentException($"{JobQueueConfigurationKey} missing from the configuration");
+        var queueName = builder.Configuration.GetRequiredValue(JobQueueNameConfigurationKey);
 
         // When running the service locally, the JobsProcessor should start in the Working state
-        builder.Services.AddSingleton(sp => ActivatorUtilities.CreateInstance<JobProcessorScopeManager>(sp, !builder.Environment.IsDevelopment()));
-        builder.Services.Configure<JobProcessorOptions>(
-            builder.Configuration.GetSection(JobProcessorOptions.ConfigurationKey));
+        builder.Services.AddSingleton(sp => ActivatorUtilities.CreateInstance<JobScopeManager>(sp, !builder.Environment.IsDevelopment()));
+        builder.Services.Configure<JobConsumerOptions>(
+            builder.Configuration.GetSection(JobConsumerOptions.ConfigurationKey));
         builder.Services.AddTransient(sp =>
             ActivatorUtilities.CreateInstance<JobProducerFactory>(sp, queueName));
-        builder.Services.AddHostedService<JobProcessor>();
+        builder.Services.AddHostedService<JobConsumer>();
 
-        AddJobRunners(builder.Services);
+        // Register all job processors
+        builder.Services.RegisterJobProcessor<TextJob, TextJobProcessor>();
+        builder.Services.RegisterJobProcessor<CodeFlowJob, CodeFlowJobProcessor>();
     }
+}
 
-    private static void AddJobRunners(IServiceCollection services)
+static file class JobProcessorExtensions
+{
+    public static void RegisterJobProcessor<TJob, TProcessor>(this IServiceCollection services)
+        where TProcessor : class, IJobProcessor
     {
-        services.AddKeyedTransient<IJobRunner, TextJobRunner>(nameof(TextJob));
+        services.AddKeyedTransient<IJobProcessor, TProcessor>(typeof(TJob).Name);
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/Queue/QueueConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Queue/QueueConfiguration.cs
@@ -7,18 +7,18 @@ using ProductConstructionService.Api.Queue.Jobs;
 
 namespace ProductConstructionService.Api.Queue;
 
-public static class QueueConfiguration
+internal static class QueueConfiguration
 {
     public const string JobQueueNameConfigurationKey = $"{JobConsumerOptions.ConfigurationKey}:JobQueueName";
 
-    public static void AddWorkitemQueues(this WebApplicationBuilder builder, DefaultAzureCredential credential)
+    public static void AddWorkitemQueues(this WebApplicationBuilder builder, DefaultAzureCredential credential, bool waitForInitialization)
     {
-        builder.AddAzureQueueService("queues", (settings) => { settings.Credential = credential; });
+        builder.AddAzureQueueService("queues", settings => settings.Credential = credential);
 
         var queueName = builder.Configuration.GetRequiredValue(JobQueueNameConfigurationKey);
 
         // When running the service locally, the JobsProcessor should start in the Working state
-        builder.Services.AddSingleton(sp => ActivatorUtilities.CreateInstance<JobScopeManager>(sp, !builder.Environment.IsDevelopment()));
+        builder.Services.AddSingleton(sp => ActivatorUtilities.CreateInstance<JobScopeManager>(sp, waitForInitialization));
         builder.Services.Configure<JobConsumerOptions>(
             builder.Configuration.GetSection(JobConsumerOptions.ConfigurationKey));
         builder.Services.AddTransient(sp =>

--- a/src/ProductConstructionService/ProductConstructionService.Api/TestController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/TestController.cs
@@ -15,7 +15,7 @@ public class TestController(JobProducerFactory pcsJobProducerFactory) : Controll
     public async Task<IActionResult> Index()
     {
         var jobProducer = _jobProducerFactory.Create<TextJob>();
-        await jobProducer.ProduceJobAsync(new() { Text = "some text", Id = Guid.NewGuid() });
+        await jobProducer.ProduceJobAsync(new() { Text = "some text" });
         return Ok("Message sent");
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/VirtualMonoRepo/VmrConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/VirtualMonoRepo/VmrConfiguration.cs
@@ -19,13 +19,13 @@ public static class VmrConfiguration
 
     public static void AddVmrRegistrations(this WebApplicationBuilder builder, string vmrPath, string tmpPath, string vmrUri)
     {
-        builder.Services.TryAddSingleton<IBasicBarClient, SqlBarClient>();
+        builder.Services.TryAddTransient<IBasicBarClient, SqlBarClient>();
         builder.Services.AddVmrManagers(
             "git",
             vmrPath,
             tmpPath,
-            builder.Configuration["BotAccount-dotnet-bot-repo-PAT"],
-            builder.Configuration["dn-bot-all-orgs-code-r"]);
+            builder.Configuration[PcsConfiguration.GitHubToken],
+            builder.Configuration[PcsConfiguration.AzDOToken]);
 
         if (!builder.Environment.IsDevelopment())
         {

--- a/src/ProductConstructionService/ProductConstructionService.Api/VirtualMonoRepo/VmrConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/VirtualMonoRepo/VmrConfiguration.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Maestro.DataProviders;
-using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace ProductConstructionService.Api.VirtualMonoRepo;
 
@@ -17,21 +14,20 @@ public static class VmrConfiguration
     public const string VmrReadyHealthCheckName = "VmrReady";
     public const string VmrReadyHealthCheckTag = "vmrReady";
 
-    public static void AddVmrRegistrations(this WebApplicationBuilder builder, string vmrPath, string tmpPath, string vmrUri)
+    public static void AddVmrRegistrations(this WebApplicationBuilder builder, string vmrPath, string tmpPath)
     {
-        builder.Services.TryAddTransient<IBasicBarClient, SqlBarClient>();
         builder.Services.AddVmrManagers(
             "git",
             vmrPath,
             tmpPath,
             builder.Configuration[PcsConfiguration.GitHubToken],
             builder.Configuration[PcsConfiguration.AzDOToken]);
+    }
 
-        if (!builder.Environment.IsDevelopment())
-        {
-            builder.Services.AddSingleton(new InitializationBackgroundServiceOptions(vmrUri));
-            builder.Services.AddHostedService<InitializationBackgroundService>();
-            builder.Services.AddHealthChecks().AddCheck<InitializationHealthCheck>(VmrReadyHealthCheckName, tags: [VmrReadyHealthCheckTag]);
-        }
+    public static void AddVmrInitialization(this WebApplicationBuilder builder, string vmrUri)
+    {
+        builder.Services.AddSingleton(new InitializationBackgroundServiceOptions(vmrUri));
+        builder.Services.AddHostedService<InitializationBackgroundService>();
+        builder.Services.AddHealthChecks().AddCheck<InitializationHealthCheck>(VmrReadyHealthCheckName, tags: [VmrReadyHealthCheckTag]);
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Development.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Development.json
@@ -2,15 +2,18 @@
     "Logging": {
         "LogLevel": {
             "Default": "Information",
-            "Microsoft.AspNetCore": "Warning"
+            "Microsoft.AspNetCore": "Warning",
+            "Azure.Core": "Warning",
+            "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+            "Microsoft.DotNet.DarcLib": "Trace"
         }
     },
     "KeyVaultName": "ProductConstructionDev",
     "build-asset-registry-sql-connection-string": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true",
-    "JobProcessorOptions": {
+    "JobConsumerOptions": {
         "JobQueueName": "pcs-jobs",
-        "QueuePollTimeout": "00:00:20",
+        "QueuePollTimeout": "00:00:05",
         "MaxJobRetries": 3,
-        "QueueMessageInvisibilityTime": "00:01:00"
+        "QueueMessageInvisibilityTime": "00:05:00"
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.json
@@ -6,7 +6,7 @@
         }
     },
     "AllowedHosts": "*",
-    "JobProcessorOptions": {
+    "JobConsumerOptions": {
         "JobQueueName": "pcs-jobs",
         "QueuePollTimeout": "00:01:00",
         "MaxJobRetries": 3,

--- a/test/ProductConstructionService.Api.Tests/JobScopeTests.cs
+++ b/test/ProductConstructionService.Api.Tests/JobScopeTests.cs
@@ -6,8 +6,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using ProductConstructionService.Api.Telemetry;
 using ProductConstructionService.Api.Queue;
-using ProductConstructionService.Api.Queue.JobRunners;
 using ProductConstructionService.Api.Queue.Jobs;
+using ProductConstructionService.Api.Queue.JobProcessors;
 
 namespace ProductConstructionService.Api.Tests;
 public class JobScopeTests
@@ -19,16 +19,16 @@ public class JobScopeTests
 
         Mock<ITelemetryScope> telemetryScope = new();
         Mock<ITelemetryRecorder> metricRecorderMock = new();
-        TextJob textJob = new() { Id = Guid.NewGuid(), Text = string.Empty };
+        TextJob textJob = new() { Text = string.Empty };
 
         metricRecorderMock.Setup(m => m.RecordJob(textJob)).Returns(telemetryScope.Object);
 
         services.AddSingleton(metricRecorderMock.Object);
-        services.AddKeyedSingleton(nameof(TextJob), new Mock<IJobRunner>().Object);
+        services.AddKeyedSingleton(nameof(TextJob), new Mock<IJobProcessor>().Object);
 
         IServiceProvider serviceProvider = services.BuildServiceProvider();
 
-        JobProcessorScopeManager scopeManager = new(false, serviceProvider);
+        JobScopeManager scopeManager = new(false, serviceProvider);
 
         using (JobScope jobScope = scopeManager.BeginJobScopeWhenReady())
         {
@@ -48,19 +48,19 @@ public class JobScopeTests
 
         Mock<ITelemetryScope> metricRecorderScopeMock = new();
         Mock<ITelemetryRecorder> metricRecorderMock = new();
-        TextJob textJob = new() { Id = Guid.NewGuid(), Text = string.Empty };
+        TextJob textJob = new() { Text = string.Empty };
 
         metricRecorderMock.Setup(m => m.RecordJob(textJob)).Returns(metricRecorderScopeMock.Object);
 
         services.AddSingleton(metricRecorderMock.Object);
 
-        Mock<IJobRunner> jobRunnerMock = new();
-        jobRunnerMock.Setup(j => j.RunAsync(textJob, It.IsAny<CancellationToken>())).Throws<Exception>();
+        Mock<IJobProcessor> jobRunnerMock = new();
+        jobRunnerMock.Setup(j => j.ProcessJobAsync(textJob, It.IsAny<CancellationToken>())).Throws<Exception>();
         services.AddKeyedSingleton(nameof(TextJob), jobRunnerMock.Object);
 
         IServiceProvider serviceProvider = services.BuildServiceProvider();
 
-        JobProcessorScopeManager scopeManager = new(false, serviceProvider);
+        JobScopeManager scopeManager = new(false, serviceProvider);
 
         using (JobScope jobScope = scopeManager.BeginJobScopeWhenReady())
         {

--- a/test/ProductConstructionService.Api.Tests/JobsProcessorScopeManagerTests.cs
+++ b/test/ProductConstructionService.Api.Tests/JobsProcessorScopeManagerTests.cs
@@ -25,7 +25,7 @@ public class JobsProcessorScopeManagerTests
     [Test, CancelAfter(30000)]
     public async Task JobsProcessorStatusNormalFlow()
     {
-        JobProcessorScopeManager scopeManager = new(true, _serviceProvider);
+        JobScopeManager scopeManager = new(true, _serviceProvider);
         // When it starts, the processor is not initializing
         scopeManager.State.Should().Be(JobsProcessorState.Initializing);
 
@@ -90,7 +90,7 @@ public class JobsProcessorScopeManagerTests
     [Test, CancelAfter(30000)]
     public async Task JobsProcessorMultipleStopFlow()
     {
-        JobProcessorScopeManager scopeManager = new(true, _serviceProvider);
+        JobScopeManager scopeManager = new(true, _serviceProvider);
 
         scopeManager.InitializingDone();
         // The jobs processor should start in a stopped state
@@ -126,7 +126,7 @@ public class JobsProcessorScopeManagerTests
     [Test, CancelAfter(30000)]
     public async Task JobsProcessorMultipleStartStop()
     {
-        JobProcessorScopeManager scopeManager = new(true, _serviceProvider);
+        JobScopeManager scopeManager = new(true, _serviceProvider);
 
         scopeManager.InitializingDone();
 


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/3316

This PR adds a first meaningful background job for code flow. The job is not 100% functional but a stub only so far.

While doing so, I improved how PCS behaves locally + how the code is named:
- Less log noise from SQL, Queue client
- Increased verbosity for our code (`DarcLib`)
- Lowered queue read period for faster debugging
- Improved configuration - configuration keys are now unified in one class
- Renamed `JobProcessor` to `JobConsumer` to match `JobProducer`
- Renamed `JobRunner` to `JobProcessor` as it better reflects its function

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes