### PR TITLE
Pcs deployment allow retries

### DIFF
--- a/azure-pipelines-product-construction-service.yml
+++ b/azure-pipelines-product-construction-service.yml
@@ -43,8 +43,9 @@ stages:
   - job: Publish
     displayName: Publish Product Construction Service
     pool:
-      name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals 1es-ubuntu-2004
+      # name: NetCore1ESPool-Internal
+      # demands: ImageOverride -equals 1es-ubuntu-2004
+      vmImage: 'ubuntu-latest'
 
     steps:
     - checkout: self
@@ -52,7 +53,7 @@ stages:
     - powershell: |
         Write-Host "Dev branch suffix is $(devBranchSuffix)"
         $shortSha = "$(Build.SourceVersion)".Substring(0,10)
-        $newDockerTag = "$(Build.BuildNumber)-$shortSha$(devBranchSuffix)"
+        $newDockerTag = "$(Build.BuildNumber)-$shortSha$(devBranchSuffix)-$(System.JobAttempt)"
         Write-Host "##vso[task.setvariable variable=newDockerImageTag]$newDockerTag"
         Write-Host "set newDockerImageTag to $newDockerTag"
       displayName: Set new docker image tag variable

--- a/azure-pipelines-product-construction-service.yml
+++ b/azure-pipelines-product-construction-service.yml
@@ -43,9 +43,8 @@ stages:
   - job: Publish
     displayName: Publish Product Construction Service
     pool:
-      # name: NetCore1ESPool-Internal
-      # demands: ImageOverride -equals 1es-ubuntu-2004
-      vmImage: 'ubuntu-latest'
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals 1es-ubuntu-2004
 
     steps:
     - checkout: self

--- a/azure-pipelines-product-construction-service.yml
+++ b/azure-pipelines-product-construction-service.yml
@@ -53,7 +53,7 @@ stages:
     - powershell: |
         Write-Host "Dev branch suffix is $(devBranchSuffix)"
         $shortSha = "$(Build.SourceVersion)".Substring(0,10)
-        $newDockerTag = "$(Build.BuildNumber)-$shortSha$(devBranchSuffix)-$(System.JobAttempt)"
+        $newDockerTag = "$(Build.BuildNumber)-$shortSha-$(System.JobAttempt)$(devBranchSuffix)"
         Write-Host "##vso[task.setvariable variable=newDockerImageTag]$newDockerTag"
         Write-Host "set newDockerImageTag to $newDockerTag"
       displayName: Set new docker image tag variable


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
This PR adds `JobAttempt` to the docker image name, allowing us to retry failing deployments. Currently this is not possible, because we use the same name for the docker image and the revision name, and when we retry the deployment, it fails because a revision with that name already exists
https://github.com/dotnet/arcade-services/issues/3229
<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Allow PCS deployment retries