### PR TITLE
Refactor `PullRequestActor` a bit

### DIFF
--- a/src/Maestro/SubscriptionActorService/BatchedPullRequestActorImplementation.cs
+++ b/src/Maestro/SubscriptionActorService/BatchedPullRequestActorImplementation.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Maestro.Contracts;
+using Maestro.Data;
+using Maestro.Data.Models;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.ServiceFabric.ServiceHost;
+using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
+using Microsoft.Extensions.Logging;
+using Microsoft.ServiceFabric.Actors;
+using Microsoft.ServiceFabric.Actors.Runtime;
+
+namespace SubscriptionActorService;
+
+/// <summary>
+///     A <see cref="PullRequestActorImplementation" /> for batched subscriptions that reads its Target and Merge Policies
+///     from the configuration for a repository
+/// </summary>
+public class BatchedPullRequestActorImplementation : PullRequestActorImplementation
+{
+    private readonly ActorId _id;
+    private readonly BuildAssetRegistryContext _context;
+
+    public BatchedPullRequestActorImplementation(
+        ActorId id,
+        IReminderManager reminders,
+        IActorStateManager stateManager,
+        IMergePolicyEvaluator mergePolicyEvaluator,
+        ICoherencyUpdateResolver updateResolver,
+        BuildAssetRegistryContext context,
+        IRemoteFactory darcFactory,
+        IBasicBarClient barClient,
+        ILoggerFactory loggerFactory,
+        IActionRunner actionRunner,
+        IActorProxyFactory<ISubscriptionActor> subscriptionActorFactory)
+        : base(
+            id,
+            reminders,
+            stateManager,
+            mergePolicyEvaluator,
+            updateResolver,
+            context,
+            darcFactory,
+            barClient,
+            loggerFactory,
+            actionRunner,
+            subscriptionActorFactory)
+    {
+        _id = id;
+        _context = context;
+    }
+
+    private (string repository, string branch) Target => PullRequestActorId.Parse(_id);
+
+    protected override Task<(string repository, string branch)> GetTargetAsync()
+    {
+        return Task.FromResult((Target.repository, Target.branch));
+    }
+
+    protected override async Task<IReadOnlyList<MergePolicyDefinition>> GetMergePolicyDefinitions()
+    {
+        RepositoryBranch repositoryBranch =
+            await _context.RepositoryBranches.FindAsync(Target.repository, Target.branch);
+        return (IReadOnlyList<MergePolicyDefinition>) repositoryBranch?.PolicyObject?.MergePolicies ??
+               Array.Empty<MergePolicyDefinition>();
+    }
+}

--- a/src/Maestro/SubscriptionActorService/NonBatchedPullRequestActorImplementation.cs
+++ b/src/Maestro/SubscriptionActorService/NonBatchedPullRequestActorImplementation.cs
@@ -1,0 +1,115 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Maestro.Contracts;
+using Maestro.Data;
+using Maestro.Data.Models;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.ServiceFabric.ServiceHost;
+using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
+using Microsoft.Extensions.Logging;
+using Microsoft.ServiceFabric.Actors;
+using Microsoft.ServiceFabric.Actors.Runtime;
+
+namespace SubscriptionActorService;
+
+/// <summary>
+///     A <see cref="PullRequestActorImplementation" /> that reads its Merge Policies and Target information from a
+///     non-batched subscription object
+/// </summary>
+public class NonBatchedPullRequestActorImplementation : PullRequestActorImplementation
+{
+    private readonly Lazy<Task<Subscription>> _lazySubscription;
+    private readonly ActorId _id;
+    private readonly IReminderManager _reminders;
+    private readonly IActorStateManager _stateManager;
+    private readonly BuildAssetRegistryContext _context;
+    private readonly IPullRequestPolicyFailureNotifier _pullRequestPolicyFailureNotifier;
+
+    public NonBatchedPullRequestActorImplementation(
+        ActorId id,
+        IReminderManager reminders,
+        IActorStateManager stateManager,
+        IMergePolicyEvaluator mergePolicyEvaluator,
+        ICoherencyUpdateResolver updateResolver,
+        BuildAssetRegistryContext context,
+        IRemoteFactory darcFactory,
+        IBasicBarClient barClient,
+        ILoggerFactory loggerFactory,
+        IActionRunner actionRunner,
+        IActorProxyFactory<ISubscriptionActor> subscriptionActorFactory,
+        IPullRequestPolicyFailureNotifier pullRequestPolicyFailureNotifier)
+        : base(
+            id,
+            reminders,
+            stateManager,
+            mergePolicyEvaluator,
+            updateResolver,
+            context,
+            darcFactory,
+            barClient,
+            loggerFactory,
+            actionRunner,
+            subscriptionActorFactory)
+    {
+        _lazySubscription = new Lazy<Task<Subscription>>(RetrieveSubscription);
+        _id = id;
+        _reminders = reminders;
+        _stateManager = stateManager;
+        _context = context;
+        _pullRequestPolicyFailureNotifier = pullRequestPolicyFailureNotifier;
+    }
+
+    public Guid SubscriptionId => _id.GetGuidId();
+
+    private async Task<Subscription> RetrieveSubscription()
+    {
+        Subscription subscription = await _context.Subscriptions.FindAsync(SubscriptionId);
+        if (subscription == null)
+        {
+            await _reminders.TryUnregisterReminderAsync(PullRequestCheck);
+            await _reminders.TryUnregisterReminderAsync(PullRequestUpdate);
+            await _stateManager.TryRemoveStateAsync(PullRequest);
+
+            throw new SubscriptionException($"Subscription '{SubscriptionId}' was not found...");
+        }
+
+        return subscription;
+    }
+
+    private Task<Subscription> GetSubscription()
+    {
+        return _lazySubscription.Value;
+    }
+    protected override async Task TagSourceRepositoryGitHubContactsIfPossibleAsync(InProgressPullRequest pr)
+    {
+        await _pullRequestPolicyFailureNotifier.TagSourceRepositoryGitHubContactsAsync(pr);
+    }
+
+    protected override async Task<(string repository, string branch)> GetTargetAsync()
+    {
+        Subscription subscription = await GetSubscription();
+        return (subscription.TargetRepository, subscription.TargetBranch);
+    }
+
+    protected override async Task<IReadOnlyList<MergePolicyDefinition>> GetMergePolicyDefinitions()
+    {
+        Subscription subscription = await GetSubscription();
+        return (IReadOnlyList<MergePolicyDefinition>) subscription.PolicyObject.MergePolicies ??
+               Array.Empty<MergePolicyDefinition>();
+    }
+
+    public override async Task<(InProgressPullRequest pr, bool canUpdate)> SynchronizeInProgressPullRequestAsync()
+    {
+        Subscription subscription = await GetSubscription();
+        if (subscription == null)
+        {
+            return (null, false);
+        }
+
+        return await base.SynchronizeInProgressPullRequestAsync();
+    }
+}


### PR DESCRIPTION
This is a preparation for https://github.com/dotnet/arcade-services/issues/3317.
No functional changes here, just moving code around to mostly reduce nesting.

Changes:
- Moved `BatchedPullRequestActorImplementation` and `NonBatchedPullRequestActorImplementation` classes out of the main file
- Reduced nesting and return early from some more complicated methods
- Re-order flow of methods to handle state gradually "no PR `->` no updates `->` update PR"


<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes
