### PR TITLE
Add an E2E test for `Version.Details.xml` conflicts

### DIFF
--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeflowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeflowTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeflowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeflowTest.cs
@@ -437,6 +437,9 @@ internal class VmrCodeflowTest : VmrTestsBase
             <?xml version="1.0" encoding="utf-8"?>
             <Dependencies>
               <ProductDependencies>
+                <!-- Dependencies from https://github.com/dotnet/repo1 -->
+                <!-- Dependencies from https://github.com/dotnet/repo1 -->
+                <!-- Dependencies from https://github.com/dotnet/repo1 -->
                 <Dependency Name="Package.A1" Version="1.0.0">
                   <Uri>https://github.com/dotnet/repo1</Uri>
                   <Sha>a01</Sha>
@@ -445,14 +448,29 @@ internal class VmrCodeflowTest : VmrTestsBase
                   <Uri>https://github.com/dotnet/repo1</Uri>
                   <Sha>b02</Sha>
                 </Dependency>
+                <!-- End of dependencies from https://github.com/dotnet/repo1 -->
+                <!-- End of dependencies from https://github.com/dotnet/repo1 -->
+                <!-- End of dependencies from https://github.com/dotnet/repo1 -->
+                <!-- Dependencies from https://github.com/dotnet/repo2 -->
+                <!-- Dependencies from https://github.com/dotnet/repo2 -->
+                <!-- Dependencies from https://github.com/dotnet/repo2 -->
                 <Dependency Name="Package.C2" Version="1.0.0">
                   <Uri>https://github.com/dotnet/repo2</Uri>
                   <Sha>c03</Sha>
                 </Dependency>
+                <!-- End of dependencies from https://github.com/dotnet/repo2 -->
+                <!-- End of dependencies from https://github.com/dotnet/repo2 -->
+                <!-- End of dependencies from https://github.com/dotnet/repo2 -->
+                <!-- Dependencies from https://github.com/dotnet/repo3 -->
+                <!-- Dependencies from https://github.com/dotnet/repo3 -->
+                <!-- Dependencies from https://github.com/dotnet/repo3 -->
                 <Dependency Name="Package.D3" Version="1.0.0">
                   <Uri>https://github.com/dotnet/repo3</Uri>
                   <Sha>d04</Sha>
                 </Dependency>
+                <!-- End of dependencies from https://github.com/dotnet/repo3 -->
+                <!-- End of dependencies from https://github.com/dotnet/repo3 -->
+                <!-- End of dependencies from https://github.com/dotnet/repo3 -->
               </ProductDependencies>
               <ToolsetDependencies />
             </Dependencies>
@@ -472,19 +490,37 @@ internal class VmrCodeflowTest : VmrTestsBase
                 <VersionPrefix>9.0.100</VersionPrefix>
               </PropertyGroup>
               <!-- Production Dependencies -->
+              <!-- Dependencies from https://github.com/dotnet/repo1 -->
+              <!-- Dependencies from https://github.com/dotnet/repo1 -->
+              <!-- Dependencies from https://github.com/dotnet/repo1 -->
               <PropertyGroup>
-                <!-- Dependencies from https://github.com/dotnet/repo1 -->
+                <!-- Dependencies from https://github.com/dotnet/repo1-->
                 <PackageA1PackageVersion>1.0.0</PackageA1PackageVersion>
                 <PackageB1PackageVersion>1.0.0</PackageB1PackageVersion>
               </PropertyGroup>
+              <!-- End of dependencies from https://github.com/dotnet/repo1 -->
+              <!-- End of dependencies from https://github.com/dotnet/repo1 -->
+              <!-- End of dependencies from https://github.com/dotnet/repo1 -->
+              <!-- Dependencies from https://github.com/dotnet/repo2 -->
+              <!-- Dependencies from https://github.com/dotnet/repo2 -->
+              <!-- Dependencies from https://github.com/dotnet/repo2 -->
               <PropertyGroup>
-                <!-- Dependencies from https://github.com/dotnet/repo2 -->
+                <!-- Dependencies from https://github.com/dotnet/repo2-->
                 <PackageC2PackageVersion>1.0.0</PackageC2PackageVersion>
               </PropertyGroup>
+              <!-- End of dependencies from https://github.com/dotnet/repo2 -->
+              <!-- End of dependencies from https://github.com/dotnet/repo2 -->
+              <!-- End of dependencies from https://github.com/dotnet/repo2 -->
+              <!-- Dependencies from https://github.com/dotnet/repo3 -->
+              <!-- Dependencies from https://github.com/dotnet/repo3 -->
+              <!-- Dependencies from https://github.com/dotnet/repo3 -->
               <PropertyGroup>
                 <!-- Dependencies from https://github.com/dotnet/repo3 -->
                 <PackageD3PackageVersion>1.0.0</PackageD3PackageVersion>
               </PropertyGroup>
+              <!-- End of dependencies from https://github.com/dotnet/repo3 -->
+              <!-- End of dependencies from https://github.com/dotnet/repo3 -->
+              <!-- End of dependencies from https://github.com/dotnet/repo3 -->
             </Project>
             """);
 
@@ -501,21 +537,21 @@ internal class VmrCodeflowTest : VmrTestsBase
                 {
                     Name = "Package.A1",
                     Version = "1.0.1",
-                    RepoUri = ProductRepoPath,
+                    RepoUri = "https://github.com/dotnet/repo1",
                     Commit = "abc",
                 },
                 new DependencyDetail
                 {
                     Name = "Package.B1",
                     Version = "1.0.1",
-                    RepoUri = ProductRepoPath,
+                    RepoUri = "https://github.com/dotnet/repo1",
                     Commit = "abc",
                 },
                 new DependencyDetail
                 {
                     Name = "Package.D3",
                     Version = "1.0.3",
-                    RepoUri = ProductRepoPath,
+                    RepoUri = "https://github.com/dotnet/repo3",
                     Commit = "def",
                 },
             ],
@@ -541,55 +577,63 @@ internal class VmrCodeflowTest : VmrTestsBase
         await GitOperations.CommitAll(VmrPath, "Update repo2 dependencies in the VMR");
 
         // Flow repo to the VMR
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
+        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName + "2");
         hadUpdates.ShouldHaveUpdates();
-        await GitOperations.MergePrBranch(VmrPath, branchName);
+        await GitOperations.MergePrBranch(VmrPath, branchName + "2");
 
         // Flow changes back from the VMR
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName);
+        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName + "3");
         hadUpdates.ShouldHaveUpdates();
-        await GitOperations.MergePrBranch(ProductRepoPath, branchName);
+        await GitOperations.MergePrBranch(ProductRepoPath, branchName + "3");
 
         // Verify the version files have both of the changes
-        Local local = GetLocal(ProductRepoPath);
-        List<DependencyDetail> dependencies = await local.GetDependenciesAsync();
+        List<DependencyDetail> expectedDependencies =
+        [
+            new()
+            {
+                Name = "Package.A1",
+                Version = "1.0.1",
+                RepoUri = "https://github.com/dotnet/repo1",
+                Commit = "abc",
+                Type = DependencyType.Product,
+            },
+            new()
+            {
+                Name = "Package.B1",
+                Version = "1.0.1",
+                RepoUri = "https://github.com/dotnet/repo1",
+                Commit = "abc",
+                Type = DependencyType.Product,
+            },
+            new()
+            {
+                Name = "Package.C2",
+                Version = "2.0.0",
+                RepoUri = "https://github.com/dotnet/repo2",
+                Commit = "c04",
+                Type = DependencyType.Product,
+            },
+            new()
+            {
+                Name = "Package.D3",
+                Version = "1.0.3",
+                RepoUri = "https://github.com/dotnet/repo3",
+                Commit = "def",
+                Type = DependencyType.Product,
+            },
+        ];
 
-        dependencies.Should().BeEquivalentTo(
-            [
-                new DependencyDetail
-                {
-                    Name = "Package.A1",
-                    Version = "1.0.1",
-                    RepoUri = ProductRepoPath,
-                    Commit = "abc",
-                },
-                new DependencyDetail
-                {
-                    Name = "Package.B1",
-                    Version = "1.0.1",
-                    RepoUri = ProductRepoPath,
-                    Commit = "abc",
-                },
-                new DependencyDetail
-                {
-                    Name = "Package.C2",
-                    Version = "2.0.0",
-                    RepoUri = ProductRepoPath,
-                    Commit = "c04",
-                },
-                new DependencyDetail
-                {
-                    Name = "Package.D3",
-                    Version = "1.0.3",
-                    RepoUri = ProductRepoPath,
-                    Commit = "def",
-                },
-            ]);
+        var dependencies = await GetLocal(ProductRepoPath)
+            .GetDependenciesAsync();
 
-        vmrVersionDetails = await File.ReadAllTextAsync(_productRepoVmrPath / VersionFiles.VersionDetailsXml);
+        var vmrDependencies = new VersionDetailsParser()
+            .ParseVersionDetailsFile(_productRepoVmrPath / VersionFiles.VersionDetailsXml)
+            .Dependencies;
+
+        dependencies.Should().BeEquivalentTo(expectedDependencies);
+        vmrDependencies.Should().BeEquivalentTo(expectedDependencies);
+
         vmrVersionProps = await File.ReadAllTextAsync(_productRepoVmrPath / VersionFiles.VersionProps);
-
-        CheckFileContents(ProductRepoPath / VersionFiles.VersionDetailsXml, expected: vmrVersionDetails);
         CheckFileContents(ProductRepoPath / VersionFiles.VersionProps, expected: vmrVersionProps);
     }
 
@@ -640,7 +684,7 @@ internal class VmrCodeflowTest : VmrTestsBase
 
         sourceMappings.Defaults.Exclude =
         [
-            "externals/external-repo/**/*.exe", 
+            "externals/external-repo/**/*.exe",
             "excluded/*",
             "**/*.dll",
             "**/*.Dll",

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeflowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeflowTest.cs
@@ -438,8 +438,6 @@ internal class VmrCodeflowTest : VmrTestsBase
             <Dependencies>
               <ProductDependencies>
                 <!-- Dependencies from https://github.com/dotnet/repo1 -->
-                <!-- Dependencies from https://github.com/dotnet/repo1 -->
-                <!-- Dependencies from https://github.com/dotnet/repo1 -->
                 <Dependency Name="Package.A1" Version="1.0.0">
                   <Uri>https://github.com/dotnet/repo1</Uri>
                   <Sha>a01</Sha>
@@ -449,27 +447,17 @@ internal class VmrCodeflowTest : VmrTestsBase
                   <Sha>b02</Sha>
                 </Dependency>
                 <!-- End of dependencies from https://github.com/dotnet/repo1 -->
-                <!-- End of dependencies from https://github.com/dotnet/repo1 -->
-                <!-- End of dependencies from https://github.com/dotnet/repo1 -->
-                <!-- Dependencies from https://github.com/dotnet/repo2 -->
-                <!-- Dependencies from https://github.com/dotnet/repo2 -->
                 <!-- Dependencies from https://github.com/dotnet/repo2 -->
                 <Dependency Name="Package.C2" Version="1.0.0">
                   <Uri>https://github.com/dotnet/repo2</Uri>
                   <Sha>c03</Sha>
                 </Dependency>
                 <!-- End of dependencies from https://github.com/dotnet/repo2 -->
-                <!-- End of dependencies from https://github.com/dotnet/repo2 -->
-                <!-- End of dependencies from https://github.com/dotnet/repo2 -->
-                <!-- Dependencies from https://github.com/dotnet/repo3 -->
-                <!-- Dependencies from https://github.com/dotnet/repo3 -->
                 <!-- Dependencies from https://github.com/dotnet/repo3 -->
                 <Dependency Name="Package.D3" Version="1.0.0">
                   <Uri>https://github.com/dotnet/repo3</Uri>
                   <Sha>d04</Sha>
                 </Dependency>
-                <!-- End of dependencies from https://github.com/dotnet/repo3 -->
-                <!-- End of dependencies from https://github.com/dotnet/repo3 -->
                 <!-- End of dependencies from https://github.com/dotnet/repo3 -->
               </ProductDependencies>
               <ToolsetDependencies />
@@ -489,9 +477,6 @@ internal class VmrCodeflowTest : VmrTestsBase
               <PropertyGroup>
                 <VersionPrefix>9.0.100</VersionPrefix>
               </PropertyGroup>
-              <!-- Production Dependencies -->
-              <!-- Dependencies from https://github.com/dotnet/repo1 -->
-              <!-- Dependencies from https://github.com/dotnet/repo1 -->
               <!-- Dependencies from https://github.com/dotnet/repo1 -->
               <PropertyGroup>
                 <!-- Dependencies from https://github.com/dotnet/repo1-->
@@ -499,27 +484,17 @@ internal class VmrCodeflowTest : VmrTestsBase
                 <PackageB1PackageVersion>1.0.0</PackageB1PackageVersion>
               </PropertyGroup>
               <!-- End of dependencies from https://github.com/dotnet/repo1 -->
-              <!-- End of dependencies from https://github.com/dotnet/repo1 -->
-              <!-- End of dependencies from https://github.com/dotnet/repo1 -->
-              <!-- Dependencies from https://github.com/dotnet/repo2 -->
-              <!-- Dependencies from https://github.com/dotnet/repo2 -->
               <!-- Dependencies from https://github.com/dotnet/repo2 -->
               <PropertyGroup>
                 <!-- Dependencies from https://github.com/dotnet/repo2-->
                 <PackageC2PackageVersion>1.0.0</PackageC2PackageVersion>
               </PropertyGroup>
               <!-- End of dependencies from https://github.com/dotnet/repo2 -->
-              <!-- End of dependencies from https://github.com/dotnet/repo2 -->
-              <!-- End of dependencies from https://github.com/dotnet/repo2 -->
-              <!-- Dependencies from https://github.com/dotnet/repo3 -->
-              <!-- Dependencies from https://github.com/dotnet/repo3 -->
               <!-- Dependencies from https://github.com/dotnet/repo3 -->
               <PropertyGroup>
                 <!-- Dependencies from https://github.com/dotnet/repo3 -->
                 <PackageD3PackageVersion>1.0.0</PackageD3PackageVersion>
               </PropertyGroup>
-              <!-- End of dependencies from https://github.com/dotnet/repo3 -->
-              <!-- End of dependencies from https://github.com/dotnet/repo3 -->
               <!-- End of dependencies from https://github.com/dotnet/repo3 -->
             </Project>
             """);

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -31,9 +31,11 @@ internal abstract class VmrTestsBase
     protected NativePath DependencyRepoPath { get; private set; } = null!;
     protected NativePath InstallerRepoPath { get; private set; } = null!;
     protected GitOperationsHelper GitOperations { get; } = new();
-    
-    private Lazy<IServiceProvider> _serviceProvider = null!;
+    protected IServiceProvider ServiceProvider => _serviceProvider.Value;
+
     private readonly CancellationTokenSource _cancellationToken = new();
+
+    private Lazy<IServiceProvider> _serviceProvider = null!;
 
     [SetUp]
     public async Task Setup()
@@ -161,7 +163,7 @@ internal abstract class VmrTestsBase
 
     private async Task CallDarcInitialize(string repository, string commit, LocalPath sourceMappingsPath)
     {
-        var vmrInitializer = _serviceProvider.Value.GetRequiredService<IVmrInitializer>();
+        var vmrInitializer = ServiceProvider.GetRequiredService<IVmrInitializer>();
         await vmrInitializer.InitializeRepository(repository, commit, null, true, sourceMappingsPath, Array.Empty<AdditionalRemote>(), null, null, false, true, _cancellationToken.Token);
     }
 
@@ -172,31 +174,31 @@ internal abstract class VmrTestsBase
 
     protected async Task CallDarcUpdate(string repository, string commit, AdditionalRemote[] additionalRemotes, bool generateCodeowners = false)
     {
-        var vmrUpdater = _serviceProvider.Value.GetRequiredService<IVmrUpdater>();
+        var vmrUpdater = ServiceProvider.GetRequiredService<IVmrUpdater>();
         await vmrUpdater.UpdateRepository(repository, commit, null, true, additionalRemotes, null, null, generateCodeowners, true, _cancellationToken.Token);
     }
 
     protected async Task<bool> CallDarcBackflow(string mappingName, NativePath repoPath, string branch, string? shaToFlow = null, int? buildToFlow = null)
     {
-        var codeflower = _serviceProvider.Value.GetRequiredService<IVmrBackFlower>();
+        var codeflower = ServiceProvider.GetRequiredService<IVmrBackFlower>();
         return await codeflower.FlowBackAsync(mappingName, repoPath, shaToFlow, buildToFlow, branch, cancellationToken: _cancellationToken.Token);
     }
 
     protected async Task<bool> CallDarcForwardflow(string mappingName, NativePath repoPath, string branch, string? shaToFlow = null, int? buildToFlow = null)
     {
-        var codeflower = _serviceProvider.Value.GetRequiredService<IVmrForwardFlower>();
+        var codeflower = ServiceProvider.GetRequiredService<IVmrForwardFlower>();
         return await codeflower.FlowForwardAsync(mappingName, repoPath, shaToFlow, buildToFlow, branch, cancellationToken: _cancellationToken.Token);
     }
 
     protected async Task<List<string>> CallDarcCloakedFileScan(string baselinesFilePath)
     {
-        var cloakedFileScanner = _serviceProvider.Value.GetRequiredService<VmrCloakedFileScanner>();
+        var cloakedFileScanner = ServiceProvider.GetRequiredService<VmrCloakedFileScanner>();
         return await cloakedFileScanner.ScanVmr(baselinesFilePath, _cancellationToken.Token);
     }
 
     protected async Task<List<string>> CallDarcBinaryFileScan(string baselinesFilePath)
     {
-        var binaryFileScanner = _serviceProvider.Value.GetRequiredService<VmrBinaryFileScanner>();
+        var binaryFileScanner = ServiceProvider.GetRequiredService<VmrBinaryFileScanner>();
         return await binaryFileScanner.ScanVmr(baselinesFilePath, _cancellationToken.Token);
     }
 
@@ -302,6 +304,6 @@ internal abstract class VmrTestsBase
     }
 
     // Needed for some local git operations
-    protected Local GetLocal(NativePath repoPath) => ActivatorUtilities.CreateInstance<Local>(_serviceProvider.Value, repoPath.ToString());
-    protected DependencyFileManager GetDependencyFileManager() => ActivatorUtilities.CreateInstance<DependencyFileManager>(_serviceProvider.Value);
+    protected Local GetLocal(NativePath repoPath) => ActivatorUtilities.CreateInstance<Local>(ServiceProvider, repoPath.ToString());
+    protected DependencyFileManager GetDependencyFileManager() => ActivatorUtilities.CreateInstance<DependencyFileManager>(ServiceProvider);
 }


### PR DESCRIPTION
The `Version.Details.xml` file will be getting changes via code flow as well as Maestro updates. We are adding a test that makes sure that bumps of packages from different repos do not clash with each other.

https://github.com/dotnet/arcade-services/issues/3379

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes