### PR TITLE
Make GitHub check tests more resilient

### DIFF
--- a/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
@@ -42,7 +42,7 @@ internal class ScenarioTests_MergePolicies : MaestroScenarioTestBase
 
     private string GetTargetBranch()
     {
-        return _random.Next(int.MaxValue).ToString();
+        return Guid.NewGuid().ToString();
     }
 
     [Test]


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/3031

- Adds more logging to E2E tests
- Searches for closed PRs as well - they are unique by target branch which is a GUID - so if the PR gets closed fast, we would still find it

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description

Skip in release notes
