### PR TITLE
Make working with SF state more safe

### DIFF
--- a/src/Maestro/SubscriptionActorService/BatchedPullRequestActorImplementation.cs
+++ b/src/Maestro/SubscriptionActorService/BatchedPullRequestActorImplementation.cs
@@ -20,7 +20,7 @@ namespace SubscriptionActorService;
 ///     A <see cref="PullRequestActorImplementation" /> for batched subscriptions that reads its Target and Merge Policies
 ///     from the configuration for a repository
 /// </summary>
-public class BatchedPullRequestActorImplementation : PullRequestActorImplementation
+internal class BatchedPullRequestActorImplementation : PullRequestActorImplementation
 {
     private readonly ActorId _id;
     private readonly BuildAssetRegistryContext _context;
@@ -38,7 +38,6 @@ public class BatchedPullRequestActorImplementation : PullRequestActorImplementat
         IActionRunner actionRunner,
         IActorProxyFactory<ISubscriptionActor> subscriptionActorFactory)
         : base(
-            id,
             reminders,
             stateManager,
             mergePolicyEvaluator,

--- a/src/Maestro/SubscriptionActorService/IPullRequestPolicyFailureNotifier.cs
+++ b/src/Maestro/SubscriptionActorService/IPullRequestPolicyFailureNotifier.cs
@@ -3,6 +3,7 @@
 
 
 using System.Threading.Tasks;
+using SubscriptionActorService.StateModel;
 
 namespace SubscriptionActorService;
 

--- a/src/Maestro/SubscriptionActorService/NonBatchedPullRequestActorImplementation.cs
+++ b/src/Maestro/SubscriptionActorService/NonBatchedPullRequestActorImplementation.cs
@@ -25,8 +25,6 @@ internal class NonBatchedPullRequestActorImplementation : PullRequestActorImplem
 {
     private readonly Lazy<Task<Subscription>> _lazySubscription;
     private readonly ActorId _id;
-    private readonly IReminderManager _reminders;
-    private readonly IActorStateManager _stateManager;
     private readonly BuildAssetRegistryContext _context;
     private readonly IPullRequestPolicyFailureNotifier _pullRequestPolicyFailureNotifier;
 
@@ -44,7 +42,6 @@ internal class NonBatchedPullRequestActorImplementation : PullRequestActorImplem
         IActorProxyFactory<ISubscriptionActor> subscriptionActorFactory,
         IPullRequestPolicyFailureNotifier pullRequestPolicyFailureNotifier)
         : base(
-            id,
             reminders,
             stateManager,
             mergePolicyEvaluator,
@@ -58,8 +55,6 @@ internal class NonBatchedPullRequestActorImplementation : PullRequestActorImplem
     {
         _lazySubscription = new Lazy<Task<Subscription>>(RetrieveSubscription);
         _id = id;
-        _reminders = reminders;
-        _stateManager = stateManager;
         _context = context;
         _pullRequestPolicyFailureNotifier = pullRequestPolicyFailureNotifier;
     }
@@ -71,9 +66,9 @@ internal class NonBatchedPullRequestActorImplementation : PullRequestActorImplem
         Subscription subscription = await _context.Subscriptions.FindAsync(SubscriptionId);
         if (subscription == null)
         {
-            await _reminders.TryUnregisterReminderAsync(PullRequestCheck);
-            await _reminders.TryUnregisterReminderAsync(PullRequestUpdate);
-            await _stateManager.TryRemoveStateAsync(PullRequest);
+            await _pullRequestCheckState.UnsetReminderAsync();
+            await _pullRequestUpdateState.UnsetReminderAsync();
+            await _pullRequestState.RemoveStateAsync();
 
             throw new SubscriptionException($"Subscription '{SubscriptionId}' was not found...");
         }

--- a/src/Maestro/SubscriptionActorService/NonBatchedPullRequestActorImplementation.cs
+++ b/src/Maestro/SubscriptionActorService/NonBatchedPullRequestActorImplementation.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
 using Microsoft.Extensions.Logging;
 using Microsoft.ServiceFabric.Actors;
 using Microsoft.ServiceFabric.Actors.Runtime;
+using SubscriptionActorService.StateModel;
 
 namespace SubscriptionActorService;
 
@@ -20,7 +21,7 @@ namespace SubscriptionActorService;
 ///     A <see cref="PullRequestActorImplementation" /> that reads its Merge Policies and Target information from a
 ///     non-batched subscription object
 /// </summary>
-public class NonBatchedPullRequestActorImplementation : PullRequestActorImplementation
+internal class NonBatchedPullRequestActorImplementation : PullRequestActorImplementation
 {
     private readonly Lazy<Task<Subscription>> _lazySubscription;
     private readonly ActorId _id;

--- a/src/Maestro/SubscriptionActorService/Properties/AssemblyInfo.cs
+++ b/src/Maestro/SubscriptionActorService/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SubscriptionActorService.Tests")]

--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -19,7 +19,6 @@ using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
 using Microsoft.Extensions.Logging;
 using Microsoft.ServiceFabric.Actors;
 using Microsoft.ServiceFabric.Actors.Runtime;
-using Microsoft.ServiceFabric.Data;
 using SubscriptionActorService.StateModel;
 using Asset = Maestro.Contracts.Asset;
 using AssetData = Microsoft.DotNet.Maestro.Client.Models.AssetData;
@@ -58,7 +57,7 @@ namespace SubscriptionActorService
     ///     A service fabric actor implementation that is responsible for creating and updating pull requests for dependency
     ///     updates.
     /// </summary>
-    public class PullRequestActor : IPullRequestActor, IRemindable, IActionTracker, IActorImplementation
+    internal class PullRequestActor : IPullRequestActor, IRemindable, IActionTracker, IActorImplementation
     {
         private readonly IMergePolicyEvaluator _mergePolicyEvaluator;
         private readonly BuildAssetRegistryContext _context;
@@ -180,7 +179,7 @@ namespace SubscriptionActorService
         }
     }
 
-    public abstract class PullRequestActorImplementation : IPullRequestActor, IActionTracker
+    internal abstract class PullRequestActorImplementation : IPullRequestActor, IActionTracker
     {
         // Actor state keys
         public const string PullRequestCheckKey = "pullRequestCheck";
@@ -201,12 +200,11 @@ namespace SubscriptionActorService
         private readonly IActorProxyFactory<ISubscriptionActor> _subscriptionActorFactory;
         private readonly ICoherencyUpdateResolver _coherencyUpdateResolver;
 
-        private readonly ActorCollectionStateManager<UpdateAssetsParameters> _pullRequestUpdateState;
-        private readonly ActorStateManager<UpdateAssetsParameters> _pullRequestCheckState;
-        private readonly ActorStateManager<InProgressPullRequest> _pullRequestState;
+        protected readonly ActorCollectionStateManager<UpdateAssetsParameters> _pullRequestUpdateState;
+        protected readonly ActorStateManager<UpdateAssetsParameters> _pullRequestCheckState;
+        protected readonly ActorStateManager<InProgressPullRequest> _pullRequestState;
 
         protected PullRequestActorImplementation(
-            ActorId id,
             IReminderManager reminders,
             IActorStateManager stateManager,
             IMergePolicyEvaluator mergePolicyEvaluator,

--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -20,7 +20,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.ServiceFabric.Actors;
 using Microsoft.ServiceFabric.Actors.Runtime;
 using Microsoft.ServiceFabric.Data;
-
+using SubscriptionActorService.StateModel;
 using Asset = Maestro.Contracts.Asset;
 using AssetData = Microsoft.DotNet.Maestro.Client.Models.AssetData;
 
@@ -1254,39 +1254,6 @@ namespace SubscriptionActorService
             }
 
             return repoBranch;
-        }
-
-        #nullable disable
-        [DataContract]
-        public class UpdateAssetsParameters
-        {
-            [DataMember]
-            public Guid SubscriptionId { get; set; }
-
-            [DataMember]
-            public int BuildId { get; set; }
-
-            [DataMember]
-            public string SourceSha { get; set; }
-
-            [DataMember]
-            public string SourceRepo { get; set; }
-
-            [DataMember]
-            public List<Asset> Assets { get; set; }
-
-            /// <summary>
-            ///     If true, this is a coherency update and not driven by specific
-            ///     subscription ids (e.g. could be multiple if driven by a batched subscription)
-            /// </summary>
-            [DataMember]
-            public bool IsCoherencyUpdate { get; set; }
-
-            /// <summary>
-            ///     True for code-flow (VMR) subscriptions.
-            /// </summary>
-            [DataMember]
-            public bool IsCodeFlow { get; set; }
         }
     }
 }

--- a/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestDescriptionBuilder.cs
@@ -4,6 +4,7 @@
 using Maestro.Data.Models;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.Extensions.Logging;
+using SubscriptionActorService.StateModel;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Maestro/SubscriptionActorService/PullRequestPolicyFailureNotifier.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestPolicyFailureNotifier.cs
@@ -4,6 +4,7 @@
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.Extensions.Logging;
+using SubscriptionActorService.StateModel;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Maestro/SubscriptionActorService/StateModel/ActorCollectionStateManager.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/ActorCollectionStateManager.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
+using Microsoft.ServiceFabric.Actors.Runtime;
+
+#nullable enable
+namespace SubscriptionActorService.StateModel;
+
+/// <summary>
+/// Wrapper class that binds the key under which the state is stored.
+/// Allows to store multiple items of the same type in the state
+/// </summary>
+internal class ActorCollectionStateManager<T> : ActorStateManager<List<T>>
+{
+    private readonly IActorStateManager _stateManager;
+    private readonly string _key;
+
+    public ActorCollectionStateManager(IActorStateManager stateManager, IReminderManager reminderManager, string key)
+        : base(stateManager, reminderManager, key)
+    {
+        _stateManager = stateManager;
+        _key = key;
+    }
+
+    public async Task StoreItemStateAsync(T value)
+    {
+        await _stateManager.AddOrUpdateStateAsync(
+            _key,
+            new List<T> { value },
+            (_, old) =>
+            {
+                old.Add(value);
+                return old;
+            });
+    }
+}

--- a/src/Maestro/SubscriptionActorService/StateModel/ActorCollectionStateManager.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/ActorCollectionStateManager.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
@@ -16,12 +17,14 @@ namespace SubscriptionActorService.StateModel;
 internal class ActorCollectionStateManager<T> : ActorStateManager<List<T>>
 {
     private readonly IActorStateManager _stateManager;
+    private readonly IReminderManager _reminderManager;
     private readonly string _key;
 
     public ActorCollectionStateManager(IActorStateManager stateManager, IReminderManager reminderManager, string key)
         : base(stateManager, reminderManager, key)
     {
         _stateManager = stateManager;
+        _reminderManager = reminderManager;
         _key = key;
     }
 
@@ -35,5 +38,14 @@ internal class ActorCollectionStateManager<T> : ActorStateManager<List<T>>
                 old.Add(value);
                 return old;
             });
+    }
+
+    public override async Task SetReminderAsync(int dueTimeInMinutes = DefaultDueTimeInMinutes)
+    {
+        await _reminderManager.TryRegisterReminderAsync(
+            _key,
+            [],
+            TimeSpan.FromMinutes(dueTimeInMinutes),
+            TimeSpan.FromMinutes(dueTimeInMinutes));
     }
 }

--- a/src/Maestro/SubscriptionActorService/StateModel/ActorStateManager.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/ActorStateManager.cs
@@ -15,7 +15,7 @@ namespace SubscriptionActorService.StateModel;
 /// </summary>
 internal class ActorStateManager<T> where T : class
 {
-    private const int DefaultDueTimeInMinutes = 5;
+    protected const int DefaultDueTimeInMinutes = 5;
 
     private readonly IActorStateManager _stateManager;
     private readonly IReminderManager _reminderManager;
@@ -48,11 +48,11 @@ internal class ActorStateManager<T> where T : class
         await _stateManager.TryRemoveStateAsync(_key);
     }
 
-    public async Task SetReminderAsync(int dueTimeInMinutes = DefaultDueTimeInMinutes)
+    public virtual async Task SetReminderAsync(int dueTimeInMinutes = DefaultDueTimeInMinutes)
     {
         await _reminderManager.TryRegisterReminderAsync(
             _key,
-            [],
+            null,
             TimeSpan.FromMinutes(dueTimeInMinutes),
             TimeSpan.FromMinutes(dueTimeInMinutes));
     }

--- a/src/Maestro/SubscriptionActorService/StateModel/ActorStateManager.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/ActorStateManager.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
+using Microsoft.ServiceFabric.Actors.Runtime;
+using Microsoft.ServiceFabric.Data;
+
+#nullable enable
+namespace SubscriptionActorService.StateModel;
+
+/// <summary>
+/// Wrapper class that binds the key under which the state is stored.
+/// </summary>
+internal class ActorStateManager<T> where T : class
+{
+    private const int DefaultDueTimeInMinutes = 5;
+
+    private readonly IActorStateManager _stateManager;
+    private readonly IReminderManager _reminderManager;
+    private readonly string _key;
+
+    public ActorStateManager(
+        IActorStateManager stateManager,
+        IReminderManager reminderManager,
+        string key)
+    {
+        _stateManager = stateManager;
+        _reminderManager = reminderManager;
+        _key = key;
+    }
+
+    public async Task<T?> TryGetStateAsync()
+    {
+        ConditionalValue<T> value = await _stateManager.TryGetStateAsync<T>(_key);
+        return value.HasValue ? value.Value : null;
+    }
+
+    public async Task StoreStateAsync(T value)
+    {
+        await _stateManager.SetStateAsync(_key, value);
+        await _stateManager.SaveStateAsync();
+    }
+
+    public async Task RemoveStateAsync()
+    {
+        await _stateManager.TryRemoveStateAsync(_key);
+    }
+
+    public async Task SetReminderAsync(int dueTimeInMinutes = DefaultDueTimeInMinutes)
+    {
+        await _reminderManager.TryRegisterReminderAsync(
+            _key,
+            [],
+            TimeSpan.FromMinutes(dueTimeInMinutes),
+            TimeSpan.FromMinutes(dueTimeInMinutes));
+    }
+
+    public async Task UnsetReminderAsync()
+    {
+        await _reminderManager.TryUnregisterReminderAsync(_key);
+    }
+}

--- a/src/Maestro/SubscriptionActorService/StateModel/InProgressPullRequest.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/InProgressPullRequest.cs
@@ -1,12 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Maestro.Contracts;
 
-namespace SubscriptionActorService;
+namespace SubscriptionActorService.StateModel;
 
 [DataContract]
 public class InProgressPullRequest : IPullRequest
@@ -34,14 +33,7 @@ public class InProgressPullRequest : IPullRequest
 
     [DataMember]
     public bool? SourceRepoNotified { get; set; }
-}
-
-[DataContract]
-public class SubscriptionPullRequestUpdate
-{
-    [DataMember]
-    public Guid SubscriptionId { get; set; }
 
     [DataMember]
-    public int BuildId { get; set; }
+    public string PrBranch { get; set; }
 }

--- a/src/Maestro/SubscriptionActorService/StateModel/SubscriptionPullRequestUpdate.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/SubscriptionPullRequestUpdate.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace SubscriptionActorService.StateModel;
+
+[DataContract]
+public class SubscriptionPullRequestUpdate
+{
+    [DataMember]
+    public Guid SubscriptionId { get; set; }
+
+    [DataMember]
+    public int BuildId { get; set; }
+}

--- a/src/Maestro/SubscriptionActorService/StateModel/SynchronizePullRequestResult.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/SynchronizePullRequestResult.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace SubscriptionActorService;
+namespace SubscriptionActorService.StateModel;
 
 public enum SynchronizePullRequestResult
 {

--- a/src/Maestro/SubscriptionActorService/StateModel/UpdateAssetsParameters.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/UpdateAssetsParameters.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System;
+using System.Runtime.Serialization;
+using Maestro.Contracts;
+
+namespace SubscriptionActorService.StateModel;
+
+[DataContract]
+public class UpdateAssetsParameters
+{
+    [DataMember]
+    public Guid SubscriptionId { get; set; }
+
+    [DataMember]
+    public int BuildId { get; set; }
+
+    [DataMember]
+    public string SourceSha { get; set; }
+
+    [DataMember]
+    public string SourceRepo { get; set; }
+
+    [DataMember]
+    public List<Asset> Assets { get; set; }
+
+    /// <summary>
+    ///     If true, this is a coherency update and not driven by specific
+    ///     subscription ids (e.g. could be multiple if driven by a batched subscription)
+    /// </summary>
+    [DataMember]
+    public bool IsCoherencyUpdate { get; set; }
+
+    /// <summary>
+    ///     True for code-flow (VMR) subscriptions.
+    /// </summary>
+    [DataMember]
+    public bool IsCodeFlow { get; set; }
+}

--- a/test/SubscriptionActorService.Tests/Properties/AssemblyInfo.cs
+++ b/test/SubscriptionActorService.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.DotNet.Darc.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/test/SubscriptionActorService.Tests/Properties/AssemblyInfo.cs
+++ b/test/SubscriptionActorService.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Microsoft.DotNet.Darc.Tests")]
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/test/SubscriptionActorService.Tests/PullRequestActorTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestActorTests.cs
@@ -319,8 +319,8 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
                     },
                 ]
             };
-            StateManager.SetStateAsync(PullRequestActorImplementation.PullRequest, pr);
-            ExpectedActorState.Add(PullRequestActorImplementation.PullRequest, pr);
+            StateManager.SetStateAsync(PullRequestActorImplementation.PullRequestKey, pr);
+            ExpectedActorState.Add(PullRequestActorImplementation.PullRequestKey, pr);
         });
             
         ActionRunner.Setup(r => r.ExecuteAction(It.IsAny<Expression<Func<Task<ActionResult<SynchronizePullRequestResult>>>>>()))
@@ -352,9 +352,9 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
     private void AndShouldHavePullRequestCheckReminder()
     {
         ExpectedReminders.Add(
-            PullRequestActorImplementation.PullRequestCheck,
+            PullRequestActorImplementation.PullRequestCheckKey,
             new MockReminderManager.Reminder(
-                PullRequestActorImplementation.PullRequestCheck,
+                PullRequestActorImplementation.PullRequestCheckKey,
                 null,
                 TimeSpan.FromMinutes(5),
                 TimeSpan.FromMinutes(5)));
@@ -363,9 +363,9 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
     private void ThenShouldHavePullRequestUpdateReminder()
     {
         ExpectedReminders.Add(
-            PullRequestActorImplementation.PullRequestUpdate,
+            PullRequestActorImplementation.PullRequestUpdateKey,
             new MockReminderManager.Reminder(
-                PullRequestActorImplementation.PullRequestUpdate,
+                PullRequestActorImplementation.PullRequestUpdateKey,
                 [],
                 TimeSpan.FromMinutes(5),
                 TimeSpan.FromMinutes(5)));
@@ -374,7 +374,7 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
     private void AndShouldHaveInProgressPullRequestState(Build forBuild, bool coherencyCheckSuccessful = true, List<CoherencyErrorDetails>? coherencyErrors = null)
     {
         ExpectedActorState.Add(
-            PullRequestActorImplementation.PullRequest,
+            PullRequestActorImplementation.PullRequestKey,
             new InProgressPullRequest
             {
                 ContainedSubscriptions =
@@ -402,7 +402,7 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
     private void AndShouldHavePendingUpdateState(Build forBuild)
     {
         ExpectedActorState.Add(
-            PullRequestActorImplementation.PullRequestUpdate,
+            PullRequestActorImplementation.PullRequestUpdateKey,
             new List<UpdateAssetsParameters>
             {
                 new()
@@ -456,19 +456,19 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
         private void GivenAPendingUpdateReminder()
         {
             var reminder = new MockReminderManager.Reminder(
-                PullRequestActorImplementation.PullRequestUpdate,
+                PullRequestActorImplementation.PullRequestUpdateKey,
                 [],
                 TimeSpan.FromMinutes(5),
                 TimeSpan.FromMinutes(5));
-            Reminders.Data[PullRequestActorImplementation.PullRequestUpdate] = reminder;
-            ExpectedReminders[PullRequestActorImplementation.PullRequestUpdate] = reminder;
+            Reminders.Data[PullRequestActorImplementation.PullRequestUpdateKey] = reminder;
+            ExpectedReminders[PullRequestActorImplementation.PullRequestUpdateKey] = reminder;
         }
 
         private void AndNoPendingUpdates()
         {
             var updates = new List<UpdateAssetsParameters>();
-            StateManager.Data[PullRequestActorImplementation.PullRequestUpdate] = updates;
-            ExpectedActorState[PullRequestActorImplementation.PullRequestUpdate] = updates;
+            StateManager.Data[PullRequestActorImplementation.PullRequestUpdateKey] = updates;
+            ExpectedActorState[PullRequestActorImplementation.PullRequestUpdateKey] = updates;
         }
 
         private void AndPendingUpdates(Build forBuild)
@@ -490,19 +490,19 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
                             IsCoherencyUpdate = false
                         }
                     };
-                    StateManager.Data[PullRequestActorImplementation.PullRequestUpdate] = updates;
-                    ExpectedActorState[PullRequestActorImplementation.PullRequestUpdate] = updates;
+                    StateManager.Data[PullRequestActorImplementation.PullRequestUpdateKey] = updates;
+                    ExpectedActorState[PullRequestActorImplementation.PullRequestUpdateKey] = updates;
                 });
         }
 
         private void ThenUpdateReminderIsRemoved()
         {
-            ExpectedReminders.Remove(PullRequestActorImplementation.PullRequestUpdate);
+            ExpectedReminders.Remove(PullRequestActorImplementation.PullRequestUpdateKey);
         }
 
         private void AndPendingUpdateIsRemoved()
         {
-            ExpectedActorState.Remove(PullRequestActorImplementation.PullRequestUpdate);
+            ExpectedActorState.Remove(PullRequestActorImplementation.PullRequestUpdateKey);
         }
 
         [Test]

--- a/test/SubscriptionActorService.Tests/PullRequestActorTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestActorTests.cs
@@ -20,7 +20,7 @@ using Microsoft.ServiceFabric.Actors;
 using Microsoft.VisualStudio.Services.Common;
 using Moq;
 using NUnit.Framework;
-
+using SubscriptionActorService.StateModel;
 using Asset = Maestro.Contracts.Asset;
 using AssetData = Microsoft.DotNet.Maestro.Client.Models.AssetData;
 
@@ -403,7 +403,7 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
     {
         ExpectedActorState.Add(
             PullRequestActorImplementation.PullRequestUpdate,
-            new List<PullRequestActorImplementation.UpdateAssetsParameters>
+            new List<UpdateAssetsParameters>
             {
                 new()
                 {
@@ -466,7 +466,7 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
 
         private void AndNoPendingUpdates()
         {
-            var updates = new List<PullRequestActorImplementation.UpdateAssetsParameters>();
+            var updates = new List<UpdateAssetsParameters>();
             StateManager.Data[PullRequestActorImplementation.PullRequestUpdate] = updates;
             ExpectedActorState[PullRequestActorImplementation.PullRequestUpdate] = updates;
         }
@@ -476,7 +476,7 @@ public class PullRequestActorTests : SubscriptionOrPullRequestActorTests
             AfterDbUpdateActions.Add(
                 () =>
                 {
-                    var updates = new List<PullRequestActorImplementation.UpdateAssetsParameters>
+                    var updates = new List<UpdateAssetsParameters>
                     {
                         new()
                         {

--- a/test/SubscriptionActorService.Tests/PullRequestDescriptionBuilderTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestDescriptionBuilderTests.cs
@@ -9,6 +9,7 @@ using Maestro.Data.Models;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
+using SubscriptionActorService.StateModel;
 using static SubscriptionActorService.PullRequestActorImplementation;
 
 namespace SubscriptionActorService.Tests;

--- a/test/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
+using SubscriptionActorService.StateModel;
 using ClientModels = Microsoft.DotNet.Maestro.Client.Models;
 
 namespace SubscriptionActorService.Tests;


### PR DESCRIPTION
Every time we need to set Service Fabric reminders or read/store/remove stored state, we need to pass in the key. We could mess up the key/stored type combination so it's a bit error prone. Together with the fact that I will be adding more state, I decided to encapsulate the state access and bind the key once at the initialization.

I also moved the state model classes in a separate folder.

This is a preparation for https://github.com/dotnet/arcade-services/issues/3317.
No functional changes here.

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes