### PR TITLE
Set `DotNetReleaseShipping` property in `manifest.json`

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/ManifestHelper.cs
@@ -23,10 +23,9 @@ public class ManifestHelper
         IEnumerable<DownloadedBuild> downloadedBuilds,
         string outputPath,
         bool makeAssetsRelativePaths,
-        bool writeReleaseLayoutTarget,
         ILogger logger)
     {
-        return GenerateDarcAssetJsonManifest(downloadedBuilds, null, outputPath, makeAssetsRelativePaths, writeReleaseLayoutTarget, logger);
+        return GenerateDarcAssetJsonManifest(downloadedBuilds, null, outputPath, makeAssetsRelativePaths, logger);
     }
 
     public static JObject GenerateDarcAssetJsonManifest(
@@ -34,7 +33,6 @@ public class ManifestHelper
         List<DownloadedAsset>? alwaysDownloadedAssets,
         string outputPath,
         bool makeAssetsRelativePaths,
-        bool writeReleaseLayoutTarget,
         ILogger logger)
     {
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/ManifestHelper.cs
@@ -164,7 +164,7 @@ public class ManifestHelper
                     continue;
 
                 string? assetOrigin = asset.Attribute("Origin")?.Value;
-                bool dotNetReleaseShipping = asset.Attribute("DotNetReleaseShipping")?.Value == "true";
+                bool dotNetReleaseShipping = asset.Attribute("DotNetReleaseShipping")?.Value.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
 
                 // An Origin attribute has been added to the MergeManifest.xml file for the VMR build to differentiate assets produced by different repos,
                 // as mentioned in https://github.com/dotnet/source-build/issues/3898.
@@ -191,16 +191,5 @@ public class ManifestHelper
         return assetMetadataMap;
     }
 
-    private class AssetReleaseMetadata
-    {
-        public AssetReleaseMetadata(string origin, bool dotNetReleaseShipping)
-        {
-            Origin = origin;
-            DotNetReleaseShipping = dotNetReleaseShipping;
-        }
-
-        public string Origin { get; set; }
-
-        public bool DotNetReleaseShipping { get; set; }
-    }
+    private record AssetReleaseMetadata(string Origin, bool DotNetReleaseShipping);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/ManifestHelper.cs
@@ -19,15 +19,23 @@ public class ManifestHelper
 {
     private const string MergedManifestFileName = "MergedManifest.xml";
 
-    public static JObject GenerateDarcAssetJsonManifest(IEnumerable<DownloadedBuild> downloadedBuilds,
-        string outputPath, bool makeAssetsRelativePaths, ILogger logger)
+    public static JObject GenerateDarcAssetJsonManifest(
+        IEnumerable<DownloadedBuild> downloadedBuilds,
+        string outputPath,
+        bool makeAssetsRelativePaths,
+        bool writeReleaseLayoutTarget,
+        ILogger logger)
     {
-        return GenerateDarcAssetJsonManifest(downloadedBuilds, null, outputPath, makeAssetsRelativePaths, logger);
+        return GenerateDarcAssetJsonManifest(downloadedBuilds, null, outputPath, makeAssetsRelativePaths, writeReleaseLayoutTarget, logger);
     }
 
-
-    public static JObject GenerateDarcAssetJsonManifest(IEnumerable<DownloadedBuild> downloadedBuilds, List<DownloadedAsset>? alwaysDownloadedAssets,
-        string outputPath, bool makeAssetsRelativePaths, ILogger logger)
+    public static JObject GenerateDarcAssetJsonManifest(
+        IEnumerable<DownloadedBuild> downloadedBuilds,
+        List<DownloadedAsset>? alwaysDownloadedAssets,
+        string outputPath,
+        bool makeAssetsRelativePaths,
+        bool writeReleaseLayoutTarget,
+        ILogger logger)
     {
 
         // Construct an ad-hoc object with the necessary fields and use the json
@@ -41,7 +49,7 @@ public class ManifestHelper
         }
 
         List<DownloadedAsset> mergedManifestAssets = SelectMergedManifestAssets(downloadedBuilds);
-        Dictionary<string, string> assetOriginMap = RetrieveAssetOriginMap(mergedManifestAssets, logger);
+        Dictionary<string, AssetReleaseMetadata> assetReleaseMetadataMap = RetrieveAssetReleaseMetadata(mergedManifestAssets, logger);
 
         var manifestObject = new
         {
@@ -65,7 +73,8 @@ public class ManifestHelper
                         new
                         {
                             name = asset.Asset.Name,
-                            origin = assetOriginMap.TryGetValue(asset.Asset.Name, out var origin) ? origin : null,
+                            origin = assetReleaseMetadataMap.TryGetValue(asset.Asset.Name, out var data) ? data.Origin : null,
+                            dotnetReleaseShipping = data != null && data.DotNetReleaseShipping,
                             version = asset.Asset.Version,
                             nonShipping = asset.Asset.NonShipping,
                             source = asset.SourceLocation,
@@ -113,6 +122,7 @@ public class ManifestHelper
                 ];
             }
         }
+
         return JObject.FromObject(manifestObject, JsonSerializer.CreateDefault(new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore }));
     }
 
@@ -124,9 +134,9 @@ public class ManifestHelper
             .ToList();
     }
 
-    private static Dictionary<string, string> RetrieveAssetOriginMap(IEnumerable<DownloadedAsset> mergedManifests, ILogger logger)
+    private static Dictionary<string, AssetReleaseMetadata> RetrieveAssetReleaseMetadata(IEnumerable<DownloadedAsset> mergedManifests, ILogger logger)
     {
-        Dictionary<string, string> assetOriginMap = [];
+        Dictionary<string, AssetReleaseMetadata> assetMetadataMap = [];
 
         foreach (var mergedManifest in mergedManifests)
         {
@@ -156,6 +166,7 @@ public class ManifestHelper
                     continue;
 
                 string? assetOrigin = asset.Attribute("Origin")?.Value;
+                bool dotNetReleaseShipping = asset.Attribute("DotNetReleaseShipping")?.Value == "true";
 
                 // An Origin attribute has been added to the MergeManifest.xml file for the VMR build to differentiate assets produced by different repos,
                 // as mentioned in https://github.com/dotnet/source-build/issues/3898.
@@ -164,21 +175,34 @@ public class ManifestHelper
                 // it is taken from the Build.Name, which corresponds to the repository name.
                 assetOrigin ??= repoName;
 
-                if (assetOriginMap.TryGetValue(assetName, out var existingAssetOrigin))
+                if (assetMetadataMap.TryGetValue(assetName, out var existingAssetMetadata))
                 {
-                    if (existingAssetOrigin != assetOrigin)
+                    if (existingAssetMetadata.Origin != assetOrigin)
                     {
                         logger.LogWarning($"Warning: The same asset '{assetName}' is listed in various '{MergedManifestFileName}', " +
-                            $"with differing origins specified in each: {existingAssetOrigin}, {assetOrigin}.");
+                            $"with differing origins specified in each: {existingAssetMetadata.Origin}, {assetOrigin}.");
                     }
                 }
                 else
                 {
-                    assetOriginMap.Add(assetName, assetOrigin);
+                    assetMetadataMap.Add(assetName, new AssetReleaseMetadata(assetOrigin, dotNetReleaseShipping));
                 }
             }
         }
 
-        return assetOriginMap;
+        return assetMetadataMap;
+    }
+
+    private class AssetReleaseMetadata
+    {
+        public AssetReleaseMetadata(string origin, bool dotNetReleaseShipping)
+        {
+            Origin = origin;
+            DotNetReleaseShipping = dotNetReleaseShipping;
+        }
+
+        public string Origin { get; set; }
+
+        public bool DotNetReleaseShipping { get; set; }
     }
 }


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

Propagating `DotNetReleaseShipping` from `MergedManifest.xml` to assets in `manifest.json`

Issue: https://github.com/dotnet/release/issues/740

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Set `DotNetReleaseShipping` property in `manifest.json` in gather-drop