### PR TITLE
Improve workaround for EOL problems on Windows

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
@@ -149,5 +149,13 @@ public interface ILocalGitClient
     /// </summary>
     /// <param name="args">Where to add the new argument into</param>
     /// <param name="envVars">Where to add the new variables into</param>
-    public void AddGitAuthHeader(IList<string> args, IDictionary<string, string> envVars, string repoUri);
+    void AddGitAuthHeader(IList<string> args, IDictionary<string, string> envVars, string repoUri);
+
+    /// <summary>
+    /// Runs git with the given arguments and returns the result.
+    /// </summary>
+    Task<ProcessExecutionResult> RunGitCommandAsync(
+        string repoPath,
+        string[] args,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -434,4 +434,12 @@ public class LocalGitClient : ILocalGitClient
         };
         envVars["GIT_TERMINAL_PROMPT"] = "0";
     }
+
+    public async Task<ProcessExecutionResult> RunGitCommandAsync(
+        string repoPath,
+        string[] args,
+        CancellationToken cancellationToken = default)
+    {
+        return await _processManager.ExecuteGit(repoPath, args, cancellationToken: cancellationToken);
+    }
 }


### PR DESCRIPTION
This PR improves a workaround for problems described in #3277. The problem is that with a weird mix of conditions under which files were created and which git config EOL settings were set, files are left behind dirty in the working tree with no chance of discarding the changes. Not even hard reset works. This just commits them in another way.

This PR doesn't solve https://github.com/dotnet/arcade-services/issues/3277 entirely but unblocks the synchronization with a (possibly unsafe) operation so that installer PR unified build legs get working again (https://github.com/dotnet/installer/pull/18917)

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Fixes a problem with EOLs during VMR synchronization on Windows