### PR TITLE
Fixes VMR synchronization for cases with VMR patches with renames inside

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -16,7 +16,8 @@ public interface IVmrPatchHandler
         VmrIngestionPatch patch,
         NativePath targetDirectory,
         bool removePatchAfter,
-        CancellationToken cancellationToken);
+        bool reverseApply = false,
+        CancellationToken cancellationToken = default);
 
     Task<List<VmrIngestionPatch>> CreatePatches(
         SourceMapping mapping,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -279,7 +279,7 @@ internal class VmrBackFlower(
         {
             foreach (VmrIngestionPatch patch in patches)
             {
-                await _vmrPatchHandler.ApplyPatch(patch, targetRepo.Path, discardPatches, cancellationToken);
+                await _vmrPatchHandler.ApplyPatch(patch, targetRepo.Path, discardPatches, reverseApply: false, cancellationToken);
             }
         }
         catch (PatchApplicationFailedException e)
@@ -316,7 +316,7 @@ internal class VmrBackFlower(
             foreach (VmrIngestionPatch patch in patches)
             {
                 // TODO https://github.com/dotnet/arcade-services/issues/2995: Catch exceptions?
-                await _vmrPatchHandler.ApplyPatch(patch, targetRepo.Path, discardPatches, cancellationToken);
+                await _vmrPatchHandler.ApplyPatch(patch, targetRepo.Path, discardPatches, reverseApply: false, cancellationToken);
             }
         }
 
@@ -388,7 +388,7 @@ internal class VmrBackFlower(
         foreach (var patch in patches)
         {
             // TODO https://github.com/dotnet/arcade-services/issues/2995: Handle exceptions
-            await _vmrPatchHandler.ApplyPatch(patch, targetRepo.Path, discardPatches, cancellationToken);
+            await _vmrPatchHandler.ApplyPatch(patch, targetRepo.Path, discardPatches, reverseApply: false, cancellationToken);
         }
 
         // TODO https://github.com/dotnet/arcade-services/issues/2995: Check if there are any changes and only commit if there are

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -99,7 +99,7 @@ public abstract class VmrManagerBase
 
         foreach (var patch in patches)
         {
-            await _patchHandler.ApplyPatch(patch, _vmrInfo.VmrPath, discardPatches, cancellationToken);
+            await _patchHandler.ApplyPatch(patch, _vmrInfo.VmrPath, discardPatches, reverseApply: false, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
         }
 
@@ -178,7 +178,7 @@ public abstract class VmrManagerBase
                 continue;
             }
 
-            await _patchHandler.ApplyPatch(patch, _vmrInfo.VmrPath, false, cancellationToken);
+            await _patchHandler.ApplyPatch(patch, _vmrInfo.VmrPath, false, reverseApply: false, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
         }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -247,7 +247,8 @@ public class VmrPatchHandler : IVmrPatchHandler
         VmrIngestionPatch patch,
         NativePath targetDirectory,
         bool removePatchAfter,
-        CancellationToken cancellationToken)
+        bool reverseApply = false,
+        CancellationToken cancellationToken = default)
     {
         var info = _fileSystem.GetFileInfo(patch.Path);
         if (!info.Exists)
@@ -282,6 +283,11 @@ public class VmrPatchHandler : IVmrPatchHandler
             // Options to help with CR/LF and similar problems
             "--ignore-space-change",
         };
+
+        if (reverseApply)
+        {
+            args.Add("--reverse");
+        }
 
         // Where to apply the patch into (usualy src/[repo name] but can be root for VMR's non-src/ content)
         if (patch.ApplicationPath != null)

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -143,7 +143,7 @@ public class VmrPatchHandlerTests
         _fileSystem.SetReturnsDefault(Mock.Of<IFileInfo>(x => x.Exists == true && x.Length == 1243));
 
         // Act
-        await _patchHandler.ApplyPatch(patch, _vmrInfo.Object.VmrPath, true, new CancellationToken());
+        await _patchHandler.ApplyPatch(patch, _vmrInfo.Object.VmrPath, true, false, new CancellationToken());
 
         // Verify
         VerifyGitCall(new List<string>
@@ -842,7 +842,7 @@ public class VmrPatchHandlerTests
         _fileSystem.SetReturnsDefault(Mock.Of<IFileInfo>(x => x.Exists == true && x.Length == 1243));
 
         // Act
-        await _patchHandler.ApplyPatch(patch, _vmrInfo.Object.VmrPath, false, new CancellationToken());
+        await _patchHandler.ApplyPatch(patch, _vmrInfo.Object.VmrPath, false, false, new CancellationToken());
 
         // Verify
         VerifyGitCall(new List<string>


### PR DESCRIPTION
We do not restore files one by one but rather reverse-apply the patch

https://github.com/dotnet/arcade-services/issues/3410

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Fixed VMR synchronization for cases with VMR patches with renames inside