### PR TITLE
[HOTFIX] Fix calling firewall script

### DIFF
--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -49,13 +49,14 @@ stages:
     - download: current
       artifact: ReleaseUtilities
 
-    - task: AzurePowerShell@3
+    - task: AzureCLI@2
       displayName: Add firewall rule
       inputs:
         azureSubscription: ${{ parameters.Subscription }}
-        ScriptPath: $(Pipeline.Workspace)/ReleaseUtilities/firewall.ps1
-        ScriptArguments: -RuleName UnblockSQLForUpgrade -Add -ConnectionString "$(build-asset-registry-admin-connection-string)"
-        azurePowerShellVersion: LatestVersion
+        scriptType: ps
+        scriptLocation: scriptPath
+        scriptPath: $(Pipeline.Workspace)/ReleaseUtilities/firewall.ps1
+        arguments: -RuleName UnblockSQLForUpgrade -Add -ConnectionString "$(build-asset-registry-admin-connection-string)"
 
     - powershell: |
         .\eng\common\build.ps1 -restore -build -projects src\Maestro\Maestro.Data\Maestro.Data.csproj
@@ -69,13 +70,14 @@ stages:
       env:
         BUILD_ASSET_REGISTRY_DB_CONNECTION_STRING: $(build-asset-registry-admin-connection-string)
 
-    - task: AzurePowerShell@3
+    - task: AzureCLI@2
       displayName: Remove firewall rule
       inputs:
         azureSubscription: ${{ parameters.Subscription }}
-        ScriptPath: $(Pipeline.Workspace)/ReleaseUtilities/firewall.ps1
-        ScriptArguments: -RuleName UnblockSQLForUpgrade -Remove -ConnectionString "$(build-asset-registry-admin-connection-string)"
-        azurePowerShellVersion: LatestVersion
+        scriptType: ps
+        scriptLocation: scriptPath
+        scriptPath: $(Pipeline.Workspace)/ReleaseUtilities/firewall.ps1
+        arguments: -RuleName UnblockSQLForUpgrade -Remove -ConnectionString "$(build-asset-registry-admin-connection-string)"
       condition: always()
 
   - job: deployMaestro


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
Now that we're using azure cli, we need to use the `AzureCLI` task when calling the script to authenticate properly
https://github.com/dotnet/arcade-services/issues/3419
<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Use `AzureCLI` task when calling `firewall.ps1` script