### PR TITLE
Harden SF state deserialization

### DIFF
--- a/src/Maestro/SubscriptionActorService/StateModel/ActorStateManager.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/ActorStateManager.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
+using Microsoft.Extensions.Logging;
 using Microsoft.ServiceFabric.Actors.Runtime;
 using Microsoft.ServiceFabric.Data;
 
@@ -19,22 +21,35 @@ internal class ActorStateManager<T> where T : class
 
     private readonly IActorStateManager _stateManager;
     private readonly IReminderManager _reminderManager;
+    private readonly ILogger _logger;
     private readonly string _key;
 
     public ActorStateManager(
         IActorStateManager stateManager,
         IReminderManager reminderManager,
+        ILogger logger,
         string key)
     {
         _stateManager = stateManager;
         _reminderManager = reminderManager;
+        _logger = logger;
         _key = key;
     }
 
     public async Task<T?> TryGetStateAsync()
     {
-        ConditionalValue<T> value = await _stateManager.TryGetStateAsync<T>(_key);
-        return value.HasValue ? value.Value : null;
+        try
+        {
+            ConditionalValue<T> value = await _stateManager.TryGetStateAsync<T>(_key);
+            return value.HasValue ? value.Value : null;
+        }
+        catch (SerializationException e)
+        {
+            // If we can't deserialize (maybe the model changed?), we drop the state
+            _logger.LogError(e, "Failed to deserialize state {type} stored in {key}. Removing from state memory", typeof(T).Name, _key);
+            await RemoveStateAsync();
+            return null;
+        }
     }
 
     public async Task StoreStateAsync(T value)


### PR DESCRIPTION
This should prevent all problems where we can't deserialize the state properly.

https://github.com/dotnet/arcade-services/issues/3423

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Fixed problems with Maestro being unable to read previous PR state