### PR TITLE
Read BAR connection string secret after connecting to the KV

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/PcsConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/PcsConfiguration.cs
@@ -39,7 +39,6 @@ internal static class PcsConfiguration
         string tmpPath,
         string vmrUri,
         DefaultAzureCredential credential,
-        string databaseConnectionString,
         bool initializeService,
         bool addEndpointAuthentication,
         Uri? keyVaultUri = null)
@@ -48,6 +47,8 @@ internal static class PcsConfiguration
         {
             builder.Configuration.AddAzureKeyVault(keyVaultUri, credential);
         }
+
+        string databaseConnectionString = builder.Configuration.GetRequiredValue(PcsConfiguration.DatabaseConnectionString);
 
         builder.AddBuildAssetRegistry(databaseConnectionString);
         builder.AddTelemetry();

--- a/src/ProductConstructionService/ProductConstructionService.Api/Program.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Program.cs
@@ -18,14 +18,12 @@ DefaultAzureCredential credential = new(new DefaultAzureCredentialOptions
     ManagedIdentityClientId = builder.Configuration[PcsConfiguration.ManagedIdentityId]
 });
 
-string databaseConnectionString = builder.Configuration.GetRequiredValue(PcsConfiguration.DatabaseConnectionString);
 
 builder.ConfigurePcs(
     vmrPath: vmrPath,
     tmpPath: tmpPath,
     vmrUri: vmrUri,
     credential: credential,
-    databaseConnectionString: databaseConnectionString,
     keyVaultUri: new Uri($"https://{builder.Configuration.GetRequiredValue(PcsConfiguration.KeyVaultName)}.vault.azure.net/"),
     initializeService: !builder.Environment.IsDevelopment(),
     addEndpointAuthentication: !builder.Environment.IsDevelopment());

--- a/test/ProductConstructionService.Api.Tests/DependencyRegistrationTests.cs
+++ b/test/ProductConstructionService.Api.Tests/DependencyRegistrationTests.cs
@@ -29,6 +29,7 @@ public class DependencyRegistrationTests
 
         builder.Configuration[PcsConfiguration.GitHubClientId] = _clientId;
         builder.Configuration[PcsConfiguration.GitHubClientSecret] = _clientSecret;
+        builder.Configuration[PcsConfiguration.DatabaseConnectionString] = _databaseConnectionString;
 
         DefaultAzureCredential credential = new();
 
@@ -37,7 +38,6 @@ public class DependencyRegistrationTests
             tmpPath: _tmpPath,
             vmrUri: _vmrUri,
             credential: credential,
-            databaseConnectionString: _databaseConnectionString,
             initializeService: true,
             addEndpointAuthentication: true);
 


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
In a previous PR I introduced a bug that attempted to read a secret before initializing secrets from the KV. This PR fixes it
https://github.com/dotnet/arcade-services/issues/3435
<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Read BAR connection string secret after connecting to the KV