### PR TITLE
Only use swagger when running locally, bump aspire version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <AspNetAzureVersion>3.1.24</AspNetAzureVersion>
     <AspNetCoreVersion>6.0.26</AspNetCoreVersion>
     <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>
-    <AspireVersion>8.0.0-preview.3.24105.21</AspireVersion>
+    <AspireVersion>8.0.0-preview.4.24156.9</AspireVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
@@ -15,7 +15,7 @@
     <PackageVersion Include="Aspire.Hosting" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Azure.Storage.Queues" Version="$(AspireVersion)" />
-    <PackageVersion Include="Azure.Core" Version="1.36.0" />
+    <PackageVersion Include="Azure.Core" Version="1.37.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.1.0" />
@@ -96,7 +96,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.ServiceFabric.Actors" Version="5.2.1571" />
     <PackageVersion Include="Microsoft.ServiceFabric.AspNetCore.HttpSys" Version="5.2.1571" />
@@ -125,7 +125,7 @@
     <PackageVersion Include="ServiceFabricMocks" Version="$(ServiceFabricMocksVersion)" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
-    <PackageVersion Include="System.IO.Hashing" Version="7.0.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <!-- Pin of a transitive dependency. Can be removed after we migrate to net7.0+
@@ -135,6 +135,6 @@
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageVersion Include="Verify.NUnit" Version="19.6" />
-    <PackageVersion Include="YamlDotNet" Version="13.7.1" />
+    <PackageVersion Include="YamlDotNet" Version="15.1.0" />
   </ItemGroup>
 </Project>

--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/PcsConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/PcsConfiguration.cs
@@ -41,6 +41,7 @@ internal static class PcsConfiguration
         DefaultAzureCredential credential,
         bool initializeService,
         bool addEndpointAuthentication,
+        bool addSwagger,
         Uri? keyVaultUri = null)
     {
         if (keyVaultUri != null) 
@@ -68,6 +69,10 @@ internal static class PcsConfiguration
 
         builder.AddServiceDefaults();
         builder.Services.AddControllers().EnableInternalControllers();
-        builder.ConfigureSwagger();
+
+        if (addSwagger)
+        {
+            builder.ConfigureSwagger();
+        }
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.AppHost/Program.cs
+++ b/src/ProductConstructionService/ProductConstructionService.AppHost/Program.cs
@@ -4,10 +4,10 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var queues = builder.AddAzureStorage("storage")
-    .UseEmulator()
+    .RunAsEmulator()
     .AddQueues("queues");
 
-builder.AddProject<Projects.ProductConstructionService_Api>("productConstructionService.api")
+builder.AddProject<Projects.ProductConstructionService_Api>("productConstructionServiceApi")
     .WithReference(queues);
 
 builder.Build().Run();

--- a/test/ProductConstructionService.Api.Tests/DependencyRegistrationTests.cs
+++ b/test/ProductConstructionService.Api.Tests/DependencyRegistrationTests.cs
@@ -39,7 +39,8 @@ public class DependencyRegistrationTests
             vmrUri: _vmrUri,
             credential: credential,
             initializeService: true,
-            addEndpointAuthentication: true);
+            addEndpointAuthentication: true,
+            addSwagger: true);
 
         DependencyInjectionValidation.IsDependencyResolutionCoherent(s =>
         {


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/dnceng/issues/1797
https://github.com/dotnet/dnceng/issues/1917

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Bump aspire version to preview 4, only use swagger when running locally