### PR TITLE
Add `TargetDirectory` field to subscriptions

### DIFF
--- a/src/Maestro/Client/src/Generated/Models/Subscription.cs
+++ b/src/Maestro/Client/src/Generated/Models/Subscription.cs
@@ -9,16 +9,7 @@ namespace Microsoft.DotNet.Maestro.Client.Models
 {
     public partial class Subscription
     {
-        public Subscription(
-            Guid id,
-            bool enabled,
-            bool sourceEnabled,
-            string sourceRepository,
-            string targetRepository,
-            string targetBranch,
-            string sourceDirectory,
-            string pullRequestFailureNotificationTags,
-            IImmutableList<string> excludedAssets)
+        public Subscription(Guid id, bool enabled, bool sourceEnabled, string sourceRepository, string targetRepository, string targetBranch, string sourceDirectory, string targetDirectory, string pullRequestFailureNotificationTags, IImmutableList<string> excludedAssets)
         {
             Id = id;
             Enabled = enabled;
@@ -27,6 +18,7 @@ namespace Microsoft.DotNet.Maestro.Client.Models
             TargetRepository = targetRepository;
             TargetBranch = targetBranch;
             SourceDirectory = sourceDirectory;
+            TargetDirectory = targetDirectory;
             PullRequestFailureNotificationTags = pullRequestFailureNotificationTags;
             ExcludedAssets = excludedAssets;
         }

--- a/src/Maestro/Client/src/Generated/Models/Subscription.cs
+++ b/src/Maestro/Client/src/Generated/Models/Subscription.cs
@@ -61,6 +61,9 @@ namespace Microsoft.DotNet.Maestro.Client.Models
         [JsonProperty("sourceDirectory")]
         public string SourceDirectory { get; }
 
+        [JsonProperty("targetDirectory")]
+        public string TargetDirectory { get; }
+
         [JsonProperty("pullRequestFailureNotificationTags")]
         public string PullRequestFailureNotificationTags { get; }
 

--- a/src/Maestro/Client/src/Generated/Models/SubscriptionData.cs
+++ b/src/Maestro/Client/src/Generated/Models/SubscriptionData.cs
@@ -39,6 +39,9 @@ namespace Microsoft.DotNet.Maestro.Client.Models
         [JsonProperty("sourceDirectory")]
         public string SourceDirectory { get; set; }
 
+        [JsonProperty("targetDirectory")]
+        public string TargetDirectory { get; set; }
+
         [JsonProperty("policy")]
         public Models.SubscriptionPolicy Policy { get; set; }
 

--- a/src/Maestro/Client/src/Generated/Models/SubscriptionUpdate.cs
+++ b/src/Maestro/Client/src/Generated/Models/SubscriptionUpdate.cs
@@ -33,6 +33,9 @@ namespace Microsoft.DotNet.Maestro.Client.Models
         [JsonProperty("sourceDirectory")]
         public string SourceDirectory { get; set; }
 
+        [JsonProperty("targetDirectory")]
+        public string TargetDirectory { get; set; }
+
         [JsonProperty("excludedAssets")]
         public IImmutableList<string> ExcludedAssets { get; set; }
     }

--- a/src/Maestro/Client/src/Generated/Subscriptions.cs
+++ b/src/Maestro/Client/src/Generated/Subscriptions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.Maestro.Client
             string sourceRepository = default,
             string targetRepository = default,
             string sourceDirectory = default,
+            string targetDirectory = default,
             CancellationToken cancellationToken = default
         );
 
@@ -98,6 +99,7 @@ namespace Microsoft.DotNet.Maestro.Client
             string sourceRepository = default,
             string targetRepository = default,
             string sourceDirectory = default,
+            string targetDirectory = default,
             CancellationToken cancellationToken = default
         )
         {
@@ -134,6 +136,10 @@ namespace Microsoft.DotNet.Maestro.Client
             if (!string.IsNullOrEmpty(sourceDirectory))
             {
                 _url.AppendQuery("sourceDirectory", Client.Serialize(sourceDirectory));
+            }
+            if (!string.IsNullOrEmpty(targetDirectory))
+            {
+                _url.AppendQuery("targetDirectory", Client.Serialize(targetDirectory));
             }
             _url.AppendQuery("api-version", Client.Serialize(apiVersion));
 

--- a/src/Maestro/Maestro.Data/Migrations/20240403133733_CodeEnabledSubscriptions3.Designer.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20240403133733_CodeEnabledSubscriptions3.Designer.cs
@@ -4,6 +4,7 @@ using Maestro.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Maestro.Data.Migrations
 {
     [DbContext(typeof(BuildAssetRegistryContext))]
-    partial class BuildAssetRegistryContextModelSnapshot : ModelSnapshot
+    [Migration("20240403133733_CodeEnabledSubscriptions3")]
+    partial class CodeEnabledSubscriptions3
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Maestro/Maestro.Data/Migrations/20240403133733_CodeEnabledSubscriptions3.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20240403133733_CodeEnabledSubscriptions3.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Maestro.Data.Migrations
+{
+    public partial class CodeEnabledSubscriptions3 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TargetDirectory",
+                table: "Subscriptions",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TargetDirectory",
+                table: "Subscriptions");
+        }
+    }
+}

--- a/src/Maestro/Maestro.Data/Models/Subscription.cs
+++ b/src/Maestro/Maestro.Data/Models/Subscription.cs
@@ -75,9 +75,18 @@ public class Subscription
     public bool SourceEnabled { get; set; }
 
     /// <summary>
-    /// Denotes the directory of the VMR with which are the sources synchronized.
+    /// Denotes the directory of the VMR which are the sources synchronized from.
+    /// (for VMR->repo subscriptions)
+    /// Only Source or Target repository can be set at a time.
     /// </summary>
     public string SourceDirectory { get; set; }
+
+    /// <summary>
+    /// Denotes the directory in the VMR which are the sources synchronized into.
+    /// (for repo->VMR subscriptions)
+    /// Only Source or Target repository can be set at a time.
+    /// </summary>
+    public string TargetDirectory { get; set; }
 
     /// <summary>
     /// Dependencies to ignore when synchronizing code of source-enabled subscriptions.

--- a/src/Maestro/Maestro.DataProviders/SqlBarClient.cs
+++ b/src/Maestro/Maestro.DataProviders/SqlBarClient.cs
@@ -51,6 +51,7 @@ public class SqlBarClient : IBasicBarClient
             sub.TargetRepository,
             sub.TargetBranch,
             sub.SourceDirectory,
+            sub.TargetDirectory,
             sub.PullRequestFailureNotificationTags,
             sub.ExcludedAssets.Select(s => s.Filter).ToImmutableList());
     }
@@ -284,6 +285,7 @@ public class SqlBarClient : IBasicBarClient
             other.TargetBranch,
             other.PullRequestFailureNotificationTags,
             other.SourceDirectory,
+            other.TargetDirectory,
             other.ExcludedAssets?.Select(a => a.Filter).ToImmutableList())
         {
             Channel = ToClientModelChannel(other.Channel),

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.ApiVersioning.Swashbuckle;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.EntityFrameworkCore;
-using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
 
 namespace Maestro.Web.Api.v2020_02_20.Controllers;
 
@@ -220,7 +219,7 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
             doUpdate = true;
         }
 
-        if (subscription.Enabled && update.SourceDirectory == null && update.TargetDirectory == null)
+        if (subscription.SourceEnabled && update.SourceDirectory == null && update.TargetDirectory == null)
         {
             return BadRequest(new ApiError("The request is invalid. Source-enabled subscriptions require the source or target directory to be set"));
         }
@@ -406,14 +405,14 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
             }
         }
 
-        if (subscription.Enabled.HasValue)
+        if (subscription.SourceEnabled.HasValue)
         {
-            if (subscription.Enabled.Value && subscription.SourceDirectory == null && subscription.TargetDirectory == null)
+            if (subscription.SourceEnabled.Value && subscription.SourceDirectory == null && subscription.TargetDirectory == null)
             {
                 return BadRequest(new ApiError("The request is invalid. Source-enabled subscriptions require the source or target directory to be set"));
             }
 
-            if (!subscription.Enabled.Value && (subscription.SourceDirectory ?? subscription.TargetDirectory) != null)
+            if (!subscription.SourceEnabled.Value && (subscription.SourceDirectory ?? subscription.TargetDirectory) != null)
             {
                 return BadRequest(new ApiError("The request is invalid. Source or target directory can be set only for source-enabled subscriptions"));
             }
@@ -445,7 +444,7 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
 
         Data.Models.Subscription subscriptionModel = subscription.ToDb();
         subscriptionModel.Channel = channel;
-            
+
         // Check that we're not about add an existing subscription that is identical
         Data.Models.Subscription equivalentSubscription = await FindEquivalentSubscription(subscriptionModel);
         if (equivalentSubscription != null)
@@ -459,7 +458,7 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
                     }));
         }
 
-        if (!string.IsNullOrEmpty(subscriptionModel.PullRequestFailureNotificationTags ))
+        if (!string.IsNullOrEmpty(subscriptionModel.PullRequestFailureNotificationTags))
         {
             if (!await AllNotificationTagsValid(subscriptionModel.PullRequestFailureNotificationTags))
             {

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/Subscription.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/Subscription.cs
@@ -22,6 +22,7 @@ public class Subscription
         Enabled = other.Enabled;
         SourceEnabled = other.SourceEnabled;
         SourceDirectory = other.SourceDirectory;
+        TargetDirectory = other.TargetDirectory;
         Policy = new v2018_07_16.Models.SubscriptionPolicy(other.PolicyObject);
         PullRequestFailureNotificationTags = other.PullRequestFailureNotificationTags;
         ExcludedAssets = other.ExcludedAssets != null ? [..other.ExcludedAssets.Select(s => s.Filter)] : [];
@@ -46,6 +47,8 @@ public class Subscription
     public bool SourceEnabled { get; }
 
     public string SourceDirectory { get; }
+
+    public string TargetDirectory { get; }
 
     public string PullRequestFailureNotificationTags { get; }
 

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/SubscriptionData.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/SubscriptionData.cs
@@ -28,6 +28,8 @@ public class SubscriptionData
 
     public string SourceDirectory { get; set; }
 
+    public string TargetDirectory { get; set; }
+
     [Required]
     public v2018_07_16.Models.SubscriptionPolicy Policy { get; set; }
 
@@ -44,6 +46,7 @@ public class SubscriptionData
         Enabled = Enabled ?? true,
         SourceEnabled = SourceEnabled ?? false,
         SourceDirectory = SourceDirectory,
+        TargetDirectory = TargetDirectory,
         PullRequestFailureNotificationTags = PullRequestFailureNotificationTags,
         ExcludedAssets = ExcludedAssets == null ? [] : [..ExcludedAssets.Select(asset => new Data.Models.AssetFilter() { Filter = asset })],
     };

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/SubscriptionUpdate.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Models/SubscriptionUpdate.cs
@@ -14,5 +14,6 @@ public class SubscriptionUpdate
     public bool? SourceEnabled { get; set; }
     public string PullRequestFailureNotificationTags { get; set; }
     public string SourceDirectory { get; set; }
+    public string TargetDirectory { get; set; }
     public IReadOnlyCollection<string> ExcludedAssets { get; set; }
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/UxHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/UxHelpers.cs
@@ -214,7 +214,14 @@ public static class UxHelpers
 
         if (subscription.SourceEnabled)
         {
-            subInfo.AppendLine($"  - Source Directory: {subscription.SourceDirectory}");
+            if (!string.IsNullOrEmpty(subscription.SourceDirectory))
+            {
+                subInfo.AppendLine($"  - Source Directory: {subscription.SourceDirectory}");
+            }
+            else
+            {
+                subInfo.AppendLine($"  - Target Directory: {subscription.TargetDirectory}");
+            }
 
             string excludedAssets;
             if (subscription.ExcludedAssets.Any())

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AddSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AddSubscriptionPopUp.cs
@@ -32,6 +32,7 @@ public class AddSubscriptionPopUp : SubscriptionPopUp
         string failureNotificationTags,
         bool? sourceEnabled,
         string? sourceDirectory,
+        string? targetDirectory,
         List<string> excludedAssets)
         : base(path, suggestedChannels, suggestedRepositories, availableMergePolicyHelp, logger,
             new SubscriptionData
@@ -45,7 +46,8 @@ public class AddSubscriptionPopUp : SubscriptionPopUp
                 MergePolicies = MergePoliciesPopUpHelpers.ConvertMergePolicies(mergePolicies),
                 FailureNotificationTags = failureNotificationTags,
                 SourceEnabled = GetCurrentSettingForDisplay(sourceEnabled?.ToString(), false.ToString(), false),
-                SourceDirectory = GetCurrentSettingForDisplay(sourceDirectory, "<default>", false),
+                SourceDirectory = GetCurrentSettingForDisplay(sourceDirectory, string.Empty, false),
+                TargetDirectory = GetCurrentSettingForDisplay(targetDirectory, string.Empty, false),
                 ExcludedAssets = excludedAssets,
             },
             header: [
@@ -57,8 +59,9 @@ public class AddSubscriptionPopUp : SubscriptionPopUp
                 new("For non-batched subscriptions, providing a list of semicolon-delineated GitHub tags will tag these", true),
                 new("logins when monitoring the pull requests, once one or more policy checks fail.", true),
                 Line.Empty,
-                new("Source directory must match the source mapping / folder in the VMR.", true),
-                new("If left empty, it will be automatically computed from the URL.", true),
+                new("Source and target directories only apply to source-enabled subscription (VMR code flow subscriptions).", true),
+                new("They define which directory of the VMR (under src/) are the sources synchronized with.", true),
+                new("Only one of those needs to be set based on whether the source or the target repo is the VMR.", true),
                 Line.Empty,
                 new("Excluded assets is a list of package names to be ignored during source-enabled subscriptions (VMR code flow). ", true),
                 new("Asterisks can be used to filter whole namespaces, e.g. - Microsoft.DotNet.Arcade.*", true),

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
@@ -108,19 +108,6 @@ public abstract class SubscriptionPopUp : EditorPopUp
         {
             Contents.Add(new($"  {mergeHelp}", true));
         }
-
-        Contents.AddRange(
-        [
-            Line.Empty,
-            new("Source directory only applies to source-enabled subscription (VMR code flow subscriptions).", true),
-            new("It defines which directory of the VMR (under src/) are the sources synchronized with.", true),
-            Line.Empty,
-            new("Excluded assets only apply to source-enabled subscription (VMR code flow subscriptions).", true),
-            new("They can contain * to ignore whole groups of assets.", true),
-            new("Examples of excluded assets:", true),
-            new($"  - Microsoft.DotNet.Arcade.Sdk", true),
-            new($"  - Microsoft.Extensions.*", true),
-        ]);
     }
 
     protected int ParseAndValidateData(SubscriptionData outputYamlData)

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
@@ -27,6 +27,7 @@ public abstract class SubscriptionPopUp : EditorPopUp
     private const string FailureNotificationTagsElement = "Pull Request Failure Notification Tags";
     protected const string SourceEnabledElement = "Source Enabled";
     private const string SourceDirectoryElement = "Source Directory";
+    private const string TargetDirectoryElement = "Target Directory";
     private const string ExcludedAssetsElement = "Excluded Assets";
 
     protected readonly SubscriptionData _data;
@@ -46,6 +47,7 @@ public abstract class SubscriptionPopUp : EditorPopUp
     public bool SourceEnabled => bool.Parse(_data.SourceEnabled);
     public IReadOnlyCollection<string> ExcludedAssets => _data.ExcludedAssets;
     public string? SourceDirectory => _data.SourceDirectory;
+    public string? TargetDirectory => _data.TargetDirectory;
 
     protected SubscriptionPopUp(
         string path,
@@ -175,31 +177,31 @@ public abstract class SubscriptionPopUp : EditorPopUp
             return Constants.ErrorCode;
         }
 
-        // When we disable the source flow, we zero out the source directory
+        if (sourceEnabled)
+        {
+            if (string.IsNullOrEmpty(outputYamlData.SourceDirectory ?? outputYamlData.TargetDirectory))
+            {
+                _logger.LogError("Source or target directory must be provided for source-enabled subscriptions");
+                return Constants.ErrorCode;
+            }
+
+            if (!string.IsNullOrEmpty(outputYamlData.SourceDirectory) && !string.IsNullOrEmpty(outputYamlData.TargetDirectory))
+            {
+                _logger.LogError("Only one of source or target directory can be provided for source-enabled subscriptions");
+                return Constants.ErrorCode;
+            }
+        }
+
+        // When we disable the source flow, we zero out the source/target directory
         if (!sourceEnabled)
         {
             outputYamlData.SourceDirectory = null;
-        }
-        else
-        {
-            // When left empty/default, we can generate it out of the source repository URL
-            if (outputYamlData.SourceDirectory == null || outputYamlData.SourceDirectory.StartsWith("<default>"))
-            {
-                var (repoName, _) = GitRepoUrlParser.GetRepoNameAndOwner(outputYamlData.SourceRepository);
-
-                // We need to take the repo that is not the VMR
-                if (repoName == "dotnet")
-                {
-                    (repoName, _) = GitRepoUrlParser.GetRepoNameAndOwner(outputYamlData.TargetRepository);
-                }
-
-                outputYamlData.SourceDirectory = repoName;
-                _logger.LogInformation($"Source directory was not provided, using '{repoName}'");
-            }
+            outputYamlData.TargetDirectory = null;
         }
 
         _data.FailureNotificationTags = ParseSetting(outputYamlData.FailureNotificationTags, _data.FailureNotificationTags, false);
         _data.SourceDirectory = outputYamlData.SourceDirectory;
+        _data.TargetDirectory = outputYamlData.TargetDirectory;
         _data.ExcludedAssets = outputYamlData.ExcludedAssets;
 
         return Constants.SuccessCode;
@@ -241,6 +243,9 @@ public abstract class SubscriptionPopUp : EditorPopUp
 
         [YamlMember(Alias = SourceDirectoryElement, ApplyNamingConventions = false)]
         public string SourceDirectory { get; set; }
+
+        [YamlMember(Alias = TargetDirectoryElement, ApplyNamingConventions = false)]
+        public string TargetDirectory { get; set; }
 
         [YamlMember(Alias = ExcludedAssetsElement, ApplyNamingConventions = false)]
         public List<string> ExcludedAssets { get; set; }

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
@@ -33,7 +33,7 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
                 new Line($"Use this form to update the values of subscription '{subscription.Id}'.", true),
                 new Line($"Note that if you are setting 'Is batchable' to true you need to remove all Merge Policies.", true),
                 Line.Empty,
-                new("Source and target directories only apply to source-enabled subscription (VMR code flow subscriptions).", true),
+                new("Source and target directories only apply to source-enabled subscriptions (VMR code flow subscriptions).", true),
                 new("They define which directory of the VMR (under src/) are the sources synchronized with.", true),
                 new("Only one of those needs to be set based on whether the source or the target repo is the VMR.", true),
                 Line.Empty,

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
@@ -35,7 +35,7 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
                 Line.Empty,
                 new("Source and target directories only apply to source-enabled subscriptions (VMR code flow subscriptions).", true),
                 new("They define which directory of the VMR (under src/) are the sources synchronized with.", true),
-                new("Only one of those needs to be set based on whether the source or the target repo is the VMR.", true),
+                new("Only one of those must be set based on whether the source or the target repo is the VMR.", true),
                 Line.Empty,
                 new("Excluded assets is a list of package names to be ignored during source-enabled subscriptions (VMR code flow). ", true),
                 new("Asterisks can be used to filter whole namespaces, e.g. - Microsoft.DotNet.Arcade.*", true),

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
@@ -50,6 +50,7 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
         string failureNotificationTags,
         bool? sourceEnabled,
         string sourceDirectory,
+        string targetDirectory,
         List<string> excludedAssets)
         : this(path, logger, subscription, suggestedChannels, suggestedRepositories, availableMergePolicyHelp,
               new SubscriptionUpdateData
@@ -64,6 +65,7 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
                   MergePolicies = MergePoliciesPopUpHelpers.ConvertMergePolicies(subscription.Policy.MergePolicies),
                   SourceEnabled = GetCurrentSettingForDisplay(sourceEnabled?.ToString(), false.ToString(), false),
                   SourceDirectory = GetCurrentSettingForDisplay(sourceDirectory, subscription.SourceDirectory, false),
+                  TargetDirectory = GetCurrentSettingForDisplay(targetDirectory, subscription.TargetDirectory, false),
                   ExcludedAssets = excludedAssets,
               })
     {

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
@@ -32,7 +32,14 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
             header: [
                 new Line($"Use this form to update the values of subscription '{subscription.Id}'.", true),
                 new Line($"Note that if you are setting 'Is batchable' to true you need to remove all Merge Policies.", true),
-                new Line()
+                Line.Empty,
+                new("Source and target directories only apply to source-enabled subscription (VMR code flow subscriptions).", true),
+                new("They define which directory of the VMR (under src/) are the sources synchronized with.", true),
+                new("Only one of those needs to be set based on whether the source or the target repo is the VMR.", true),
+                Line.Empty,
+                new("Excluded assets is a list of package names to be ignored during source-enabled subscriptions (VMR code flow). ", true),
+                new("Asterisks can be used to filter whole namespaces, e.g. - Microsoft.DotNet.Arcade.*", true),
+                Line.Empty,
             ])
     {
         _logger = logger;
@@ -58,6 +65,8 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
                   Id = GetCurrentSettingForDisplay(subscription.Id.ToString(), subscription.Id.ToString(), false),
                   Channel = GetCurrentSettingForDisplay(subscription.Channel.Name, subscription.Channel.Name, false),
                   SourceRepository = GetCurrentSettingForDisplay(subscription.SourceRepository, subscription.SourceRepository, false),
+                  TargetRepository = GetCurrentSettingForDisplay(subscription.TargetRepository, subscription.TargetRepository, false),
+                  TargetBranch = GetCurrentSettingForDisplay(subscription.TargetBranch, subscription.TargetBranch, false),
                   Batchable = GetCurrentSettingForDisplay(subscription.Policy.Batchable.ToString(), subscription.Policy.Batchable.ToString(), false),
                   UpdateFrequency = GetCurrentSettingForDisplay(subscription.Policy.UpdateFrequency.ToString(), subscription.Policy.UpdateFrequency.ToString(), false),
                   Enabled = GetCurrentSettingForDisplay(subscription.Enabled.ToString(), subscription.Enabled.ToString(), false),

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
@@ -121,6 +121,12 @@ internal class AddSubscriptionOperation : Operation
         string failureNotificationTags = _options.FailureNotificationTags;
         List<string> excludedAssets = _options.ExcludedAssets != null ? [.._options.ExcludedAssets.Split(';', StringSplitOptions.RemoveEmptyEntries)] : [];
 
+        if (!string.IsNullOrEmpty(sourceDirectory) && !string.IsNullOrEmpty(targetDirectory))
+        {
+            Logger.LogError("Only one of source or target directory can be specified for source-enabled subscriptions.");
+            return Constants.ErrorCode;
+        }
+
         // If in quiet (non-interactive mode), ensure that all options were passed, then
         // just call the remote API
         if (_options.Quiet && !_options.ReadStandardIn)
@@ -133,6 +139,12 @@ internal class AddSubscriptionOperation : Operation
                 !Constants.AvailableFrequencies.Contains(updateFrequency, StringComparer.OrdinalIgnoreCase))
             {
                 Logger.LogError($"Missing input parameters for the subscription. Please see command help or remove --quiet/-q for interactive mode");
+                return Constants.ErrorCode;
+            }
+
+            if (sourceEnabled && string.IsNullOrEmpty(sourceDirectory) && string.IsNullOrEmpty(targetDirectory))
+            {
+                Logger.LogError("One of source or target directory is required for source-enabled subscriptions.");
                 return Constants.ErrorCode;
             }
         }
@@ -167,6 +179,7 @@ internal class AddSubscriptionOperation : Operation
                 failureNotificationTags,
                 sourceEnabled,
                 sourceDirectory,
+                targetDirectory,
                 excludedAssets);
 
             var uxManager = new UxManager(_options.GitLocation, Logger);
@@ -236,7 +249,7 @@ internal class AddSubscriptionOperation : Operation
                 return Constants.ErrorCode;
             }
 
-            var newSubscription = await barClient.CreateSubscriptionAsync(
+            Subscription newSubscription = await barClient.CreateSubscriptionAsync(
                 channel,
                 sourceRepository,
                 targetRepository,

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
@@ -117,6 +117,7 @@ internal class AddSubscriptionOperation : Operation
         bool batchable = _options.Batchable;
         bool sourceEnabled = _options.SourceEnabled;
         string sourceDirectory = _options.SourceDirectory;
+        string targetDirectory = _options.TargetDirectory;
         string failureNotificationTags = _options.FailureNotificationTags;
         List<string> excludedAssets = _options.ExcludedAssets != null ? [.._options.ExcludedAssets.Split(';', StringSplitOptions.RemoveEmptyEntries)] : [];
 
@@ -188,6 +189,7 @@ internal class AddSubscriptionOperation : Operation
             failureNotificationTags = addSubscriptionPopup.FailureNotificationTags;
             sourceEnabled = addSubscriptionPopup.SourceEnabled;
             sourceDirectory = addSubscriptionPopup.SourceDirectory;
+            targetDirectory = addSubscriptionPopup.TargetDirectory;
             excludedAssets = [..addSubscriptionPopup.ExcludedAssets];
         }
 
@@ -245,6 +247,7 @@ internal class AddSubscriptionOperation : Operation
                 failureNotificationTags,
                 sourceEnabled,
                 sourceDirectory,
+                targetDirectory,
                 excludedAssets);
 
             Console.WriteLine($"Successfully created new subscription with id '{newSubscription.Id}'.");

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateSubscriptionOperation.cs
@@ -51,6 +51,7 @@ internal class UpdateSubscriptionOperation : Operation
         bool sourceEnabled = subscription.SourceEnabled;
         List<string> excludedAssets = [..subscription.ExcludedAssets];
         string sourceDirectory = subscription.SourceDirectory;
+        string targetDirectory = subscription.TargetDirectory;
 
         if (UpdatingViaCommandLine())
         {
@@ -95,6 +96,11 @@ internal class UpdateSubscriptionOperation : Operation
                 sourceDirectory = _options.SourceDirectory;
             }
 
+            if (_options.TargetDirectory != null)
+            {
+                targetDirectory = _options.TargetDirectory;
+            }
+
             if (_options.ExcludedAssets != null)
             {
                 excludedAssets = [.._options.ExcludedAssets.Split(';', StringSplitOptions.RemoveEmptyEntries)];
@@ -113,6 +119,7 @@ internal class UpdateSubscriptionOperation : Operation
                 subscription.PullRequestFailureNotificationTags ?? string.Empty,
                 sourceEnabled,
                 sourceDirectory,
+                targetDirectory,
                 excludedAssets);
 
             var uxManager = new UxManager(_options.GitLocation, Logger);
@@ -133,6 +140,7 @@ internal class UpdateSubscriptionOperation : Operation
             mergePolicies = updateSubscriptionPopUp.MergePolicies;
             sourceEnabled = updateSubscriptionPopUp.SourceEnabled;
             sourceDirectory = updateSubscriptionPopUp.SourceDirectory;
+            targetDirectory = updateSubscriptionPopUp.TargetDirectory;
             excludedAssets = [..updateSubscriptionPopUp.ExcludedAssets];
         }
 
@@ -154,6 +162,7 @@ internal class UpdateSubscriptionOperation : Operation
                 SourceEnabled = sourceEnabled,
                 ExcludedAssets = excludedAssets.ToImmutableList(),
                 SourceDirectory = sourceDirectory,
+                TargetDirectory = targetDirectory,
             };
 
             subscriptionToUpdate.Policy.Batchable = batchable;

--- a/src/Microsoft.DotNet.Darc/Darc/Options/SubscriptionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/SubscriptionCommandLineOptions.cs
@@ -13,8 +13,11 @@ internal abstract class SubscriptionCommandLineOptions : CommandLineOptions
     [Option("failure-notification-tags", HelpText = "Semicolon-delineated list of GitHub tags to notify for dependency flow failures from this subscription")]
     public string FailureNotificationTags { get; set; }
 
-    [Option("source-directory", HelpText = "Name of the VMR source directory which are the repository sources synchronized with.")]
+    [Option("source-directory", HelpText = "Name of the VMR source directory which are the repository sources synchronized from.")]
     public string SourceDirectory { get; set; }
+
+    [Option("target-directory", HelpText = "Name of the VMR target directory which are the repository sources synchronized to.")]
+    public string TargetDirectory { get; set; }
 
     [Option("excluded-assets", HelpText = "Semicolon-delineated list of asset filters (package name with asterisks allowed) to be excluded from source-enabled code flow.")]
     public string ExcludedAssets { get; set; }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/SubscriptionsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/SubscriptionsCommandLineOptions.cs
@@ -49,8 +49,11 @@ internal abstract class SubscriptionsCommandLineOptions : CommandLineOptions
     [Option("source-enabled", HelpText = "Get only source-enabled (VMR code flow) subscriptions.")]
     public bool? SourceEnabled { get; set; }
 
-    [Option("source-directory", HelpText = "Get only source-enabled (VMR code flow) subscriptions that target a given VMR directory.")]
+    [Option("source-directory", HelpText = "Get only source-enabled (VMR code flow) subscriptions that come from a given VMR directory.")]
     public string SourceDirectory { get; set; }
+
+    [Option("target-directory", HelpText = "Get only source-enabled (VMR code flow) subscriptions that target a given VMR directory.")]
+    public string TargetDirectory { get; set; }
 
     [Option("batchable", HelpText = "Get only batchable subscriptions.")]
     public bool Batchable { get; set; }
@@ -106,6 +109,17 @@ internal abstract class SubscriptionsCommandLineOptions : CommandLineOptions
         }
 
         return subscription.SourceDirectory == SourceDirectory;
+    }
+
+    public bool SubscriptionTargetDirectoryParameterMatches(Subscription subscription)
+    {
+        // If the parameter isn't set, it's a match
+        if (TargetDirectory == null)
+        {
+            return true;
+        }
+
+        return subscription.TargetDirectory == TargetDirectory;
     }
 
     public bool SubscriptionBatchableParameterMatches(Subscription subscription)

--- a/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
@@ -242,6 +242,7 @@ public class BarApiClient : IBarApiClient
         string failureNotificationTags,
         bool sourceEnabled,
         string sourceDirectory,
+        string targetDirectory,
         IReadOnlyCollection<string> excludedAssets)
     {
         var subscriptionData = new SubscriptionData(
@@ -262,6 +263,7 @@ public class BarApiClient : IBarApiClient
         {
             SourceEnabled = sourceEnabled,
             SourceDirectory = sourceDirectory,
+            TargetDirectory = targetDirectory,
             ExcludedAssets = excludedAssets.ToImmutableList(),
         };
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/IBarApiClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IBarApiClient.cs
@@ -28,7 +28,8 @@ public interface IBarApiClient : IBasicBarClient
     /// <param name="mergePolicies">Set of auto-merge policies.</param>
     /// <param name="failureNotificationTags">List of GitHub tags to notify with a PR comment when the build fails</param>
     /// <param name="sourceEnabled">Whether this is a VMR code flow (special VMR subscription)</param>
-    /// <param name="sourceDirectory">Directory of the VMR to synchronize the sources with</param>
+    /// <param name="sourceDirectory">Directory of the VMR to synchronize the sources from</param>
+    /// <param name="targetDirectory">Directory of the VMR to synchronize the sources to</param>
     /// <param name="excludedAssets">List of assets to exclude from the source-enabled code flow</param>
     /// <returns>Newly created subscription.</returns>
     Task<Subscription> CreateSubscriptionAsync(
@@ -42,6 +43,7 @@ public interface IBarApiClient : IBasicBarClient
         string failureNotificationTags,
         bool sourceEnabled,
         string sourceDirectory,
+        string targetDirectory,
         IReadOnlyCollection<string> excludedAssets);
 
     /// <summary>

--- a/test/Maestro.ScenarioTests/ObjectHelpers/SubscriptionBuilder.cs
+++ b/test/Maestro.ScenarioTests/ObjectHelpers/SubscriptionBuilder.cs
@@ -37,6 +37,7 @@ public class SubscriptionBuilder
             targetBranch,
             pullRequestFailureNotificationTags: failureNotificationTags,
             sourceDirectory: null,
+            targetDirectory: null,
             excludedAssets: ImmutableList<string>.Empty)
         {
             Channel = new Channel(42, channelName, "test"),

--- a/test/Microsoft.DotNet.Darc.Tests/Operations/GetBuildOperationTests.cs
+++ b/test/Microsoft.DotNet.Darc.Tests/Operations/GetBuildOperationTests.cs
@@ -48,8 +48,8 @@ public class GetBuildOperationTests
         string sha = "50c88957fb93ccaa0040b5b28ff459a29ecf88c6";
         string internalRepo = $"internal-{repo}";
         string githubRepo = $"Github-{repo}";
-        Subscription subscription1 = new(Guid.Empty, true, false, internalRepo, "target", "test", string.Empty, null, ImmutableList<string>.Empty);
-        Subscription subscription2 = new(Guid.Empty, true, false, githubRepo, "target", "test", string.Empty, null, ImmutableList<string>.Empty);
+        Subscription subscription1 = new(Guid.Empty, true, false, internalRepo, "target", "test", string.Empty, null, null, ImmutableList<string>.Empty);
+        Subscription subscription2 = new(Guid.Empty, true, false, githubRepo, "target", "test", string.Empty, null, null, ImmutableList<string>.Empty);
 
         List<Subscription> subscriptions =
         [

--- a/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_json.verified.txt
+++ b/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_json.verified.txt
@@ -18,6 +18,7 @@
     "enabled": true,
     "sourceEnabled": false,
     "sourceDirectory": null,
+    "targetDirectory": null,
     "pullRequestFailureNotificationTags": "",
     "excludedAssets": [
       "Foo.Bar",

--- a/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_sorted_text.verified.txt
+++ b/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_sorted_text.verified.txt
@@ -14,6 +14,5 @@ source2 (name) ==> 'target2' ('test')
   - PR Failure Notification tags: 
   - Source-enabled: True
   - Source Directory: repo-name
-  - Target Directory: 
   - Excluded Assets: []
   - Merge Policies: []

--- a/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_sorted_text.verified.txt
+++ b/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.GetSubscriptionsOperationTests_ExecuteAsync_returns_sorted_text.verified.txt
@@ -14,5 +14,6 @@ source2 (name) ==> 'target2' ('test')
   - PR Failure Notification tags: 
   - Source-enabled: True
   - Source Directory: repo-name
+  - Target Directory: 
   - Excluded Assets: []
   - Merge Policies: []

--- a/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.cs
+++ b/test/Microsoft.DotNet.Darc.Tests/Operations/GetSubscriptionsOperationTests.cs
@@ -98,7 +98,7 @@ public class GetSubscriptionsOperationTests
     [Test]
     public async Task GetSubscriptionsOperationTests_ExecuteAsync_returns_text()
     {
-        Subscription subscription = new(Guid.Empty, true, false, "source", "target", "test", string.Empty, null, ImmutableList<string>.Empty)
+        Subscription subscription = new(Guid.Empty, true, false, "source", "target", "test", string.Empty, null, null, ImmutableList<string>.Empty)
         {
             Channel = new(id: 1, name: "name", classification: "classification"),
             Policy = new(batchable: false, updateFrequency: UpdateFrequency.EveryDay)
@@ -130,7 +130,7 @@ public class GetSubscriptionsOperationTests
     [Test]
     public async Task GetSubscriptionsOperationTests_ExecuteAsync_returns_json()
     {
-        Subscription subscription = new(Guid.Empty, true, false, "source", "target", "test", null, string.Empty, ImmutableList.Create("Foo.Bar", "Bar.Xyz"))
+        Subscription subscription = new(Guid.Empty, true, false, "source", "target", "test", null, null, string.Empty, ImmutableList.Create("Foo.Bar", "Bar.Xyz"))
         {
             Channel = new(id: 1, name: "name", classification: "classification"),
             Policy = new(batchable: false, updateFrequency: UpdateFrequency.EveryDay)
@@ -161,7 +161,7 @@ public class GetSubscriptionsOperationTests
     [Test]
     public async Task GetSubscriptionsOperationTests_ExecuteAsync_returns_sorted_text()
     {
-        Subscription subscription1 = new(Guid.Empty, true, true, "source2", "target2", "test", "repo-name", null, ImmutableList<string>.Empty)
+        Subscription subscription1 = new(Guid.Empty, true, true, "source2", "target2", "test", "repo-name", null, null, ImmutableList<string>.Empty)
         {
             Channel = new(id: 1, name: "name", classification: "classification"),
             Policy = new(batchable: false, updateFrequency: UpdateFrequency.EveryDay)
@@ -170,7 +170,7 @@ public class GetSubscriptionsOperationTests
             }
         };
 
-        Subscription subscription2 = new(Guid.Empty, true, false, "source1", "target1", "test", string.Empty, null, ImmutableList<string>.Empty)
+        Subscription subscription2 = new(Guid.Empty, true, false, "source1", "target1", "test", string.Empty, null, null, ImmutableList<string>.Empty)
         {
             Channel = new(id: 1, name: "name", classification: "classification"),
             Policy = new(batchable: false, updateFrequency: UpdateFrequency.EveryDay)

--- a/test/Microsoft.DotNet.DarcLib.Tests/Models/Darc/DependencyFlowNodeTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Models/Darc/DependencyFlowNodeTests.cs
@@ -76,7 +76,17 @@ public class DependencyFlowNodeTests
             WorstCasePathTime = worstCasePathTime,
         };
 
-        var subscription = new Subscription(Guid.NewGuid(), true, false, "source", "target", "test", sourceDirectory: null, pullRequestFailureNotificationTags: string.Empty, excludedAssets: ImmutableList<string>.Empty)
+        var subscription = new Subscription(
+            Guid.NewGuid(),
+            true,
+            false,
+            "source",
+            "target",
+            "test",
+            sourceDirectory: null,
+            targetDirectory: null,
+            pullRequestFailureNotificationTags: string.Empty,
+            excludedAssets: ImmutableList<string>.Empty)
         {
             LastAppliedBuild = new Build(
             id: 1,

--- a/test/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -253,6 +253,7 @@ public class PullRequestPolicyFailureNotifierTests
             $"https://github.com/{FakeOrgName}/dest-repo",
             "fakebranch",
             null,
+            null,
             "@notifiedUser1;@notifiedUser2;userWithoutAtSign;",
             excludedAssets: ImmutableList<string>.Empty),
         new ClientModels.Subscription(
@@ -263,6 +264,7 @@ public class PullRequestPolicyFailureNotifierTests
             $"https://github.com/{FakeOrgName}/dest-repo",
             "fakebranch",
             null,
+            null,
             "@notifiedUser3;@notifiedUser4",
             excludedAssets: ImmutableList<string>.Empty),
         new ClientModels.Subscription(
@@ -272,6 +274,7 @@ public class PullRequestPolicyFailureNotifierTests
             $"https://github.com/{FakeOrgName}/source-repo2",
             $"https://github.com/{FakeOrgName}/dest-repo",
             "fakebranch",
+            null,
             null,
             string.Empty,
             excludedAssets: ImmutableList<string>.Empty)


### PR DESCRIPTION
- Adds the DB column
- Adds the field to API controllers
- Regenerates the API C# client
- Extends the `darc` commands/pop-ups with this new field

https://github.com/dotnet/arcade-services/issues/3368

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Added `TargetDirectory` field to subscriptions