### PR TITLE
Remove build reason for post-build stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,7 +161,7 @@ extends:
                 displayName: Publish Maestro Scenario Tests
                 condition: always()
   
-    - ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production')) }}:
+    - ${{ if in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production') }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
           enableSymbolValidation: true


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->

Resolves https://github.com/dotnet/arcade-services/issues/3483

Removes `Build.Reason` check for post-build stage in internal CI

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description

SKIP IN RELEASE NOTES
