### PR TITLE
Allow the Maestro client to target netstandard

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.1.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageVersion Include="Azure.Identity" Version="1.10.4" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.1.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageVersion Include="Azure.Identity" Version="1.10.4" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.1.0" />

--- a/src/Maestro/Client/src/Microsoft.DotNet.Maestro.Client.csproj
+++ b/src/Maestro/Client/src/Microsoft.DotNet.Maestro.Client.csproj
@@ -8,11 +8,14 @@
     <SwaggerOutputDirectory>$(MSBuildProjectDirectory)\Generated</SwaggerOutputDirectory>
     <SwaggerClientName>MaestroApi</SwaggerClientName>
     <SwaggerDocumentUri>https://maestro.int-dot.net/api/swagger.json</SwaggerDocumentUri>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFramework></TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Collections.Immutable" />
 
     <PackageReference Include="Microsoft.DotNet.SwaggerGenerator.MSBuild" />
   </ItemGroup>


### PR DESCRIPTION
This allows for easier upgrading of the client library in downlevel versions of Arcade which may not be targeting net6+

https://github.com/dotnet/arcade-services/issues/3485

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description

Target netstandrd in Maestro client libs.