### PR TITLE
Add new code flow commits on top of an existing branch

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependencyGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependencyGraphOperation.cs
@@ -26,7 +26,12 @@ internal class GetDependencyGraphOperation : Operation
         : base(options)
     {
         _options = options;
-        _gitClient = new LocalLibGit2Client(options.GetRemoteConfiguration(), new ProcessManager(Logger, _options.GitLocation), new FileSystem(), Logger);
+        _gitClient = new LocalLibGit2Client(
+            options.GetRemoteConfiguration(),
+            new NoTelemetryRecorder(),
+            new ProcessManager(Logger, _options.GitLocation),
+            new FileSystem(),
+            Logger);
     }
 
     public override async Task<int> ExecuteAsync()

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
@@ -28,6 +28,7 @@ internal class BackflowOperation(BackflowCommandLineOptions options)
                 shaToFlow,
                 _options.Build,
                 _options.BranchName,
+                _options.BranchName,
                 _options.DiscardPatches,
                 cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/ForwardFlowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/ForwardFlowOperation.cs
@@ -28,6 +28,7 @@ internal class ForwardFlowOperation(ForwardFlowCommandLineOptions options)
                 shaToFlow,
                 _options.Build,
                 _options.BranchName,
+                _options.BranchName,
                 _options.DiscardPatches,
                 cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Actions/Local.cs
@@ -34,7 +34,7 @@ public class Local
     {
         _logger = logger;
         _versionDetailsParser = new VersionDetailsParser();
-        _gitClient = new LocalLibGit2Client(remoteConfiguration, new ProcessManager(logger, GitExecutable), new FileSystem(), logger);
+        _gitClient = new LocalLibGit2Client(remoteConfiguration, new NoTelemetryRecorder(), new ProcessManager(logger, GitExecutable), new FileSystem(), logger);
         _fileManager = new DependencyFileManager(_gitClient, _versionDetailsParser, logger);
 
         _repoRootDir = new(() => overrideRootPath ?? _gitClient.GetRootDirAsync().GetAwaiter().GetResult(), LazyThreadSafetyMode.PublicationOnly);

--- a/src/Microsoft.DotNet.Darc/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Actions/Remote.cs
@@ -52,7 +52,7 @@ public sealed class Remote : IRemote
         await _remoteGitClient.DeleteBranchAsync(repoUri, branch);
     }
 
-    public Task<bool> DoesBranchExistAsync(string repoUri, string branch)
+    public Task<bool> BranchExistsAsync(string repoUri, string branch)
     {
         _logger.LogInformation("Checking if branch '{branch}' exists in '{repoUri}'", branch, repoUri);
         return _remoteGitClient.DoesBranchExistAsync(repoUri, branch); 

--- a/src/Microsoft.DotNet.Darc/DarcLib/GitRepoFactory.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitRepoFactory.cs
@@ -15,6 +15,7 @@ public interface IGitRepoFactory
 public class GitRepoFactory : IGitRepoFactory
 {
     private readonly RemoteConfiguration _remoteConfiguration;
+    private readonly ITelemetryRecorder _telemetryRecorder;
     private readonly IProcessManager _processManager;
     private readonly IFileSystem _fileSystem;
     private readonly ILoggerFactory _loggerFactory;
@@ -22,12 +23,14 @@ public class GitRepoFactory : IGitRepoFactory
 
     public GitRepoFactory(
         RemoteConfiguration remoteConfiguration,
+        ITelemetryRecorder telemetryRecorder,
         IProcessManager processManager,
         IFileSystem fileSystem,
         ILoggerFactory loggerFactory,
         string temporaryPath)
     {
         _remoteConfiguration = remoteConfiguration;
+        _telemetryRecorder = telemetryRecorder;
         _processManager = processManager;
         _fileSystem = fileSystem;
         _loggerFactory = loggerFactory;
@@ -50,7 +53,12 @@ public class GitRepoFactory : IGitRepoFactory
             // Caching not in use for Darc local client.
             null),
 
-        GitRepoType.Local => new LocalLibGit2Client(_remoteConfiguration, _processManager, _fileSystem, _loggerFactory.CreateLogger<LocalGitClient>()),
+        GitRepoType.Local => new LocalLibGit2Client(
+            _remoteConfiguration,
+            _telemetryRecorder,
+            _processManager,
+            _fileSystem,
+            _loggerFactory.CreateLogger<LocalGitClient>()),
 
         _ => throw new ArgumentException("Unknown git repository type", nameof(repoUri)),
     };

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/LocalPath.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/LocalPath.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable enable
+using System.Diagnostics;
+
 namespace Microsoft.DotNet.DarcLib.Helpers;
 
 /// <summary>
@@ -12,6 +14,7 @@ namespace Microsoft.DotNet.DarcLib.Helpers;
 /// The concatenation works thanks to overloading of the / operator:
 ///     var combinedPath = someLocalPath / "src" / "MyProject.csproj";
 /// </summary>
+[DebuggerDisplay("{Path}")]
 public abstract class LocalPath
 {
     private readonly char _separator;

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
@@ -135,6 +135,16 @@ public interface ILocalGitClient
     Task<string[]> GetStagedFiles(string repoPath);
 
     /// <summary>
+    /// Fetches from all remotes.
+    /// </summary>
+    /// <param name="repoPath">Path to a git repository</param>
+    /// <param name="remoteUris">List of remotes to fetch from</param>
+    Task FetchAllAsync(
+        string repoPath,
+        IReadOnlyCollection<string> remoteUris,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     ///     Stages files from the given path.
     /// </summary>
     /// <param name="repoPath">Path to a git repository</param>
@@ -150,6 +160,22 @@ public interface ILocalGitClient
     /// <param name="args">Where to add the new argument into</param>
     /// <param name="envVars">Where to add the new variables into</param>
     void AddGitAuthHeader(IList<string> args, IDictionary<string, string> envVars, string repoUri);
+
+    /// <summary>
+    /// Gets a value of a given git configuration setting.
+    /// </summary>
+    /// <param name="repoPath">Path to a git repository</param>
+    /// <param name="setting">Name of the setting</param>
+    /// <returns>Value of the setting</returns>
+    Task<string> GetConfigValue(string repoPath, string setting);
+
+    /// <summary>
+    /// Sets a value of a given git configuration setting.
+    /// </summary>
+    /// <param name="repoPath">Path to a git repository</param>
+    /// <param name="setting">Name of the setting</param>
+    /// <param name="value">New value</param>
+    Task SetConfigValue(string repoPath, string setting, string value);
 
     /// <summary>
     /// Runs git with the given arguments and returns the result.

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
@@ -126,6 +126,26 @@ public interface ILocalGitRepo
     Task<GitObjectType> GetObjectTypeAsync(string objectSha);
 
     /// <summary>
+    /// Gets a value of a given git configuration setting.
+    /// </summary>
+    /// <param name="setting">Name of the setting</param>
+    /// <returns>Value of the setting</returns>
+    Task<string> GetConfigValue(string setting);
+
+    /// <summary>
+    /// Sets a value of a given git configuration setting.
+    /// </summary>
+    /// <param name="setting">Name of the setting</param>
+    /// <param name="value">New value</param>
+    Task SetConfigValue(string setting, string value);
+
+    /// <summary>
+    /// Fetches from all remotes.
+    /// </summary>
+    /// <param name="remoteUris">List of remotes to fetch from</param>
+    Task FetchAllAsync(IReadOnlyCollection<string> remoteUris, CancellationToken cancellationToken = default);
+
+    /// <summary>
     ///     Returns a list of modified staged files.
     /// </summary>
     /// <returns>List of currently modified staged files</returns>

--- a/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
@@ -123,7 +123,7 @@ public interface IRemote
     /// </summary>
     /// <param name="repoUri">Repository to find the branch in</param>
     /// <param name="branch">Branch to find</param>
-    Task<bool> DoesBranchExistAsync(string repoUri, string branch);
+    Task<bool> BranchExistsAsync(string repoUri, string branch);
 
     /// <summary>
     ///     Commit a set of updated dependencies to a repository

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -22,17 +22,20 @@ namespace Microsoft.DotNet.DarcLib;
 public class LocalGitClient : ILocalGitClient
 {
     private readonly RemoteConfiguration _remoteConfiguration;
+    private readonly ITelemetryRecorder _telemetryRecorder;
     private readonly IProcessManager _processManager;
     private readonly IFileSystem _fileSystem;
     private readonly ILogger _logger;
 
     public LocalGitClient(
         RemoteConfiguration remoteConfiguration,
+        ITelemetryRecorder telemetryRecorder,
         IProcessManager processManager,
         IFileSystem fileSystem,
         ILogger logger)
     {
         _remoteConfiguration = remoteConfiguration;
+        _telemetryRecorder = telemetryRecorder;
         _processManager = processManager;
         _fileSystem = fileSystem;
         _logger = logger;
@@ -209,6 +212,24 @@ public class LocalGitClient : ILocalGitClient
             "tag" => GitObjectType.Tag,
             _ => GitObjectType.Unknown,
         };
+    }
+
+    public async Task FetchAllAsync(
+        string repoPath,
+        IReadOnlyCollection<string> remoteUris,
+        CancellationToken cancellationToken = default)
+    {
+        foreach (var remoteUri in remoteUris.Distinct())
+        {
+            _logger.LogDebug("Fetching {uri} from {repo}", remoteUri, repoPath);
+            var remote = await AddRemoteIfMissingAsync(repoPath, remoteUri, cancellationToken);
+
+            // We cannot do `fetch --all` as tokens might be needed but fetch +refs/heads/*:+refs/remotes/origin/* doesn't fetch new refs
+            // So we need to call `remote update origin` to fetch everything
+            using ITelemetryScope scope = _telemetryRecorder.RecordGitOperation(TrackedGitOperation.Fetch, remoteUri);
+            await UpdateRemoteAsync(repoPath, remote, cancellationToken);
+            scope.SetSuccess();
+        }
     }
 
     /// <summary>
@@ -441,5 +462,18 @@ public class LocalGitClient : ILocalGitClient
         CancellationToken cancellationToken = default)
     {
         return await _processManager.ExecuteGit(repoPath, args, cancellationToken: cancellationToken);
+    }
+
+    public async Task<string> GetConfigValue(string repoPath, string setting)
+    {
+        var res = await _processManager.ExecuteGit(repoPath, "config", setting);
+        res.ThrowIfFailed($"Failed to determine {setting} value for {repoPath}");
+        return res.StandardOutput.Trim();
+    }
+
+    public async Task SetConfigValue(string repoPath, string setting, string value)
+    {
+        var res = await _processManager.ExecuteGit(repoPath, "config", setting, value);
+        res.ThrowIfFailed($"Failed to set {setting} value to {value} for {repoPath}");
     }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitRepo.cs
@@ -12,7 +12,8 @@ namespace Microsoft.DotNet.DarcLib;
 /// <summary>
 /// This class can manage a specific local git repository.
 /// </summary>
-public class LocalGitRepo(NativePath repoPath, ILocalGitClient localGitClient, IProcessManager processManager) : ILocalGitRepo
+public class LocalGitRepo(NativePath repoPath, ILocalGitClient localGitClient, IProcessManager processManager)
+    : ILocalGitRepo
 {
     public NativePath Path { get; } = repoPath;
 
@@ -61,8 +62,17 @@ public class LocalGitRepo(NativePath repoPath, ILocalGitClient localGitClient, I
     public async Task<string> GetShaForRefAsync(string? gitRef = null)
         => await _localGitClient.GetShaForRefAsync(Path, gitRef);
 
+    public async Task FetchAllAsync(IReadOnlyCollection<string> remoteUris, CancellationToken cancellationToken = default)
+        => await _localGitClient.FetchAllAsync(Path, remoteUris, cancellationToken);
+
     public async Task<string[]> GetStagedFiles()
         => await _localGitClient.GetStagedFiles(Path);
+
+    public async Task<string> GetConfigValue(string setting)
+        => await _localGitClient.GetConfigValue(Path, setting);
+
+    public async Task SetConfigValue(string setting, string value)
+        => await _localGitClient.SetConfigValue(Path, setting, value);
 
     public async Task ResetWorkingTree(UnixPath? relativePath = null)
         => await _localGitClient.ResetWorkingTree(new NativePath(Path), relativePath);

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
@@ -24,8 +24,8 @@ public class LocalLibGit2Client : LocalGitClient, ILocalLibGit2Client
     private readonly IProcessManager _processManager;
     private readonly ILogger _logger;
 
-    public LocalLibGit2Client(RemoteConfiguration remoteConfiguration, IProcessManager processManager, IFileSystem fileSystem, ILogger logger)
-        : base(remoteConfiguration, processManager, fileSystem, logger)
+    public LocalLibGit2Client(RemoteConfiguration remoteConfiguration, ITelemetryRecorder telemetryRecorder, IProcessManager processManager, IFileSystem fileSystem, ILogger logger)
+        : base(remoteConfiguration, telemetryRecorder, processManager, fileSystem, logger)
     {
         _remoteConfiguration = remoteConfiguration;
         _processManager = processManager;

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DependencyGraph.cs
@@ -781,7 +781,13 @@ public class DependencyGraph
             {
                 // If a repo folder or a mapping was not set we use the current parent's 
                 // parent folder.
-                var gitClient = new LocalLibGit2Client(new RemoteConfiguration(null, null), new ProcessManager(logger, gitExecutable), new FileSystem(), logger);
+                var gitClient = new LocalLibGit2Client(
+                    new RemoteConfiguration(null, null),
+                    new NoTelemetryRecorder(),
+                    new ProcessManager(logger, gitExecutable),
+                    new FileSystem(),
+                    logger);
+
                 string parent = await gitClient.GetRootDirAsync();
                 folder = Directory.GetParent(parent).FullName;
             }

--- a/src/Microsoft.DotNet.Darc/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/RemoteRepoBase.cs
@@ -36,7 +36,7 @@ public class RemoteRepoBase : GitRepoCloner
         ILogger logger,
         ProcessManager processManager,
         RemoteConfiguration remoteConfiguration)
-        : base(remoteConfiguration, new LocalLibGit2Client(remoteConfiguration, processManager, new FileSystem(), logger), logger)
+        : base(remoteConfiguration, new LocalLibGit2Client(remoteConfiguration, new NoTelemetryRecorder(), processManager, new FileSystem(), logger), logger)
     {
         TemporaryRepositoryPath = temporaryRepositoryPath;
         GitExecutable = gitExecutable;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
@@ -47,6 +47,10 @@ public abstract class CloneManager
         _logger = logger;
     }
 
+    /// <summary>
+    /// Prepares a clone of a repository by fetching from given remotes one-by-one until all requested commits are available.
+    /// Then checks out the given ref.
+    /// </summary>
     protected async Task<ILocalGitRepo> PrepareCloneInternalAsync(
         string dirName,
         IReadOnlyCollection<string> remoteUris,
@@ -112,6 +116,11 @@ public abstract class CloneManager
         return repo;
     }
 
+    /// <summary>
+    /// Prepares a clone of the given remote URI in the given directory name (under tmp path).
+    /// When clone is already present, it is re-used and we only fetch.
+    /// When given remotes have already been fetched during this run, they are not fetched again.
+    /// </summary>
     protected async Task<NativePath> PrepareCloneInternal(string remoteUri, string dirName, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
@@ -27,7 +27,7 @@ public abstract class CloneManager
     private readonly ILocalGitRepoFactory _localGitRepoFactory;
     private readonly ITelemetryRecorder _telemetryRecorder;
     private readonly IFileSystem _fileSystem;
-    private readonly ILogger<VmrPatchHandler> _logger;
+    private readonly ILogger _logger;
 
     public CloneManager(
         IVmrInfo vmrInfo,
@@ -36,7 +36,7 @@ public abstract class CloneManager
         ILocalGitRepoFactory localGitRepoFactory,
         ITelemetryRecorder telemetryRecorder,
         IFileSystem fileSystem,
-        ILogger<VmrPatchHandler> logger)
+        ILogger logger)
     {
         _vmrInfo = vmrInfo;
         _gitRepoCloner = gitRepoCloner;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
@@ -1,0 +1,160 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LibGit2Sharp;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.Logging;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+public abstract class CloneManager
+{
+    // Map of URI => dir name
+    private readonly Dictionary<string, NativePath> _clones = [];
+
+    // Repos we have already pulled updates for during this run
+    private readonly List<string> _upToDateRepos = [];
+
+    private readonly IVmrInfo _vmrInfo;
+    private readonly IGitRepoCloner _gitRepoCloner;
+    private readonly ILocalGitClient _localGitRepo;
+    private readonly ILocalGitRepoFactory _localGitRepoFactory;
+    private readonly ITelemetryRecorder _telemetryRecorder;
+    private readonly IFileSystem _fileSystem;
+    private readonly ILogger<VmrPatchHandler> _logger;
+
+    public CloneManager(
+        IVmrInfo vmrInfo,
+        IGitRepoCloner gitRepoCloner,
+        ILocalGitClient localGitRepo,
+        ILocalGitRepoFactory localGitRepoFactory,
+        ITelemetryRecorder telemetryRecorder,
+        IFileSystem fileSystem,
+        ILogger<VmrPatchHandler> logger)
+    {
+        _vmrInfo = vmrInfo;
+        _gitRepoCloner = gitRepoCloner;
+        _localGitRepo = localGitRepo;
+        _localGitRepoFactory = localGitRepoFactory;
+        _telemetryRecorder = telemetryRecorder;
+        _fileSystem = fileSystem;
+        _logger = logger;
+    }
+
+    protected async Task<ILocalGitRepo> PrepareCloneInternalAsync(
+        string dirName,
+        IReadOnlyCollection<string> remoteUris,
+        IReadOnlyCollection<string> requestedRefs,
+        string checkoutRef,
+        CancellationToken cancellationToken)
+    {
+        if (remoteUris.Count == 0)
+        {
+            throw new ArgumentException("No remote URIs provided to clone");
+        }
+
+        // Rule out the null commit
+        var refsToVerify = new HashSet<string>(requestedRefs.Where(sha => !Constants.EmptyGitObject.StartsWith(sha)));
+
+        _logger.LogDebug("Fetching refs {refs} from {uris}",
+            string.Join(", ", requestedRefs),
+            string.Join(", ", remoteUris));
+
+        NativePath path = null!;
+        foreach (string remoteUri in remoteUris)
+        {
+            // Path should be returned the same for all invocations
+            // We checkout a default ref
+            path = await PrepareCloneInternal(remoteUri, dirName, cancellationToken);
+            var missingCommit = false;
+
+            // Verify that all requested commits are available
+            foreach (string commit in refsToVerify.ToArray())
+            {
+                try
+                {
+                    var objectType = await _localGitRepo.GetObjectTypeAsync(path, commit);
+                    if (objectType == GitObjectType.Commit)
+                    {
+                        refsToVerify.Remove(commit);
+                    }
+                }
+                catch
+                {
+                    // Ref not found yet, let's try another remote
+                    missingCommit = true;
+                    break;
+                }
+            }
+
+            if (!missingCommit)
+            {
+                _logger.LogDebug("All requested refs ({refs}) found in {repo}", string.Join(", ", requestedRefs), path);
+                break;
+            }
+        }
+
+        if (refsToVerify.Count > 0)
+        {
+            throw new NotFoundException($"Failed to find all requested refs ({string.Join(", ", requestedRefs)}) in {string.Join(", ", remoteUris)}");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var repo = _localGitRepoFactory.Create(path);
+        await repo.CheckoutAsync(checkoutRef);
+        return repo;
+    }
+
+    protected async Task<NativePath> PrepareCloneInternal(string remoteUri, string dirName, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (_upToDateRepos.Contains(remoteUri))
+        {
+            var path = _clones[remoteUri];
+            if (_fileSystem.DirectoryExists(path))
+            {
+                return path;
+            }
+
+            _upToDateRepos.Remove(remoteUri);
+        }
+
+        var clonePath = _clones.TryGetValue(remoteUri, out var cachedPath)
+            ? cachedPath
+            : GetClonePath(dirName);
+
+        if (!_fileSystem.DirectoryExists(clonePath))
+        {
+            _logger.LogDebug("Cloning {repo} to {clonePath}", remoteUri, clonePath);
+
+            using ITelemetryScope scope = _telemetryRecorder.RecordGitOperation(TrackedGitOperation.Clone, remoteUri);
+            await _gitRepoCloner.CloneNoCheckoutAsync(remoteUri, clonePath, null);
+            scope.SetSuccess();
+        }
+        else
+        {
+            _logger.LogDebug("Clone of {repo} found in {clonePath}", remoteUri, clonePath);
+            var remote = await _localGitRepo.AddRemoteIfMissingAsync(clonePath, remoteUri, cancellationToken);
+
+            // We cannot do `fetch --all` as tokens might be needed but fetch +refs/heads/*:+refs/remotes/origin/* doesn't fetch new refs
+            // So we need to call `remote update origin` to fetch everything
+            using ITelemetryScope scope = _telemetryRecorder.RecordGitOperation(TrackedGitOperation.Fetch, remoteUri);
+            await _localGitRepo.UpdateRemoteAsync(clonePath, remote, cancellationToken);
+            scope.SetSuccess();
+        }
+
+        _upToDateRepos.Add(remoteUri);
+        _clones[remoteUri] = clonePath;
+        return clonePath;
+    }
+
+    protected virtual NativePath GetClonePath(string dirName) => _vmrInfo.TmpPath / dirName;
+}

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrBackFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrBackFlower.cs
@@ -123,15 +123,7 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
             .OrderRemotesByLocalPublicOther()
             .ToList();
 
-        // Check out base branch first
-        ILocalGitRepo targetRepo = await _repositoryCloneManager.PrepareCloneAsync(
-            mapping,
-            remotes,
-            baseBranch,
-            cancellationToken);
-
-        // Refresh the repo
-        await targetRepo.FetchAllAsync(remotes, cancellationToken);
+        ILocalGitRepo targetRepo;
 
         // Now try to see if the target branch exists already
         try
@@ -146,7 +138,11 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
         catch (NotFoundException)
         {
             // If target branch does not exist, we create it off of the base branch
-            await targetRepo.CheckoutAsync(baseBranch);
+            targetRepo = await _repositoryCloneManager.PrepareCloneAsync(
+                mapping,
+                remotes,
+                baseBranch,
+                cancellationToken);
             await targetRepo.CreateBranchAsync(targetBranch);
         }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrBackFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrBackFlower.cs
@@ -1,0 +1,155 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LibGit2Sharp;
+using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.Logging;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+/// <summary>
+/// Class for flowing code from the VMR to product repos.
+/// This class is used in the context of darc CLI as some behaviours around repo preparation differ.
+/// </summary>
+public interface IPcsVmrBackFlower : IVmrBackFlower
+{
+    /// <summary>
+    /// Flows backward the code from the VMR to the target branch of a product repo.
+    /// This overload is used in the context of the PCS.
+    /// </summary>
+    /// <param name="mappingName">Mapping to flow</param>
+    /// <param name="build">Build to flow</param>
+    /// <param name="baseBranch">If target branch does not exist, it is created off of this branch</param>
+    /// <param name="targetBranch">Target branch to make the changes on</param>
+    /// <returns>
+    ///     Boolean whether there were any changes to be flown
+    ///     and a path to the local repo where the new branch is created
+    ///  </returns>
+    Task<(bool HadUpdates, NativePath RepoPath)> FlowBackAsync(
+        string mappingName,
+        Build build,
+        string baseBranch,
+        string targetBranch,
+        CancellationToken cancellationToken = default);
+}
+
+internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
+{
+    private readonly ISourceManifest _sourceManifest;
+    private readonly IVmrDependencyTracker _dependencyTracker;
+    private readonly IVmrCloneManager _vmrCloneManager;
+    private readonly IRepositoryCloneManager _repositoryCloneManager;
+
+    public PcsVmrBackFlower(
+            IVmrInfo vmrInfo,
+            ISourceManifest sourceManifest,
+            IVmrDependencyTracker dependencyTracker,
+            IDependencyFileManager dependencyFileManager,
+            IVmrCloneManager vmrCloneManager,
+            IRepositoryCloneManager repositoryCloneManager,
+            ILocalGitClient localGitClient,
+            ILocalGitRepoFactory localGitRepoFactory,
+            IVersionDetailsParser versionDetailsParser,
+            IVmrPatchHandler vmrPatchHandler,
+            IWorkBranchFactory workBranchFactory,
+            IBasicBarClient basicBarClient,
+            ILocalLibGit2Client libGit2Client,
+            ICoherencyUpdateResolver coherencyUpdateResolver,
+            IAssetLocationResolver assetLocationResolver,
+            IFileSystem fileSystem,
+            ILogger<VmrCodeFlower> logger)
+        : base(vmrInfo, sourceManifest, dependencyTracker, dependencyFileManager, vmrCloneManager, repositoryCloneManager, localGitClient, localGitRepoFactory, versionDetailsParser, vmrPatchHandler, workBranchFactory, basicBarClient, libGit2Client, coherencyUpdateResolver, assetLocationResolver, fileSystem, logger)
+    {
+        _sourceManifest = sourceManifest;
+        _dependencyTracker = dependencyTracker;
+        _vmrCloneManager = vmrCloneManager;
+        _repositoryCloneManager = repositoryCloneManager;
+    }
+
+    public async Task<(bool HadUpdates, NativePath RepoPath)> FlowBackAsync(
+        string mappingName,
+        Build build,
+        string baseBranch,
+        string targetBranch,
+        CancellationToken cancellationToken = default)
+    {
+        (SourceMapping mapping, ILocalGitRepo targetRepo) = await PrepareVmrAndRepo(
+            mappingName,
+            build,
+            baseBranch,
+            targetBranch,
+            cancellationToken);
+
+        Codeflow lastFlow = await GetLastFlowAsync(mapping, targetRepo, currentIsBackflow: true);
+
+        var hadUpdates = await FlowBackAsync(
+            mapping,
+            targetRepo,
+            lastFlow,
+            build.Commit,
+            build,
+            baseBranch,
+            targetBranch,
+            true,
+            cancellationToken);
+
+        return (hadUpdates, targetRepo.Path);
+    }
+
+    private async Task<(SourceMapping, ILocalGitRepo)> PrepareVmrAndRepo(
+        string mappingName,
+        Build build,
+        string baseBranch,
+        string targetBranch,
+        CancellationToken cancellationToken)
+    {
+        // Prepare the VMR
+        await _vmrCloneManager.PrepareVmrAsync(
+            [build.GetRepository()],
+            [build.Commit],
+            build.Commit,
+            cancellationToken);
+
+        // Prepare repo
+        SourceMapping mapping = _dependencyTracker.GetMapping(mappingName);
+        var remotes = new[] { mapping.DefaultRemote, _sourceManifest.GetRepoVersion(mapping.Name).RemoteUri }
+            .Distinct()
+            .OrderRemotesByLocalPublicOther()
+            .ToList();
+
+        // Check out base branch first
+        ILocalGitRepo targetRepo = await _repositoryCloneManager.PrepareCloneAsync(
+            mapping,
+            remotes,
+            baseBranch,
+            cancellationToken);
+
+        // Refresh the repo
+        await targetRepo.FetchAllAsync(remotes, cancellationToken);
+
+        // Now try to see if the target branch exists already
+        try
+        {
+            targetRepo = await _repositoryCloneManager.PrepareCloneAsync(
+                mapping,
+                remotes,
+                [baseBranch, targetBranch],
+                targetBranch,
+                cancellationToken);
+        }
+        catch (NotFoundException)
+        {
+            // If target branch does not exist, we create it off of the base branch
+            await targetRepo.CheckoutAsync(baseBranch);
+            await targetRepo.CreateBranchAsync(targetBranch);
+        }
+
+        return (mapping, targetRepo);
+    }
+}

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrForwardFlower.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LibGit2Sharp;
+using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.Logging;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+/// <summary>
+/// Interface for VmrForwardFlower used in the context of the PCS.
+/// </summary>
+public interface IPcsVmrForwardFlower
+{
+    /// <summary>
+    /// Flows forward the code from the source repo to the target branch of the VMR.
+    /// This overload is used in the context of the PCS.
+    /// </summary>
+    /// <param name="mappingName">Mapping to flow</param>
+    /// <param name="build">Build to flow</param>
+    /// <param name="baseBranch">If target branch does not exist, it is created off of this branch</param>
+    /// <param name="targetBranch">Target branch to make the changes on</param>
+    /// <returns>True when there were changes to be flown</returns>
+    Task<bool> FlowForwardAsync(
+        string mappingName,
+        Build build,
+        string baseBranch,
+        string targetBranch,
+        CancellationToken cancellationToken = default);
+}
+
+internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
+{
+    private readonly IVmrInfo _vmrInfo;
+    private readonly ISourceManifest _sourceManifest;
+    private readonly IVmrDependencyTracker _dependencyTracker;
+    private readonly IVmrCloneManager _vmrCloneManager;
+    private readonly IRepositoryCloneManager _repositoryCloneManager;
+
+    public PcsVmrForwardFlower(
+        IVmrInfo vmrInfo,
+        ISourceManifest sourceManifest,
+        IVmrUpdater vmrUpdater,
+        IVmrDependencyTracker dependencyTracker,
+        IVmrCloneManager vmrCloneManager,
+        IDependencyFileManager dependencyFileManager,
+        IRepositoryCloneManager repositoryCloneManager,
+        ILocalGitClient localGitClient,
+        ILocalLibGit2Client libGit2Client,
+        IBasicBarClient basicBarClient,
+        ILocalGitRepoFactory localGitRepoFactory,
+        IVersionDetailsParser versionDetailsParser,
+        IProcessManager processManager,
+        IWorkBranchFactory workBranchFactory,
+        ICoherencyUpdateResolver coherencyUpdateResolver,
+        IAssetLocationResolver assetLocationResolver,
+        IFileSystem fileSystem,
+        ILogger<VmrCodeFlower> logger)
+        : base(vmrInfo, sourceManifest, vmrUpdater, dependencyTracker, vmrCloneManager, dependencyFileManager, repositoryCloneManager, localGitClient, libGit2Client, basicBarClient, localGitRepoFactory, versionDetailsParser, processManager, workBranchFactory, coherencyUpdateResolver, assetLocationResolver, fileSystem, logger)
+    {
+        _vmrInfo = vmrInfo;
+        _sourceManifest = sourceManifest;
+        _dependencyTracker = dependencyTracker;
+        _vmrCloneManager = vmrCloneManager;
+        _repositoryCloneManager = repositoryCloneManager;
+    }
+
+    public async Task<bool> FlowForwardAsync(
+        string mappingName,
+        Build build,
+        string baseBranch,
+        string targetBranch,
+        CancellationToken cancellationToken = default)
+    {
+        await PrepareVmr(baseBranch, targetBranch, cancellationToken);
+
+        // Prepare repo
+        SourceMapping mapping = _dependencyTracker.GetMapping(mappingName);
+        var remotes = new[] { mapping.DefaultRemote, _sourceManifest.GetRepoVersion(mapping.Name).RemoteUri }
+            .Distinct()
+            .OrderRemotesByLocalPublicOther()
+            .ToList();
+
+        ILocalGitRepo sourceRepo = await _repositoryCloneManager.PrepareCloneAsync(
+            mapping,
+            remotes,
+            build.Commit,
+            cancellationToken);
+
+        Codeflow lastFlow = await GetLastFlowAsync(mapping, sourceRepo, currentIsBackflow: false);
+
+        return await FlowCodeAsync(
+            lastFlow,
+            new ForwardFlow(lastFlow.TargetSha, build.Commit),
+            sourceRepo,
+            mapping,
+            build,
+            baseBranch,
+            targetBranch,
+            discardPatches: true,
+            cancellationToken);
+    }
+}

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrForwardFlower.cs
@@ -1,10 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using LibGit2Sharp;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.Maestro.Client.Models;
@@ -37,10 +37,8 @@ public interface IPcsVmrForwardFlower
 
 internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
 {
-    private readonly IVmrInfo _vmrInfo;
     private readonly ISourceManifest _sourceManifest;
     private readonly IVmrDependencyTracker _dependencyTracker;
-    private readonly IVmrCloneManager _vmrCloneManager;
     private readonly IRepositoryCloneManager _repositoryCloneManager;
 
     public PcsVmrForwardFlower(
@@ -64,10 +62,8 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
         ILogger<VmrCodeFlower> logger)
         : base(vmrInfo, sourceManifest, vmrUpdater, dependencyTracker, vmrCloneManager, dependencyFileManager, repositoryCloneManager, localGitClient, libGit2Client, basicBarClient, localGitRepoFactory, versionDetailsParser, processManager, workBranchFactory, coherencyUpdateResolver, assetLocationResolver, fileSystem, logger)
     {
-        _vmrInfo = vmrInfo;
         _sourceManifest = sourceManifest;
         _dependencyTracker = dependencyTracker;
-        _vmrCloneManager = vmrCloneManager;
         _repositoryCloneManager = repositoryCloneManager;
     }
 
@@ -82,7 +78,8 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
 
         // Prepare repo
         SourceMapping mapping = _dependencyTracker.GetMapping(mappingName);
-        var remotes = new[] { mapping.DefaultRemote, _sourceManifest.GetRepoVersion(mapping.Name).RemoteUri }
+        ISourceComponent repoVersion = _sourceManifest.GetRepoVersion(mapping.Name);
+        List<string> remotes = (new[] { mapping.DefaultRemote, repoVersion.RemoteUri })
             .Distinct()
             .OrderRemotesByLocalPublicOther()
             .ToList();

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
@@ -50,7 +49,7 @@ public interface IRepositoryCloneManager
     /// </summary>
     /// <param name="mapping">Mapping that clone is associated with</param>
     /// <param name="remoteUris">Remotes to fetch one by one</param>
-    /// <param name="requestedRefs">List of commits that </param>
+    /// <param name="requestedRefs">List of refs that need to be available</param>
     /// <param name="checkoutRef">Ref to check out at the end</param>
     /// <returns>Path to the clone</returns>
     Task<ILocalGitRepo> PrepareCloneAsync(
@@ -59,11 +58,6 @@ public interface IRepositoryCloneManager
         IReadOnlyCollection<string> requestedRefs,
         string checkoutRef,
         CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Prepares a clone of the VMR.
-    /// </summary>
-    Task<ILocalGitRepo> PrepareVmrCloneAsync(string vmrUri, CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -72,21 +66,9 @@ public interface IRepositoryCloneManager
 ///   - Previously cloned repositories are re-used
 ///   - Re-used clones pull newest updates once per run (the first time we use them)
 /// </summary>
-public class RepositoryCloneManager : IRepositoryCloneManager
+public class RepositoryCloneManager : CloneManager, IRepositoryCloneManager
 {
-    private readonly IVmrInfo _vmrInfo;
-    private readonly IGitRepoCloner _gitRepoCloner;
-    private readonly ILocalGitClient _localGitRepo;
     private readonly ILocalGitRepoFactory _localGitRepoFactory;
-    private readonly ITelemetryRecorder _telemetryRecorder;
-    private readonly IFileSystem _fileSystem;
-    private readonly ILogger<VmrPatchHandler> _logger;
-
-    // Map of URI => dir name
-    private readonly Dictionary<string, NativePath> _clones = [];
-
-    // Repos we have already pulled updates for during this run
-    private readonly List<string> _upToDateRepos = [];
 
     public RepositoryCloneManager(
         IVmrInfo vmrInfo,
@@ -96,14 +78,9 @@ public class RepositoryCloneManager : IRepositoryCloneManager
         ITelemetryRecorder telemetryRecorder,
         IFileSystem fileSystem,
         ILogger<VmrPatchHandler> logger)
+        : base(vmrInfo, gitRepoCloner, localGitRepo, localGitRepoFactory, telemetryRecorder, fileSystem, logger)
     {
-        _vmrInfo = vmrInfo;
-        _gitRepoCloner = gitRepoCloner;
-        _localGitRepo = localGitRepo;
         _localGitRepoFactory = localGitRepoFactory;
-        _telemetryRecorder = telemetryRecorder;
-        _fileSystem = fileSystem;
-        _logger = logger;
     }
 
     public async Task<ILocalGitRepo> PrepareCloneAsync(
@@ -143,125 +120,11 @@ public class RepositoryCloneManager : IRepositoryCloneManager
         return repo;
     }
 
-    public async Task<ILocalGitRepo> PrepareCloneAsync(
+    public Task<ILocalGitRepo> PrepareCloneAsync(
         SourceMapping mapping,
         IReadOnlyCollection<string> remoteUris,
         IReadOnlyCollection<string> requestedRefs,
         string checkoutRef,
         CancellationToken cancellationToken)
-    {
-        if (remoteUris.Count == 0)
-        {
-            throw new ArgumentException("No remote URIs provided to clone");
-        }
-
-        // Rule out the null commit
-        var refsToVerify = new HashSet<string>(requestedRefs.Where(sha => !Constants.EmptyGitObject.StartsWith(sha)));
-
-        _logger.LogDebug("Fetching refs {refs} from {uris}",
-            string.Join(", ", requestedRefs),
-            string.Join(", ", remoteUris));
-
-        NativePath path = null!;
-        foreach (string remoteUri in remoteUris)
-        {
-            // Path should be returned the same for all invocations
-            // We checkout a default ref
-            path = await PrepareCloneInternal(remoteUri, mapping.Name, cancellationToken);
-            var missingCommit = false;
-
-            // Verify that all requested commits are available
-            foreach (string commit in refsToVerify.ToArray())
-            {
-                try
-                {
-                    var objectType = await _localGitRepo.GetObjectTypeAsync(path, commit);
-                    if (objectType == GitObjectType.Commit)
-                    {
-                        refsToVerify.Remove(commit);
-                    }
-                }
-                catch
-                {
-                    // Ref not found yet, let's try another remote
-                    missingCommit = true;
-                    break;
-                }
-            }
-
-            if (!missingCommit)
-            {
-                _logger.LogDebug("All requested refs ({refs}) found in {repo}", string.Join(", ", requestedRefs), path);
-                break;
-            }
-        }
-
-        if (refsToVerify.Count > 0)
-        {
-            throw new Exception($"Failed to find all requested refs ({string.Join(", ", requestedRefs)}) in {string.Join(", ", remoteUris)}");
-        }
-
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var repo = _localGitRepoFactory.Create(path);
-        await repo.CheckoutAsync(checkoutRef);
-        return repo;
-    }
-
-    public async Task<ILocalGitRepo> PrepareVmrCloneAsync(string vmrUri, CancellationToken cancellationToken)
-    {
-        // The vmr directory won't use a hash for its name, so we don't accidentally overwrite it
-        var path = await PrepareCloneInternal(vmrUri, Constants.VmrFolderName, cancellationToken);
-        var repo = _localGitRepoFactory.Create(path);
-        await repo.CheckoutAsync("main");
-
-        _vmrInfo.VmrPath = path;
-        _vmrInfo.VmrUri = vmrUri;
-
-        return repo;
-    }
-
-    private async Task<NativePath> PrepareCloneInternal(string remoteUri, string dirName, CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        if (_upToDateRepos.Contains(remoteUri))
-        {
-            var path = _clones[remoteUri];
-            if (_fileSystem.DirectoryExists(path))
-            {
-                return _clones[remoteUri];
-            }
-
-            _upToDateRepos.Remove(remoteUri);
-        }
-
-        var clonePath = _clones.TryGetValue(remoteUri, out var cachedPath)
-            ? cachedPath
-            : _vmrInfo.TmpPath / dirName;
-
-        if (!_fileSystem.DirectoryExists(clonePath))
-        {
-            _logger.LogDebug("Cloning {repo} to {clonePath}", remoteUri, clonePath);
-
-            using ITelemetryScope scope = _telemetryRecorder.RecordGitOperation(TrackedGitOperation.Clone, remoteUri);
-            await _gitRepoCloner.CloneNoCheckoutAsync(remoteUri, clonePath, null);
-            scope.SetSuccess();
-        }
-        else
-        {
-            _logger.LogDebug("Clone of {repo} found in {clonePath}", remoteUri, clonePath);
-            var remote = await _localGitRepo.AddRemoteIfMissingAsync(clonePath, remoteUri, cancellationToken);
-
-            // We cannot do `fetch --all` as tokens might be needed but fetch +refs/heads/*:+refs/remotes/origin/* doesn't fetch new refs
-            // So we need to call `remote update origin` to fetch everything
-            using ITelemetryScope scope = _telemetryRecorder.RecordGitOperation(TrackedGitOperation.Fetch, remoteUri);
-            await _localGitRepo.UpdateRemoteAsync(clonePath, remote, cancellationToken);
-            scope.SetSuccess();
-        }
-
-        _upToDateRepos.Add(remoteUri);
-        _clones[remoteUri] = clonePath;
-        return clonePath;
-    }
+        => PrepareCloneInternalAsync(mapping.Name, remoteUris, requestedRefs, checkoutRef, cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -77,7 +77,7 @@ public class RepositoryCloneManager : CloneManager, IRepositoryCloneManager
         ILocalGitRepoFactory localGitRepoFactory,
         ITelemetryRecorder telemetryRecorder,
         IFileSystem fileSystem,
-        ILogger<VmrPatchHandler> logger)
+        ILogger<RepositoryCloneManager> logger)
         : base(vmrInfo, gitRepoCloner, localGitRepo, localGitRepoFactory, telemetryRecorder, fileSystem, logger)
     {
         _localGitRepoFactory = localGitRepoFactory;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -46,6 +46,7 @@ public interface IRepositoryCloneManager
 
     /// <summary>
     /// Prepares a clone of a repository by fetching from given remotes one-by-one until all requested commits are available.
+    /// Then checks out the given ref.
     /// </summary>
     /// <param name="mapping">Mapping that clone is associated with</param>
     /// <param name="remoteUris">Remotes to fetch one by one</param>

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.Maestro.Client.Models;
@@ -24,15 +25,16 @@ public interface IVmrBackFlower
     /// <param name="targetRepo">Local checkout of the repository</param>
     /// <param name="shaToFlow">SHA to flow</param>
     /// <param name="buildToFlow">Build to flow</param>
-    /// <param name="newBranchName">New branch name</param>
-    /// <param name="targetBranch">Target branch to create the PR branch on top of</param>
+    /// <param name="baseBranch">If target branch does not exist, it is created off of this branch</param>
+    /// <param name="targetBranch">Target branch to make the changes on</param>
     /// <param name="discardPatches">Keep patch files?</param>
     Task<bool> FlowBackAsync(
         string mapping,
         NativePath targetRepo,
         string? shaToFlow,
         int? buildToFlow,
-        string? newBranchName,
+        string baseBranch,
+        string targetBranch,
         bool discardPatches = false,
         CancellationToken cancellationToken = default);
 
@@ -44,75 +46,76 @@ public interface IVmrBackFlower
     /// <param name="targetRepo">Local checkout of the repository</param>
     /// <param name="shaToFlow">SHA to flow</param>
     /// <param name="buildToFlow">Build to flow</param>
-    /// <param name="newBranchName">New branch name</param>
-    /// <param name="targetBranch">Target branch to create the PR branch on top of</param>
+    /// <param name="baseBranch">If target branch does not exist, it is created off of this branch</param>
+    /// <param name="targetBranch">Target branch to make the changes on</param>
     /// <param name="discardPatches">Keep patch files?</param>
     Task<bool> FlowBackAsync(
         string mapping,
         ILocalGitRepo targetRepo,
         string? shaToFlow,
         int? buildToFlow,
-        string? newBranchName,
-        bool discardPatches = false,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Flows backward the code from the VMR to the target branch of a product repo.
-    /// This overload is used in the context of the PCS.
-    /// </summary>
-    /// <param name="mappingName">Mapping to flow</param>
-    /// <param name="build">Build to flow</param>
-    /// <param name="newBranchName">New branch name</param>
-    /// <param name="targetBranch">Target branch to create the PR branch on top of</param>
-    /// <returns>
-    ///     Boolean whether there were any changes to be flown
-    ///     and a path to the local repo where the new branch is created
-    ///  </returns>
-    Task<(bool HadUpdates, NativePath RepoPath)> FlowBackAsync(
-        string mappingName,
-        Build build,
-        string newBranchName,
+        string baseBranch,
         string targetBranch,
+        bool discardPatches = false,
         CancellationToken cancellationToken = default);
 }
 
-internal class VmrBackFlower(
-        IVmrInfo vmrInfo,
-        ISourceManifest sourceManifest,
-        IVmrDependencyTracker dependencyTracker,
-        IDependencyFileManager dependencyFileManager,
-        IRepositoryCloneManager repositoryCloneManager,
-        ILocalGitClient localGitClient,
-        ILocalGitRepoFactory localGitRepoFactory,
-        IVersionDetailsParser versionDetailsParser,
-        IVmrPatchHandler vmrPatchHandler,
-        IWorkBranchFactory workBranchFactory,
-        IBasicBarClient basicBarClient,
-        ILocalLibGit2Client libGit2Client,
-        ICoherencyUpdateResolver coherencyUpdateResolver,
-        IAssetLocationResolver assetLocationResolver,
-        IFileSystem fileSystem,
-        ILogger<VmrCodeFlower> logger)
-    : VmrCodeFlower(vmrInfo, sourceManifest, dependencyTracker, repositoryCloneManager, localGitClient, libGit2Client, localGitRepoFactory, versionDetailsParser, dependencyFileManager, coherencyUpdateResolver, assetLocationResolver, fileSystem, logger),
-    IVmrBackFlower
+internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
 {
-    private readonly IVmrInfo _vmrInfo = vmrInfo;
-    private readonly ISourceManifest _sourceManifest = sourceManifest;
-    private readonly IVmrDependencyTracker _dependencyTracker = dependencyTracker;
-    private readonly ILocalGitClient _localGitClient = localGitClient;
-    private readonly ILocalGitRepoFactory _localGitRepoFactory = localGitRepoFactory;
-    private readonly IVmrPatchHandler _vmrPatchHandler = vmrPatchHandler;
-    private readonly IWorkBranchFactory _workBranchFactory = workBranchFactory;
-    private readonly IBasicBarClient _barClient = basicBarClient;
-    private readonly IFileSystem _fileSystem = fileSystem;
-    private readonly ILogger<VmrCodeFlower> _logger = logger;
+    private readonly IVmrInfo _vmrInfo;
+    private readonly ISourceManifest _sourceManifest;
+    private readonly IVmrDependencyTracker _dependencyTracker;
+    private readonly IVmrCloneManager _vmrCloneManager;
+    private readonly IRepositoryCloneManager _repositoryCloneManager;
+    private readonly ILocalGitClient _localGitClient;
+    private readonly ILocalGitRepoFactory _localGitRepoFactory;
+    private readonly IVmrPatchHandler _vmrPatchHandler;
+    private readonly IWorkBranchFactory _workBranchFactory;
+    private readonly IBasicBarClient _barClient;
+    private readonly IFileSystem _fileSystem;
+    private readonly ILogger<VmrCodeFlower> _logger;
+
+    public VmrBackFlower(
+            IVmrInfo vmrInfo,
+            ISourceManifest sourceManifest,
+            IVmrDependencyTracker dependencyTracker,
+            IDependencyFileManager dependencyFileManager,
+            IVmrCloneManager vmrCloneManager,
+            IRepositoryCloneManager repositoryCloneManager,
+            ILocalGitClient localGitClient,
+            ILocalGitRepoFactory localGitRepoFactory,
+            IVersionDetailsParser versionDetailsParser,
+            IVmrPatchHandler vmrPatchHandler,
+            IWorkBranchFactory workBranchFactory,
+            IBasicBarClient basicBarClient,
+            ILocalLibGit2Client libGit2Client,
+            ICoherencyUpdateResolver coherencyUpdateResolver,
+            IAssetLocationResolver assetLocationResolver,
+            IFileSystem fileSystem,
+            ILogger<VmrCodeFlower> logger)
+        : base(vmrInfo, sourceManifest, dependencyTracker, localGitClient, libGit2Client, localGitRepoFactory, versionDetailsParser, dependencyFileManager, coherencyUpdateResolver, assetLocationResolver, fileSystem, logger)
+    {
+        _vmrInfo = vmrInfo;
+        _sourceManifest = sourceManifest;
+        _dependencyTracker = dependencyTracker;
+        _vmrCloneManager = vmrCloneManager;
+        _repositoryCloneManager = repositoryCloneManager;
+        _localGitClient = localGitClient;
+        _localGitRepoFactory = localGitRepoFactory;
+        _vmrPatchHandler = vmrPatchHandler;
+        _workBranchFactory = workBranchFactory;
+        _barClient = basicBarClient;
+        _fileSystem = fileSystem;
+        _logger = logger;
+    }
 
     public Task<bool> FlowBackAsync(
         string mapping,
         NativePath targetRepoPath,
         string? shaToFlow,
         int? buildToFlow,
-        string? branchName,
+        string baseBranch,
+        string targetBranch,
         bool discardPatches = false,
         CancellationToken cancellationToken = default)
         => FlowBackAsync(
@@ -120,40 +123,18 @@ internal class VmrBackFlower(
             _localGitRepoFactory.Create(targetRepoPath),
             shaToFlow,
             buildToFlow,
-            branchName,
+            baseBranch,
+            targetBranch,
             discardPatches,
             cancellationToken);
-
-    public async Task<(bool HadUpdates, NativePath RepoPath)> FlowBackAsync(
-        string mappingName,
-        Build build,
-        string newBranchName,
-        string targetBranch,
-        CancellationToken cancellationToken = default)
-    {
-        ILocalGitRepo targetRepo = await PrepareRepoAndVmr(mappingName, targetBranch, build.Commit, cancellationToken);
-        SourceMapping mapping = _dependencyTracker.GetMapping(mappingName);
-        Codeflow lastFlow = await GetLastFlowAsync(mapping, targetRepo, currentIsBackflow: true);
-
-        var hadUpdates = await FlowBackAsync(
-            mapping,
-            targetRepo,
-            lastFlow,
-            build.Commit,
-            build,
-            newBranchName,
-            true,
-            cancellationToken);
-
-        return (hadUpdates, targetRepo.Path);
-    }
 
     public async Task<bool> FlowBackAsync(
         string mappingName,
         ILocalGitRepo targetRepo,
         string? shaToFlow,
         int? buildToFlow,
-        string? newBranchName,
+        string baseBranch,
+        string targetBranch,
         bool discardPatches = false,
         CancellationToken cancellationToken = default)
     {
@@ -166,16 +147,14 @@ internal class VmrBackFlower(
 
         // SHA comes either directly or from the build or if none supplied, from tip of the VMR
         shaToFlow ??= build?.Commit;
-        if (shaToFlow is null)
-        {
-            shaToFlow = await _localGitClient.GetShaForRefAsync(_vmrInfo.VmrPath);
-        }
-        else
-        {
-            await CheckOutVmr(shaToFlow);
-        }
+        (SourceMapping mapping, shaToFlow) = await PrepareVmrAndRepo(
+            mappingName,
+            targetRepo,
+            shaToFlow,
+            baseBranch,
+            targetBranch,
+            cancellationToken);
 
-        var mapping = _dependencyTracker.GetMapping(mappingName);
         Codeflow lastFlow = await GetLastFlowAsync(mapping, targetRepo, currentIsBackflow: true);
         return await FlowBackAsync(
             mapping,
@@ -183,18 +162,20 @@ internal class VmrBackFlower(
             lastFlow,
             shaToFlow,
             build,
-            newBranchName,
+            baseBranch,
+            targetBranch,
             discardPatches,
             cancellationToken);
     }
 
-    private async Task<bool> FlowBackAsync(
+    protected async Task<bool> FlowBackAsync(
         SourceMapping mapping,
         ILocalGitRepo targetRepo,
         Codeflow lastFlow,
         string shaToFlow,
         Build? build,
-        string? newBranchName,
+        string baseBranch,
+        string targetBranch,
         bool discardPatches,
         CancellationToken cancellationToken)
     {
@@ -204,7 +185,8 @@ internal class VmrBackFlower(
             targetRepo,
             mapping,
             build,
-            newBranchName,
+            baseBranch,
+            targetBranch,
             discardPatches,
             cancellationToken);
 
@@ -226,7 +208,8 @@ internal class VmrBackFlower(
         Codeflow currentFlow,
         ILocalGitRepo targetRepo,
         Build? build,
-        string newBranchName,
+        string baseBranch,
+        string targetBranch,
         bool discardPatches,
         CancellationToken cancellationToken)
     {
@@ -237,6 +220,7 @@ internal class VmrBackFlower(
             .Select(VmrPatchHandler.GetExclusionRule)
             .ToList();
 
+        string newBranchName = currentFlow.GetBranchName();
         var patchName = _vmrInfo.TmpPath / $"{mapping.Name}-{Commit.GetShortSha(lastFlow.VmrSha)}-{Commit.GetShortSha(currentFlow.TargetSha)}.patch";
 
         // When flowing from the VMR, ignore all submodules
@@ -271,7 +255,7 @@ internal class VmrBackFlower(
         _logger.LogInformation("Created {count} patch(es)", patches.Count);
 
         await targetRepo.CheckoutAsync(lastFlow.TargetSha);
-        await _workBranchFactory.CreateWorkBranchAsync(targetRepo, newBranchName);
+        var workBranch = await _workBranchFactory.CreateWorkBranchAsync(targetRepo, newBranchName, targetBranch);
 
         // TODO https://github.com/dotnet/arcade-services/issues/3302: Remove VMR patches before we create the patches
 
@@ -298,6 +282,7 @@ internal class VmrBackFlower(
                 line => line.Contains(VersionDetailsParser.SourceElementName) && line.Contains(lastFlow.SourceSha),
                 lastFlow.TargetSha);
             await targetRepo.CheckoutAsync(previousRepoSha);
+            await targetRepo.CreateBranchAsync(targetBranch, overwriteExistingBranch: true);
 
             // Reconstruct the previous flow's branch
             var lastLastFlow = await GetLastFlowAsync(mapping, targetRepo, currentIsBackflow: true);
@@ -308,9 +293,14 @@ internal class VmrBackFlower(
                 targetRepo,
                 mapping,
                 /* TODO: Find a previous build? */ null,
-                newBranchName,
+                targetBranch,
+                targetBranch,
                 discardPatches,
                 cancellationToken);
+
+            // The recursive call right above would returned checked out at targetBranch
+            // The original work branch from above is no longer relevant. We need to create it again
+            workBranch = await _workBranchFactory.CreateWorkBranchAsync(targetRepo, newBranchName, targetBranch);
 
             // The current patches should apply now
             foreach (VmrIngestionPatch patch in patches)
@@ -328,8 +318,9 @@ internal class VmrBackFlower(
 
         await targetRepo.CommitAsync(commitMessage, allowEmpty: false, cancellationToken: cancellationToken);
         await targetRepo.ResetWorkingTree();
+        await workBranch.MergeBackAsync(commitMessage);
 
-        _logger.LogInformation("New branch {branch} with flown code is ready in {repoDir}", newBranchName, targetRepo);
+        _logger.LogInformation("Branch {branch} with code changes is ready in {repoDir}", targetBranch, targetRepo);
 
         return true;
     }
@@ -340,14 +331,16 @@ internal class VmrBackFlower(
         Codeflow currentFlow,
         ILocalGitRepo targetRepo,
         Build? build,
-        string branchName,
+        string baseBranch,
+        string targetBranch,
         bool discardPatches,
         CancellationToken cancellationToken)
     {
         await targetRepo.CheckoutAsync(lastFlow.SourceSha);
 
         var patchName = _vmrInfo.TmpPath / $"{mapping.Name}-{Commit.GetShortSha(lastFlow.VmrSha)}-{Commit.GetShortSha(currentFlow.TargetSha)}.patch";
-        var prBanch = await _workBranchFactory.CreateWorkBranchAsync(targetRepo, branchName);
+        var branchName = currentFlow.GetBranchName();
+        IWorkBranch workBranch = await _workBranchFactory.CreateWorkBranchAsync(targetRepo, branchName, targetBranch);
         _logger.LogInformation("Created temporary branch {branchName} in {repoDir}", branchName, targetRepo);
 
         // We leave the inlined submodules in the VMR
@@ -408,7 +401,56 @@ internal class VmrBackFlower(
 
         await targetRepo.CommitAsync(commitMessage, false, cancellationToken: cancellationToken);
         await targetRepo.ResetWorkingTree();
+        await workBranch.MergeBackAsync(commitMessage);
 
         return true;
+    }
+
+    private async Task<(SourceMapping, string)> PrepareVmrAndRepo(
+        string mappingName,
+        ILocalGitRepo targetRepo,
+        string? shaToFlow,
+        string baseBranch,
+        string targetBranch,
+        CancellationToken cancellationToken)
+    {
+        if (shaToFlow is null)
+        {
+            shaToFlow = await _localGitClient.GetShaForRefAsync(_vmrInfo.VmrPath);
+        }
+        else
+        {
+            await _vmrCloneManager.PrepareVmrAsync(shaToFlow, CancellationToken.None);
+        }
+
+        SourceMapping mapping = _dependencyTracker.GetMapping(mappingName);
+        ISourceComponent repoInfo = _sourceManifest.GetRepoVersion(mappingName);
+
+        var remotes = new[] { mapping.DefaultRemote, repoInfo.RemoteUri }
+            .Distinct()
+            .OrderRemotesByLocalPublicOther()
+            .ToArray();
+
+        // Refresh the repo
+        await targetRepo.FetchAllAsync(remotes, cancellationToken);
+
+        try
+        {
+            // Try to see if both base and target branch are available
+            await _repositoryCloneManager.PrepareCloneAsync(
+                mapping,
+                remotes,
+                [baseBranch, targetBranch],
+                targetBranch,
+                cancellationToken);
+        }
+        catch (NotFoundException)
+        {
+            // If target branch does not exist, we create it off of the base branch
+            await targetRepo.CheckoutAsync(baseBranch);
+            await targetRepo.CreateBranchAsync(targetBranch);
+        };
+
+        return (mapping, shaToFlow);
     }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCloneManager.cs
@@ -47,7 +47,7 @@ public class VmrCloneManager : CloneManager, IVmrCloneManager
         ILocalGitRepoFactory localGitRepoFactory,
         ITelemetryRecorder telemetryRecorder,
         IFileSystem fileSystem,
-        ILogger<VmrPatchHandler> logger)
+        ILogger<VmrCloneManager> logger)
         : base(vmrInfo, gitRepoCloner, localGitRepo, localGitRepoFactory, telemetryRecorder, fileSystem, logger)
     {
         _vmrInfo = vmrInfo;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCloneManager.cs
@@ -1,0 +1,88 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.Logging;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+public interface IVmrCloneManager
+{
+    /// <summary>
+    /// Prepares the local VMR clone by fetching from given remotes one-by-one until all requested commits are available.
+    /// </summary>
+    /// <param name="remoteUris">Remotes to fetch from one by one</param>
+    /// <param name="requestedRefs">List of refs that need to be available</param>
+    /// <param name="checkoutRef">Ref to check out at the end</param>
+    /// <returns>Path to the clone</returns>
+    Task<ILocalGitRepo> PrepareVmrAsync(
+        IReadOnlyCollection<string> remoteUris,
+        IReadOnlyCollection<string> requestedRefs,
+        string checkoutRef,
+        CancellationToken cancellationToken);
+
+    Task<ILocalGitRepo> PrepareVmrAsync(
+        string checkoutRef,
+        CancellationToken cancellationToken);
+}
+
+public class VmrCloneManager : CloneManager, IVmrCloneManager
+{
+    private readonly IVmrInfo _vmrInfo;
+    private readonly IVmrDependencyTracker _dependencyTracker;
+    private readonly ISourceManifest _sourceManifest;
+
+    public VmrCloneManager(
+        IVmrInfo vmrInfo,
+        IVmrDependencyTracker dependencyTracker,
+        ISourceManifest sourceManifest,
+        IGitRepoCloner gitRepoCloner,
+        ILocalGitClient localGitRepo,
+        ILocalGitRepoFactory localGitRepoFactory,
+        ITelemetryRecorder telemetryRecorder,
+        IFileSystem fileSystem,
+        ILogger<VmrPatchHandler> logger)
+        : base(vmrInfo, gitRepoCloner, localGitRepo, localGitRepoFactory, telemetryRecorder, fileSystem, logger)
+    {
+        _vmrInfo = vmrInfo;
+        _dependencyTracker = dependencyTracker;
+        _sourceManifest = sourceManifest;
+    }
+
+    public async Task<ILocalGitRepo> PrepareVmrAsync(
+        IReadOnlyCollection<string> remoteUris,
+        IReadOnlyCollection<string> requestedRefs,
+        string checkoutRef,
+        CancellationToken cancellationToken)
+    {
+        var repo = await PrepareCloneInternalAsync(
+            Constants.VmrFolderName,
+            remoteUris,
+            requestedRefs,
+            checkoutRef,
+            cancellationToken);
+
+        _vmrInfo.VmrPath = repo.Path;
+        _vmrInfo.VmrUri = remoteUris.First();
+
+        await _dependencyTracker.InitializeSourceMappings();
+        _sourceManifest.Refresh(_vmrInfo.SourceManifestPath);
+
+        return repo;
+    }
+
+    public async Task<ILocalGitRepo> PrepareVmrAsync(string checkoutRef, CancellationToken cancellationToken)
+        => await PrepareVmrAsync(
+            [_vmrInfo.VmrUri],
+            [checkoutRef],
+            checkoutRef,
+            cancellationToken);
+
+    protected override NativePath GetClonePath(string dirName) => _vmrInfo.VmrPath;
+}

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCloneManager.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
@@ -61,28 +60,32 @@ public class VmrCloneManager : CloneManager, IVmrCloneManager
         string checkoutRef,
         CancellationToken cancellationToken)
     {
-        var repo = await PrepareCloneInternalAsync(
+        ILocalGitRepo vmr = await PrepareCloneInternalAsync(
             Constants.VmrFolderName,
             remoteUris,
             requestedRefs,
             checkoutRef,
             cancellationToken);
 
-        _vmrInfo.VmrPath = repo.Path;
-        _vmrInfo.VmrUri = remoteUris.First();
-
         await _dependencyTracker.InitializeSourceMappings();
         _sourceManifest.Refresh(_vmrInfo.SourceManifestPath);
 
-        return repo;
+        return vmr;
     }
 
     public async Task<ILocalGitRepo> PrepareVmrAsync(string checkoutRef, CancellationToken cancellationToken)
-        => await PrepareVmrAsync(
+    {
+        _vmrInfo.VmrUri = _vmrInfo.VmrUri;
+
+        ILocalGitRepo vmr = await PrepareVmrAsync(
             [_vmrInfo.VmrUri],
             [checkoutRef],
             checkoutRef,
             cancellationToken);
+
+        _vmrInfo.VmrPath = vmr.Path;
+        return vmr;
+    }
 
     protected override NativePath GetClonePath(string dirName) => _vmrInfo.VmrPath;
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.Maestro.Client.Models;
@@ -14,6 +15,10 @@ using Microsoft.Extensions.Logging;
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
+/// <summary>
+/// Class for flowing code from a source repo to the target branch of the VMR.
+/// This class is used in the context of darc CLI as some behaviours around repo preparation differ.
+/// </summary>
 public interface IVmrForwardFlower
 {
     /// <summary>
@@ -24,8 +29,8 @@ public interface IVmrForwardFlower
     /// <param name="sourceRepo">Local checkout of the repository</param>
     /// <param name="shaToFlow">SHA to flow</param>
     /// <param name="buildToFlow">Build to flow</param>
-    /// <param name="branchName">New branch name</param>
-    /// <param name="targetBranch">Target branch to create the PR branch on top of</param>
+    /// <param name="baseBranch">If target branch does not exist, it is created off of this branch</param>
+    /// <param name="targetBranch">Target branch to make the changes on</param>
     /// <param name="discardPatches">Keep patch files?</param>
     /// <returns>True when there were changes to be flown</returns>
     Task<bool> FlowForwardAsync(
@@ -33,77 +38,58 @@ public interface IVmrForwardFlower
         NativePath sourceRepo,
         string? shaToFlow,
         int? buildToFlow,
-        string branchName,
-        bool discardPatches = false,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Flows forward the code from the source repo to the target branch of the VMR.
-    /// This overload is used in the context of the PCS.
-    /// </summary>
-    /// <param name="mappingName">Mapping to flow</param>
-    /// <param name="build">Build to flow</param>
-    /// <param name="branchName">New branch name</param>
-    /// <param name="targetBranch">Target branch to create the PR branch on top of</param>
-    /// <returns>True when there were changes to be flown</returns>
-    Task<bool> FlowForwardAsync(
-        string mappingName,
-        Build build,
-        string branchName,
+        string baseBranch,
         string targetBranch,
+        bool discardPatches = false,
         CancellationToken cancellationToken = default);
 }
 
-internal class VmrForwardFlower(
-        IVmrInfo vmrInfo,
-        ISourceManifest sourceManifest,
-        IVmrUpdater vmrUpdater,
-        IVmrDependencyTracker dependencyTracker,
-        IDependencyFileManager dependencyFileManager,
-        IRepositoryCloneManager repositoryCloneManager,
-        ILocalGitClient localGitClient,
-        ILocalLibGit2Client libGit2Client,
-        IBasicBarClient basicBarClient,
-        ILocalGitRepoFactory localGitRepoFactory,
-        IVersionDetailsParser versionDetailsParser,
-        IProcessManager processManager,
-        IWorkBranchFactory workBranchFactory,
-        ICoherencyUpdateResolver coherencyUpdateResolver,
-        IAssetLocationResolver assetLocationResolver,
-        IFileSystem fileSystem,
-        ILogger<VmrCodeFlower> logger)
-    : VmrCodeFlower(vmrInfo, sourceManifest, dependencyTracker, repositoryCloneManager, localGitClient, libGit2Client, localGitRepoFactory, versionDetailsParser, dependencyFileManager, coherencyUpdateResolver, assetLocationResolver, fileSystem, logger),
-    IVmrForwardFlower
+internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
 {
-    private readonly IVmrInfo _vmrInfo = vmrInfo;
-    private readonly IVmrUpdater _vmrUpdater = vmrUpdater;
-    private readonly IVmrDependencyTracker _dependencyTracker = dependencyTracker;
-    private readonly IBasicBarClient _barClient = basicBarClient;
-    private readonly ILocalGitRepoFactory _localGitRepoFactory = localGitRepoFactory;
-    private readonly IProcessManager _processManager = processManager;
-    private readonly IWorkBranchFactory _workBranchFactory = workBranchFactory;
-    private readonly ILogger<VmrCodeFlower> _logger = logger;
+    private readonly IVmrInfo _vmrInfo;
+    private readonly ISourceManifest _sourceManifest;
+    private readonly IVmrUpdater _vmrUpdater;
+    private readonly IVmrDependencyTracker _dependencyTracker;
+    private readonly IVmrCloneManager _vmrCloneManager;
+    private readonly IRepositoryCloneManager _repositoryCloneManager;
+    private readonly IBasicBarClient _barClient;
+    private readonly ILocalGitRepoFactory _localGitRepoFactory;
+    private readonly IProcessManager _processManager;
+    private readonly IWorkBranchFactory _workBranchFactory;
+    private readonly ILogger<VmrCodeFlower> _logger;
 
-    public async Task<bool> FlowForwardAsync(
-        string mappingName,
-        Build build,
-        string branchName,
-        string targetBranch,
-        CancellationToken cancellationToken = default)
+    public VmrForwardFlower(
+            IVmrInfo vmrInfo,
+            ISourceManifest sourceManifest,
+            IVmrUpdater vmrUpdater,
+            IVmrDependencyTracker dependencyTracker,
+            IVmrCloneManager vmrCloneManager,
+            IDependencyFileManager dependencyFileManager,
+            IRepositoryCloneManager repositoryCloneManager,
+            ILocalGitClient localGitClient,
+            ILocalLibGit2Client libGit2Client,
+            IBasicBarClient basicBarClient,
+            ILocalGitRepoFactory localGitRepoFactory,
+            IVersionDetailsParser versionDetailsParser,
+            IProcessManager processManager,
+            IWorkBranchFactory workBranchFactory,
+            ICoherencyUpdateResolver coherencyUpdateResolver,
+            IAssetLocationResolver assetLocationResolver,
+            IFileSystem fileSystem,
+            ILogger<VmrCodeFlower> logger)
+        : base(vmrInfo, sourceManifest, dependencyTracker, localGitClient, libGit2Client, localGitRepoFactory, versionDetailsParser, dependencyFileManager, coherencyUpdateResolver, assetLocationResolver, fileSystem, logger)
     {
-        ILocalGitRepo sourceRepo = await PrepareRepoAndVmr(mappingName, build.Commit, targetBranch, cancellationToken);
-        SourceMapping mapping = _dependencyTracker.GetMapping(mappingName);
-        Codeflow lastFlow = await GetLastFlowAsync(mapping, sourceRepo, currentIsBackflow: false);
-
-        return await FlowCodeAsync(
-            lastFlow,
-            new ForwardFlow(lastFlow.TargetSha, build.Commit),
-            sourceRepo,
-            mapping,
-            build,
-            branchName,
-            discardPatches: true,
-            cancellationToken);
+        _vmrInfo = vmrInfo;
+        _sourceManifest = sourceManifest;
+        _vmrUpdater = vmrUpdater;
+        _dependencyTracker = dependencyTracker;
+        _vmrCloneManager = vmrCloneManager;
+        _repositoryCloneManager = repositoryCloneManager;
+        _barClient = basicBarClient;
+        _localGitRepoFactory = localGitRepoFactory;
+        _processManager = processManager;
+        _workBranchFactory = workBranchFactory;
+        _logger = logger;
     }
 
     public async Task<bool> FlowForwardAsync(
@@ -111,10 +97,13 @@ internal class VmrForwardFlower(
         NativePath repoPath,
         string? shaToFlow,
         int? buildToFlow,
-        string branchName,
+        string baseBranch,
+        string targetBranch,
         bool discardPatches = false,
         CancellationToken cancellationToken = default)
     {
+        await PrepareVmr(baseBranch, targetBranch, cancellationToken);
+
         Build? build = null;
         if (buildToFlow.HasValue)
         {
@@ -122,7 +111,12 @@ internal class VmrForwardFlower(
                 ?? throw new Exception($"Failed to find build with BAR ID {buildToFlow}");
         }
 
-        var sourceRepo = _localGitRepoFactory.Create(repoPath);
+        ILocalGitRepo sourceRepo = _localGitRepoFactory.Create(repoPath);
+        SourceMapping mapping = _dependencyTracker.GetMapping(mappingName);
+        ISourceComponent repoInfo = _sourceManifest.GetRepoVersion(mappingName);
+
+        // Refresh the repo
+        await sourceRepo.FetchAllAsync([mapping.DefaultRemote, repoInfo.RemoteUri], cancellationToken);
 
         // SHA comes either directly or from the build or if none supplied, from tip of the repo
         shaToFlow ??= build?.Commit;
@@ -135,7 +129,6 @@ internal class VmrForwardFlower(
             await sourceRepo.CheckoutAsync(shaToFlow);
         }
 
-        var mapping = _dependencyTracker.GetMapping(mappingName);
         Codeflow lastFlow = await GetLastFlowAsync(mapping, sourceRepo, currentIsBackflow: false);
 
         return await FlowCodeAsync(
@@ -144,9 +137,33 @@ internal class VmrForwardFlower(
             sourceRepo,
             mapping,
             build,
-            branchName,
+            baseBranch,
+            targetBranch,
             discardPatches,
             cancellationToken);
+    }
+
+    protected async Task PrepareVmr(string baseBranch, string targetBranch, CancellationToken cancellationToken)
+    {
+        // Prepare the VMR
+        try
+        {
+            await _vmrCloneManager.PrepareVmrAsync(
+                [_vmrInfo.VmrUri],
+                [baseBranch, targetBranch],
+                targetBranch,
+                cancellationToken);
+        }
+        catch (NotFoundException)
+        {
+            // This means the target branch does not exist yet
+            // We will create it off of the base branch
+            await LocalVmr.CheckoutAsync(baseBranch);
+            await LocalVmr.CreateBranchAsync(targetBranch);
+        }
+
+        await _dependencyTracker.InitializeSourceMappings();
+        _sourceManifest.Refresh(_vmrInfo.SourceManifestPath);
     }
 
     protected override async Task<bool> SameDirectionFlowAsync(
@@ -155,11 +172,12 @@ internal class VmrForwardFlower(
         Codeflow currentFlow,
         ILocalGitRepo sourceRepo,
         Build? build,
-        string branchName,
+        string baseBranch,
+        string targetBranch,
         bool discardPatches,
         CancellationToken cancellationToken)
     {
-        await _workBranchFactory.CreateWorkBranchAsync(LocalVmr, branchName);
+        string branchName = currentFlow.GetBranchName();
 
         List<AdditionalRemote> additionalRemotes =
         [
@@ -209,7 +227,8 @@ internal class VmrForwardFlower(
                 _vmrInfo.SourceManifestPath,
                 line => line.Contains(lastFlow.SourceSha),
                 lastFlow.TargetSha);
-            await CheckOutVmr(previousFlowTargetSha);
+            await _vmrCloneManager.PrepareVmrAsync(previousFlowTargetSha, cancellationToken);
+            await LocalVmr.CreateBranchAsync(targetBranch, overwriteExistingBranch: true);
 
             // Reconstruct the previous flow's branch
             var lastLastFlow = await GetLastFlowAsync(mapping, sourceRepo, currentIsBackflow: true);
@@ -218,8 +237,9 @@ internal class VmrForwardFlower(
                 new ForwardFlow(lastLastFlow.SourceSha, lastFlow.SourceSha),
                 sourceRepo,
                 mapping,
-                null, // TODO: This is an interesting one - should we try to find a build for that previous SHA?
-                branchName,
+                build,
+                targetBranch, // TODO: This is an interesting one - should we try to find a build for that previous SHA?
+                targetBranch,
                 discardPatches,
                 cancellationToken);
 
@@ -248,14 +268,15 @@ internal class VmrForwardFlower(
         Codeflow currentFlow,
         ILocalGitRepo sourceRepo,
         Build? build,
-        string branchName,
+        string baseBranch,
+        string targetBranch,
         bool discardPatches,
         CancellationToken cancellationToken)
     {
         await sourceRepo.CheckoutAsync(lastFlow.TargetSha);
 
-        var patchName = _vmrInfo.TmpPath / $"{branchName.Replace('/', '-')}.patch";
-        var prBanch = await _workBranchFactory.CreateWorkBranchAsync(LocalVmr, branchName);
+        var patchName = _vmrInfo.TmpPath / $"{targetBranch.Replace('/', '-')}.patch";
+        var branchName = currentFlow.GetBranchName();
 
         List<GitSubmoduleInfo> submodules =
         [

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -51,8 +51,6 @@ public static class VmrRegistrations
         services.TryAddTransient<IThirdPartyNoticesGenerator, ThirdPartyNoticesGenerator>();
         services.TryAddTransient<IComponentListGenerator, ComponentListGenerator>();
         services.TryAddTransient<ICodeownersGenerator, CodeownersGenerator>();
-        services.TryAddTransient<IVmrCloneManager, VmrCloneManager>();
-        services.TryAddTransient<IRepositoryCloneManager, RepositoryCloneManager>();
         services.TryAddTransient<IFileSystem, FileSystem>();
         services.TryAddTransient<IGitRepoCloner, GitNativeRepoCloner>();
         services.TryAddTransient<VmrCloakedFileScanner>();
@@ -61,6 +59,8 @@ public static class VmrRegistrations
         services.TryAddTransient<ICoherencyUpdateResolver, CoherencyUpdateResolver>();
         services.TryAddTransient<IAssetLocationResolver, AssetLocationResolver>();
         services.TryAddTransient<ITelemetryRecorder, NoTelemetryRecorder>();
+        services.TryAddScoped<IVmrCloneManager, VmrCloneManager>();
+        services.TryAddScoped<IRepositoryCloneManager, RepositoryCloneManager>();
 
         services.AddHttpClient("GraphQL", httpClient =>
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -42,13 +42,16 @@ public static class VmrRegistrations
         services.TryAddTransient<IVmrUpdater, VmrUpdater>();
         services.TryAddTransient<IVmrInitializer, VmrInitializer>();
         services.TryAddTransient<IVmrBackFlower, VmrBackFlower>();
+        services.TryAddTransient<IPcsVmrBackFlower, PcsVmrBackFlower>();
         services.TryAddTransient<IVmrForwardFlower, VmrForwardFlower>();
+        services.TryAddTransient<IPcsVmrForwardFlower, PcsVmrForwardFlower>();
         services.TryAddTransient<IVmrRepoVersionResolver, VmrRepoVersionResolver>();
         services.TryAddSingleton<IVmrDependencyTracker, VmrDependencyTracker>();
         services.TryAddTransient<IWorkBranchFactory, WorkBranchFactory>();
         services.TryAddTransient<IThirdPartyNoticesGenerator, ThirdPartyNoticesGenerator>();
         services.TryAddTransient<IComponentListGenerator, ComponentListGenerator>();
         services.TryAddTransient<ICodeownersGenerator, CodeownersGenerator>();
+        services.TryAddTransient<IVmrCloneManager, VmrCloneManager>();
         services.TryAddTransient<IRepositoryCloneManager, RepositoryCloneManager>();
         services.TryAddTransient<IFileSystem, FileSystem>();
         services.TryAddTransient<IGitRepoCloner, GitNativeRepoCloner>();

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/WorkBranch.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/WorkBranch.cs
@@ -36,7 +36,7 @@ public class WorkBranch(
         var result = await _repo.ExecuteGitCommand(
             [ "merge", _workBranch, "--no-commit", "--no-ff", "--no-edit", "--no-squash", "-q" ]);
 
-        result.ThrowIfFailed("Failed to merge work branch back into the original branch");
+        result.ThrowIfFailed($"Failed to merge work branch {_workBranch} into {OriginalBranch}");
 
         await _repo.CommitAsync(commitMessage, true);
     }

--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/PcsConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/PcsConfiguration.cs
@@ -6,6 +6,7 @@ using ProductConstructionService.Api.Telemetry;
 using ProductConstructionService.Api.VirtualMonoRepo;
 using ProductConstructionService.Api.Queue;
 using ProductConstructionService.Api.Controllers;
+using Microsoft.DotNet.Maestro.Client;
 
 namespace ProductConstructionService.Api.Configuration;
 
@@ -66,6 +67,18 @@ internal static class PcsConfiguration
         builder.AddVmrRegistrations(vmrPath, tmpPath);
         builder.AddGitHubClientFactory();
         builder.AddWorkitemQueues(credential, waitForInitialization: initializeService);
+
+
+        builder.Services.AddSingleton<IMaestroApi>(s =>
+        {
+            var config = s.GetRequiredService<IConfiguration>();
+            var uri = config.GetValue<string>("Maestro:Uri");
+            var token = config.GetValue<string>("Maestro:Token");
+
+            return string.IsNullOrEmpty(token)
+                ? ApiFactory.GetAnonymous(uri)
+                : ApiFactory.GetAuthenticated(uri, token);
+        });
 
         if (initializeService)
         {

--- a/src/ProductConstructionService/ProductConstructionService.Api/Controllers/CodeFlowController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Controllers/CodeFlowController.cs
@@ -21,7 +21,7 @@ internal class CodeFlowController(
     private readonly JobProducerFactory _jobProducerFactory = jobProducerFactory;
 
     [HttpPost(Name = "Flow")]
-    public async Task<IActionResult> FlowBuild([Required, FromBody] CreateBranchRequest request)
+    public async Task<IActionResult> FlowBuild([Required, FromBody] CodeFlowRequest request)
     {
         if (!ModelState.IsValid)
         {
@@ -45,6 +45,7 @@ internal class CodeFlowController(
             BuildId = request.BuildId,
             SubscriptionId = request.SubscriptionId,
             PrBranch = request.PrBranch,
+            PrUrl = request.PrUrl,
         });
 
         return Ok();

--- a/src/ProductConstructionService/ProductConstructionService.Api/Controllers/Models/CodeFlowRequest.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Controllers/Models/CodeFlowRequest.cs
@@ -1,12 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace ProductConstructionService.Api.Queue.Jobs;
+namespace ProductConstructionService.Api.Controllers.Models;
 
-/// <summary>
-/// Main code flow job which causes new code changes to be flown to a new branch in the target repo.
-/// </summary>
-internal class CodeFlowJob : Job
+public class CodeFlowRequest
 {
     /// <summary>
     /// Subscription that is being flown/triggered.
@@ -24,9 +21,7 @@ internal class CodeFlowJob : Job
     public required string PrBranch { get; init; }
 
     /// <summary>
-    /// URL to the code flow PR.
+    /// URL to the PR that was created.
     /// </summary>
     public string? PrUrl { get; init; }
-
-    public override string Type => nameof(CodeFlowJob);
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/InitializationBackgroundService.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/InitializationBackgroundService.cs
@@ -8,7 +8,7 @@ using ProductConstructionService.Api.Queue;
 namespace ProductConstructionService.Api;
 
 internal class InitializationBackgroundService(
-        IRepositoryCloneManager repositoryCloneManager,
+        IVmrCloneManager repositoryCloneManager,
         ITelemetryRecorder telemetryRecorder,
         InitializationBackgroundServiceOptions options,
         JobScopeManager jobScopeManager)
@@ -21,7 +21,7 @@ internal class InitializationBackgroundService(
             // If Vmr cloning is taking more than 20 min, something is wrong
             var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, new CancellationTokenSource(TimeSpan.FromMinutes(20)).Token);
 
-            ILocalGitRepo repo = await repositoryCloneManager.PrepareVmrCloneAsync(options.VmrUri, linkedTokenSource.Token);
+            ILocalGitRepo repo = await repositoryCloneManager.PrepareVmrAsync("main", linkedTokenSource.Token);
             linkedTokenSource.Token.ThrowIfCancellationRequested();
 
             scope.SetSuccess();

--- a/src/ProductConstructionService/ProductConstructionService.Api/InitializationBackgroundService.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/InitializationBackgroundService.cs
@@ -8,7 +8,7 @@ using ProductConstructionService.Api.Queue;
 namespace ProductConstructionService.Api;
 
 internal class InitializationBackgroundService(
-        IVmrCloneManager repositoryCloneManager,
+        IServiceScopeFactory serviceScopeFactory,
         ITelemetryRecorder telemetryRecorder,
         InitializationBackgroundServiceOptions options,
         JobScopeManager jobScopeManager)
@@ -16,15 +16,17 @@ internal class InitializationBackgroundService(
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        using (ITelemetryScope scope = telemetryRecorder.RecordGitOperation(TrackedGitOperation.Clone, options.VmrUri))
+        using (IServiceScope scope = serviceScopeFactory.CreateScope())
+        using (ITelemetryScope telemetryScope = telemetryRecorder.RecordGitOperation(TrackedGitOperation.Clone, options.VmrUri))
         {
             // If Vmr cloning is taking more than 20 min, something is wrong
             var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, new CancellationTokenSource(TimeSpan.FromMinutes(20)).Token);
 
-            ILocalGitRepo repo = await repositoryCloneManager.PrepareVmrAsync("main", linkedTokenSource.Token);
+            IVmrCloneManager vmrCloneManager = scope.ServiceProvider.GetRequiredService<IVmrCloneManager>();
+            ILocalGitRepo repo = await vmrCloneManager.PrepareVmrAsync("main", linkedTokenSource.Token);
             linkedTokenSource.Token.ThrowIfCancellationRequested();
 
-            scope.SetSuccess();
+            telemetryScope.SetSuccess();
             jobScopeManager.InitializingDone();
         }
     }

--- a/src/ProductConstructionService/ProductConstructionService.Api/InitializationBackgroundService.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/InitializationBackgroundService.cs
@@ -23,7 +23,7 @@ internal class InitializationBackgroundService(
             var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, new CancellationTokenSource(TimeSpan.FromMinutes(20)).Token);
 
             IVmrCloneManager vmrCloneManager = scope.ServiceProvider.GetRequiredService<IVmrCloneManager>();
-            ILocalGitRepo repo = await vmrCloneManager.PrepareVmrAsync("main", linkedTokenSource.Token);
+            await vmrCloneManager.PrepareVmrAsync("main", linkedTokenSource.Token);
             linkedTokenSource.Token.ThrowIfCancellationRequested();
 
             telemetryScope.SetSuccess();

--- a/src/ProductConstructionService/ProductConstructionService.Api/ProductConstructionService.Api.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.Api/ProductConstructionService.Api.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Maestro\Client\src\Microsoft.DotNet.Maestro.Client.csproj" />
     <ProjectReference Include="..\..\Maestro\Maestro.Authentication\Maestro.Authentication.csproj" />
     <ProjectReference Include="..\..\Maestro\Maestro.DataProviders\Maestro.DataProviders.csproj" />
     <ProjectReference Include="..\..\Maestro\Maestro.Data\Maestro.Data.csproj" />

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Development.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Development.json
@@ -16,5 +16,9 @@
         "QueuePollTimeout": "00:00:05",
         "MaxJobRetries": 3,
         "QueueMessageInvisibilityTime": "00:05:00"
+    },
+    "Maestro": {
+        "Uri": "http://localhost:8088/",
+        "Token": ""
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
@@ -4,5 +4,9 @@
         "queues": "https://productconstructionint.queue.core.windows.net"
     },
     "ManagedIdentityClientId": "1f6e0054-8fec-4721-95b7-2a62a9938481",
-    "VmrUri": "https://github.com/maestro-auth-test/dnceng-vmr"
+    "VmrUri": "https://github.com/maestro-auth-test/dnceng-vmr",
+    "Maestro": {
+        "Uri": "https://maestro.int-dot.net/",
+        "Token": "[vault(product-construction-service-int-token)]"
+    }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Client/Generated/CodeFlow.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Client/Generated/CodeFlow.cs
@@ -18,7 +18,7 @@ namespace ProductConstructionService.Client
     public partial interface ICodeFlow
     {
         Task FlowAsync(
-            Models.CreateBranchRequest body,
+            Models.CodeFlowRequest body,
             CancellationToken cancellationToken = default
         );
 
@@ -38,12 +38,12 @@ namespace ProductConstructionService.Client
         partial void HandleFailedFlowRequest(RestApiException ex);
 
         public async Task FlowAsync(
-            Models.CreateBranchRequest body,
+            Models.CodeFlowRequest body,
             CancellationToken cancellationToken = default
         )
         {
 
-            if (body == default(Models.CreateBranchRequest))
+            if (body == default(Models.CodeFlowRequest))
             {
                 throw new ArgumentNullException(nameof(body));
             }
@@ -63,7 +63,7 @@ namespace ProductConstructionService.Client
                 _req.Uri = _url;
                 _req.Method = RequestMethod.Post;
 
-                if (body != default(Models.CreateBranchRequest))
+                if (body != default(Models.CodeFlowRequest))
                 {
                     _req.Content = RequestContent.Create(Encoding.UTF8.GetBytes(Client.Serialize(body)));
                     _req.Headers.Add("Content-Type", "application/json; charset=utf-8");

--- a/src/ProductConstructionService/ProductConstructionService.Client/Generated/Models/CodeFlowRequest.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Client/Generated/Models/CodeFlowRequest.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Immutable;
+using Newtonsoft.Json;
+
+namespace ProductConstructionService.Client.Models
+{
+    public partial class CodeFlowRequest
+    {
+        public CodeFlowRequest()
+        {
+        }
+
+        [JsonProperty("subscriptionId")]
+        public Guid? SubscriptionId { get; set; }
+
+        [JsonProperty("buildId")]
+        public int? BuildId { get; set; }
+
+        [JsonProperty("prBranch")]
+        public string PrBranch { get; set; }
+
+        [JsonProperty("prUrl")]
+        public string PrUrl { get; set; }
+    }
+}

--- a/test/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
+++ b/test/Microsoft.DotNet.Darc.Tests/DependencyTestDriver.cs
@@ -65,7 +65,7 @@ internal class DependencyTestDriver
 
         // Set up a git file manager
         var processManager = new ProcessManager(NullLogger.Instance, "git");
-        GitClient = new LocalLibGit2Client(new RemoteConfiguration(), processManager, new FileSystem(), NullLogger.Instance);
+        GitClient = new LocalLibGit2Client(new RemoteConfiguration(), new NoTelemetryRecorder(), processManager, new FileSystem(), NullLogger.Instance);
         _versionDetailsParser = new VersionDetailsParser();
         DependencyFileManager = new DependencyFileManager(GitClient, _versionDetailsParser, NullLogger.Instance);
 

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/GitOperationsHelper.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/GitOperationsHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Numerics;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.DarcLib.Helpers;
@@ -162,6 +163,7 @@ internal class GitOperationsHelper
             result = await _processManager.ExecuteGit(repo, "checkout", mergeTheirs.Value ? "--theirs" : "--ours", ".");
             result.ThrowIfFailed($"Failed to merge {(mergeTheirs.Value ? "theirs" : "ours")} {repo}");
             await CommitAll(repo, $"Merged {branch} into {targetBranch} {(mergeTheirs.Value ? "using " + targetBranch : "using " + targetBranch)}");
+            await DeleteBranch(repo, branch);
         }
         else
         {

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/GitOperationsHelper.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/GitOperationsHelper.cs
@@ -60,6 +60,12 @@ internal class GitOperationsHelper
         result.ThrowIfFailed($"Could not checkout {gitRef} in {repo}");
     }
 
+    public async Task DeleteBranch(NativePath repo, string branch)
+    {
+        var result = await _processManager.ExecuteGit(repo, "branch", "-D", branch);
+        result.ThrowIfFailed($"Could not delete branch {branch} in {repo}");
+    }
+
     public async Task InitializeSubmodule(
         NativePath repo,
         string submoduleName,
@@ -120,6 +126,7 @@ internal class GitOperationsHelper
         result.ThrowIfFailed($"Could not merge branch {branch} to {targetBranch} in {repo}");
 
         await CommitAll(repo, $"Merged branch {branch} into {targetBranch}");
+        await DeleteBranch(repo, branch);
     }
 
     private async Task ConfigureGit(NativePath repo)
@@ -135,7 +142,7 @@ internal class GitOperationsHelper
     public async Task VerifyMergeConflict(
         NativePath repo,
         string branch,
-        string? expectedFileInConflict = null,
+        string? expectedConflictingFile = null,
         bool? mergeTheirs = null,
         string targetBranch = "main")
     {
@@ -145,9 +152,9 @@ internal class GitOperationsHelper
         result = await _processManager.ExecuteGit(repo, "merge", "--no-commit", "--no-ff", branch);
         result.Succeeded.Should().BeFalse($"Expected merge conflict in {repo} but none happened");
 
-        if (expectedFileInConflict != null)
+        if (expectedConflictingFile != null)
         {
-            result.StandardOutput.Should().Contain($"CONFLICT (content): Merge conflict in {expectedFileInConflict}");
+            result.StandardOutput.Should().Contain($"CONFLICT (content): Merge conflict in {expectedConflictingFile}");
         }
 
         if (mergeTheirs.HasValue)

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeflowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeflowTest.cs
@@ -412,7 +412,10 @@ internal class VmrCodeflowTest : VmrTestsBase
         // 2. Open a backflow PR
         await File.WriteAllTextAsync(_productRepoVmrPath / "b.txt", bFileContent);
         await GitOperations.CommitAll(VmrPath, bFileContent);
-        var backflowBranch = await ChangeVmrFileAndFlowIt("New content from the VMR", backBranchName);
+        var backflowBranch = await ChangeVmrFileAndFlowIt("New content from the VMR #1", backBranchName);
+        backflowBranch.ShouldHaveUpdates();
+        // We make another commit in the repo and add it to the PR branch (this is not in the diagram above)
+        backflowBranch = await ChangeVmrFileAndFlowIt("New content from the VMR #2", backBranchName);
         backflowBranch.ShouldHaveUpdates();
         await GitOperations.Checkout(ProductRepoPath, "main");
 
@@ -420,7 +423,10 @@ internal class VmrCodeflowTest : VmrTestsBase
         // 4. Open a forward flow PR
         await File.WriteAllTextAsync(ProductRepoPath / "a.txt", aFileContent);
         await GitOperations.CommitAll(ProductRepoPath, aFileContent);
-        var forwardFlowBranch = await ChangeRepoFileAndFlowIt("New content from the individual repo", forwardBranchName);
+        var forwardFlowBranch = await ChangeRepoFileAndFlowIt("New content from the individual repo #1", forwardBranchName);
+        forwardFlowBranch.ShouldHaveUpdates();
+        // We make another commit in the repo and add it to the PR branch (this is not in the diagram above)
+        forwardFlowBranch = await ChangeRepoFileAndFlowIt("New content from the individual repo #2", forwardBranchName);
         forwardFlowBranch.ShouldHaveUpdates();
         await GitOperations.Checkout(VmrPath, "main");
 
@@ -429,7 +435,7 @@ internal class VmrCodeflowTest : VmrTestsBase
         await GitOperations.VerifyMergeConflict(ProductRepoPath, backBranchName,
             mergeTheirs: true,
             expectedConflictingFile: _productRepoFileName);
-        CheckFileContents(_productRepoFilePath, "New content from the VMR");
+        CheckFileContents(_productRepoFilePath, "New content from the VMR #2");
         await GitOperations.Checkout(ProductRepoPath, "main");
         await GitOperations.DeleteBranch(ProductRepoPath, backBranchName);
 
@@ -438,7 +444,7 @@ internal class VmrCodeflowTest : VmrTestsBase
         await GitOperations.VerifyMergeConflict(VmrPath, forwardBranchName,
             mergeTheirs: true,
             expectedConflictingFile: VmrInfo.SourcesDir / Constants.ProductRepoName / _productRepoFileName);
-        CheckFileContents(_productRepoVmrFilePath, "New content from the individual repo");
+        CheckFileContents(_productRepoVmrFilePath, "New content from the individual repo #2");
         await GitOperations.Checkout(VmrPath, "main");
         await GitOperations.DeleteBranch(VmrPath, forwardBranchName);
 
@@ -449,8 +455,8 @@ internal class VmrCodeflowTest : VmrTestsBase
         await GitOperations.MergePrBranch(VmrPath, forwardBranchName);
 
         // Both VMR and repo need to have the version from the VMR as it flowed to the repo and back
-        CheckFileContents(_productRepoFilePath, "New content from the VMR");
-        CheckFileContents(_productRepoVmrFilePath, "New content from the VMR");
+        CheckFileContents(_productRepoFilePath, "New content from the VMR #2");
+        CheckFileContents(_productRepoVmrFilePath, "New content from the VMR #2");
         CheckFileContents(_productRepoVmrPath / "a.txt", aFileContent);
         CheckFileContents(_productRepoVmrPath / "b.txt", bFileContent);
         CheckFileContents(ProductRepoPath / "a.txt", aFileContent);

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -18,7 +18,6 @@ using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
-using static System.Formats.Asn1.AsnWriter;
 
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -31,11 +31,9 @@ internal abstract class VmrTestsBase
     protected NativePath DependencyRepoPath { get; private set; } = null!;
     protected NativePath InstallerRepoPath { get; private set; } = null!;
     protected GitOperationsHelper GitOperations { get; } = new();
-    protected IServiceProvider ServiceProvider => _serviceProvider.Value;
+    protected IServiceProvider ServiceProvider { get; private set; } = null!;
 
     private readonly CancellationTokenSource _cancellationToken = new();
-
-    private Lazy<IServiceProvider> _serviceProvider = null!;
 
     [SetUp]
     public async Task Setup()
@@ -55,8 +53,9 @@ internal abstract class VmrTestsBase
         
         await CopyReposForCurrentTest();
         await CopyVmrForCurrentTest();
-        
-        _serviceProvider = new Lazy<IServiceProvider>(() => CreateServiceProvider().BuildServiceProvider());
+
+        ServiceProvider = CreateServiceProvider().BuildServiceProvider();
+        ServiceProvider.GetRequiredService<IVmrInfo>().VmrUri = VmrPath;
     }
 
     [TearDown]
@@ -181,13 +180,13 @@ internal abstract class VmrTestsBase
     protected async Task<bool> CallDarcBackflow(string mappingName, NativePath repoPath, string branch, string? shaToFlow = null, int? buildToFlow = null)
     {
         var codeflower = ServiceProvider.GetRequiredService<IVmrBackFlower>();
-        return await codeflower.FlowBackAsync(mappingName, repoPath, shaToFlow, buildToFlow, branch, cancellationToken: _cancellationToken.Token);
+        return await codeflower.FlowBackAsync(mappingName, repoPath, shaToFlow, buildToFlow, "main", branch, cancellationToken: _cancellationToken.Token);
     }
 
     protected async Task<bool> CallDarcForwardflow(string mappingName, NativePath repoPath, string branch, string? shaToFlow = null, int? buildToFlow = null)
     {
         var codeflower = ServiceProvider.GetRequiredService<IVmrForwardFlower>();
-        return await codeflower.FlowForwardAsync(mappingName, repoPath, shaToFlow, buildToFlow, branch, cancellationToken: _cancellationToken.Token);
+        return await codeflower.FlowForwardAsync(mappingName, repoPath, shaToFlow, buildToFlow, "main", branch, cancellationToken: _cancellationToken.Token);
     }
 
     protected async Task<List<string>> CallDarcCloakedFileScan(string baselinesFilePath)

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -18,6 +18,7 @@ using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
+using static System.Formats.Asn1.AsnWriter;
 
 namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
 
@@ -42,7 +43,7 @@ internal abstract class VmrTestsBase
         CurrentTestDirectory = VmrTestsOneTimeSetUp.TestsDirectory / testsDirName / Path.GetRandomFileName();
         Directory.CreateDirectory(CurrentTestDirectory);
 
-        TmpPath = CurrentTestDirectory / "tmp";
+        TmpPath = CurrentTestDirectory;
         ProductRepoPath = CurrentTestDirectory / Constants.ProductRepoName;
         VmrPath = CurrentTestDirectory / "vmr";
         SecondRepoPath = CurrentTestDirectory / Constants.SecondRepoName;
@@ -162,7 +163,8 @@ internal abstract class VmrTestsBase
 
     private async Task CallDarcInitialize(string repository, string commit, LocalPath sourceMappingsPath)
     {
-        var vmrInitializer = ServiceProvider.GetRequiredService<IVmrInitializer>();
+        using var scope = ServiceProvider.CreateScope();
+        var vmrInitializer = scope.ServiceProvider.GetRequiredService<IVmrInitializer>();
         await vmrInitializer.InitializeRepository(repository, commit, null, true, sourceMappingsPath, Array.Empty<AdditionalRemote>(), null, null, false, true, _cancellationToken.Token);
     }
 
@@ -173,31 +175,36 @@ internal abstract class VmrTestsBase
 
     protected async Task CallDarcUpdate(string repository, string commit, AdditionalRemote[] additionalRemotes, bool generateCodeowners = false)
     {
-        var vmrUpdater = ServiceProvider.GetRequiredService<IVmrUpdater>();
+        using var scope = ServiceProvider.CreateScope();
+        var vmrUpdater = scope.ServiceProvider.GetRequiredService<IVmrUpdater>();
         await vmrUpdater.UpdateRepository(repository, commit, null, true, additionalRemotes, null, null, generateCodeowners, true, _cancellationToken.Token);
     }
 
     protected async Task<bool> CallDarcBackflow(string mappingName, NativePath repoPath, string branch, string? shaToFlow = null, int? buildToFlow = null)
     {
-        var codeflower = ServiceProvider.GetRequiredService<IVmrBackFlower>();
+        using var scope = ServiceProvider.CreateScope();
+        var codeflower = scope.ServiceProvider.GetRequiredService<IVmrBackFlower>();
         return await codeflower.FlowBackAsync(mappingName, repoPath, shaToFlow, buildToFlow, "main", branch, cancellationToken: _cancellationToken.Token);
     }
 
     protected async Task<bool> CallDarcForwardflow(string mappingName, NativePath repoPath, string branch, string? shaToFlow = null, int? buildToFlow = null)
     {
-        var codeflower = ServiceProvider.GetRequiredService<IVmrForwardFlower>();
+        using var scope = ServiceProvider.CreateScope();
+        var codeflower = scope.ServiceProvider.GetRequiredService<IVmrForwardFlower>();
         return await codeflower.FlowForwardAsync(mappingName, repoPath, shaToFlow, buildToFlow, "main", branch, cancellationToken: _cancellationToken.Token);
     }
 
     protected async Task<List<string>> CallDarcCloakedFileScan(string baselinesFilePath)
     {
-        var cloakedFileScanner = ServiceProvider.GetRequiredService<VmrCloakedFileScanner>();
+        using var scope = ServiceProvider.CreateScope();
+        var cloakedFileScanner = scope.ServiceProvider.GetRequiredService<VmrCloakedFileScanner>();
         return await cloakedFileScanner.ScanVmr(baselinesFilePath, _cancellationToken.Token);
     }
 
     protected async Task<List<string>> CallDarcBinaryFileScan(string baselinesFilePath)
     {
-        var binaryFileScanner = ServiceProvider.GetRequiredService<VmrBinaryFileScanner>();
+        using var scope = ServiceProvider.CreateScope();
+        var binaryFileScanner = scope.ServiceProvider.GetRequiredService<VmrBinaryFileScanner>();
         return await binaryFileScanner.ScanVmr(baselinesFilePath, _cancellationToken.Token);
     }
 

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/RepositoryCloneManagerTests.cs
@@ -67,7 +67,7 @@ public class RepositoryCloneManagerTests
             _localGitRepoFactory.Object,
             new NoTelemetryRecorder(),
             _fileSystem.Object,
-            new NullLogger<VmrPatchHandler>());
+            new NullLogger<RepositoryCloneManager>());
     }
 
     [Test]


### PR DESCRIPTION
This PR changes the VMR code flow logic so that we can give it a base branch and target branch (e.g. `main` and `pr-branch`).
It will then detect whether the branch already exists (for cases when the PR already exists) and we can pile changes on top of it, or whether the branch needs to be created fresh (from base branch).
This allows Maestro to keep calling PCS with new code flow requests regardless of whether the branch already exists or not.

This PR also changes PCS to accept a bit different request payload and makes PCS also call back to Maestro once it's done producing a branch.

https://github.com/dotnet/arcade-services/issues/3317

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes