### PR TITLE
Add code flow support to Maestro's PR actors

### DIFF
--- a/src/Maestro/Maestro.Contracts/IPullRequestActor.cs
+++ b/src/Maestro/Maestro.Contracts/IPullRequestActor.cs
@@ -11,5 +11,12 @@ namespace Maestro.Contracts;
 public interface IPullRequestActor : IActor
 {
     Task<string> RunActionAsync(string method, string arguments);
-    Task UpdateAssetsAsync(Guid subscriptionId, int buildId, string sourceRepo, string sourceSha, List<Asset> assets);
+
+    Task UpdateAssetsAsync(
+        Guid subscriptionId,
+        int buildId,
+        string sourceRepo,
+        string sourceSha,
+        List<Asset> assets,
+        bool isCodeFlow);
 }

--- a/src/Maestro/SubscriptionActorService/BatchedPullRequestActorImplementation.cs
+++ b/src/Maestro/SubscriptionActorService/BatchedPullRequestActorImplementation.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
 using Microsoft.Extensions.Logging;
 using Microsoft.ServiceFabric.Actors;
 using Microsoft.ServiceFabric.Actors.Runtime;
+using ProductConstructionService.Client;
 
 namespace SubscriptionActorService;
 
@@ -25,6 +26,14 @@ internal class BatchedPullRequestActorImplementation : PullRequestActorImplement
     private readonly ActorId _id;
     private readonly BuildAssetRegistryContext _context;
 
+    /// <param name="id">
+    ///     The actor id for this actor.
+    ///     If it is a <see cref="Guid" /> actor id, then it is required to be the id of a non-batched subscription in the
+    ///     database
+    ///     If it is a <see cref="string" /> actor id, then it MUST be an actor id created with
+    ///     <see cref="PullRequestActorId.Create(string, string)" /> for use with all subscriptions targeting the specified
+    ///     repository and branch.
+    /// </param>
     public BatchedPullRequestActorImplementation(
         ActorId id,
         IReminderManager reminders,
@@ -33,6 +42,7 @@ internal class BatchedPullRequestActorImplementation : PullRequestActorImplement
         ICoherencyUpdateResolver updateResolver,
         BuildAssetRegistryContext context,
         IRemoteFactory remoteFactory,
+        IProductConstructionServiceApi pcsClient,
         IPullRequestBuilder pullRequestBuilder,
         ILoggerFactory loggerFactory,
         IActionRunner actionRunner,
@@ -44,6 +54,7 @@ internal class BatchedPullRequestActorImplementation : PullRequestActorImplement
             updateResolver,
             context,
             remoteFactory,
+            pcsClient,
             pullRequestBuilder,
             loggerFactory,
             actionRunner,

--- a/src/Maestro/SubscriptionActorService/NonBatchedPullRequestActorImplementation.cs
+++ b/src/Maestro/SubscriptionActorService/NonBatchedPullRequestActorImplementation.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
 using Microsoft.Extensions.Logging;
 using Microsoft.ServiceFabric.Actors;
 using Microsoft.ServiceFabric.Actors.Runtime;
+using ProductConstructionService.Client;
 using SubscriptionActorService.StateModel;
 
 namespace SubscriptionActorService;
@@ -28,6 +29,14 @@ internal class NonBatchedPullRequestActorImplementation : PullRequestActorImplem
     private readonly BuildAssetRegistryContext _context;
     private readonly IPullRequestPolicyFailureNotifier _pullRequestPolicyFailureNotifier;
 
+    /// <param name="id">
+    ///     The actor id for this actor.
+    ///     If it is a <see cref="Guid" /> actor id, then it is required to be the id of a non-batched subscription in the
+    ///     database
+    ///     If it is a <see cref="string" /> actor id, then it MUST be an actor id created with
+    ///     <see cref="PullRequestActorId.Create(string, string)" /> for use with all subscriptions targeting the specified
+    ///     repository and branch.
+    /// </param>
     public NonBatchedPullRequestActorImplementation(
         ActorId id,
         IReminderManager reminders,
@@ -35,7 +44,8 @@ internal class NonBatchedPullRequestActorImplementation : PullRequestActorImplem
         IMergePolicyEvaluator mergePolicyEvaluator,
         ICoherencyUpdateResolver updateResolver,
         BuildAssetRegistryContext context,
-        IRemoteFactory remoteFactory,
+        IRemoteFactory darcFactory,
+        IProductConstructionServiceApi pcsClient,
         IPullRequestBuilder pullRequestBuilder,
         ILoggerFactory loggerFactory,
         IActionRunner actionRunner,
@@ -47,7 +57,8 @@ internal class NonBatchedPullRequestActorImplementation : PullRequestActorImplem
             mergePolicyEvaluator,
             updateResolver,
             context,
-            remoteFactory,
+            darcFactory,
+            pcsClient,
             pullRequestBuilder,
             loggerFactory,
             actionRunner,

--- a/src/Maestro/SubscriptionActorService/StateModel/ActorCollectionStateManager.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/ActorCollectionStateManager.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
@@ -15,17 +14,15 @@ namespace SubscriptionActorService.StateModel;
 /// Wrapper class that binds the key under which the state is stored.
 /// Allows to store multiple items of the same type in the state
 /// </summary>
-internal class ActorCollectionStateManager<T> : ActorStateManager<List<T>>
+internal class ActorCollectionStateManager<T> : ActorStateAndReminderManager<List<T>>
 {
     private readonly IActorStateManager _stateManager;
-    private readonly IReminderManager _reminderManager;
     private readonly string _key;
 
     public ActorCollectionStateManager(IActorStateManager stateManager, IReminderManager reminderManager, ILogger logger, string key)
         : base(stateManager, reminderManager, logger, key)
     {
         _stateManager = stateManager;
-        _reminderManager = reminderManager;
         _key = key;
     }
 
@@ -39,14 +36,5 @@ internal class ActorCollectionStateManager<T> : ActorStateManager<List<T>>
                 old.Add(value);
                 return old;
             });
-    }
-
-    public override async Task SetReminderAsync(int dueTimeInMinutes = DefaultDueTimeInMinutes)
-    {
-        await _reminderManager.TryRegisterReminderAsync(
-            _key,
-            [],
-            TimeSpan.FromMinutes(dueTimeInMinutes),
-            TimeSpan.FromMinutes(dueTimeInMinutes));
     }
 }

--- a/src/Maestro/SubscriptionActorService/StateModel/ActorReminderManager.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/ActorReminderManager.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
+
+#nullable enable
+namespace SubscriptionActorService.StateModel;
+
+/// <summary>
+/// Wrapper class that binds the key under which the reminders are stored.
+/// </summary>
+internal class ActorReminderManager<T> where T : class
+{
+    private readonly IReminderManager _reminderManager;
+    private readonly string _key;
+
+    public ActorReminderManager(IReminderManager reminderManager, string key)
+    {
+        _reminderManager = reminderManager;
+        _key = key;
+    }
+
+    public virtual async Task SetReminderAsync(int dueTimeInMinutes = ActorStateManager<T>.DefaultDueTimeInMinutes)
+    {
+        await _reminderManager.TryRegisterReminderAsync(
+            _key,
+            null,
+            TimeSpan.FromMinutes(dueTimeInMinutes),
+            TimeSpan.FromMinutes(dueTimeInMinutes));
+    }
+
+    public async Task UnsetReminderAsync()
+    {
+        await _reminderManager.TryUnregisterReminderAsync(_key);
+    }
+}

--- a/src/Maestro/SubscriptionActorService/StateModel/ActorStateAndReminderManager.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/ActorStateAndReminderManager.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
+using Microsoft.Extensions.Logging;
+using Microsoft.ServiceFabric.Actors.Runtime;
+
+#nullable enable
+namespace SubscriptionActorService.StateModel;
+
+/// <summary>
+/// Wrapper class that binds the key under which the state and reminders are stored.
+/// </summary>
+internal class ActorStateAndReminderManager<T>
+    : ActorStateManager<T> where T : class
+{
+    private readonly IReminderManager _reminderManager;
+    private readonly string _key;
+
+    public ActorStateAndReminderManager(
+            IActorStateManager stateManager,
+            IReminderManager reminderManager,
+            ILogger logger,
+            string key)
+        : base(stateManager, logger, key)
+    {
+        _reminderManager = reminderManager;
+        _key = key;
+    }
+
+    public virtual async Task SetReminderAsync(int dueTimeInMinutes = DefaultDueTimeInMinutes)
+    {
+        await _reminderManager.TryRegisterReminderAsync(
+            _key,
+            null,
+            TimeSpan.FromMinutes(dueTimeInMinutes),
+            TimeSpan.FromMinutes(dueTimeInMinutes));
+    }
+
+    public async Task UnsetReminderAsync()
+    {
+        await _reminderManager.TryUnregisterReminderAsync(_key);
+    }
+}

--- a/src/Maestro/SubscriptionActorService/StateModel/ActorStateManager.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/ActorStateManager.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
-using Microsoft.DotNet.ServiceFabric.ServiceHost.Actors;
 using Microsoft.Extensions.Logging;
 using Microsoft.ServiceFabric.Actors.Runtime;
 using Microsoft.ServiceFabric.Data;
@@ -17,21 +15,18 @@ namespace SubscriptionActorService.StateModel;
 /// </summary>
 internal class ActorStateManager<T> where T : class
 {
-    protected const int DefaultDueTimeInMinutes = 5;
+    public const int DefaultDueTimeInMinutes = 5;
 
     private readonly IActorStateManager _stateManager;
-    private readonly IReminderManager _reminderManager;
     private readonly ILogger _logger;
     private readonly string _key;
 
     public ActorStateManager(
         IActorStateManager stateManager,
-        IReminderManager reminderManager,
         ILogger logger,
         string key)
     {
         _stateManager = stateManager;
-        _reminderManager = reminderManager;
         _logger = logger;
         _key = key;
     }
@@ -61,19 +56,5 @@ internal class ActorStateManager<T> where T : class
     public async Task RemoveStateAsync()
     {
         await _stateManager.TryRemoveStateAsync(_key);
-    }
-
-    public virtual async Task SetReminderAsync(int dueTimeInMinutes = DefaultDueTimeInMinutes)
-    {
-        await _reminderManager.TryRegisterReminderAsync(
-            _key,
-            null,
-            TimeSpan.FromMinutes(dueTimeInMinutes),
-            TimeSpan.FromMinutes(dueTimeInMinutes));
-    }
-
-    public async Task UnsetReminderAsync()
-    {
-        await _reminderManager.TryUnregisterReminderAsync(_key);
     }
 }

--- a/src/Maestro/SubscriptionActorService/StateModel/CodeFlowStatus.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/CodeFlowStatus.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+
+namespace SubscriptionActorService.StateModel;
+
+[DataContract]
+public class CodeFlowStatus
+{
+    [DataMember]
+    public string PrBranch { get; set; }
+
+    [DataMember]
+    public string SourceSha { get; set; }
+}

--- a/src/Maestro/SubscriptionActorService/StateModel/InProgressPullRequest.cs
+++ b/src/Maestro/SubscriptionActorService/StateModel/InProgressPullRequest.cs
@@ -33,7 +33,4 @@ public class InProgressPullRequest : IPullRequest
 
     [DataMember]
     public bool? SourceRepoNotified { get; set; }
-
-    [DataMember]
-    public string PrBranch { get; set; }
 }

--- a/src/Maestro/SubscriptionActorService/SubscriptionActor.cs
+++ b/src/Maestro/SubscriptionActorService/SubscriptionActor.cs
@@ -119,7 +119,7 @@ namespace SubscriptionActorService
 
         public async Task<bool> UpdateForMergedPullRequestAsync(int updateBuildId)
         {
-            Logger.LogInformation($"Updating {SubscriptionId} with latest build id {updateBuildId}");
+            Logger.LogInformation("Updating {subscriptionId} with latest build id {buildId}", SubscriptionId, updateBuildId);
             Subscription subscription = await Context.Subscriptions.FindAsync(SubscriptionId);
             
             if (subscription != null)
@@ -131,7 +131,7 @@ namespace SubscriptionActorService
             }
             else
             {
-                Logger.LogInformation($"Could not find subscription with ID {SubscriptionId}. Skipping latestBuild update.");
+                Logger.LogInformation("Could not find subscription with ID {subscriptionId}. Skipping latestBuild update.", SubscriptionId);
                 return false;
             }
         }
@@ -155,22 +155,22 @@ namespace SubscriptionActorService
                 var dfe = new DependencyFlowEvent
                 {
                     SourceRepository = subscription.SourceRepository,
-                        TargetRepository = subscription.TargetRepository,
-                        ChannelId = subscription.ChannelId,
-                        BuildId = updateBuildId,
-                        Timestamp = DateTimeOffset.UtcNow,
-                        Event = flowEvent.ToString(),
-                        Reason = updateReason,
-                        FlowType = flowType,
-                        Url = url
-                        };
+                    TargetRepository = subscription.TargetRepository,
+                    ChannelId = subscription.ChannelId,
+                    BuildId = updateBuildId,
+                    Timestamp = DateTimeOffset.UtcNow,
+                    Event = flowEvent.ToString(),
+                    Reason = updateReason,
+                    FlowType = flowType,
+                    Url = url,
+                };
                 Context.DependencyFlowEvents.Add(dfe);
                 await Context.SaveChangesAsync();
                 return true;
             }
             else
             {
-                Logger.LogInformation($"Could not find subscription with ID {SubscriptionId}. Skipping adding dependency flow event.");
+                Logger.LogInformation("Could not find subscription with ID {subscriptionId}. Skipping adding dependency flow event.", SubscriptionId);
                 return false;
             }
         }
@@ -188,7 +188,7 @@ namespace SubscriptionActorService
                 "PR",
                 null);
 
-            Logger.LogInformation($"Looking up build {buildId}");
+            Logger.LogInformation("Looking up build {buildId}", buildId);
 
             Build build = await Context.Builds.Include(b => b.Assets)
                 .ThenInclude(a => a.Locations)
@@ -207,7 +207,7 @@ namespace SubscriptionActorService
                 pullRequestActorId = PullRequestActorId.Create(SubscriptionId);
             }
 
-            Logger.LogInformation($"Creating pull request actor for '{pullRequestActorId}'");
+            Logger.LogInformation("Creating pull request actor for '{pullRequestActorId}'", pullRequestActorId);
 
             IPullRequestActor pullRequestActor = PullRequestActorFactory.Lookup(pullRequestActorId);
 
@@ -219,16 +219,17 @@ namespace SubscriptionActorService
                     })
                 .ToList();
 
-            Logger.LogInformation($"Running asset update for {SubscriptionId}");
+            Logger.LogInformation("Running asset update for {subscriptionId}", SubscriptionId);
 
             await pullRequestActor.UpdateAssetsAsync(
                 SubscriptionId, 
                 build.Id, 
                 build.GitHubRepository ?? build.AzureDevOpsRepository, 
                 build.Commit, 
-                assets);
+                assets,
+                subscription.SourceEnabled);
 
-            Logger.LogInformation($"Asset update complete for {SubscriptionId}");
+            Logger.LogInformation("Asset update complete for {subscriptionId}", SubscriptionId);
 
             return ActionResult.Create(true, "Update Sent");
         }

--- a/src/ProductConstructionService/ProductConstructionService.Client/Generated/CodeFlow.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Client/Generated/CodeFlow.cs
@@ -18,7 +18,7 @@ namespace ProductConstructionService.Client
     public partial interface ICodeFlow
     {
         Task FlowAsync(
-            Models.CreateBranchRequest body,
+            Models.CodeFlowRequest body,
             CancellationToken cancellationToken = default
         );
 
@@ -38,12 +38,12 @@ namespace ProductConstructionService.Client
         partial void HandleFailedFlowRequest(RestApiException ex);
 
         public async Task FlowAsync(
-            Models.CreateBranchRequest body,
+            Models.CodeFlowRequest body,
             CancellationToken cancellationToken = default
         )
         {
 
-            if (body == default(Models.CreateBranchRequest))
+            if (body == default(Models.CodeFlowRequest))
             {
                 throw new ArgumentNullException(nameof(body));
             }
@@ -63,7 +63,7 @@ namespace ProductConstructionService.Client
                 _req.Uri = _url;
                 _req.Method = RequestMethod.Post;
 
-                if (body != default(Models.CreateBranchRequest))
+                if (body != default(Models.CodeFlowRequest))
                 {
                     _req.Content = RequestContent.Create(Encoding.UTF8.GetBytes(Client.Serialize(body)));
                     _req.Headers.Add("Content-Type", "application/json; charset=utf-8");

--- a/src/ProductConstructionService/ProductConstructionService.Client/Generated/Models/CodeFlowRequest.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Client/Generated/Models/CodeFlowRequest.cs
@@ -7,9 +7,9 @@ using Newtonsoft.Json;
 
 namespace ProductConstructionService.Client.Models
 {
-    public partial class CreateBranchRequest
+    public partial class CodeFlowRequest
     {
-        public CreateBranchRequest()
+        public CodeFlowRequest()
         {
         }
 
@@ -21,5 +21,8 @@ namespace ProductConstructionService.Client.Models
 
         [JsonProperty("prBranch")]
         public string PrBranch { get; set; }
+
+        [JsonProperty("prUrl")]
+        public string PrUrl { get; set; }
     }
 }

--- a/test/SubscriptionActorService.Tests/ActorTests.cs
+++ b/test/SubscriptionActorService.Tests/ActorTests.cs
@@ -30,7 +30,7 @@ public abstract class ActorTests : TestsWithServices
     [TearDown]
     public void ActorTests_TearDown()
     {
-        Reminders.Data.Should().BeEquivalentTo(ExpectedReminders);
+        Reminders.Data.Should().BeEquivalentTo(ExpectedReminders, options => options.ExcludingProperties());
         StateManager.Data.Should().BeEquivalentTo(ExpectedActorState);
     }
 }

--- a/test/SubscriptionActorService.Tests/PendingCodeFlowUpdatesTests.cs
+++ b/test/SubscriptionActorService.Tests/PendingCodeFlowUpdatesTests.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using FluentAssertions;
+using Maestro.Data.Models;
+using NUnit.Framework;
+using SubscriptionActorService.StateModel;
+
+namespace SubscriptionActorService.Tests;
+
+[TestFixture, NonParallelizable]
+internal class PendingCodeFlowUpdatesTests : PendingUpdatePullRequestActorTests
+{
+    [Test]
+    public async Task PendingCodeFlowUpdatesNotUpdatablePr()
+    {
+        GivenATestChannel();
+        GivenACodeFlowSubscription(
+            new SubscriptionPolicy
+            {
+                Batchable = true,
+                UpdateFrequency = UpdateFrequency.EveryBuild
+            });
+        Build build = GivenANewBuild(true);
+
+        GivenAPendingUpdateReminder();
+        WithExistingCodeFlowStatus(build);
+        WithExistingPrBranch();
+        AndPendingUpdates(build, isCodeFlow: true);
+
+        using (WithExistingCodeFlowPullRequest(SynchronizePullRequestResult.InProgressCannotUpdate))
+        {
+            await WhenProcessPendingUpdatesAsyncIsCalled();
+
+            ThenPcsShouldNotHaveBeenCalled(build, InProgressPrUrl);
+            AndShouldHaveCodeFlowState(build, InProgressPrHeadBranch);
+            AndShouldHaveFollowingState(
+                pullRequestUpdateReminder: true,
+                pullRequestUpdateState: true,
+                pullRequestState: true,
+                codeFlowState: true);
+        }
+    }
+
+    [Test]
+    public async Task PendingUpdatesUpdatablePrButNoNewBuild()
+    {
+        GivenATestChannel();
+        GivenACodeFlowSubscription(
+            new SubscriptionPolicy
+            {
+                Batchable = true,
+                UpdateFrequency = UpdateFrequency.EveryBuild
+            });
+        Build build = GivenANewBuild(true);
+
+        GivenAPendingUpdateReminder();
+        WithExistingCodeFlowStatus(build);
+        WithExistingPrBranch();
+        AndPendingUpdates(build, isCodeFlow: true);
+
+        using (WithExistingCodeFlowPullRequest(SynchronizePullRequestResult.InProgressCanUpdate))
+        {
+            await WhenProcessPendingUpdatesAsyncIsCalled();
+
+            ThenPcsShouldNotHaveBeenCalled(build, InProgressPrUrl);
+            AndShouldHaveCodeFlowState(build, InProgressPrHeadBranch);
+            AndShouldHaveFollowingState(
+                pullRequestUpdateReminder: true,
+                pullRequestUpdateState: true,
+                pullRequestState: true,
+                codeFlowState: true);
+        }
+    }
+
+    [Test]
+    public async Task PendingUpdatesUpdatablePr()
+    {
+        GivenATestChannel();
+        GivenACodeFlowSubscription(
+            new SubscriptionPolicy
+            {
+                Batchable = true,
+                UpdateFrequency = UpdateFrequency.EveryBuild
+            });
+        Build oldBuild = GivenANewBuild(true);
+        Build newBuild = GivenANewBuild(true);
+        newBuild.Commit = "sha456";
+
+        GivenAPendingUpdateReminder();
+        WithExistingCodeFlowStatus(oldBuild);
+        WithExistingPrBranch();
+        AndPendingUpdates(newBuild, isCodeFlow: true);
+        ExpectPcsToGetCalled(newBuild);
+
+        using (WithExistingCodeFlowPullRequest(SynchronizePullRequestResult.InProgressCanUpdate))
+        {
+            await WhenProcessPendingUpdatesAsyncIsCalled();
+
+            ThenPcsShouldHaveBeenCalled(newBuild, InProgressPrUrl, out var prBranch);
+            AndShouldHaveNoPendingUpdateState();
+            AndShouldHavePullRequestCheckReminder();
+            prBranch.Should().Be(InProgressPrHeadBranch);
+            AndShouldHaveCodeFlowState(newBuild, InProgressPrHeadBranch);
+            AndShouldHaveFollowingState(
+                pullRequestCheckReminder: true,
+                pullRequestState: true,
+                codeFlowState: true);
+        }
+    }
+}

--- a/test/SubscriptionActorService.Tests/PendingUpdatePullRequestActorTests.cs
+++ b/test/SubscriptionActorService.Tests/PendingUpdatePullRequestActorTests.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Maestro.Data.Models;
+using SubscriptionActorService.StateModel;
+
+using Asset = Maestro.Contracts.Asset;
+
+namespace SubscriptionActorService.Tests;
+
+internal abstract class PendingUpdatePullRequestActorTests : PullRequestActorTests
+{
+    protected async Task WhenProcessPendingUpdatesAsyncIsCalled()
+    {
+        await Execute(
+            async context =>
+            {
+                PullRequestActor actor = CreateActor(context);
+                await actor.Implementation!.ProcessPendingUpdatesAsync();
+            });
+    }
+
+    protected void GivenAPendingUpdateReminder()
+    {
+        var reminder = new MockReminderManager.Reminder(
+            PullRequestActorImplementation.PullRequestUpdateKey,
+            [],
+            TimeSpan.FromMinutes(5),
+            TimeSpan.FromMinutes(5));
+        Reminders.Data[PullRequestActorImplementation.PullRequestUpdateKey] = reminder;
+        ExpectedReminders[PullRequestActorImplementation.PullRequestUpdateKey] = reminder;
+    }
+
+    protected void AndNoPendingUpdates()
+    {
+        var updates = new List<UpdateAssetsParameters>();
+        StateManager.Data[PullRequestActorImplementation.PullRequestUpdateKey] = updates;
+        ExpectedActorState[PullRequestActorImplementation.PullRequestUpdateKey] = updates;
+    }
+
+    protected void AndPendingUpdates(Build forBuild, bool isCodeFlow = false)
+    {
+        AfterDbUpdateActions.Add(
+            () =>
+            {
+                var updates = new List<UpdateAssetsParameters>
+                {
+                        new()
+                        {
+                            SubscriptionId = Subscription.Id,
+                            BuildId = forBuild.Id,
+                            SourceRepo = forBuild.GitHubRepository ?? forBuild.AzureDevOpsRepository,
+                            SourceSha = forBuild.Commit,
+                            Assets = forBuild.Assets
+                                .Select(a => new Asset {Name = a.Name, Version = a.Version})
+                                .ToList(),
+                            IsCoherencyUpdate = false,
+                            IsCodeFlow = isCodeFlow,
+                        }
+                };
+                StateManager.Data[PullRequestActorImplementation.PullRequestUpdateKey] = updates;
+                ExpectedActorState[PullRequestActorImplementation.PullRequestUpdateKey] = updates;
+            });
+    }
+}

--- a/test/SubscriptionActorService.Tests/PendingUpdatesTests.cs
+++ b/test/SubscriptionActorService.Tests/PendingUpdatesTests.cs
@@ -1,83 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Maestro.Data.Models;
 using NUnit.Framework;
 using SubscriptionActorService.StateModel;
 
-using Asset = Maestro.Contracts.Asset;
-
 namespace SubscriptionActorService.Tests;
 
 [TestFixture, NonParallelizable]
-internal class PendingUpdatesTests : PullRequestActorTests
+internal class PendingUpdatesTests : PendingUpdatePullRequestActorTests
 {
-    private async Task WhenProcessPendingUpdatesAsyncIsCalled()
-    {
-        await Execute(
-            async context =>
-            {
-                PullRequestActor actor = CreateActor(context);
-                await actor.Implementation!.ProcessPendingUpdatesAsync();
-            });
-    }
-
-    private void GivenAPendingUpdateReminder()
-    {
-        var reminder = new MockReminderManager.Reminder(
-            PullRequestActorImplementation.PullRequestUpdateKey,
-            [],
-            TimeSpan.FromMinutes(5),
-            TimeSpan.FromMinutes(5));
-        Reminders.Data[PullRequestActorImplementation.PullRequestUpdateKey] = reminder;
-        ExpectedReminders[PullRequestActorImplementation.PullRequestUpdateKey] = reminder;
-    }
-
-    private void AndNoPendingUpdates()
-    {
-        var updates = new List<UpdateAssetsParameters>();
-        StateManager.Data[PullRequestActorImplementation.PullRequestUpdateKey] = updates;
-        ExpectedActorState[PullRequestActorImplementation.PullRequestUpdateKey] = updates;
-    }
-
-    private void AndPendingUpdates(Build forBuild)
-    {
-        AfterDbUpdateActions.Add(
-            () =>
-            {
-                var updates = new List<UpdateAssetsParameters>
-                {
-                        new()
-                        {
-                            SubscriptionId = Subscription.Id,
-                            BuildId = forBuild.Id,
-                            SourceRepo = forBuild.GitHubRepository ?? forBuild.AzureDevOpsRepository,
-                            SourceSha = forBuild.Commit,
-                            Assets = forBuild.Assets
-                                .Select(a => new Asset {Name = a.Name, Version = a.Version})
-                                .ToList(),
-                            IsCoherencyUpdate = false
-                        }
-                };
-                StateManager.Data[PullRequestActorImplementation.PullRequestUpdateKey] = updates;
-                ExpectedActorState[PullRequestActorImplementation.PullRequestUpdateKey] = updates;
-            });
-    }
-
-    private void ThenUpdateReminderIsRemoved()
-    {
-        ExpectedReminders.Remove(PullRequestActorImplementation.PullRequestUpdateKey);
-    }
-
-    private void AndPendingUpdateIsRemoved()
-    {
-        ExpectedActorState.Remove(PullRequestActorImplementation.PullRequestUpdateKey);
-    }
-
     [Test]
     public async Task NoPendingUpdates()
     {

--- a/test/SubscriptionActorService.Tests/PullRequestBuilderTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestBuilderTests.cs
@@ -43,7 +43,7 @@ public class PullRequestBuilderTests : SubscriptionOrPullRequestActorTests
         _remoteFactory.Setup(f => f.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>()))
             .ReturnsAsync(
                 (string repo, ILogger logger) =>
-                    _darcRemotes.GetOrAddValue(repo, CreateMock<IRemote>).Object);
+                    _darcRemotes.GetOrAddValue(repo, () => CreateMock<IRemote>()).Object);
 
         services.AddSingleton(_remoteFactory.Object);
         services.AddSingleton(_barClient.Object);

--- a/test/SubscriptionActorService.Tests/SubscriptionActorTests.cs
+++ b/test/SubscriptionActorService.Tests/SubscriptionActorTests.cs
@@ -37,7 +37,7 @@ public class SubscriptionActorTests : SubscriptionOrPullRequestActorTests
             {
                 Mock<IPullRequestActor> mock = _pullRequestActors.GetOrAddValue(
                     actorId,
-                    CreateMock<IPullRequestActor>);
+                    () => CreateMock<IPullRequestActor>());
                 return mock.Object;
             });
         services.AddSingleton(proxyFactory.Object);
@@ -62,7 +62,7 @@ public class SubscriptionActorTests : SubscriptionOrPullRequestActorTests
         _pullRequestActors.Should()
             .ContainKey(forActor)
             .WhoseValue.Verify(
-                a => a.UpdateAssetsAsync(Subscription.Id, withBuild.Id, SourceRepo, NewCommit, Capture.In(updatedAssets)));
+                a => a.UpdateAssetsAsync(Subscription.Id, withBuild.Id, SourceRepo, NewCommit, Capture.In(updatedAssets), false));
         updatedAssets.Should()
             .BeEquivalentTo(
                 new List<List<Asset>>

--- a/test/SubscriptionActorService.Tests/SubscriptionOrPullRequestActorTests.cs
+++ b/test/SubscriptionActorService.Tests/SubscriptionOrPullRequestActorTests.cs
@@ -107,6 +107,23 @@ public abstract class SubscriptionOrPullRequestActorTests : ActorTests
         ContextUpdates.Add(context => context.Subscriptions.Add(Subscription));
     }
 
+    internal void GivenACodeFlowSubscription(SubscriptionPolicy policy)
+    {
+        Subscription = new Subscription
+        {
+            Channel = Channel,
+            SourceRepository = SourceRepo,
+            TargetRepository = TargetRepo,
+            TargetBranch = TargetBranch,
+            PolicyObject = policy,
+
+            SourceEnabled = true,
+            SourceDirectory = "repo",
+            ExcludedAssets = [ new AssetFilter() { Filter = "Excluded.Package" }],
+        };
+        ContextUpdates.Add(context => context.Subscriptions.Add(Subscription));
+    }
+
     internal Build GivenANewBuild(bool addToChannel, (string name, string version, bool nonShipping)[]? assets = null)
     {
         assets ??= [("quail.eating.ducks", "1.1.0", false), ("quail.eating.ducks", "1.1.0", false), ("quite.expensive.device", "2.0.1", true)];

--- a/test/SubscriptionActorService.Tests/TestsWithMocks.cs
+++ b/test/SubscriptionActorService.Tests/TestsWithMocks.cs
@@ -23,7 +23,7 @@ public class TestsWithMocks
         _mocks.VerifyNoUnverifiedCalls();
     }
 
-    protected Mock<T> CreateMock<T>() where T : class
+    protected Mock<T> CreateMock<T>(MockBehavior behavior = MockBehavior.Default) where T : class
     {
         return _mocks.Create<T>();
     }

--- a/test/SubscriptionActorService.Tests/UpdateAssetsForCodeFlowTests.cs
+++ b/test/SubscriptionActorService.Tests/UpdateAssetsForCodeFlowTests.cs
@@ -1,0 +1,237 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Maestro.Data.Models;
+using NUnit.Framework;
+using SubscriptionActorService.StateModel;
+using Asset = Maestro.Contracts.Asset;
+
+namespace SubscriptionActorService.Tests;
+
+/// <summary>
+/// Tests the code flow PR update logic.
+/// The tests are writter in the order in which the different phases of the PR are written.
+/// Each test should have the inner state that is left behind by the previous state.
+/// </summary>
+[TestFixture, NonParallelizable]
+internal class UpdateAssetsForCodeFlowTests : UpdateAssetsPullRequestActorTests
+{
+    [Test]
+    public async Task UpdateWithNoExistingStateOrPrBranch()
+    {
+        GivenATestChannel();
+        GivenACodeFlowSubscription(
+            new SubscriptionPolicy
+            {
+                Batchable = false,
+                UpdateFrequency = UpdateFrequency.EveryBuild,
+            });
+        Build build = GivenANewBuild(true);
+
+        ExpectPcsToGetCalled(build);
+
+        await WhenUpdateAssetsAsyncIsCalled(build);
+
+        ThenShouldHavePendingUpdateState(build);
+        AndPcsShouldHaveBeenCalled(build, prUrl: null, out var requestedBranch);
+        AndShouldHaveCodeFlowState(build, requestedBranch);
+        AndShouldHaveFollowingState(
+            pullRequestUpdateState: true,
+            pullRequestUpdateReminder: true,
+            codeFlowState: true);
+    }
+
+    [Test]
+    public async Task WaitForPrBranch()
+    {
+        GivenATestChannel();
+        GivenACodeFlowSubscription(
+            new SubscriptionPolicy
+            {
+                Batchable = false,
+                UpdateFrequency = UpdateFrequency.EveryBuild,
+            });
+        Build build = GivenANewBuild(true);
+
+        GivenPendingUpdates(build);
+        WithExistingCodeFlowStatus(build);
+        WithoutExistingPrBranch();
+
+        await WhenUpdateAssetsAsyncIsCalled(build);
+
+        ThenShouldHavePendingUpdateState(build);
+        AndShouldHaveCodeFlowState(build, InProgressPrHeadBranch);
+        AndShouldHaveFollowingState(
+            codeFlowState: true,
+            pullRequestUpdateState: true,
+            pullRequestUpdateReminder: true);
+    }
+
+    [Test]
+    public async Task UpdateWithPrBranchReady()
+    {
+        GivenATestChannel();
+        GivenACodeFlowSubscription(
+            new SubscriptionPolicy
+            {
+                Batchable = false,
+                UpdateFrequency = UpdateFrequency.EveryBuild,
+            });
+        Build build = GivenANewBuild(true);
+
+        GivenPendingUpdates(build);
+        WithExistingCodeFlowStatus(build);
+        WithExistingPrBranch();
+        CreatePullRequestShouldReturnAValidValue();
+
+        await WhenUpdateAssetsAsyncIsCalled(build);
+
+        ThenUpdateReminderIsRemoved();
+        ThenPcsShouldNotHaveBeenCalled(build);
+        AndCodeFlowPullRequestShouldHaveBeenCreated();
+        AndShouldHaveCodeFlowState(build, InProgressPrHeadBranch);
+        AndShouldHavePullRequestCheckReminder();
+        AndShouldHaveInProgressCodeFlowPullRequestState(build);
+        AndDependencyFlowEventsShouldBeAdded();
+        AndPendingUpdateIsRemoved();
+        AndShouldHaveFollowingState(
+            codeFlowState: true,
+            pullRequestState: true,
+            pullRequestCheckReminder: true);
+    }
+
+    [Test]
+    public async Task UpdateWithPrNotUpdatable()
+    {
+        GivenATestChannel();
+        GivenACodeFlowSubscription(
+            new SubscriptionPolicy
+            {
+                Batchable = false,
+                UpdateFrequency = UpdateFrequency.EveryBuild,
+            });
+        Build build = GivenANewBuild(true);
+
+        WithExistingCodeFlowStatus(build);
+        WithExistingPrBranch();
+
+        using (WithExistingCodeFlowPullRequest(SynchronizePullRequestResult.InProgressCannotUpdate))
+        {
+            await WhenUpdateAssetsAsyncIsCalled(build);
+
+            ThenShouldHavePendingUpdateState(build);
+            ThenPcsShouldNotHaveBeenCalled(build, InProgressPrUrl);
+            AndShouldHaveCodeFlowState(build, InProgressPrHeadBranch);
+            AndShouldHaveFollowingState(
+                codeFlowState: true,
+                pullRequestState: true,
+                pullRequestUpdateState: true,
+                pullRequestUpdateReminder: true);
+        }
+    }
+
+    [Test]
+    public async Task UpdateWithPrUpdatableButNoUpdates()
+    {
+        GivenATestChannel();
+        GivenACodeFlowSubscription(
+            new SubscriptionPolicy
+            {
+                Batchable = false,
+                UpdateFrequency = UpdateFrequency.EveryBuild,
+            });
+        Build build = GivenANewBuild(true);
+
+        GivenAPullRequestCheckReminder();
+        WithExistingCodeFlowStatus(build);
+        WithExistingPrBranch();
+
+        using (WithExistingCodeFlowPullRequest(SynchronizePullRequestResult.InProgressCanUpdate))
+        {
+            await WhenUpdateAssetsAsyncIsCalled(build);
+
+            ThenPcsShouldNotHaveBeenCalled(build, InProgressPrUrl);
+            AndShouldHaveCodeFlowState(build, InProgressPrHeadBranch);
+            AndShouldHavePullRequestCheckReminder();
+            AndShouldHaveFollowingState(
+                codeFlowState: true,
+                pullRequestState: true,
+                pullRequestCheckReminder: true);
+        }
+    }
+
+    [Test]
+    public async Task UpdateCodeFlowPrWithNewBuild()
+    {
+        GivenATestChannel();
+        GivenACodeFlowSubscription(
+            new SubscriptionPolicy
+            {
+                Batchable = false,
+                UpdateFrequency = UpdateFrequency.EveryBuild,
+            });
+
+        Build oldBuild = GivenANewBuild(true);
+        Build newBuild = GivenANewBuild(true);
+        newBuild.Commit = "sha456";
+
+        GivenAPullRequestCheckReminder();
+        WithExistingCodeFlowStatus(oldBuild);
+        WithExistingPrBranch();
+        ExpectPcsToGetCalled(newBuild);
+
+        using (WithExistingCodeFlowPullRequest(SynchronizePullRequestResult.InProgressCanUpdate))
+        {
+            await WhenUpdateAssetsAsyncIsCalled(newBuild);
+
+            ThenPcsShouldHaveBeenCalled(newBuild, InProgressPrUrl, out _);
+            AndShouldHaveCodeFlowState(newBuild, InProgressPrHeadBranch);
+            AndShouldHavePullRequestCheckReminder();
+            AndShouldHaveFollowingState(
+                codeFlowState: true,
+                pullRequestState: true,
+                pullRequestCheckReminder: true);
+        }
+    }
+
+    protected override void ThenShouldHavePendingUpdateState(Build forBuild, bool _ = false)
+    {
+        base.ThenShouldHavePendingUpdateState(forBuild, true);
+    }
+
+    protected void GivenPendingUpdates(Build forBuild)
+    {
+        AfterDbUpdateActions.Add(
+            () =>
+            {
+                var updates = new List<UpdateAssetsParameters>
+                {
+                    new()
+                    {
+                        SubscriptionId = Subscription.Id,
+                        BuildId = forBuild.Id,
+                        SourceRepo = forBuild.GitHubRepository ?? forBuild.AzureDevOpsRepository,
+                        SourceSha = forBuild.Commit,
+                        Assets = forBuild.Assets
+                            .Select(a => new Asset {Name = a.Name, Version = a.Version})
+                            .ToList(),
+                        IsCoherencyUpdate = false,
+                        IsCodeFlow = true,
+                    }
+                };
+
+                var reminder = new MockReminderManager.Reminder(
+                    PullRequestActorImplementation.PullRequestUpdateKey,
+                    null,
+                    TimeSpan.FromMinutes(3),
+                    TimeSpan.FromMinutes(3));
+
+                StateManager.Data[PullRequestActorImplementation.PullRequestUpdateKey] = updates;
+                Reminders.Data[PullRequestActorImplementation.PullRequestUpdateKey] = reminder;
+            });
+    }
+}

--- a/test/SubscriptionActorService.Tests/UpdateAssetsPullRequestActorTests.cs
+++ b/test/SubscriptionActorService.Tests/UpdateAssetsPullRequestActorTests.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Maestro.Data.Models;
+
+using Asset = Maestro.Contracts.Asset;
+
+namespace SubscriptionActorService.Tests;
+
+internal abstract class UpdateAssetsPullRequestActorTests : PullRequestActorTests
+{
+    protected async Task WhenUpdateAssetsAsyncIsCalled(Build forBuild)
+    {
+        await Execute(
+            async context =>
+            {
+                PullRequestActor actor = CreateActor(context);
+                await actor.Implementation!.UpdateAssetsAsync(
+                    Subscription.Id,
+                    forBuild.Id,
+                    SourceRepo,
+                    forBuild.Commit,
+                    forBuild.Assets.Select(
+                            a => new Asset
+                            {
+                                Name = a.Name,
+                                Version = a.Version
+                            })
+                        .ToList(),
+                    Subscription.SourceEnabled);
+            });
+    }
+}

--- a/test/SubscriptionActorService.Tests/UpdateAssetsTests.cs
+++ b/test/SubscriptionActorService.Tests/UpdateAssetsTests.cs
@@ -3,41 +3,17 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Maestro.Contracts;
 using Maestro.Data.Models;
 using NUnit.Framework;
 using SubscriptionActorService.StateModel;
 
-using Asset = Maestro.Contracts.Asset;
-
 namespace SubscriptionActorService.Tests;
 
 [TestFixture, NonParallelizable]
-internal class UpdateAssetsTests : PullRequestActorTests
+internal class UpdateAssetsTests : UpdateAssetsPullRequestActorTests
 {
-    private async Task WhenUpdateAssetsAsyncIsCalled(Build forBuild)
-    {
-        await Execute(
-            async context =>
-            {
-                PullRequestActor actor = CreateActor(context);
-                await actor.Implementation!.UpdateAssetsAsync(
-                    Subscription.Id,
-                    forBuild.Id,
-                    SourceRepo,
-                    NewCommit,
-                    forBuild.Assets.Select(
-                            a => new Asset
-                            {
-                                Name = a.Name,
-                                Version = a.Version
-                            })
-                        .ToList());
-            });
-    }
-
     [TestCase(false)]
     [TestCase(true)]
     public async Task UpdateWithAssetsNoExistingPR(bool batchable)
@@ -112,9 +88,7 @@ internal class UpdateAssetsTests : PullRequestActorTests
         using (WithExistingPullRequest(SynchronizePullRequestResult.InProgressCannotUpdate))
         {
             await WhenUpdateAssetsAsyncIsCalled(b);
-
-            ThenShouldHavePullRequestUpdateReminder();
-            AndShouldHavePendingUpdateState(b);
+            ThenShouldHavePendingUpdateState(b);
         }
     }
 


### PR DESCRIPTION
This PR adds a different code path for Maestro to handle code-enabled subscription by delegating to PCS.

https://github.com/dotnet/arcade-services/issues/3317

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes