### PR TITLE
Fix PCS deployment

### DIFF
--- a/azure-pipelines-product-construction-service.yml
+++ b/azure-pipelines-product-construction-service.yml
@@ -19,6 +19,7 @@ variables:
 - name: diffFolder
   value: $(Build.ArtifactStagingDirectory)/diff
 - ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/production') }}:
+  # https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=189
   - group: Product-Construction-Service-Int
   - name: containerappName
     value: product-construction-int
@@ -36,12 +37,12 @@ variables:
       value: -dev
 
 stages:
-- stage: PublishProductConstructionService
-  displayName: Publish Product Construction Service
+- stage: PublishPCS
+  displayName: Deploy Product Construction Service
   dependsOn: []
   jobs:
-  - job: Publish
-    displayName: Publish Product Construction Service
+  - job: Deploy
+    displayName: Deploy Product Construction Service
     pool:
       name: NetCore1ESPool-Internal
       demands: ImageOverride -equals 1es-ubuntu-2004
@@ -55,21 +56,24 @@ stages:
         $newDockerTag = "$(Build.BuildNumber)-$shortSha$(devBranchSuffix)"
         Write-Host "##vso[task.setvariable variable=newDockerImageTag]$newDockerTag"
         Write-Host "set newDockerImageTag to $newDockerTag"
-      displayName: Set new docker image tag variable
+      displayName: Generate docker image tag
 
-    - powershell: docker build . -f $(Build.SourcesDirectory)/src/ProductConstructionService/ProductConstructionService.Api/Dockerfile -t "$(dockerRegistryUrl)/$(containerName):$(newDockerImageTag)"
+    - powershell: >
+        docker build .
+        -f $(Build.SourcesDirectory)/src/ProductConstructionService/ProductConstructionService.Api/Dockerfile
+        -t "$(dockerRegistryUrl)/$(containerName):$(newDockerImageTag)"
       displayName: Build docker image
 
     - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
       - powershell: |
           echo $(container-registry-password) | docker login --username $(container-registry-username) --password-stdin $(dockerRegistryUrl)
           docker push "$(dockerRegistryUrl)/$(containerName):$(newDockerImageTag)"
-        displayName: Push docker image to registry
+        displayName: Push docker image
 
-      # The Service Connection name needs to be known at compile time, so we can't use a variable for the azure subscription
       - ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/production') }}:
         - task: AzureCLI@2
           inputs:
+            # The Service Connection name needs to be known at compile time, so we can't use a variable for the azure subscription
             azureSubscription: NetHelixStaging
             scriptType: pscore
             scriptLocation: inlineScript
@@ -77,7 +81,7 @@ stages:
               New-Item -ItemType Directory -Path $(diffFolder)
               $before = az containerapp show --name $(containerappName) -g $(resourceGroupName) --output json
               Set-Content -Path $(diffFolder)/before.json -Value $before
-          displayName: Create before-deployment configuration snapshot
+          displayName: Snapshot configuration (before)
 
         - task: AzureCLI@2
           inputs:
@@ -85,8 +89,15 @@ stages:
             scriptType: pscore
             scriptLocation: scriptPath
             scriptPath: $(Build.SourcesDirectory)/eng/deployment/product-construction-service-deploy.ps1
-            arguments: -resourceGroupName $(resourceGroupName) -containerappName $(containerappName) -newImageTag $(newDockerImageTag) -containerRegistryName $(containerRegistryName) -imageName $(containerName) -pcsUrl $(pcsUrl) -token $(maestro-token)
-          displayName: Product Construction Service Deploy
+            arguments: >
+              -resourceGroupName $(resourceGroupName)
+              -containerappName $(containerappName)
+              -newImageTag $(newDockerImageTag)
+              -containerRegistryName $(containerRegistryName)
+              -imageName $(containerName)
+              -pcsUrl $(pcsUrl)
+              -token $(maestro-token)
+          displayName: Deploy container app
 
         - task: AzureCLI@2
           inputs:
@@ -96,16 +107,16 @@ stages:
             inlineScript: |
               $after = az containerapp show --name $(containerappName) -g $(resourceGroupName) --output json
               Set-Content -Path $(diffFolder)/after.json -Value $after
-          displayName: Create after-deployment configuration snapshot
+          displayName: Snapshot configuration (after)
 
         # git diff will set the exit code to 1, since the files are different, we have to manually set it back to 0
         - powershell: |
             $diff = git diff before.json after.json
             $LASTEXITCODE = 0
             Set-Content -Path diff -Value $diff
-          displayName: Create configuration diff
+          displayName: Diff configuration snapshots
           workingDirectory: $(diffFolder)
 
         - publish: $(diffFolder)
-          displayName: Upload configuration diff
+          displayName: Upload snapshot diff
           artifact: DeploymentDiff

--- a/eng/deployment/product-construction-service-deploy.ps1
+++ b/eng/deployment/product-construction-service-deploy.ps1
@@ -16,7 +16,7 @@ $pcsStopUrl = $pcsStatusUrl + "/stop"
 $pcsStartUrl = $pcsStatusUrl + "/start"
 $patToken = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("$($token)"))
 $authenticationHeader = @{
-    "Authorization" = "Bearer $Token"
+    "Authorization" = "Bearer $patToken"
 }
 
 function StopAndWait([string]$pcsStatusUrl, [string]$pcsStopUrl, [hashtable]$authenticationHeader) {


### PR DESCRIPTION
The pipelines fails because of token variable typo introduced in 0dcdc1c1157372aeae9ae74757930abaddebb4c6.
Also improves the YAML a bit and renames some build steps to make the pipeline easier to read.

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes