### PR TITLE
Fixed a bug that prevents customers from updating the Source-enabled parameter on the subscription level.

### DIFF
--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
@@ -219,7 +219,7 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
             doUpdate = true;
         }
 
-        if (subscription.SourceEnabled && update.SourceDirectory == null && update.TargetDirectory == null)
+        if (update.SourceEnabled.HasValue && update.SourceEnabled.Value && update.SourceDirectory == null && update.TargetDirectory == null)
         {
             return BadRequest(new ApiError("The request is invalid. Source-enabled subscriptions require the source or target directory to be set"));
         }


### PR DESCRIPTION

<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade-services/issues/3540

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Fixed a bug that prevents customers from updating the Source-enabled parameter on the subscription level.