### PR TITLE
Fixed a bug that prevents customers from updating the Source-enabled parameter on the subscription level

### DIFF
--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs
@@ -219,7 +219,7 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
             doUpdate = true;
         }
 
-        if (subscription.SourceEnabled && update.SourceDirectory == null && update.TargetDirectory == null)
+        if (subscription.SourceEnabled && update.SourceEnabled.HasValue && update.SourceEnabled.Value && update.SourceDirectory == null && update.TargetDirectory == null)
         {
             return BadRequest(new ApiError("The request is invalid. Source-enabled subscriptions require the source or target directory to be set"));
         }


### PR DESCRIPTION
<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
https://github.com/dotnet/arcade-services/issues/3540

The difference between the cli interface and the popup interface is that when you set sourceEnabled to False in the popUp interface, both SourceDirectory and TargetDirectory are set to null [arcade-services/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs at main · dotnet/arcade-services (github.com)](https://github.com/dotnet/arcade-services/blob/main/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs#L182C1-L187C10)



Then, in [arcade-services/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs at main · dotnet/arcade-services (github.com)](https://github.com/dotnet/arcade-services/blob/main/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs#L222C1-L225C10) we see that both SourceDirectory and TargetDirectory are null and return a BadRequest.



[arcade-services/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs at main · dotnet/arcade-services (github.com)](https://github.com/dotnet/arcade-services/blob/main/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/SubscriptionsController.cs#L246C3-L260C14) <-- here we are setting both SourceDirectory and TargetDirectory to null anyway.

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Fixed a bug that prevents customers from updating the Source-enabled parameter on the subscription level.