### PR TITLE
Make `darc` work without a BAR token

### DIFF
--- a/src/Maestro/Client/src/MaestroApi.cs
+++ b/src/Maestro/Client/src/MaestroApi.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Maestro.Client
         /// <param name="barApiPassword">Old BAR PATs created through the Maestro website that will be deprecated soon</param>
         /// <param name="managedIdentityId">Optional managed identity to use (otherwise MI is determined from a hardcoded config)</param>
         /// <returns>Credential that can be used to call the Maestro API</returns>
-        public static TokenCredential CreateApiCredential(string barApiBaseUri, string? barApiPassword = null, string? managedIdentityId = null)
+        public static TokenCredential CreateApiCredential(string barApiBaseUri, string? barApiPassword = null)
         {
             // This will be deprecated once we stop using Maestro tokens
             if (barApiPassword != null)
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.Maestro.Client
 
             return new ChainedTokenCredential(
                 MaestroApiCredential.CreateUserCredential(barApiBaseUri),
-                MaestroApiCredential.CreateNonUserCredential(barApiBaseUri, managedIdentityId));
+                MaestroApiCredential.CreateNonUserCredential(barApiBaseUri));
         }
     }
 }

--- a/src/Maestro/Client/src/MaestroApi.cs
+++ b/src/Maestro/Client/src/MaestroApi.cs
@@ -77,8 +77,8 @@ namespace Microsoft.DotNet.Maestro.Client
             barApiBaseUri ??= ProductionBuildAssetRegistryBaseUri;
 
             return new ChainedTokenCredential(
-                MaestroApiCredential.CreateUserCredential(barApiBaseUri),
-                MaestroApiCredential.CreateNonUserCredential(barApiBaseUri));
+                MaestroApiCredential.CreateNonUserCredential(barApiBaseUri),
+                MaestroApiCredential.CreateUserCredential(barApiBaseUri));
         }
     }
 }

--- a/src/Maestro/Client/src/MaestroApi.cs
+++ b/src/Maestro/Client/src/MaestroApi.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Azure.Core;
-using Azure.Identity;
 using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
@@ -62,12 +61,12 @@ namespace Microsoft.DotNet.Maestro.Client
         /// Creates a credential that should work both in user-based and non-user-based scenarios.
         /// </summary>
         /// <param name="barApiBaseUri">BAR API URI used to determine the right set of credentials (INT vs PROD)</param>
-        /// <param name="includeInteractive">Whether to include interactive login flows</param>
+        /// <param name="disableInteractiveAuth">Whether to include interactive login flows</param>
         /// <param name="barApiToken">Token to use for the call. If none supplied, will try Azure CLI and then interactive browser login flows.</param>
         /// <returns>Credential that can be used to call the Maestro API</returns>
         public static TokenCredential CreateApiCredential(
             string barApiBaseUri,
-            bool includeInteractive,
+            bool disableInteractiveAuth,
             string? barApiToken = null)
         {
             // This will be deprecated once we stop using Maestro tokens
@@ -78,9 +77,9 @@ namespace Microsoft.DotNet.Maestro.Client
 
             barApiBaseUri ??= ProductionBuildAssetRegistryBaseUri;
 
-            return includeInteractive
-                ? MaestroApiCredential.CreateUserCredential(barApiBaseUri)
-                : MaestroApiCredential.CreateNonUserCredential(barApiBaseUri);
+            return disableInteractiveAuth
+                ? MaestroApiCredential.CreateNonUserCredential(barApiBaseUri)
+                : MaestroApiCredential.CreateUserCredential(barApiBaseUri);
         }
     }
 }

--- a/src/Maestro/Client/src/MaestroApi.cs
+++ b/src/Maestro/Client/src/MaestroApi.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Azure.Core;
+using Azure.Identity;
 using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
@@ -8,25 +10,28 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 
+#nullable enable
 namespace Microsoft.DotNet.Maestro.Client
 {
     internal partial class MaestroApiResponseClassifier
     {
-        public override bool IsRetriableException(Exception exception)
-        {
-            return base.IsRetriableException(exception) ||
-                exception is OperationCanceledException ||
-                exception is HttpRequestException ||
-                exception is RestApiException raex && raex.Response.Status >= 500 && raex.Response.Status <= 599 ||
-                exception is IOException ||
-                exception is SocketException;
-        }
+        public override bool IsRetriableException(Exception exception) =>
+            base.IsRetriableException(exception)
+                || exception is OperationCanceledException
+                || exception is HttpRequestException
+                || (exception is RestApiException raex && raex.Response.Status >= 500 && raex.Response.Status <= 599)
+                || exception is IOException
+                || exception is SocketException;
     }
 
     public partial class MaestroApi
     {
-        //Special error handler to consumes the generated MaestroApi code. If this method returns without throwing a specific exception
-        //then a generic RestApiException is thrown.
+        public const string ProductionBuildAssetRegistryBaseUri = "https://maestro.dot.net/";
+
+        public const string StagingBuildAssetRegistryBaseUri = "https://maestro.dot-int.net/";
+
+        // Special error handler to consumes the generated MaestroApi code. If this method returns without throwing a specific exception
+        // then a generic RestApiException is thrown.
         partial void HandleFailedRequest(RestApiException ex)
         {
             if (ex.Response.Status == (int)HttpStatusCode.BadRequest)
@@ -37,7 +42,7 @@ namespace Microsoft.DotNet.Maestro.Client
                     content = JObject.Parse(ex.Response.Content);
                     if (content["Message"] is JValue value && value.Type == JTokenType.String)
                     {
-                        string message = content.Value<string>("Message");
+                        string? message = content.Value<string>("Message");
                         throw new ArgumentException(message, ex);
                     }
                 }
@@ -51,6 +56,29 @@ namespace Microsoft.DotNet.Maestro.Client
                 throw new AuthenticationException("Unauthorized access while trying to access Maestro API. " +
                     "Please make sure the PAT you're using is valid.");
             }
+        }
+
+        /// <summary>
+        /// Creates a credential that should work both in user-based and non-user-based scenarios.
+        /// If the old BAR token is supplied, it is used. Otherwise, the secretless auth flows are used.
+        /// </summary>
+        /// <param name="barApiPassword">Old BAR PATs created through the Maestro website that will be deprecated soon</param>
+        /// <param name="barApiBaseUri">BAR API URI used to determine the right set of credentials (INT vs PROD)</param>
+        /// <param name="managedIdentityId">Optional managed identity to use (otherwise MI is determined from a hardcoded config)</param>
+        /// <returns>Credential that can be used to call the Maestro API</returns>
+        public static TokenCredential CreateApiCredential(string? barApiPassword = null, string? barApiBaseUri = null, string? managedIdentityId = null)
+        {
+            // This will be deprecated once we stop using Maestro tokens
+            if (barApiPassword != null)
+            {
+                return new MaestroApiTokenCredential(barApiPassword);
+            }
+
+            barApiBaseUri ??= ProductionBuildAssetRegistryBaseUri;
+
+            return new ChainedTokenCredential(
+                MaestroApiCredential.CreateUserCredential(barApiBaseUri),
+                MaestroApiCredential.CreateNonUserCredential(barApiBaseUri, managedIdentityId));
         }
     }
 }

--- a/src/Maestro/Client/src/MaestroApi.cs
+++ b/src/Maestro/Client/src/MaestroApi.cs
@@ -60,18 +60,16 @@ namespace Microsoft.DotNet.Maestro.Client
 
         /// <summary>
         /// Creates a credential that should work both in user-based and non-user-based scenarios.
-        /// If the old BAR token is supplied, it is used. Otherwise, the secretless auth flows are used.
         /// </summary>
         /// <param name="barApiBaseUri">BAR API URI used to determine the right set of credentials (INT vs PROD)</param>
-        /// <param name="barApiPassword">Old BAR PATs created through the Maestro website that will be deprecated soon</param>
-        /// <param name="managedIdentityId">Optional managed identity to use (otherwise MI is determined from a hardcoded config)</param>
+        /// <param name="barApiToken">Token to use for the call. If none supplied, will try Azure CLI and then interactive browser login flows.</param>
         /// <returns>Credential that can be used to call the Maestro API</returns>
-        public static TokenCredential CreateApiCredential(string barApiBaseUri, string? barApiPassword = null)
+        public static TokenCredential CreateApiCredential(string barApiBaseUri, string? barApiToken = null)
         {
             // This will be deprecated once we stop using Maestro tokens
-            if (barApiPassword != null)
+            if (barApiToken != null)
             {
-                return new MaestroApiTokenCredential(barApiPassword);
+                return new MaestroApiTokenCredential(barApiToken);
             }
 
             barApiBaseUri ??= ProductionBuildAssetRegistryBaseUri;

--- a/src/Maestro/Client/src/MaestroApi.cs
+++ b/src/Maestro/Client/src/MaestroApi.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Maestro.Client
     {
         public const string ProductionBuildAssetRegistryBaseUri = "https://maestro.dot.net/";
 
-        public const string StagingBuildAssetRegistryBaseUri = "https://maestro.dot-int.net/";
+        public const string StagingBuildAssetRegistryBaseUri = "https://maestro.int-dot.net/";
 
         // Special error handler to consumes the generated MaestroApi code. If this method returns without throwing a specific exception
         // then a generic RestApiException is thrown.

--- a/src/Maestro/Client/src/MaestroApi.cs
+++ b/src/Maestro/Client/src/MaestroApi.cs
@@ -67,9 +67,9 @@ namespace Microsoft.DotNet.Maestro.Client
         public static TokenCredential CreateApiCredential(string barApiBaseUri, string? barApiToken = null)
         {
             // This will be deprecated once we stop using Maestro tokens
-            if (barApiToken != null)
+            if (!string.IsNullOrEmpty(barApiToken))
             {
-                return new MaestroApiTokenCredential(barApiToken);
+                return new MaestroApiTokenCredential(barApiToken!);
             }
 
             barApiBaseUri ??= ProductionBuildAssetRegistryBaseUri;

--- a/src/Maestro/Client/src/MaestroApi.cs
+++ b/src/Maestro/Client/src/MaestroApi.cs
@@ -62,11 +62,11 @@ namespace Microsoft.DotNet.Maestro.Client
         /// Creates a credential that should work both in user-based and non-user-based scenarios.
         /// If the old BAR token is supplied, it is used. Otherwise, the secretless auth flows are used.
         /// </summary>
-        /// <param name="barApiPassword">Old BAR PATs created through the Maestro website that will be deprecated soon</param>
         /// <param name="barApiBaseUri">BAR API URI used to determine the right set of credentials (INT vs PROD)</param>
+        /// <param name="barApiPassword">Old BAR PATs created through the Maestro website that will be deprecated soon</param>
         /// <param name="managedIdentityId">Optional managed identity to use (otherwise MI is determined from a hardcoded config)</param>
         /// <returns>Credential that can be used to call the Maestro API</returns>
-        public static TokenCredential CreateApiCredential(string? barApiPassword = null, string? barApiBaseUri = null, string? managedIdentityId = null)
+        public static TokenCredential CreateApiCredential(string barApiBaseUri, string? barApiPassword = null, string? managedIdentityId = null)
         {
             // This will be deprecated once we stop using Maestro tokens
             if (barApiPassword != null)

--- a/src/Maestro/Client/src/MaestroApi.cs
+++ b/src/Maestro/Client/src/MaestroApi.cs
@@ -62,9 +62,13 @@ namespace Microsoft.DotNet.Maestro.Client
         /// Creates a credential that should work both in user-based and non-user-based scenarios.
         /// </summary>
         /// <param name="barApiBaseUri">BAR API URI used to determine the right set of credentials (INT vs PROD)</param>
+        /// <param name="includeInteractive">Whether to include interactive login flows</param>
         /// <param name="barApiToken">Token to use for the call. If none supplied, will try Azure CLI and then interactive browser login flows.</param>
         /// <returns>Credential that can be used to call the Maestro API</returns>
-        public static TokenCredential CreateApiCredential(string barApiBaseUri, string? barApiToken = null)
+        public static TokenCredential CreateApiCredential(
+            string barApiBaseUri,
+            bool includeInteractive,
+            string? barApiToken = null)
         {
             // This will be deprecated once we stop using Maestro tokens
             if (!string.IsNullOrEmpty(barApiToken))
@@ -74,9 +78,9 @@ namespace Microsoft.DotNet.Maestro.Client
 
             barApiBaseUri ??= ProductionBuildAssetRegistryBaseUri;
 
-            return new ChainedTokenCredential(
-                MaestroApiCredential.CreateNonUserCredential(barApiBaseUri),
-                MaestroApiCredential.CreateUserCredential(barApiBaseUri));
+            return includeInteractive
+                ? MaestroApiCredential.CreateUserCredential(barApiBaseUri)
+                : MaestroApiCredential.CreateNonUserCredential(barApiBaseUri);
         }
     }
 }

--- a/src/Maestro/Client/src/MaestroApiCredential.cs
+++ b/src/Maestro/Client/src/MaestroApiCredential.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Maestro.Client
         private static readonly Dictionary<string, string> EntraAppIds = new Dictionary<string, string>
         {
             [MaestroApi.StagingBuildAssetRegistryBaseUri] = "baf98f1b-374e-487d-af42-aa33807f11e4",
-            [MaestroApi.ProductionBuildAssetRegistryBaseUri] = "TODO",
+            [MaestroApi.ProductionBuildAssetRegistryBaseUri] = "54c17f3d-7325-4eca-9db7-f090bfc765a8",
         };
 
         private readonly TokenRequestContext _requestContext;

--- a/src/Maestro/Client/src/MaestroApiCredential.cs
+++ b/src/Maestro/Client/src/MaestroApiCredential.cs
@@ -20,8 +20,8 @@ namespace Microsoft.DotNet.Maestro.Client
 
         private static readonly Dictionary<string, string> EntraAppIds = new Dictionary<string, string>
         {
-            [MaestroApi.StagingBuildAssetRegistryBaseUri] = "baf98f1b-374e-487d-af42-aa33807f11e4",
-            [MaestroApi.ProductionBuildAssetRegistryBaseUri] = "54c17f3d-7325-4eca-9db7-f090bfc765a8",
+            [MaestroApi.StagingBuildAssetRegistryBaseUri.TrimEnd('/')] = "baf98f1b-374e-487d-af42-aa33807f11e4",
+            [MaestroApi.ProductionBuildAssetRegistryBaseUri.TrimEnd('/')] = "54c17f3d-7325-4eca-9db7-f090bfc765a8",
         };
 
         private readonly TokenRequestContext _requestContext;
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Maestro.Client
         /// </summary>
         internal static MaestroApiCredential CreateUserCredential(string barApiBaseUri)
         {
-            string appId = EntraAppIds[barApiBaseUri];
+            string appId = EntraAppIds[barApiBaseUri.TrimEnd('/')];
 
             // This is a usual credential obtained against an entra app through a browser sign-in
             var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Maestro.Client
         /// </summary>
         internal static MaestroApiCredential CreateNonUserCredential(string barApiBaseUri)
         {
-            var requestContext = new TokenRequestContext(new string[] { $"{EntraAppIds[barApiBaseUri]}/.default" });
+            var requestContext = new TokenRequestContext(new string[] { $"{EntraAppIds[barApiBaseUri.TrimEnd('/')]}/.default" });
             var credential = new AzureCliCredential();
             return new MaestroApiCredential(credential, requestContext);
         }

--- a/src/Maestro/Client/src/MaestroApiCredential.cs
+++ b/src/Maestro/Client/src/MaestroApiCredential.cs
@@ -50,11 +50,13 @@ namespace Microsoft.DotNet.Maestro.Client
         /// </summary>
         internal static MaestroApiCredential CreateUserCredential(string barApiBaseUri)
         {
+            string appId = WellKnownAuthIds[barApiBaseUri].EntraAppId;
+
             // This is a usual credential obtained against an entra app through a browser sign-in
             var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
             {
                 TenantId = TENANT_ID,
-                ClientId = WellKnownAuthIds[barApiBaseUri].EntraAppId,
+                ClientId = appId,
                 RedirectUri = new Uri("http://localhost"),
                 TokenCachePersistenceOptions = new TokenCachePersistenceOptions()
                 {
@@ -62,30 +64,19 @@ namespace Microsoft.DotNet.Maestro.Client
                 }
             });
 
-            var requestContext = new TokenRequestContext(new string[] { $"api://{WellKnownAuthIds[barApiBaseUri].EntraAppId}/Maestro.User" });
+            var requestContext = new TokenRequestContext(new string[] { $"api://{appId}/Maestro.User" });
             return new MaestroApiCredential(credential, requestContext);
         }
 
         /// <summary>
         /// Use this for non-user-based flows (darc invocation from pipelines).
         /// </summary>
-        internal static MaestroApiCredential CreateNonUserCredential(string barApiBaseUri, string? managedIdentityId = null)
+        internal static MaestroApiCredential CreateNonUserCredential(string barApiBaseUri)
         {
             string appId = WellKnownAuthIds[barApiBaseUri].EntraAppId;
-
-            // This is a required audience during federated credential token creation
-            var miRequestContext = new TokenRequestContext(new string[] { "api://AzureADTokenExchange/.default" });
-            var appRequestContext = new TokenRequestContext(new string[] { $"{appId}/.default" });
-
-            // This credential is obtained through a managed identity
-            // which is added as a federated credential onto the entra app
-            var miCreds = new ManagedIdentityCredential(managedIdentityId ?? WellKnownAuthIds[barApiBaseUri].ManagedIdentityId);
-            var credential = new ClientAssertionCredential(
-               TENANT_ID,
-               appId,
-               async (ct) => (await miCreds.GetTokenAsync(miRequestContext, ct).ConfigureAwait(false)).Token);
-
-            return new MaestroApiCredential(credential, appRequestContext);
+            var requestContext = new TokenRequestContext(new string[] { $"{appId}/.default" });
+            var credential = new AzureCliCredential();
+            return new MaestroApiCredential(credential, requestContext);
         }
     }
 }

--- a/src/Maestro/Client/src/MaestroApiCredential.cs
+++ b/src/Maestro/Client/src/MaestroApiCredential.cs
@@ -18,10 +18,10 @@ namespace Microsoft.DotNet.Maestro.Client
     {
         private const string TENANT_ID = "72f988bf-86f1-41af-91ab-2d7cd011db47";
 
-        private static readonly Dictionary<string, (string ManagedIdentityId, string EntraAppId)> WellKnownAuthIds = new Dictionary<string, (string ManagedIdentityId, string EntraAppId)>
+        private static readonly Dictionary<string, string> EntraAppIds = new Dictionary<string, string>
         {
-            [MaestroApi.StagingBuildAssetRegistryBaseUri] = ("610d68a4-8c62-46b0-b0b9-e859e7f3564e", "baf98f1b-374e-487d-af42-aa33807f11e4"),
-            [MaestroApi.ProductionBuildAssetRegistryBaseUri] = ("TODO", "TODO"),
+            [MaestroApi.StagingBuildAssetRegistryBaseUri] = "baf98f1b-374e-487d-af42-aa33807f11e4",
+            [MaestroApi.ProductionBuildAssetRegistryBaseUri] = "TODO",
         };
 
         private readonly TokenRequestContext _requestContext;
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Maestro.Client
         /// </summary>
         internal static MaestroApiCredential CreateUserCredential(string barApiBaseUri)
         {
-            string appId = WellKnownAuthIds[barApiBaseUri].EntraAppId;
+            string appId = EntraAppIds[barApiBaseUri];
 
             // This is a usual credential obtained against an entra app through a browser sign-in
             var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
@@ -73,8 +73,7 @@ namespace Microsoft.DotNet.Maestro.Client
         /// </summary>
         internal static MaestroApiCredential CreateNonUserCredential(string barApiBaseUri)
         {
-            string appId = WellKnownAuthIds[barApiBaseUri].EntraAppId;
-            var requestContext = new TokenRequestContext(new string[] { $"{appId}/.default" });
+            var requestContext = new TokenRequestContext(new string[] { $"{EntraAppIds[barApiBaseUri]}/.default" });
             var credential = new AzureCliCredential();
             return new MaestroApiCredential(credential, requestContext);
         }

--- a/src/Maestro/Client/src/MaestroApiCredential.cs
+++ b/src/Maestro/Client/src/MaestroApiCredential.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Maestro.Client
 
         private static readonly Dictionary<string, (string ManagedIdentityId, string EntraAppId)> WellKnownAuthIds = new Dictionary<string, (string ManagedIdentityId, string EntraAppId)>
         {
-            [MaestroApi.StagingBuildAssetRegistryBaseUri] = ("TODO", "baf98f1b-374e-487d-af42-aa33807f11e4"),
+            [MaestroApi.StagingBuildAssetRegistryBaseUri] = ("610d68a4-8c62-46b0-b0b9-e859e7f3564e", "baf98f1b-374e-487d-af42-aa33807f11e4"),
             [MaestroApi.ProductionBuildAssetRegistryBaseUri] = ("TODO", "TODO"),
         };
 

--- a/src/Maestro/Client/src/MaestroApiCredential.cs
+++ b/src/Maestro/Client/src/MaestroApiCredential.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+
+#nullable enable
+namespace Microsoft.DotNet.Maestro.Client
+{
+    /// <summary>
+    /// A credential that first tries a user-based browser auth flow then falls back to a managed identity-based flow.
+    /// </summary>
+    internal class MaestroApiCredential : TokenCredential
+    {
+        private const string TENANT_ID = "72f988bf-86f1-41af-91ab-2d7cd011db47";
+
+        private static readonly Dictionary<string, (string ManagedIdentityId, string EntraAppId)> WellKnownAuthIds = new Dictionary<string, (string ManagedIdentityId, string EntraAppId)>
+        {
+            [MaestroApi.StagingBuildAssetRegistryBaseUri] = ("TODO", "baf98f1b-374e-487d-af42-aa33807f11e4"),
+            [MaestroApi.ProductionBuildAssetRegistryBaseUri] = ("TODO", "TODO"),
+        };
+
+        private readonly TokenRequestContext _requestContext;
+        private readonly TokenCredential _tokenCredential;
+
+        private MaestroApiCredential(TokenCredential credential, TokenRequestContext requestContext)
+        {
+            _requestContext = requestContext;
+            _tokenCredential = credential;
+        }
+
+        public override AccessToken GetToken(TokenRequestContext _, CancellationToken cancellationToken)
+        {
+            // We hardcode the request context as we know which scopes we need to invoke in each scenario (user vs daemon)
+            return _tokenCredential.GetToken(_requestContext, cancellationToken);
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext _, CancellationToken cancellationToken)
+        {
+            // We hardcode the request context as we know which scopes we need to invoke in each scenario (user vs daemon)
+            return _tokenCredential.GetTokenAsync(_requestContext, cancellationToken);
+        }
+
+        /// <summary>
+        /// Use this for user-based flows (darc invocation from dev machines).
+        /// </summary>
+        internal static MaestroApiCredential CreateUserCredential(string barApiBaseUri)
+        {
+            // This is a usual credential obtained against an entra app through a browser sign-in
+            var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
+            {
+                TenantId = TENANT_ID,
+                ClientId = WellKnownAuthIds[barApiBaseUri].EntraAppId,
+                RedirectUri = new Uri("http://localhost"),
+                TokenCachePersistenceOptions = new TokenCachePersistenceOptions()
+                {
+                    Name = "darc"
+                }
+            });
+
+            var requestContext = new TokenRequestContext(new string[] { $"api://{WellKnownAuthIds[barApiBaseUri].EntraAppId}/Maestro.User" });
+            return new MaestroApiCredential(credential, requestContext);
+        }
+
+        /// <summary>
+        /// Use this for non-user-based flows (darc invocation from pipelines).
+        /// </summary>
+        internal static MaestroApiCredential CreateNonUserCredential(string barApiBaseUri, string? managedIdentityId = null)
+        {
+            string appId = WellKnownAuthIds[barApiBaseUri].EntraAppId;
+
+            // This is a required audience during federated credential token creation
+            var miRequestContext = new TokenRequestContext(new string[] { "api://AzureADTokenExchange/.default" });
+            var appRequestContext = new TokenRequestContext(new string[] { $"{appId}/.default" });
+
+            // This credential is obtained through a managed identity
+            // which is added as a federated credential onto the entra app
+            var miCreds = new ManagedIdentityCredential(managedIdentityId ?? WellKnownAuthIds[barApiBaseUri].ManagedIdentityId);
+            var credential = new ClientAssertionCredential(
+               TENANT_ID,
+               appId,
+               async (ct) => (await miCreds.GetTokenAsync(miRequestContext, ct).ConfigureAwait(false)).Token);
+
+            return new MaestroApiCredential(credential, appRequestContext);
+        }
+    }
+}

--- a/src/Maestro/Client/src/MaestroApiFactory.cs
+++ b/src/Maestro/Client/src/MaestroApiFactory.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Azure.Core;
 
 #nullable enable
 namespace Microsoft.DotNet.Maestro.Client
@@ -13,15 +12,20 @@ namespace Microsoft.DotNet.Maestro.Client
         /// Obtains API client for authenticated access to internal queues.
         /// The client will access production Maestro instance.
         /// </summary>
-        /// <param name="accessToken">
-        /// Optional BAR token. When provided, will be used as the primary auth method.
-        /// You can get the access token by logging in to your Maestro instance
-        /// and proceeding to Profile page.
-        /// </param>
+        /// <param name="accessToken">Optional BAR token. When provided, will be used as the primary auth method.</param>
         public static IMaestroApi GetAuthenticated(string baseUri, string? accessToken)
         {
-            TokenCredential credential = MaestroApi.CreateApiCredential(baseUri, accessToken);
-            return new MaestroApi(new MaestroApiOptions(new Uri(baseUri), credential));
+            return new MaestroApi(new MaestroApiOptions(baseUri, accessToken));
+        }
+
+        /// <summary>
+        /// Obtains API client for authenticated access to internal queues.
+        /// The client will access production Maestro instance.
+        /// </summary>
+        /// <param name="accessToken">Optional BAR token. When provided, will be used as the primary auth method.</param>
+        public static IMaestroApi GetAuthenticated(string? accessToken)
+        {
+            return new MaestroApi(new MaestroApiOptions(MaestroApi.StagingBuildAssetRegistryBaseUri, accessToken));
         }
 
         /// <summary>
@@ -35,21 +39,6 @@ namespace Microsoft.DotNet.Maestro.Client
         public static IMaestroApi GetAnonymous()
         {
             return new MaestroApi(new MaestroApiOptions());
-        }
-
-        /// <summary>
-        /// Obtains API client for authenticated access to internal queues.
-        /// The client will access production Maestro instance.
-        /// </summary>
-        /// <param name="accessToken">
-        /// Optional BAR token. When provided, will be used as the primary auth method.
-        /// You can get the access token by logging in to your Maestro instance
-        /// and proceeding to Profile page.
-        /// </param>
-        public static IMaestroApi GetAuthenticated(string? accessToken)
-        {
-            TokenCredential credential = MaestroApi.CreateApiCredential(MaestroApi.StagingBuildAssetRegistryBaseUri, accessToken);
-            return new MaestroApi(new MaestroApiOptions(credential));
         }
 
         /// <summary>

--- a/src/Maestro/Client/src/MaestroApiFactory.cs
+++ b/src/Maestro/Client/src/MaestroApiFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Azure.Core;
 
 #nullable enable
 namespace Microsoft.DotNet.Maestro.Client
@@ -20,7 +21,7 @@ namespace Microsoft.DotNet.Maestro.Client
         /// <param name="managedIdentityId">Optional managed identity ID to use during auth</param>
         public static IMaestroApi GetAuthenticated(string baseUri, string? accessToken, string? managedIdentityId)
         {
-            Azure.Core.TokenCredential credential = MaestroApi.CreateApiCredential(baseUri, accessToken, managedIdentityId);
+            TokenCredential credential = MaestroApi.CreateApiCredential(baseUri, accessToken, managedIdentityId);
             return new MaestroApi(new MaestroApiOptions(new Uri(baseUri), credential));
         }
 
@@ -49,7 +50,7 @@ namespace Microsoft.DotNet.Maestro.Client
         /// <param name="managedIdentityId">Optional managed identity ID to use during auth</param>
         public static IMaestroApi GetAuthenticated(string? accessToken, string? managedIdentityId)
         {
-            var credential = MaestroApi.CreateApiCredential(MaestroApi.StagingBuildAssetRegistryBaseUri, accessToken, managedIdentityId);
+            TokenCredential credential = MaestroApi.CreateApiCredential(MaestroApi.StagingBuildAssetRegistryBaseUri, accessToken, managedIdentityId);
             return new MaestroApi(new MaestroApiOptions(credential));
         }
 

--- a/src/Maestro/Client/src/MaestroApiFactory.cs
+++ b/src/Maestro/Client/src/MaestroApiFactory.cs
@@ -13,20 +13,20 @@ namespace Microsoft.DotNet.Maestro.Client
         /// </summary>
         /// <param name="baseUri">URI of the build asset registry service to use.</param>
         /// <param name="accessToken">Optional BAR token. When provided, will be used as the primary auth method.</param>
-        /// <param name="includeInteractive">Whether to include interactive login flows</param>
-        public static IMaestroApi GetAuthenticated(string baseUri, string? accessToken, bool includeInteractive)
+        /// <param name="disableInteractiveAuth">Whether to include interactive login flows</param>
+        public static IMaestroApi GetAuthenticated(string baseUri, string? accessToken, bool disableInteractiveAuth)
         {
-            return new MaestroApi(new MaestroApiOptions(baseUri, accessToken, includeInteractive));
+            return new MaestroApi(new MaestroApiOptions(baseUri, accessToken, disableInteractiveAuth));
         }
 
         /// <summary>
         /// Obtains API client for authenticated access to Maestro.
         /// </summary>
         /// <param name="accessToken">Optional BAR token. When provided, will be used as the primary auth method.</param>
-        /// <param name="includeInteractive">Whether to include interactive login flows</param>
-        public static IMaestroApi GetAuthenticated(string? accessToken, bool includeInteractive)
+        /// <param name="disableInteractiveAuth">Whether to include interactive login flows</param>
+        public static IMaestroApi GetAuthenticated(string? accessToken, bool disableInteractiveAuth)
         {
-            return new MaestroApi(new MaestroApiOptions(MaestroApi.StagingBuildAssetRegistryBaseUri, accessToken, includeInteractive));
+            return new MaestroApi(new MaestroApiOptions(MaestroApi.StagingBuildAssetRegistryBaseUri, accessToken, disableInteractiveAuth));
         }
 
         /// <summary>

--- a/src/Maestro/Client/src/MaestroApiFactory.cs
+++ b/src/Maestro/Client/src/MaestroApiFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+#nullable enable
 namespace Microsoft.DotNet.Maestro.Client
 {
     public static class MaestroApiFactory
@@ -12,12 +13,15 @@ namespace Microsoft.DotNet.Maestro.Client
         /// The client will access production Maestro instance.
         /// </summary>
         /// <param name="accessToken">
+        /// Optional BAR token. When provided, will be used as the primary auth method.
         /// You can get the access token by logging in to your Maestro instance
         /// and proceeding to Profile page.
         /// </param>
-        public static IMaestroApi GetAuthenticated(string accessToken)
+        /// <param name="managedIdentityId">Optional managed identity ID to use during auth</param>
+        public static IMaestroApi GetAuthenticated(string baseUri, string? accessToken, string? managedIdentityId)
         {
-            return new MaestroApi(new MaestroApiOptions(new MaestroApiTokenCredential(accessToken)));
+            Azure.Core.TokenCredential credential = MaestroApi.CreateApiCredential(baseUri, accessToken, managedIdentityId);
+            return new MaestroApi(new MaestroApiOptions(new Uri(baseUri), credential));
         }
 
         /// <summary>
@@ -35,15 +39,18 @@ namespace Microsoft.DotNet.Maestro.Client
 
         /// <summary>
         /// Obtains API client for authenticated access to internal queues.
-        /// The client will access Maestro instance at the provided URI.
+        /// The client will access production Maestro instance.
         /// </summary>
         /// <param name="accessToken">
+        /// Optional BAR token. When provided, will be used as the primary auth method.
         /// You can get the access token by logging in to your Maestro instance
         /// and proceeding to Profile page.
         /// </param>
-        public static IMaestroApi GetAuthenticated(string baseUri, string accessToken)
+        /// <param name="managedIdentityId">Optional managed identity ID to use during auth</param>
+        public static IMaestroApi GetAuthenticated(string? accessToken, string? managedIdentityId)
         {
-            return new MaestroApi(new MaestroApiOptions(new Uri(baseUri), new MaestroApiTokenCredential(accessToken)));
+            var credential = MaestroApi.CreateApiCredential(MaestroApi.StagingBuildAssetRegistryBaseUri, accessToken, managedIdentityId);
+            return new MaestroApi(new MaestroApiOptions(credential));
         }
 
         /// <summary>

--- a/src/Maestro/Client/src/MaestroApiFactory.cs
+++ b/src/Maestro/Client/src/MaestroApiFactory.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.DotNet.Maestro.Client
 {
-    public static class ApiFactory
+    public static class MaestroApiFactory
     {
         /// <summary>
         /// Obtains API client for authenticated access to internal queues.

--- a/src/Maestro/Client/src/MaestroApiFactory.cs
+++ b/src/Maestro/Client/src/MaestroApiFactory.cs
@@ -9,46 +9,37 @@ namespace Microsoft.DotNet.Maestro.Client
     public static class MaestroApiFactory
     {
         /// <summary>
-        /// Obtains API client for authenticated access to internal queues.
-        /// The client will access production Maestro instance.
+        /// Obtains API client for authenticated access to Maestro.
         /// </summary>
+        /// <param name="baseUri">URI of the build asset registry service to use.</param>
         /// <param name="accessToken">Optional BAR token. When provided, will be used as the primary auth method.</param>
-        public static IMaestroApi GetAuthenticated(string baseUri, string? accessToken)
+        /// <param name="includeInteractive">Whether to include interactive login flows</param>
+        public static IMaestroApi GetAuthenticated(string baseUri, string? accessToken, bool includeInteractive)
         {
-            return new MaestroApi(new MaestroApiOptions(baseUri, accessToken));
+            return new MaestroApi(new MaestroApiOptions(baseUri, accessToken, includeInteractive));
         }
 
         /// <summary>
-        /// Obtains API client for authenticated access to internal queues.
-        /// The client will access production Maestro instance.
+        /// Obtains API client for authenticated access to Maestro.
         /// </summary>
         /// <param name="accessToken">Optional BAR token. When provided, will be used as the primary auth method.</param>
-        public static IMaestroApi GetAuthenticated(string? accessToken)
+        /// <param name="includeInteractive">Whether to include interactive login flows</param>
+        public static IMaestroApi GetAuthenticated(string? accessToken, bool includeInteractive)
         {
-            return new MaestroApi(new MaestroApiOptions(MaestroApi.StagingBuildAssetRegistryBaseUri, accessToken));
+            return new MaestroApi(new MaestroApiOptions(MaestroApi.StagingBuildAssetRegistryBaseUri, accessToken, includeInteractive));
         }
 
         /// <summary>
-        /// Obtains API client for unauthenticated access to external queues.
-        /// The client will access production Maestro instance.
+        /// Obtains API client for non-authenticated access to Maestro.
         /// </summary>
-        /// <remarks>
-        /// Attempt to access internal queues by such client will cause
-        /// <see cref="ArgumentException"/> triggered by <c>SendAsync</c> call.
-        /// </remarks>
         public static IMaestroApi GetAnonymous()
         {
             return new MaestroApi(new MaestroApiOptions());
         }
 
         /// <summary>
-        /// Obtains API client for unauthenticated access to external queues.
-        /// The client will access Maestro instance at the provided URI.
+        /// Obtains API client for non-authenticated access to Maestro.
         /// </summary>
-        /// <remarks>
-        /// Attempt to access internal queues by such client will cause
-        /// <see cref="ArgumentException"/> triggered by <c>SendAsync</c> call.
-        /// </remarks>
         public static IMaestroApi GetAnonymous(string baseUri)
         {
             return new MaestroApi(new MaestroApiOptions(new Uri(baseUri)));

--- a/src/Maestro/Client/src/MaestroApiFactory.cs
+++ b/src/Maestro/Client/src/MaestroApiFactory.cs
@@ -18,10 +18,9 @@ namespace Microsoft.DotNet.Maestro.Client
         /// You can get the access token by logging in to your Maestro instance
         /// and proceeding to Profile page.
         /// </param>
-        /// <param name="managedIdentityId">Optional managed identity ID to use during auth</param>
-        public static IMaestroApi GetAuthenticated(string baseUri, string? accessToken, string? managedIdentityId)
+        public static IMaestroApi GetAuthenticated(string baseUri, string? accessToken)
         {
-            TokenCredential credential = MaestroApi.CreateApiCredential(baseUri, accessToken, managedIdentityId);
+            TokenCredential credential = MaestroApi.CreateApiCredential(baseUri, accessToken);
             return new MaestroApi(new MaestroApiOptions(new Uri(baseUri), credential));
         }
 
@@ -47,10 +46,9 @@ namespace Microsoft.DotNet.Maestro.Client
         /// You can get the access token by logging in to your Maestro instance
         /// and proceeding to Profile page.
         /// </param>
-        /// <param name="managedIdentityId">Optional managed identity ID to use during auth</param>
-        public static IMaestroApi GetAuthenticated(string? accessToken, string? managedIdentityId)
+        public static IMaestroApi GetAuthenticated(string? accessToken)
         {
-            TokenCredential credential = MaestroApi.CreateApiCredential(MaestroApi.StagingBuildAssetRegistryBaseUri, accessToken, managedIdentityId);
+            TokenCredential credential = MaestroApi.CreateApiCredential(MaestroApi.StagingBuildAssetRegistryBaseUri, accessToken);
             return new MaestroApi(new MaestroApiOptions(credential));
         }
 

--- a/src/Maestro/Client/src/MaestroApiOptions.cs
+++ b/src/Maestro/Client/src/MaestroApiOptions.cs
@@ -15,12 +15,12 @@ namespace Microsoft.DotNet.Maestro.Client
         /// </summary>
         /// <param name="baseUri">API base URI</param>
         /// <param name="accessToken">Optional BAR token. When provided, will be used as the primary auth method.</param>
-        /// <param name="includeInteractive">Whether to include interactive login flows</param>
-        public MaestroApiOptions(string baseUri, string accessToken, bool includeInteractive)
+        /// <param name="disableInteractiveAuth">Whether to include interactive login flows</param>
+        public MaestroApiOptions(string baseUri, string accessToken, bool disableInteractiveAuth)
             : this(
                   new Uri(baseUri),
                   string.IsNullOrEmpty(accessToken)
-                    ? MaestroApi.CreateApiCredential(baseUri, includeInteractive, accessToken)
+                    ? MaestroApi.CreateApiCredential(baseUri, disableInteractiveAuth, accessToken)
                     : null)
         {
         }

--- a/src/Maestro/Client/src/MaestroApiOptions.cs
+++ b/src/Maestro/Client/src/MaestroApiOptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Maestro.Client
         /// <param name="baseUri">API base URI</param>
         /// <param name="accessToken">Optional BAR token. When provided, will be used as the primary auth method.</param>
         public MaestroApiOptions(string baseUri, string accessToken)
-            : this(new Uri(baseUri), accessToken != null ? MaestroApi.CreateApiCredential(baseUri, accessToken) : null)
+            : this(new Uri(baseUri), string.IsNullOrEmpty(accessToken) ? MaestroApi.CreateApiCredential(baseUri, accessToken) : null)
         {
         }
 

--- a/src/Maestro/Client/src/MaestroApiOptions.cs
+++ b/src/Maestro/Client/src/MaestroApiOptions.cs
@@ -15,8 +15,13 @@ namespace Microsoft.DotNet.Maestro.Client
         /// </summary>
         /// <param name="baseUri">API base URI</param>
         /// <param name="accessToken">Optional BAR token. When provided, will be used as the primary auth method.</param>
-        public MaestroApiOptions(string baseUri, string accessToken)
-            : this(new Uri(baseUri), string.IsNullOrEmpty(accessToken) ? MaestroApi.CreateApiCredential(baseUri, accessToken) : null)
+        /// <param name="includeInteractive">Whether to include interactive login flows</param>
+        public MaestroApiOptions(string baseUri, string accessToken, bool includeInteractive)
+            : this(
+                  new Uri(baseUri),
+                  string.IsNullOrEmpty(accessToken)
+                    ? MaestroApi.CreateApiCredential(baseUri, includeInteractive, accessToken)
+                    : null)
         {
         }
 
@@ -26,8 +31,7 @@ namespace Microsoft.DotNet.Maestro.Client
             {
                 AddPolicy(
                     new BearerTokenAuthenticationPolicy(Credentials, Array.Empty<string>()),
-                    HttpPipelinePosition.PerCall
-                    );
+                    HttpPipelinePosition.PerCall);
             }
         }
     }

--- a/src/Maestro/Client/src/MaestroApiOptions.cs
+++ b/src/Maestro/Client/src/MaestroApiOptions.cs
@@ -10,6 +10,16 @@ namespace Microsoft.DotNet.Maestro.Client
 {
     public partial class MaestroApiOptions
     {
+        /// <summary>
+        /// Creates a new instance of <see cref="MaestroApiOptions"/> with the provided base URI.
+        /// </summary>
+        /// <param name="baseUri">API base URI</param>
+        /// <param name="accessToken">Optional BAR token. When provided, will be used as the primary auth method.</param>
+        public MaestroApiOptions(string baseUri, string accessToken)
+            : this(new Uri(baseUri), accessToken != null ? MaestroApi.CreateApiCredential(baseUri, accessToken) : null)
+        {
+        }
+
         partial void InitializeOptions()
         {
             if (Credentials != null)

--- a/src/Maestro/Client/src/MaestroApiTokenCredential.cs
+++ b/src/Maestro/Client/src/MaestroApiTokenCredential.cs
@@ -1,15 +1,18 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Azure.Core;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
 
-
+#nullable enable
 namespace Microsoft.DotNet.Maestro.Client
 {
-    public class MaestroApiTokenCredential : TokenCredential
+    /// <summary>
+    /// Old credential used to authenticate to the Maestro API using a BAR token.
+    /// </summary>
+    internal class MaestroApiTokenCredential : TokenCredential
     {
         public MaestroApiTokenCredential(string token)
         {
@@ -22,7 +25,7 @@ namespace Microsoft.DotNet.Maestro.Client
         {
             return new AccessToken(Token, DateTimeOffset.MaxValue);
         }
-    
+
         public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
             return new ValueTask<AccessToken>(new AccessToken(Token, DateTimeOffset.MaxValue));

--- a/src/Maestro/Client/src/MaestroApiTokenCredential.cs
+++ b/src/Maestro/Client/src/MaestroApiTokenCredential.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 namespace Microsoft.DotNet.Maestro.Client
 {
     /// <summary>
-    /// Old credential used to authenticate to the Maestro API using a BAR token.
+    /// Credential used to authenticate to the Maestro API using a specific token.
     /// </summary>
     internal class MaestroApiTokenCredential : TokenCredential
     {

--- a/src/Maestro/Client/src/Microsoft.DotNet.Maestro.Client.csproj
+++ b/src/Maestro/Client/src/Microsoft.DotNet.Maestro.Client.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Collections.Immutable" />
 

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -27,7 +27,6 @@ namespace Microsoft.DotNet.Maestro.Tasks
         [Required] 
         public string ManifestsPath { get; set; }
 
-        [Required] 
         public string BuildAssetRegistryToken { get; set; }
 
         [Required] 
@@ -141,7 +140,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                     // populate buildData and assetData using merged manifest data 
                     BuildData buildData = GetMaestroBuildDataFromMergedManifest(modelForManifest, manifest, cancellationToken);
 
-                    IMaestroApi client = ApiFactory.GetAuthenticated(MaestroApiEndpoint, BuildAssetRegistryToken);
+                    IMaestroApi client = MaestroApiFactory.GetAuthenticated(MaestroApiEndpoint, BuildAssetRegistryToken);
 
                     var deps = await GetBuildDependenciesAsync(client, cancellationToken);
                     Log.LogMessage(MessageImportance.High, "Calculated Dependencies:");

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -140,7 +140,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                     // populate buildData and assetData using merged manifest data 
                     BuildData buildData = GetMaestroBuildDataFromMergedManifest(modelForManifest, manifest, cancellationToken);
 
-                    IMaestroApi client = MaestroApiFactory.GetAuthenticated(MaestroApiEndpoint, BuildAssetRegistryToken);
+                    IMaestroApi client = MaestroApiFactory.GetAuthenticated(MaestroApiEndpoint, BuildAssetRegistryToken, includeInteractive: false);
 
                     var deps = await GetBuildDependenciesAsync(client, cancellationToken);
                     Log.LogMessage(MessageImportance.High, "Calculated Dependencies:");

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -140,7 +140,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                     // populate buildData and assetData using merged manifest data 
                     BuildData buildData = GetMaestroBuildDataFromMergedManifest(modelForManifest, manifest, cancellationToken);
 
-                    IMaestroApi client = MaestroApiFactory.GetAuthenticated(MaestroApiEndpoint, BuildAssetRegistryToken, includeInteractive: false);
+                    IMaestroApi client = MaestroApiFactory.GetAuthenticated(MaestroApiEndpoint, BuildAssetRegistryToken, disableInteractiveAuth: true);
 
                     var deps = await GetBuildDependenciesAsync(client, cancellationToken);
                     Log.LogMessage(MessageImportance.High, "Calculated Dependencies:");

--- a/src/Maestro/SubscriptionActorService/Program.cs
+++ b/src/Maestro/SubscriptionActorService/Program.cs
@@ -82,6 +82,8 @@ public static class Program
         {
             var config = s.GetRequiredService<IConfiguration>();
             var uri = config.GetValue<string>("ProductConstructionService:Uri");
+
+            // TODO https://dev.azure.com/dnceng/internal/_workitems/edit/6451: Implement Maestro - PCS communication
             var token = config.GetValue<string>("ProductConstructionService:Token");
 
             return string.IsNullOrEmpty(token)

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
@@ -60,7 +60,7 @@ internal class LocalSettings
             {
                 throw new DarcException("Please make sure to run darc authenticate and set" +
                                         " 'github_token' or 'azure_devops_token' or append" +
-                                        "'-p <bar_password>' [--github-pat <github_token> | " +
+                                        "'-p <bar_token>' [--github-pat <github_token> | " +
                                         "--azdev-pat <azure_devops_token>] to your command");
             }
         }

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
@@ -52,6 +52,7 @@ internal class LocalSettings
             var settings = LoadSettingsFile();
             settings.GitHubToken = options.GitHubPat ?? settings.GitHubToken;
             settings.AzureDevOpsToken = options.AzureDevOpsPat ?? settings.AzureDevOpsToken;
+            settings.BuildAssetRegistryToken = options.BuildAssetRegistryToken ?? settings.BuildAssetRegistryToken;
             return settings;
         }
         catch (Exception exc) when (exc is DirectoryNotFoundException || exc is FileNotFoundException)

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Darc.Helpers;
 /// </summary>
 internal class LocalSettings
 {
-    public string BuildAssetRegistryPassword { get; set; }
+    public string BuildAssetRegistryToken { get; set; }
 
     public string GitHubToken { get; set; }
 
@@ -89,7 +89,7 @@ internal class LocalSettings
         }
 
         localSettings ??= new LocalSettings();
-        localSettings.BuildAssetRegistryPassword = options.BuildAssetRegistryPassword ?? localSettings.BuildAssetRegistryPassword;
+        localSettings.BuildAssetRegistryToken = options.BuildAssetRegistryToken ?? localSettings.BuildAssetRegistryToken;
         localSettings.BuildAssetRegistryBaseUri = options.BuildAssetRegistryBaseUri
             ?? localSettings.BuildAssetRegistryBaseUri
             ?? MaestroApi.ProductionBuildAssetRegistryBaseUri;

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
@@ -25,12 +25,6 @@ internal class LocalSettings
     public string BuildAssetRegistryBaseUri { get; set; } = MaestroApi.ProductionBuildAssetRegistryBaseUri;
 
     /// <summary>
-    ///     If the git clients need to clone a repository for whatever reason,
-    ///     this denotes the root of where the repository should be cloned.
-    /// </summary>
-    public string TemporaryRepositoryRoot { get; set; }
-
-    /// <summary>
     /// Saves the settings in the settings files
     /// </summary>
     public int SaveSettingsFile(ILogger logger)

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -15,15 +16,13 @@ namespace Microsoft.DotNet.Darc.Helpers;
 /// </summary>
 internal class LocalSettings
 {
-    private static readonly string _defaultBuildAssetRegistryBaseUri = "https://maestro.dot.net/";
-
     public string BuildAssetRegistryPassword { get; set; }
 
     public string GitHubToken { get; set; }
 
     public string AzureDevOpsToken { get; set; }
 
-    public string BuildAssetRegistryBaseUri { get; set; } = _defaultBuildAssetRegistryBaseUri;
+    public string BuildAssetRegistryBaseUri { get; set; } = MaestroApi.ProductionBuildAssetRegistryBaseUri;
 
     /// <summary>
     ///     If the git clients need to clone a repository for whatever reason,
@@ -57,12 +56,10 @@ internal class LocalSettings
         }
         catch (Exception exc) when (exc is DirectoryNotFoundException || exc is FileNotFoundException)
         {
-            if (string.IsNullOrEmpty(options.AzureDevOpsPat) &&
-                string.IsNullOrEmpty(options.GitHubPat) &&
-                string.IsNullOrEmpty(options.BuildAssetRegistryPassword))
+            if (string.IsNullOrEmpty(options.AzureDevOpsPat) && string.IsNullOrEmpty(options.GitHubPat))
             {
                 throw new DarcException("Please make sure to run darc authenticate and set" +
-                                        " 'bar_password' and 'github_token' or 'azure_devops_token' or append" +
+                                        " 'github_token' or 'azure_devops_token' or append" +
                                         "'-p <bar_password>' [--github-pat <github_token> | " +
                                         "--azdev-pat <azure_devops_token>] to your command");
             }
@@ -95,7 +92,7 @@ internal class LocalSettings
         localSettings.BuildAssetRegistryPassword = options.BuildAssetRegistryPassword ?? localSettings.BuildAssetRegistryPassword;
         localSettings.BuildAssetRegistryBaseUri = options.BuildAssetRegistryBaseUri
             ?? localSettings.BuildAssetRegistryBaseUri
-            ?? _defaultBuildAssetRegistryBaseUri;
+            ?? MaestroApi.ProductionBuildAssetRegistryBaseUri;
 
         return localSettings;
     }

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
@@ -30,7 +30,8 @@ internal class RemoteFactory : IRemoteFactory
         var settings = LocalSettings.GetSettings(options, logger);
         return new BarApiClient(
             settings?.BuildAssetRegistryPassword,
-            settings?.BuildAssetRegistryBaseUri);
+            settings?.BuildAssetRegistryBaseUri,
+            options.BarApiManagedIdentityId);
     }
 
     public Task<IRemote> GetRemoteAsync(string repoUrl, ILogger logger)

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
@@ -29,7 +29,7 @@ internal class RemoteFactory : IRemoteFactory
     {
         var settings = LocalSettings.GetSettings(options, logger);
         return new BarApiClient(
-            settings?.BuildAssetRegistryPassword,
+            settings?.BuildAssetRegistryToken,
             settings?.BuildAssetRegistryBaseUri);
     }
 

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
@@ -30,8 +30,7 @@ internal class RemoteFactory : IRemoteFactory
         var settings = LocalSettings.GetSettings(options, logger);
         return new BarApiClient(
             settings?.BuildAssetRegistryPassword,
-            settings?.BuildAssetRegistryBaseUri,
-            options.BarApiManagedIdentityId);
+            settings?.BuildAssetRegistryBaseUri);
     }
 
     public Task<IRemote> GetRemoteAsync(string repoUrl, ILogger logger)

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
@@ -30,6 +30,7 @@ internal class RemoteFactory : IRemoteFactory
         var settings = LocalSettings.GetSettings(options, logger);
         return new BarApiClient(
             settings?.BuildAssetRegistryToken,
+            options.InteractiveAuthEnabled,
             settings?.BuildAssetRegistryBaseUri);
     }
 

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
@@ -30,7 +30,7 @@ internal class RemoteFactory : IRemoteFactory
         var settings = LocalSettings.GetSettings(options, logger);
         return new BarApiClient(
             settings?.BuildAssetRegistryToken,
-            options.InteractiveAuthEnabled,
+            options.DisableInteractiveAuth,
             settings?.BuildAssetRegistryBaseUri);
     }
 

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
@@ -47,13 +47,7 @@ internal class RemoteFactory : IRemoteFactory
     {
         var darcSettings = LocalSettings.GetSettings(options, logger, repoUrl);
 
-        // If a temporary repository root was not provided, use the environment
-        // provided temp directory.
-        string temporaryRepositoryRoot = darcSettings.TemporaryRepositoryRoot;
-        if (string.IsNullOrEmpty(temporaryRepositoryRoot))
-        {
-            temporaryRepositoryRoot = Path.GetTempPath();
-        }
+        string temporaryRepositoryRoot = Path.GetTempPath();
 
         var repoType = GitRepoUrlParser.ParseTypeFromUri(repoUrl);
 

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AuthenticateEditorPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AuthenticateEditorPopUp.cs
@@ -12,7 +12,6 @@ internal class AuthenticateEditorPopUp : EditorPopUp
 {
     private readonly ILogger _logger;
 
-    private const string BarPasswordElement = "bar_password";
     private const string GithubTokenElement = "github_token";
     private const string AzureDevOpsTokenElement = "azure_devops_token";
     private const string BarBaseUriElement = "build_asset_registry_base_uri";
@@ -37,8 +36,6 @@ internal class AuthenticateEditorPopUp : EditorPopUp
         // Initialize line contents.
         Contents =
         [
-            new("Create new BAR tokens at https://maestro.dot.net/Account/Tokens", isComment: true),
-            new($"{BarPasswordElement}={GetCurrentSettingForDisplay(settings.BuildAssetRegistryPassword, string.Empty, true)}"),
             new("Create new GitHub personal access tokens at https://github.com/settings/tokens (no scopes needed but needs SSO enabled on the PAT)", isComment: true),
             new($"{GithubTokenElement}={GetCurrentSettingForDisplay(settings.GitHubToken, string.Empty, true)}"),
             new("Create new Azure Dev Ops tokens using the PatGeneratorTool https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DncEng.PatGeneratorTool", isComment: true),
@@ -61,9 +58,6 @@ internal class AuthenticateEditorPopUp : EditorPopUp
 
             switch (keyValue[0])
             {
-                case BarPasswordElement:
-                    settings.BuildAssetRegistryPassword = ParseSetting(keyValue[1], settings.BuildAssetRegistryPassword, true);
-                    break;
                 case GithubTokenElement:
                     settings.GitHubToken = ParseSetting(keyValue[1], settings.GitHubToken, true);
                     break;

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AuthenticateEditorPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AuthenticateEditorPopUp.cs
@@ -12,6 +12,7 @@ internal class AuthenticateEditorPopUp : EditorPopUp
 {
     private readonly ILogger _logger;
 
+    private const string BarPasswordElement = "bar_password";
     private const string GithubTokenElement = "github_token";
     private const string AzureDevOpsTokenElement = "azure_devops_token";
     private const string BarBaseUriElement = "build_asset_registry_base_uri";
@@ -36,6 +37,8 @@ internal class AuthenticateEditorPopUp : EditorPopUp
         // Initialize line contents.
         Contents =
         [
+            new("Create new BAR tokens at https://maestro.dot.net/Account/Tokens", isComment: true),
+            new($"{BarPasswordElement}={GetCurrentSettingForDisplay(settings.BuildAssetRegistryToken, string.Empty, true)}"),
             new("Create new GitHub personal access tokens at https://github.com/settings/tokens (no scopes needed but needs SSO enabled on the PAT)", isComment: true),
             new($"{GithubTokenElement}={GetCurrentSettingForDisplay(settings.GitHubToken, string.Empty, true)}"),
             new("Create new Azure Dev Ops tokens using the PatGeneratorTool https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DncEng.PatGeneratorTool", isComment: true),
@@ -58,6 +61,9 @@ internal class AuthenticateEditorPopUp : EditorPopUp
 
             switch (keyValue[0])
             {
+                case BarPasswordElement:
+                    settings.BuildAssetRegistryToken = ParseSetting(keyValue[1], settings.BuildAssetRegistryToken, true);
+                    break;
                 case GithubTokenElement:
                     settings.GitHubToken = ParseSetting(keyValue[1], settings.GitHubToken, true);
                     break;

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AuthenticateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AuthenticateOperation.cs
@@ -32,7 +32,7 @@ internal class AuthenticateOperation : Operation
         }
         else
         {
-            var initEditorPopUp = new AuthenticateEditorPopUp("authenticate-settings/authenticate-todo", Logger);
+            var initEditorPopUp = new AuthenticateEditorPopUp("authenticate-settings/darc-authenticate", Logger);
 
             var uxManager = new UxManager(_options.GitLocation, Logger);
             return Task.FromResult(uxManager.PopUp(initEditorPopUp));

--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -24,6 +24,9 @@ public abstract class CommandLineOptions : ICommandLineOptions
     [Option("bar-uri", HelpText = "URI of the build asset registry service to use.")]
     public string BuildAssetRegistryBaseUri { get; set; }
 
+    [Option("bar-api-mi", HelpText = "ID of the managed identity to use to connect to BAR API.")]
+    public string BarApiManagedIdentityId { get; set; }
+
     [Option("verbose", HelpText = "Turn on verbose output.")]
     public bool Verbose { get; set; }
 

--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -9,9 +9,9 @@ namespace Microsoft.DotNet.Darc.Options;
 
 public abstract class CommandLineOptions : ICommandLineOptions
 {
-    [Option('p', "password", HelpText = "BAR password.")]
+    [Option('p', "password", HelpText = "Token used to authenticate to BAR. If omitted, auth falls back to Azure CLI or an interactive browser login flow.")]
     [RedactFromLogging]
-    public string BuildAssetRegistryPassword { get; set; }
+    public string BuildAssetRegistryToken { get; set; }
 
     [Option("github-pat", HelpText = "Token used to authenticate GitHub.")]
     [RedactFromLogging]

--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using CommandLine;
 using Microsoft.DotNet.Darc.Operations;
 using Microsoft.DotNet.DarcLib;
@@ -42,7 +41,8 @@ public abstract class CommandLineOptions : ICommandLineOptions
     /// <summary>
     /// When true, Darc authenticates against Maestro using an interactive login browser flow.
     /// </summary>
-    public bool InteractiveAuthEnabled { get; } = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DARC_DISABLE_INTERACTIVE_AUTH"));
+    [Option("disable-interactive-auth", HelpText = "Disable interactive sign-in to Maestro API.")]
+    public bool DisableInteractiveAuth { get; set; }
 
     public abstract Operation GetOperation();
 

--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -24,9 +24,6 @@ public abstract class CommandLineOptions : ICommandLineOptions
     [Option("bar-uri", HelpText = "URI of the build asset registry service to use.")]
     public string BuildAssetRegistryBaseUri { get; set; }
 
-    [Option("bar-api-mi", HelpText = "ID of the managed identity to use to connect to BAR API.")]
-    public string BarApiManagedIdentityId { get; set; }
-
     [Option("verbose", HelpText = "Turn on verbose output.")]
     public bool Verbose { get; set; }
 

--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using CommandLine;
 using Microsoft.DotNet.Darc.Operations;
 using Microsoft.DotNet.DarcLib;
@@ -37,6 +38,11 @@ public abstract class CommandLineOptions : ICommandLineOptions
     [Option("output-format", Default = DarcOutputType.text,
         HelpText = "Desired output type of darc. Valid values are 'json' and 'text'. Case sensitive.")]
     public DarcOutputType OutputFormat { get; set; }
+
+    /// <summary>
+    /// When true, Darc authenticates against Maestro using an interactive login browser flow.
+    /// </summary>
+    public bool InteractiveAuthEnabled { get; } = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DARC_DISABLE_INTERACTIVE_AUTH"));
 
     public abstract Operation GetOperation();
 

--- a/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
@@ -15,7 +15,7 @@ public interface ICommandLineOptions
     DarcOutputType OutputFormat { get; set; }
     bool Debug { get; set; }
     bool Verbose { get; set; }
-    bool InteractiveAuthEnabled { get; }
+    bool DisableInteractiveAuth { get; set; }
 
     Operation GetOperation();
     RemoteConfiguration GetRemoteConfiguration();

--- a/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
@@ -10,6 +10,7 @@ public interface ICommandLineOptions
     string AzureDevOpsPat { get; set; }
     string BuildAssetRegistryBaseUri { get; set; }
     string BuildAssetRegistryPassword { get; set; }
+    string BarApiManagedIdentityId { get; set; }
     bool Debug { get; set; }
     string GitHubPat { get; set; }
     string GitLocation { get; set; }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
@@ -9,7 +9,7 @@ public interface ICommandLineOptions
 {
     string AzureDevOpsPat { get; set; }
     string BuildAssetRegistryBaseUri { get; set; }
-    string BuildAssetRegistryPassword { get; set; }
+    string BuildAssetRegistryToken { get; set; }
     bool Debug { get; set; }
     string GitHubPat { get; set; }
     string GitLocation { get; set; }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
@@ -10,7 +10,6 @@ public interface ICommandLineOptions
     string AzureDevOpsPat { get; set; }
     string BuildAssetRegistryBaseUri { get; set; }
     string BuildAssetRegistryPassword { get; set; }
-    string BarApiManagedIdentityId { get; set; }
     bool Debug { get; set; }
     string GitHubPat { get; set; }
     string GitLocation { get; set; }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
@@ -10,11 +10,12 @@ public interface ICommandLineOptions
     string AzureDevOpsPat { get; set; }
     string BuildAssetRegistryBaseUri { get; set; }
     string BuildAssetRegistryToken { get; set; }
-    bool Debug { get; set; }
     string GitHubPat { get; set; }
     string GitLocation { get; set; }
     DarcOutputType OutputFormat { get; set; }
+    bool Debug { get; set; }
     bool Verbose { get; set; }
+    bool InteractiveAuthEnabled { get; }
 
     Operation GetOperation();
     RemoteConfiguration GetRemoteConfiguration();

--- a/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
@@ -20,11 +20,11 @@ public class BarApiClient : IBarApiClient
 {
     private readonly IMaestroApi _barClient;
 
-    public BarApiClient(string buildAssetRegistryPat, string? buildAssetRegistryBaseUri = null)
+    public BarApiClient(string buildAssetRegistryPat, bool includeInteractiveAuth, string? buildAssetRegistryBaseUri = null)
     {
         _barClient = !string.IsNullOrEmpty(buildAssetRegistryBaseUri)
-            ? MaestroApiFactory.GetAuthenticated(buildAssetRegistryBaseUri, buildAssetRegistryPat)
-            : MaestroApiFactory.GetAuthenticated(buildAssetRegistryPat);
+            ? MaestroApiFactory.GetAuthenticated(buildAssetRegistryBaseUri, buildAssetRegistryPat, includeInteractiveAuth)
+            : MaestroApiFactory.GetAuthenticated(buildAssetRegistryPat, includeInteractiveAuth);
     }
 
     #region Channel Operations

--- a/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
@@ -23,13 +23,13 @@ public class BarApiClient : IBarApiClient
     {
         if (!string.IsNullOrEmpty(buildAssetRegistryBaseUri))
         {
-            _barClient = ApiFactory.GetAuthenticated(
+            _barClient = MaestroApiFactory.GetAuthenticated(
                 buildAssetRegistryBaseUri,
                 buildAssetRegistryPat);
         }
         else
         {
-            _barClient = ApiFactory.GetAuthenticated(buildAssetRegistryPat);
+            _barClient = MaestroApiFactory.GetAuthenticated(buildAssetRegistryPat);
         }
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
@@ -20,11 +20,11 @@ public class BarApiClient : IBarApiClient
 {
     private readonly IMaestroApi _barClient;
 
-    public BarApiClient(string buildAssetRegistryPat, string? buildAssetRegistryBaseUri = null, string? managedIdentityId = null)
+    public BarApiClient(string buildAssetRegistryPat, string? buildAssetRegistryBaseUri = null)
     {
         _barClient = !string.IsNullOrEmpty(buildAssetRegistryBaseUri)
-            ? MaestroApiFactory.GetAuthenticated(buildAssetRegistryBaseUri, buildAssetRegistryPat, managedIdentityId)
-            : MaestroApiFactory.GetAuthenticated(buildAssetRegistryPat, managedIdentityId);
+            ? MaestroApiFactory.GetAuthenticated(buildAssetRegistryBaseUri, buildAssetRegistryPat)
+            : MaestroApiFactory.GetAuthenticated(buildAssetRegistryPat);
     }
 
     #region Channel Operations

--- a/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
@@ -20,11 +20,11 @@ public class BarApiClient : IBarApiClient
 {
     private readonly IMaestroApi _barClient;
 
-    public BarApiClient(string buildAssetRegistryPat, bool includeInteractiveAuth, string? buildAssetRegistryBaseUri = null)
+    public BarApiClient(string buildAssetRegistryPat, bool disableInteractiveAuth, string? buildAssetRegistryBaseUri = null)
     {
         _barClient = !string.IsNullOrEmpty(buildAssetRegistryBaseUri)
-            ? MaestroApiFactory.GetAuthenticated(buildAssetRegistryBaseUri, buildAssetRegistryPat, includeInteractiveAuth)
-            : MaestroApiFactory.GetAuthenticated(buildAssetRegistryPat, includeInteractiveAuth);
+            ? MaestroApiFactory.GetAuthenticated(buildAssetRegistryBaseUri, buildAssetRegistryPat, disableInteractiveAuth)
+            : MaestroApiFactory.GetAuthenticated(buildAssetRegistryPat, disableInteractiveAuth);
     }
 
     #region Channel Operations

--- a/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/BarApiClient.cs
@@ -13,24 +13,18 @@ using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using AsyncEnumerable = Microsoft.DotNet.Maestro.Client.AsyncEnumerable;
 
+#nullable enable
 namespace Microsoft.DotNet.DarcLib;
 
 public class BarApiClient : IBarApiClient
 {
     private readonly IMaestroApi _barClient;
 
-    public BarApiClient(string buildAssetRegistryPat, string buildAssetRegistryBaseUri = null)
+    public BarApiClient(string buildAssetRegistryPat, string? buildAssetRegistryBaseUri = null, string? managedIdentityId = null)
     {
-        if (!string.IsNullOrEmpty(buildAssetRegistryBaseUri))
-        {
-            _barClient = MaestroApiFactory.GetAuthenticated(
-                buildAssetRegistryBaseUri,
-                buildAssetRegistryPat);
-        }
-        else
-        {
-            _barClient = MaestroApiFactory.GetAuthenticated(buildAssetRegistryPat);
-        }
+        _barClient = !string.IsNullOrEmpty(buildAssetRegistryBaseUri)
+            ? MaestroApiFactory.GetAuthenticated(buildAssetRegistryBaseUri, buildAssetRegistryPat, managedIdentityId)
+            : MaestroApiFactory.GetAuthenticated(buildAssetRegistryPat, managedIdentityId);
     }
 
     #region Channel Operations
@@ -42,7 +36,7 @@ public class BarApiClient : IBarApiClient
     /// <param name="branch">Optionally filter by branch</param>
     /// <param name="channel">Optionally filter by channel</param>
     /// <returns>Collection of default channels.</returns>
-    public async Task<IEnumerable<DefaultChannel>> GetDefaultChannelsAsync(string repository = null, string branch = null, string channel = null)
+    public async Task<IEnumerable<DefaultChannel>> GetDefaultChannelsAsync(string? repository = null, string? branch = null, string? channel = null)
     {
         IReadOnlyList<DefaultChannel> channels = await _barClient.DefaultChannels.ListAsync(repository: repository, branch: branch);
         if (!string.IsNullOrEmpty(channel))
@@ -102,10 +96,14 @@ public class BarApiClient : IBarApiClient
     /// <param name="channel">New channel</param>
     /// <param name="enabled">Enabled/disabled status</param>
     /// <returns>Async task</returns>
-    public async Task UpdateDefaultChannelAsync(int id, string repository = null, string branch = null,
-        string channel = null, bool? enabled = null)
+    public async Task UpdateDefaultChannelAsync(
+        int id,
+        string? repository = null,
+        string? branch = null,
+        string? channel = null,
+        bool? enabled = null)
     {
-        Channel foundChannel = null;
+        Channel? foundChannel = null;
         if (!string.IsNullOrEmpty(channel))
         {
             foundChannel = await GetChannel(channel);
@@ -299,7 +297,10 @@ public class BarApiClient : IBarApiClient
     /// <param name="targetRepo">Filter by the target repository of the subscription.</param>
     /// <param name="channelId">Filter by the source channel id of the subscription.</param>
     /// <returns>Set of subscription.</returns>
-    public async Task<IEnumerable<Subscription>> GetSubscriptionsAsync(string sourceRepo = null, string targetRepo = null, int? channelId = null)
+    public async Task<IEnumerable<Subscription>> GetSubscriptionsAsync(
+        string? sourceRepo = null,
+        string? targetRepo = null,
+        int? channelId = null)
     {
         return await _barClient.Subscriptions.ListSubscriptionsAsync(
             sourceRepository: sourceRepo,
@@ -377,7 +378,7 @@ public class BarApiClient : IBarApiClient
     /// <param name="repoUri">Optional repository</param>
     /// <param name="branch">Optional branch</param>
     /// <returns>List of repository+branch combos</returns>
-    public async Task<IEnumerable<RepositoryBranch>> GetRepositoriesAsync(string repoUri = null, string branch = null)
+    public async Task<IEnumerable<RepositoryBranch>> GetRepositoriesAsync(string? repoUri = null, string? branch = null)
     {
         return await _barClient.Repository.ListRepositoriesAsync(repository: repoUri, branch: branch);
     }
@@ -407,8 +408,9 @@ public class BarApiClient : IBarApiClient
     /// <param name="buildId">ID of build producing the asset</param>
     /// <param name="nonShipping">Only non-shipping</param>
     /// <returns>List of assets.</returns>
-    public async Task<IEnumerable<Asset>> GetAssetsAsync(string name = null,
-        string version = null,
+    public async Task<IEnumerable<Asset>> GetAssetsAsync(
+        string? name = null,
+        string? version = null,
         int? buildId = null,
         bool? nonShipping = null)
     {
@@ -458,7 +460,7 @@ public class BarApiClient : IBarApiClient
     /// </summary>
     /// <param name="channel">Channel name.</param>
     /// <returns>Channel or null if not found.</returns>
-    public async Task<Channel> GetChannelAsync(string channel)
+    public async Task<Channel?> GetChannelAsync(string channel)
     {
         return (await _barClient.Channels.ListChannelsAsync())
             .FirstOrDefault(c => c.Name.Equals(channel, StringComparison.OrdinalIgnoreCase));
@@ -469,7 +471,7 @@ public class BarApiClient : IBarApiClient
     /// </summary>
     /// <param name="channel">Channel id.</param>
     /// <returns>Channel or null if not found.</returns>
-    public async Task<Channel> GetChannelAsync(int channel)
+    public async Task<Channel?> GetChannelAsync(int channel)
     {
         try
         {
@@ -486,7 +488,7 @@ public class BarApiClient : IBarApiClient
     /// </summary>
     /// <param name="classification">Optional classification to get</param>
     /// <returns></returns>
-    public async Task<IEnumerable<Channel>> GetChannelsAsync(string classification = null)
+    public async Task<IEnumerable<Channel>> GetChannelsAsync(string? classification = null)
     {
         return await _barClient.Channels.ListChannelsAsync(classification);
     }
@@ -499,7 +501,7 @@ public class BarApiClient : IBarApiClient
     /// <returns>Latest build of <paramref name="repoUri"/> on channel <paramref name="channelId"/>,
     /// or null if there is no latest.</returns>
     /// <remarks>The build's assets are returned</remarks>
-    public async Task<Build> GetLatestBuildAsync(string repoUri, int channelId)
+    public async Task<Build?> GetLatestBuildAsync(string repoUri, int channelId)
     {
         try
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/IBarApiClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IBarApiClient.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace Microsoft.DotNet.DarcLib;
 
 /// <summary>
@@ -117,7 +118,7 @@ public interface IBarApiClient : IBasicBarClient
     /// </summary>
     /// <param name="channel">Channel name.</param>
     /// <returns>Channel or null if not found.</returns>
-    Task<Channel> GetChannelAsync(string channel);
+    Task<Channel?> GetChannelAsync(string channel);
 
     /// <summary>
     ///     Adds a default channel association.
@@ -144,7 +145,7 @@ public interface IBarApiClient : IBasicBarClient
     /// <param name="channel">New channel</param>
     /// <param name="enabled">Enabled/disabled status</param>
     /// <returns>Async task</returns>
-    Task UpdateDefaultChannelAsync(int id, string repository = null, string branch = null, string channel = null, bool? enabled = null);
+    Task UpdateDefaultChannelAsync(int id, string? repository = null, string? branch = null, string? channel = null, bool? enabled = null);
 
     /// <summary>
     ///     Create a new channel
@@ -166,7 +167,7 @@ public interface IBarApiClient : IBasicBarClient
     /// </summary>
     /// <param name="classification">Optional classification to get</param>
     /// <returns></returns>
-    Task<IEnumerable<Channel>> GetChannelsAsync(string classification = null);
+    Task<IEnumerable<Channel>> GetChannelsAsync(string? classification = null);
 
     #endregion
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalLibGit2Client.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalLibGit2Client.cs
@@ -32,7 +32,7 @@ public interface ILocalLibGit2Client : ILocalGitClient, IGitRepo
         string repoPath,
         string branchName,
         string remoteUrl,
-        Identity? identity = null);
+        LibGit2Sharp.Identity? identity = null);
 
     /// <summary>
     /// This function works around a couple common issues when checking out files in LibGit2Sharp.

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
@@ -328,9 +328,9 @@ public class LocalLibGit2Client : LocalGitClient, ILocalLibGit2Client
         string repoPath,
         string branchName,
         string remoteUrl,
-        Identity? identity = null)
+        LibGit2Sharp.Identity? identity = null)
     {
-        identity ??= new Identity(Constants.DarcBotName, Constants.DarcBotEmail);
+        identity ??= new LibGit2Sharp.Identity(Constants.DarcBotName, Constants.DarcBotEmail);
 
         using var repo = new Repository(
             repoPath,

--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/PcsConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/PcsConfiguration.cs
@@ -81,7 +81,7 @@ internal static class PcsConfiguration
 
             return string.IsNullOrEmpty(token)
                 ? MaestroApiFactory.GetAnonymous(uri)
-                : MaestroApiFactory.GetAuthenticated(uri, token, includeInteractive: false);
+                : MaestroApiFactory.GetAuthenticated(uri, token, disableInteractiveAuth: true);
         });
 
         if (initializeService)

--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/PcsConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/PcsConfiguration.cs
@@ -75,11 +75,13 @@ internal static class PcsConfiguration
             var config = s.GetRequiredService<IConfiguration>();
             var uri = config.GetValue<string>("Maestro:Uri")
                 ?? throw new Exception("Missing configuration key Maestro.Uri");
-            var managedIdentityId = config.GetValue<string>("ManagedIdentityClientId");
 
-            return !string.IsNullOrEmpty(managedIdentityId)
-                ? MaestroApiFactory.GetAuthenticated(uri, managedIdentityId)
-                : MaestroApiFactory.GetAnonymous(uri);
+            // TODO https://dev.azure.com/dnceng/internal/_workitems/edit/6451: Implement Maestro - PCS communication
+            var token = config.GetValue<string>("Maestro:Token");
+
+            return string.IsNullOrEmpty(token)
+                ? MaestroApiFactory.GetAnonymous(uri)
+                : MaestroApiFactory.GetAuthenticated(uri, token, includeInteractive: false);
         });
 
         if (initializeService)

--- a/src/ProductConstructionService/ProductConstructionService.Api/Program.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Program.cs
@@ -24,7 +24,7 @@ builder.ConfigurePcs(
     vmrPath: vmrPath,
     tmpPath: tmpPath,
     vmrUri: vmrUri,
-    credential: credential,
+    azureCredential: credential,
     keyVaultUri: new Uri($"https://{builder.Configuration.GetRequiredValue(PcsConfiguration.KeyVaultName)}.vault.azure.net/"),
     initializeService: !isDevelopment,
     addEndpointAuthentication: !isDevelopment,

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Development.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Development.json
@@ -18,8 +18,7 @@
         "QueueMessageInvisibilityTime": "00:05:00"
     },
     "Maestro": {
-        "Uri": "http://localhost:8088/",
-        "Token": ""
+        "Uri": "http://localhost:8088/"
     },
     "Kusto": {
         "Database": "engineeringdata",

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Development.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Development.json
@@ -18,7 +18,8 @@
         "QueueMessageInvisibilityTime": "00:05:00"
     },
     "Maestro": {
-        "Uri": "http://localhost:8088/"
+        "Uri": "http://localhost:8088/",
+        "Token": ""
     },
     "Kusto": {
         "Database": "engineeringdata",

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
@@ -6,7 +6,8 @@
     "ManagedIdentityClientId": "1f6e0054-8fec-4721-95b7-2a62a9938481",
     "VmrUri": "https://github.com/maestro-auth-test/dnceng-vmr",
     "Maestro": {
-        "Uri": "https://maestro.int-dot.net/"
+        "Uri": "https://maestro.int-dot.net/",
+        "Token": "[vault(product-construction-service-int-token)]"
     },
     "BuildAssetRegistrySqlConnectionString": "Data Source=tcp:maestro-int-server.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False; User Id=USER_ID_PLACEHOLDER",
     "Kusto": {

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
@@ -6,8 +6,7 @@
     "ManagedIdentityClientId": "1f6e0054-8fec-4721-95b7-2a62a9938481",
     "VmrUri": "https://github.com/maestro-auth-test/dnceng-vmr",
     "Maestro": {
-        "Uri": "https://maestro.int-dot.net/",
-        "Token": "[vault(product-construction-service-int-token)]"
+        "Uri": "https://maestro.int-dot.net/"
     },
     "BuildAssetRegistrySqlConnectionString": "Data Source=tcp:maestro-int-server.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False; User Id=USER_ID_PLACEHOLDER",
     "Kusto": {

--- a/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
+++ b/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
@@ -399,7 +399,6 @@ internal abstract class MaestroScenarioTestBase
         return TestHelpers.RunExecutableAsyncWithInput(_parameters.DarcExePath, input,
         [
             .. args,
-            "-p", _parameters.MaestroToken,
             "--bar-uri", _parameters.MaestroBaseUri,
             "--github-pat", _parameters.GitHubToken,
             "--azdev-pat", _parameters.AzDoToken,
@@ -411,7 +410,6 @@ internal abstract class MaestroScenarioTestBase
         return TestHelpers.RunExecutableAsync(_parameters.DarcExePath,
         [
             .. args,
-            "-p", _parameters.MaestroToken,
             "--bar-uri", _parameters.MaestroBaseUri,
             "--github-pat", _parameters.GitHubToken,
             "--azdev-pat", _parameters.AzDoToken,

--- a/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
+++ b/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
@@ -399,6 +399,7 @@ internal abstract class MaestroScenarioTestBase
         return TestHelpers.RunExecutableAsyncWithInput(_parameters.DarcExePath, input,
         [
             .. args,
+            "-p", _parameters.MaestroToken ?? string.Empty,
             "--bar-uri", _parameters.MaestroBaseUri,
             "--github-pat", _parameters.GitHubToken,
             "--azdev-pat", _parameters.AzDoToken,
@@ -410,6 +411,7 @@ internal abstract class MaestroScenarioTestBase
         return TestHelpers.RunExecutableAsync(_parameters.DarcExePath,
         [
             .. args,
+            "-p", _parameters.MaestroToken ?? string.Empty,
             "--bar-uri", _parameters.MaestroBaseUri,
             "--github-pat", _parameters.GitHubToken,
             "--azdev-pat", _parameters.AzDoToken,

--- a/test/Maestro.ScenarioTests/TestParameters.cs
+++ b/test/Maestro.ScenarioTests/TestParameters.cs
@@ -54,7 +54,7 @@ public class TestParameters : IDisposable
             ? maestroBaseUris.Last()
             : maestroBaseUris.First();
 
-        IMaestroApi maestroApi = MaestroApiFactory.GetAuthenticated(maestroBaseUri, accessToken: null, managedIdentityId: null);
+        IMaestroApi maestroApi = MaestroApiFactory.GetAuthenticated(maestroBaseUri, accessToken: null);
 
         string darcVersion = await maestroApi.Assets.GetDarcVersionAsync();
         string dotnetExe = await TestHelpers.Which("dotnet");

--- a/test/Maestro.ScenarioTests/TestParameters.cs
+++ b/test/Maestro.ScenarioTests/TestParameters.cs
@@ -54,7 +54,7 @@ public class TestParameters : IDisposable
             ? maestroBaseUris.Last()
             : maestroBaseUris.First();
 
-        IMaestroApi maestroApi = MaestroApiFactory.GetAuthenticated(maestroBaseUri, accessToken: null, includeInteractive: false);
+        IMaestroApi maestroApi = MaestroApiFactory.GetAuthenticated(maestroBaseUri, accessToken: null, disableInteractiveAuth: true);
 
         string darcVersion = await maestroApi.Assets.GetDarcVersionAsync();
         string dotnetExe = await TestHelpers.Which("dotnet");

--- a/test/Maestro.ScenarioTests/TestParameters.cs
+++ b/test/Maestro.ScenarioTests/TestParameters.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Configuration;
 using Octokit;
 using Octokit.Internal;
 
+#nullable enable
 namespace Maestro.ScenarioTests;
 
 public class TestParameters : IDisposable
@@ -21,7 +22,6 @@ public class TestParameters : IDisposable
     internal readonly TemporaryDirectory _dir;
 
     private static readonly string[] maestroBaseUris;
-    private static readonly string maestroToken;
     private static readonly string githubToken;
     private static readonly string darcPackageSource;
     private static readonly string azdoToken;
@@ -35,11 +35,13 @@ public class TestParameters : IDisposable
         maestroBaseUris = (Environment.GetEnvironmentVariable("MAESTRO_BASEURIS")
                 ?? userSecrets["MAESTRO_BASEURIS"]
                 ?? "https://maestro.int-dot.net")
-                .Split(',');
-        maestroToken = Environment.GetEnvironmentVariable("MAESTRO_TOKEN") ?? userSecrets["MAESTRO_TOKEN"];
-        githubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? userSecrets["GITHUB_TOKEN"];
-        darcPackageSource = Environment.GetEnvironmentVariable("DARC_PACKAGE_SOURCE");
-        azdoToken = Environment.GetEnvironmentVariable("AZDO_TOKEN") ?? userSecrets["AZDO_TOKEN"];
+            .Split(',');
+        githubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? userSecrets["GITHUB_TOKEN"]
+            ?? throw new Exception("Please configure the GitHub token");
+        darcPackageSource = Environment.GetEnvironmentVariable("DARC_PACKAGE_SOURCE")
+            ?? throw new Exception("Please configure the Darc package source");
+        azdoToken = Environment.GetEnvironmentVariable("AZDO_TOKEN") ?? userSecrets["AZDO_TOKEN"]
+            ?? throw new Exception("Please configure the Azure DevOps token");
     }
 
     /// <param name="useNonPrimaryEndpoint">If set to true, the test will attempt to use the non primary endpoint, if provided</param>
@@ -52,9 +54,7 @@ public class TestParameters : IDisposable
             ? maestroBaseUris.Last()
             : maestroBaseUris.First();
 
-        IMaestroApi maestroApi = maestroToken == null
-            ? ApiFactory.GetAnonymous(maestroBaseUri)
-            : ApiFactory.GetAuthenticated(maestroBaseUri, maestroToken);
+        IMaestroApi maestroApi = MaestroApiFactory.GetAuthenticated(maestroBaseUri);
 
         string darcVersion = await maestroApi.Assets.GetDarcVersionAsync();
         string dotnetExe = await TestHelpers.Which("dotnet");
@@ -66,11 +66,13 @@ public class TestParameters : IDisposable
             "--version", darcVersion,
             "Microsoft.DotNet.Darc",
         };
+
         if (!string.IsNullOrEmpty(darcPackageSource))
         {
             toolInstallArgs.Add("--add-source");
             toolInstallArgs.Add(darcPackageSource);
         }
+
         await TestHelpers.RunExecutableAsync(dotnetExe, [.. toolInstallArgs]);
 
         string darcExe = Path.Join(testDirSharedWrapper.Peek()!.Directory, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "darc.exe" : "darc");
@@ -83,17 +85,16 @@ public class TestParameters : IDisposable
         var azDoClient =
             new Microsoft.DotNet.DarcLib.AzureDevOpsClient(await TestHelpers.Which("git"), azdoToken, new NUnitLogger(), testDirSharedWrapper.TryTake()!.Directory);
 
-        return new TestParameters(darcExe, await TestHelpers.Which("git"), maestroBaseUri, maestroToken!, githubToken, maestroApi, githubApi, azDoClient, testDir, azdoToken);
+        return new TestParameters(darcExe, await TestHelpers.Which("git"), maestroBaseUri, githubToken, maestroApi, githubApi, azDoClient, testDir, azdoToken);
     }
 
-    private TestParameters(string darcExePath, string gitExePath, string maestroBaseUri, string maestroToken, string gitHubToken,
+    private TestParameters(string darcExePath, string gitExePath, string maestroBaseUri, string gitHubToken,
         IMaestroApi maestroApi, GitHubClient gitHubApi, Microsoft.DotNet.DarcLib.AzureDevOpsClient azdoClient, TemporaryDirectory dir, string azdoToken)
     {
         _dir = dir;
         DarcExePath = darcExePath;
         GitExePath = gitExePath;
         MaestroBaseUri = maestroBaseUri;
-        MaestroToken = maestroToken;
         GitHubToken = gitHubToken;
         MaestroApi = maestroApi;
         GitHubApi = gitHubApi;
@@ -110,8 +111,6 @@ public class TestParameters : IDisposable
     public string GitHubTestOrg { get; } = "maestro-auth-test";
 
     public string MaestroBaseUri { get; }
-
-    public string MaestroToken { get; }
 
     public string GitHubToken { get; }
 

--- a/test/Maestro.ScenarioTests/TestParameters.cs
+++ b/test/Maestro.ScenarioTests/TestParameters.cs
@@ -54,7 +54,7 @@ public class TestParameters : IDisposable
             ? maestroBaseUris.Last()
             : maestroBaseUris.First();
 
-        IMaestroApi maestroApi = MaestroApiFactory.GetAuthenticated(maestroBaseUri, accessToken: null);
+        IMaestroApi maestroApi = MaestroApiFactory.GetAuthenticated(maestroBaseUri, accessToken: null, includeInteractive: false);
 
         string darcVersion = await maestroApi.Assets.GetDarcVersionAsync();
         string dotnetExe = await TestHelpers.Which("dotnet");

--- a/test/Maestro.ScenarioTests/TestParameters.cs
+++ b/test/Maestro.ScenarioTests/TestParameters.cs
@@ -54,7 +54,7 @@ public class TestParameters : IDisposable
             ? maestroBaseUris.Last()
             : maestroBaseUris.First();
 
-        IMaestroApi maestroApi = MaestroApiFactory.GetAuthenticated(maestroBaseUri);
+        IMaestroApi maestroApi = MaestroApiFactory.GetAuthenticated(maestroBaseUri, accessToken: null, managedIdentityId: null);
 
         string darcVersion = await maestroApi.Assets.GetDarcVersionAsync();
         string dotnetExe = await TestHelpers.Which("dotnet");

--- a/test/Maestro.ScenarioTests/TestParameters.cs
+++ b/test/Maestro.ScenarioTests/TestParameters.cs
@@ -22,6 +22,7 @@ public class TestParameters : IDisposable
     internal readonly TemporaryDirectory _dir;
 
     private static readonly string[] maestroBaseUris;
+    private static readonly string? maestroToken;
     private static readonly string githubToken;
     private static readonly string darcPackageSource;
     private static readonly string azdoToken;
@@ -36,6 +37,7 @@ public class TestParameters : IDisposable
                 ?? userSecrets["MAESTRO_BASEURIS"]
                 ?? "https://maestro.int-dot.net")
             .Split(',');
+        maestroToken = Environment.GetEnvironmentVariable("MAESTRO_TOKEN") ?? userSecrets["MAESTRO_TOKEN"];
         githubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? userSecrets["GITHUB_TOKEN"]
             ?? throw new Exception("Please configure the GitHub token");
         darcPackageSource = Environment.GetEnvironmentVariable("DARC_PACKAGE_SOURCE")
@@ -54,7 +56,7 @@ public class TestParameters : IDisposable
             ? maestroBaseUris.Last()
             : maestroBaseUris.First();
 
-        IMaestroApi maestroApi = MaestroApiFactory.GetAuthenticated(maestroBaseUri, accessToken: null, disableInteractiveAuth: true);
+        IMaestroApi maestroApi = MaestroApiFactory.GetAuthenticated(maestroBaseUri, maestroToken, disableInteractiveAuth: true);
 
         string darcVersion = await maestroApi.Assets.GetDarcVersionAsync();
         string dotnetExe = await TestHelpers.Which("dotnet");
@@ -85,16 +87,17 @@ public class TestParameters : IDisposable
         var azDoClient =
             new Microsoft.DotNet.DarcLib.AzureDevOpsClient(await TestHelpers.Which("git"), azdoToken, new NUnitLogger(), testDirSharedWrapper.TryTake()!.Directory);
 
-        return new TestParameters(darcExe, await TestHelpers.Which("git"), maestroBaseUri, githubToken, maestroApi, githubApi, azDoClient, testDir, azdoToken);
+        return new TestParameters(darcExe, await TestHelpers.Which("git"), maestroBaseUri, maestroToken!, githubToken, maestroApi, githubApi, azDoClient, testDir, azdoToken);
     }
 
-    private TestParameters(string darcExePath, string gitExePath, string maestroBaseUri, string gitHubToken,
+    private TestParameters(string darcExePath, string gitExePath, string maestroBaseUri, string maestroToken, string gitHubToken,
         IMaestroApi maestroApi, GitHubClient gitHubApi, Microsoft.DotNet.DarcLib.AzureDevOpsClient azdoClient, TemporaryDirectory dir, string azdoToken)
     {
         _dir = dir;
         DarcExePath = darcExePath;
         GitExePath = gitExePath;
         MaestroBaseUri = maestroBaseUri;
+        MaestroToken = maestroToken;
         GitHubToken = gitHubToken;
         MaestroApi = maestroApi;
         GitHubApi = gitHubApi;
@@ -111,6 +114,8 @@ public class TestParameters : IDisposable
     public string GitHubTestOrg { get; } = "maestro-auth-test";
 
     public string MaestroBaseUri { get; }
+
+    public string MaestroToken { get; }
 
     public string GitHubToken { get; }
 

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -82,7 +82,7 @@ internal abstract class VmrTestsBase
     protected virtual IServiceCollection CreateServiceProvider() => new ServiceCollection()
         .AddLogging(b => b.AddConsole().AddFilter(l => l >= LogLevel.Debug))
         .AddVmrManagers("git", VmrPath, TmpPath, null, null)
-        .AddSingleton<IBasicBarClient>(new BarApiClient(MaestroApi.StagingBuildAssetRegistryBaseUri, includeInteractiveAuth: false));
+        .AddSingleton<IBasicBarClient>(new BarApiClient(MaestroApi.StagingBuildAssetRegistryBaseUri, disableInteractiveAuth: true));
 
     protected static List<NativePath> GetExpectedFilesInVmr(
         NativePath vmrPath,

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -15,6 +15,7 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
@@ -81,7 +82,7 @@ internal abstract class VmrTestsBase
     protected virtual IServiceCollection CreateServiceProvider() => new ServiceCollection()
         .AddLogging(b => b.AddConsole().AddFilter(l => l >= LogLevel.Debug))
         .AddVmrManagers("git", VmrPath, TmpPath, null, null)
-        .AddSingleton<IBasicBarClient>(new BarApiClient(buildAssetRegistryPat: null));
+        .AddSingleton<IBasicBarClient>(new BarApiClient(MaestroApi.StagingBuildAssetRegistryBaseUri));
 
     protected static List<NativePath> GetExpectedFilesInVmr(
         NativePath vmrPath,

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -82,7 +82,7 @@ internal abstract class VmrTestsBase
     protected virtual IServiceCollection CreateServiceProvider() => new ServiceCollection()
         .AddLogging(b => b.AddConsole().AddFilter(l => l >= LogLevel.Debug))
         .AddVmrManagers("git", VmrPath, TmpPath, null, null)
-        .AddSingleton<IBasicBarClient>(new BarApiClient(MaestroApi.StagingBuildAssetRegistryBaseUri));
+        .AddSingleton<IBasicBarClient>(new BarApiClient(MaestroApi.StagingBuildAssetRegistryBaseUri, includeInteractiveAuth: false));
 
     protected static List<NativePath> GetExpectedFilesInVmr(
         NativePath vmrPath,

--- a/test/ProductConstructionService.Api.Tests/DependencyRegistrationTests.cs
+++ b/test/ProductConstructionService.Api.Tests/DependencyRegistrationTests.cs
@@ -37,7 +37,7 @@ public class DependencyRegistrationTests
             vmrPath: _vmrPath,
             tmpPath: _tmpPath,
             vmrUri: _vmrUri,
-            credential: credential,
+            azureCredential: credential,
             initializeService: true,
             addEndpointAuthentication: true,
             addSwagger: true);


### PR DESCRIPTION
This makes the `-p` argument optional.
- If provided, will use it in the auth header
- If omitted, will try to authenticate using the browser auth flow using the `InteractiveBrowserCredential`
- If omitted and `--disable-interactive-auth` argument provided, will use `AzureCliCredential`

https://github.com/dotnet/dnceng/issues/2694

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
`darc` does not require BAR password anymore and support interactive sign-in