### PR TITLE
Fix Maestro API credential factory

### DIFF
--- a/src/Maestro/Client/src/MaestroApiOptions.cs
+++ b/src/Maestro/Client/src/MaestroApiOptions.cs
@@ -19,9 +19,7 @@ namespace Microsoft.DotNet.Maestro.Client
         public MaestroApiOptions(string baseUri, string accessToken, bool disableInteractiveAuth)
             : this(
                   new Uri(baseUri),
-                  string.IsNullOrEmpty(accessToken)
-                    ? MaestroApi.CreateApiCredential(baseUri, disableInteractiveAuth, accessToken)
-                    : null)
+                  MaestroApi.CreateApiCredential(baseUri, disableInteractiveAuth, accessToken))
         {
         }
 


### PR DESCRIPTION
The credential needs to recieve the `null` token instead and decide based on that. Otherwise it would act as an anonymous (no-credential) API client.


<!-- https://github.com/dotnet/arcade-services/issues/3577 -->

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes