### PR TITLE
Fix PAT initialization when no local dark settings

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
@@ -79,15 +79,15 @@ internal class LocalSettings
             logger.LogWarning(e, $"Failed to load the darc settings file, may be corrupted");
         }
 
-        static string UseOption(string option, string localSetting)
+        static string PreferOptionToSetting(string option, string localSetting)
         {
             return !string.IsNullOrEmpty(option) ? option : localSetting;
         }
 
         // Prefer the command line options over the settings file
-        localSettings.AzureDevOpsToken = UseOption(options.AzureDevOpsPat, localSettings.AzureDevOpsToken);
-        localSettings.GitHubToken = UseOption(options.GitHubPat, localSettings.GitHubToken);
-        localSettings.BuildAssetRegistryToken = UseOption(options.BuildAssetRegistryToken, localSettings.BuildAssetRegistryToken);
+        localSettings.AzureDevOpsToken = PreferOptionToSetting(options.AzureDevOpsPat, localSettings.AzureDevOpsToken);
+        localSettings.GitHubToken = PreferOptionToSetting(options.GitHubPat, localSettings.GitHubToken);
+        localSettings.BuildAssetRegistryToken = PreferOptionToSetting(options.BuildAssetRegistryToken, localSettings.BuildAssetRegistryToken);
         localSettings.BuildAssetRegistryBaseUri = options.BuildAssetRegistryBaseUri
             ?? localSettings.BuildAssetRegistryBaseUri
             ?? MaestroApi.ProductionBuildAssetRegistryBaseUri;

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
@@ -45,7 +45,7 @@ internal class RemoteFactory : IRemoteFactory
 
     private static IRemoteGitRepo GetRemoteGitClient(ICommandLineOptions options, string repoUrl, ILogger logger)
     {
-        var darcSettings = LocalSettings.GetSettings(options, logger, repoUrl);
+        var darcSettings = LocalSettings.GetSettings(options, logger);
 
         string temporaryRepositoryRoot = Path.GetTempPath();
 

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
@@ -213,7 +213,7 @@ internal class AddBuildToChannelOperation : Operation
             return Constants.SuccessCode;
         }
 
-        LocalSettings localSettings = LocalSettings.LoadSettingsFile(_options);
+        LocalSettings localSettings = LocalSettings.GetSettings(_options, Logger);
         _options.AzureDevOpsPat = (string.IsNullOrEmpty(_options.AzureDevOpsPat)) ? localSettings.AzureDevOpsToken : _options.AzureDevOpsPat;
 
         if (string.IsNullOrEmpty(_options.AzureDevOpsPat))

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GatherDropOperation.cs
@@ -1074,7 +1074,7 @@ internal class GatherDropOperation : Operation
 
         if (string.IsNullOrEmpty(_options.AzureDevOpsPat))
         {
-            var localSettings = LocalSettings.LoadSettingsFile(_options);
+            var localSettings = LocalSettings.GetSettings(_options, Logger);
             _options.AzureDevOpsPat = localSettings.AzureDevOpsToken;
         }
 

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrCommandLineOptionsBase.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrCommandLineOptionsBase.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 #nullable enable
 namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
@@ -25,11 +26,13 @@ internal abstract class VmrCommandLineOptionsBase : CommandLineOptions
         var gitHubToken = GitHubPat;
         var azureDevOpsToken = AzureDevOpsPat;
 
+        // Read tokens from local settings if not provided
+        // We silence errors because the VMR synchronization often works with public repositories where tokens are not required
         if (gitHubToken == null || azureDevOpsToken == null)
         {
             try
             {
-                localDarcSettings = LocalSettings.LoadSettingsFile(this);
+                localDarcSettings = LocalSettings.GetSettings(this, NullLogger.Instance);
             }
             catch (DarcException)
             {


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/dotnet/arcade-services/issues/3561 where we no longer use the PATs provided in arguments if no local darc settings file was found.


<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes