### PR TITLE
Add the `darc get-channel` command

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetChannelOperation.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Darc.Operations;
+
+internal class GetChannelOperation : Operation
+{
+    private readonly GetChannelCommandLineOptions _options;
+    public GetChannelOperation(GetChannelCommandLineOptions options)
+        : base(options)
+    {
+        _options = options;
+    }
+
+    /// <summary>
+    /// Retrieve information about a specific channel
+    /// </summary>
+    /// <param name="options">Command line options</param>
+    /// <returns>Process exit code.</returns>
+    public override async Task<int> ExecuteAsync()
+    {
+        try
+        {
+            IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
+
+            var channel = await barClient.GetChannelAsync(_options.Id);
+
+            if (channel == null)
+            {
+                Logger.LogError("Channel with id {channelId} not found", _options.Id);
+                return Constants.ErrorCode;
+            }
+
+            switch (_options.OutputFormat)
+            {
+                case DarcOutputType.json:
+                    Console.WriteLine(JsonConvert.SerializeObject(channel, Formatting.Indented));
+                    break;
+                case DarcOutputType.text:
+                    Console.WriteLine($"({channel.Id}) {channel.Name}");
+                    break;
+                default:
+                    throw new NotImplementedException($"Output format {_options.OutputFormat} not supported for get-channel");
+            }
+
+            return Constants.SuccessCode;
+        }
+        catch (AuthenticationException e)
+        {
+            Console.WriteLine(e.Message);
+            return Constants.ErrorCode;
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, "Error: Failed to retrieve the channel");
+            return Constants.ErrorCode;
+        }
+    }
+
+    protected override bool IsOutputFormatSupported(DarcOutputType outputFormat)
+        => outputFormat switch
+        {
+            DarcOutputType.json => true,
+            _ => base.IsOutputFormatSupported(outputFormat),
+        };
+}

--- a/src/Microsoft.DotNet.Darc/Darc/Options/GetChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/GetChannelCommandLineOptions.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using CommandLine;
+using Microsoft.DotNet.Darc.Operations;
+
+namespace Microsoft.DotNet.Darc.Options;
+
+[Verb("get-channel", HelpText = "Get a specific channel.")]
+internal class GetChannelCommandLineOptions : CommandLineOptions
+{
+    [Option("id", Required = true, HelpText = "ID of the channel to show.")]
+    public int Id { get; set; }
+
+    public override Operation GetOperation()
+    {
+        return new GetChannelOperation(this);
+    }
+}

--- a/src/Microsoft.DotNet.Darc/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Program.cs
@@ -87,6 +87,7 @@ internal static class Program
         typeof(GatherDropCommandLineOptions),
         typeof(GetAssetCommandLineOptions),
         typeof(GetBuildCommandLineOptions),
+        typeof(GetChannelCommandLineOptions),
         typeof(GetChannelsCommandLineOptions),
         typeof(GetDefaultChannelsCommandLineOptions),
         typeof(GetDependenciesCommandLineOptions),


### PR DESCRIPTION
This will be required the replace the PowerShell version of the command from https://github.com/dotnet/arcade/blob/2c08708d18855f2e2779ac5d0623a5978751c4f3/eng/common/post-build/post-build-utils.ps1#L23-L31


<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Added the `darc get-channel` command