### PR TITLE
Run E2E scenario tests in parallel

### DIFF
--- a/test/Maestro.ScenarioTests/ScenarioTests_Builds.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Builds.cs
@@ -13,6 +13,7 @@ namespace Maestro.ScenarioTests;
 
 [TestFixture]
 [Category("PostDeployment")]
+[Parallelizable]
 internal class ScenarioTests_Builds : MaestroScenarioTestBase
 {
     private string _repoUrl;

--- a/test/Maestro.ScenarioTests/ScenarioTests_Channels.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Channels.cs
@@ -10,6 +10,7 @@ namespace Maestro.ScenarioTests;
 
 [TestFixture]
 [Category("PostDeployment")]
+[Parallelizable]
 internal class ScenarioTests_Channels : MaestroScenarioTestBase
 {
     private TestParameters _parameters;

--- a/test/Maestro.ScenarioTests/ScenarioTests_DefaultChannels.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_DefaultChannels.cs
@@ -10,6 +10,7 @@ namespace Maestro.ScenarioTests;
 
 [TestFixture]
 [Category("PostDeployment")]
+[Parallelizable]
 internal class ScenarioTests_DefaultChannels : MaestroScenarioTestBase
 {
     private readonly string _repoName = TestRepository.TestRepo1Name;

--- a/test/Maestro.ScenarioTests/ScenarioTests_Dependencies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Dependencies.cs
@@ -15,6 +15,7 @@ namespace Maestro.ScenarioTests;
 
 [TestFixture]
 [Category("PostDeployment")]
+[Parallelizable]
 internal class ScenarioTests_Dependencies : MaestroScenarioTestBase
 {
 

--- a/test/Maestro.ScenarioTests/ScenarioTests_GitHubFlow.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_GitHubFlow.cs
@@ -16,6 +16,7 @@ namespace Maestro.ScenarioTests;
 [TestFixture]
 [NonParallelizable]
 [Category("PostDeployment")]
+[Parallelizable]
 internal class ScenarioTests_GitHubFlow : MaestroScenarioTestBase
 {
     private readonly IImmutableList<AssetData> _source1Assets;

--- a/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_MergePolicies.cs
@@ -14,6 +14,7 @@ namespace Maestro.ScenarioTests;
 
 [TestFixture]
 [Category("PostDeployment")]
+[Parallelizable]
 internal class ScenarioTests_MergePolicies : MaestroScenarioTestBase
 {
     private TestParameters _parameters;

--- a/test/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_RepoPolicies.cs
@@ -11,6 +11,7 @@ namespace Maestro.ScenarioTests;
 
 [TestFixture]
 [Category("PostDeployment")]
+[Parallelizable]
 internal class ScenarioTests_RepoPolicies : MaestroScenarioTestBase
 {
     // The RepoPolicies logic does a partial string match for the branch name in the base,

--- a/test/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
@@ -15,6 +15,7 @@ namespace Maestro.ScenarioTests;
 
 [TestFixture]
 [Category("PostDeployment")]
+[Parallelizable]
 internal class ScenarioTests_SdkUpdate : MaestroScenarioTestBase
 {
     private TestParameters _parameters;

--- a/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_Subscriptions.cs
@@ -15,6 +15,7 @@ namespace Maestro.ScenarioTests;
 
 [TestFixture]
 [Category("PostDeployment")]
+[Parallelizable]
 internal class ScenarioTests_Subscriptions : MaestroScenarioTestBase
 {
     private TestParameters _parameters;


### PR DESCRIPTION
Let's try speeding up the E2E tests. Some tests are already marked as non-parallelizable

<!--https://github.com/dotnet/arcade-services/issues/3595-->

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes