### PR TITLE
Enable printing full build info in `darc get-build`

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetBuildOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetBuildOperation.cs
@@ -90,8 +90,17 @@ internal class GetBuildOperation : Operation
                     }
                     break;
                 case DarcOutputType.json:
-                    Console.WriteLine(JsonConvert.SerializeObject(
-                        matchingBuilds.Select(build => UxHelpers.GetJsonBuildDescription(build)), Formatting.Indented));
+                    object objectToSerialize;
+                    if (_options.ExtendedDetails)
+                    {
+                        objectToSerialize = matchingBuilds;
+                    }
+                    else
+                    {
+                        objectToSerialize = matchingBuilds.Select(UxHelpers.GetJsonBuildDescription);
+                    }
+
+                    Console.WriteLine(JsonConvert.SerializeObject(objectToSerialize, Formatting.Indented));
                     break;
                 default:
                     throw new NotImplementedException($"Output format type {_options.OutputFormat} not yet supported for get-build.");

--- a/src/Microsoft.DotNet.Darc/Darc/Options/GetBuildCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/GetBuildCommandLineOptions.cs
@@ -20,6 +20,9 @@ internal class GetBuildCommandLineOptions : CommandLineOptions
     [RedactFromLogging]
     public string Commit { get; set; }
 
+    [Option("extended", HelpText = "Show all available fields (applies to JSON output-format only)")]
+    public bool ExtendedDetails { get; set; }
+
     public override Operation GetOperation()
     {
         return new GetBuildOperation(this);


### PR DESCRIPTION
Our infra relies on custom HTTP calls to Maestro API which provides this information but `darc` only offers a slice of that. This PR makes it possible to print everything.

We will need this for https://dev.azure.com/dnceng/internal/_workitems/edit/6478

<!-- https://github.com/dotnet/arcade-services/issues/3598 -->

### Release Note Category
- [x] Feature changes/additions 
- [ ] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Allowed printing full build info in `darc get-build`