### PR TITLE
Make test `ArcadeSdkUpdate` non-parallizable

### DIFF
--- a/test/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
@@ -15,7 +15,7 @@ namespace Maestro.ScenarioTests;
 
 [TestFixture]
 [Category("PostDeployment")]
-[Parallelizable]
+[NonParallelizable]
 internal class ScenarioTests_SdkUpdate : MaestroScenarioTestBase
 {
     private TestParameters _parameters;


### PR DESCRIPTION
In https://github.com/dotnet/arcade-services/issues/3595, we made teste parallizable and this test started to fail.

<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes