### PR TITLE
Make test fixtures run in parallel

### DIFF
--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -148,6 +148,7 @@ stages:
         testAssemblyVer2: |
           Maestro.ScenarioTests.dll
         searchFolder: $(Pipeline.Workspace)/Maestro.ScenarioTests
+        runInParallel: true
       env:
         MAESTRO_BASEURIS: ${{ parameters.MaestroTestEndpoints }}
         MAESTRO_TOKEN: $(scenario-test-maestro-token)

--- a/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
+++ b/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
@@ -22,6 +22,8 @@ using NuGet.Configuration;
 using NUnit.Framework;
 using Octokit;
 
+[assembly: Parallelizable(ParallelScope.Fixtures)]
+
 #nullable enable
 namespace Maestro.ScenarioTests;
 


### PR DESCRIPTION
In https://github.com/dotnet/arcade-services/issues/3595, we made teste parallizable but they still don't run in parallel
<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes