### PR TITLE
Fix multiple PR notifications getting posted to PRs

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestPolicyFailureNotifier.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestPolicyFailureNotifier.cs
@@ -116,7 +116,17 @@ public class PullRequestPolicyFailureNotifier : IPullRequestPolicyFailureNotifie
 - If you're being tagged in this comment it is due to an entry in the related Maestro Subscription of the Build Asset Registry.  If you feel this entry has added your GitHub login or your GitHub team in error, please update the subscription to reflect this.
 - For more details, please read [the Arcade Darc documentation](https://github.com/dotnet/arcade/blob/main/Documentation/Darc.md#update-subscription)
 ";
-        await gitHubClient.Issue.Comment.Create(owner, repo, prIssueId, sourceRepoNotificationComment);
-        pr.SourceRepoNotified = true;
+        try
+        {
+            await gitHubClient.Issue.Comment.Create(owner, repo, prIssueId, sourceRepoNotificationComment);
+            pr.SourceRepoNotified = true;
+        }
+        catch (OverflowException)
+        {
+            // There is a bug in Octokit that causes an overflow exception when the comment ID is > int.MaxValue
+            // The comment gets posted but we can't serialize the response and we do not note down that we've notified the source repo
+            // https://github.com/dotnet/arcade-services/issues/3601
+            pr.SourceRepoNotified = true;
+        }
     }
 }


### PR DESCRIPTION
As reported in https://github.com/dotnet/arcade-services/issues/3601, multiple comments get posted when a build check fails.
This happens because a bug within the GitHub Octokit library cannot parse the ID of the created comment and we never note down that we have created the comment.


### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Fixed a problem were Maestro kept notifying repo owners about a failed check