### PR TITLE
Do not log an exception when PR branch no longer exists

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -507,9 +507,9 @@ namespace SubscriptionActorService
                         _logger.LogInformation("Trying to clean up the branch for Pull Request {url}", prUrl);
                         await remote.DeletePullRequestBranchAsync(prUrl);
                     }
-                    catch (DarcException e)
+                    catch (DarcException)
                     {
-                        _logger.LogInformation(e, "Failed to delete branch associated with Pull Request {url}", prUrl);
+                        _logger.LogInformation("Failed to delete branch associated with Pull Request {url}", prUrl);
                     }
 
                     return ActionResult.Create(SynchronizePullRequestResult.Completed, $"PR has been manually {status}");


### PR DESCRIPTION
This will then stop showing in exceptions because it is handled correctly and not a problem in the service.
Currently the most frequent exception.

<!--  -->


<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Skip in release notes