### PR TITLE
Support old BAR password in local settings

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
@@ -91,6 +91,7 @@ internal class LocalSettings
 
         if (string.IsNullOrEmpty(localSettings.BuildAssetRegistryToken))
         {
+            // Old way of storing the settings had the password and not the token
             localSettings.BuildAssetRegistryToken = localSettings.BuildAssetRegistryPassword;
         }
 

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
@@ -18,6 +18,7 @@ internal class LocalSettings
 {
     public string BuildAssetRegistryToken { get; set; }
 
+    // Old way of storing the settings had the password and not the token so we keep both to deserialize these correctly.
     public string BuildAssetRegistryPassword { get; set; }
 
     public string GitHubToken { get; set; }

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
@@ -18,6 +18,8 @@ internal class LocalSettings
 {
     public string BuildAssetRegistryToken { get; set; }
 
+    public string BuildAssetRegistryPassword { get; set; }
+
     public string GitHubToken { get; set; }
 
     public string AzureDevOpsToken { get; set; }
@@ -85,6 +87,11 @@ internal class LocalSettings
         static string PreferOptionToSetting(string option, string localSetting)
         {
             return !string.IsNullOrEmpty(option) ? option : localSetting;
+        }
+
+        if (string.IsNullOrEmpty(localSettings.BuildAssetRegistryToken))
+        {
+            localSettings.BuildAssetRegistryToken = localSettings.BuildAssetRegistryPassword;
         }
 
         // Prefer the command line options over the settings file


### PR DESCRIPTION
This fixes a problem where people's old local settings had the old name serialized.

<!-- https://github.com/dotnet/arcade-services/issues/3621 -->

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Fixed a problem where `darc` forgot the BAR password