### PR TITLE
Fix GitHub check updates

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
@@ -472,7 +472,7 @@ public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
         }
         foreach (var updatedCheckRun in toBeUpdated)
         {                
-            MergePolicyEvaluationResult eval = evaluations.Single(e => updatedCheckRun.ExternalId == CheckRunId(e, prSha));
+            MergePolicyEvaluationResult eval = evaluations.Last(e => updatedCheckRun.ExternalId == CheckRunId(e, prSha));
             CheckRunUpdate newCheckRunUpdateValidation = CheckRunForUpdate(eval);
             await Client.Check.Run.Update(owner, repo, updatedCheckRun.Id, newCheckRunUpdateValidation);
         }


### PR DESCRIPTION
We see a large amount of exceptions where the check does not get updated because it finds more than one check with the given ID

```
System.InvalidOperationException:
   at System.Linq.ThrowHelper.ThrowMoreThanOneMatchException (System.Linq, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at System.Linq.Enumerable.TryGetSingle (System.Linq, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at Microsoft.DotNet.DarcLib.GitHubClient+<CreateOrUpdatePullRequestMergeStatusInfoAsync>d__34.MoveNext (Microsoft.DotNet.DarcLib, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null: /_/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs:475)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at SubscriptionActorService.PullRequestActorImplementation+<CheckMergePolicyAsync>d__29.MoveNext (SubscriptionActorService, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null: /_/src/Maestro/SubscriptionActorService/PullRequestActor.cs:575)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at SubscriptionActorService.PullRequestActorImplementation+<SynchronizePullRequestAsync>d__28.MoveNext (SubscriptionActorService, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null: /_/src/Maestro/SubscriptionActorService/PullRequestActor.cs:520)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at SubscriptionActorService.ActionRunner+<InvokeAction>d__11`1.MoveNext (SubscriptionActorService, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null: /_/src/Maestro/SubscriptionActorService/ActionRunner/ActionRunner.cs:124)
```
<!-- https://github.com/dotnet/arcade-services/issues/3622 -->


<!-- Potentially also include release notes in the PR directly -->

### Release Note Category
- [ ] Feature changes/additions 
- [x] Bug fixes
- [ ] Internal Infrastructure Improvements

### Release Note Description
Fixed a problem where GitHub checks are not updated by Maestro