### PR TITLE
Stop requiring rollout notes in PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,1 @@
-<!-- Link the issue this pull request is resolving below. Please copy and paste the link rather than using the dotnet/arcade# syntax -->
-
-
-<!-- Potentially also include release notes in the PR directly -->
-
-### Release Note Category
-- [ ] Feature changes/additions 
-- [ ] Bug fixes
-- [ ] Internal Infrastructure Improvements
-
-### Release Note Description
+<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

--- a/eng/enforce-issue.ps1
+++ b/eng/enforce-issue.ps1
@@ -6,10 +6,6 @@ param (
 	$RepositoryName
 )
 
-function HasReleaseNotes($description) {
-	return $description -Match "### Release Note Description(?:\r?\n)+([^\s]+)"
-}
-
 $prDetail = Invoke-WebRequest `
 		-UseBasicParsing `
 		-Uri "https://api.github.com/repos/$RepositoryName/pulls/$PullRequestNumber" `
@@ -39,35 +35,4 @@ if (-not $hasIssue) {
 	}
 }
 
-if (HasReleaseNotes $prDetail.body) {
-	Write-Host "PR has release notes in the description. Check passed."
-	exit 0
-}
-
-
-try {
-	$issueDetail = Invoke-WebRequest `
-		-UseBasicParsing `
-		-Uri "https://api.github.com/repos/dotnet/$($matches[1])/issues/$($matches[2])" `
-	| ConvertFrom-Json
-}
-catch {
-	Write-Host "##vso[task.LogIssue type=error;]Error fetching issue dotnet/$($matches[1])#$($matches[2]) from arcade. Does it exist?"
-	exit 1
-}
-
-if (HasReleaseNotes $issueDetail.body) {
-	Write-Host "PR links a GitHub issue with release notes. Check passed."
-	exit 0
-}
-
-$issueIsAzdoMirror = $issueDetail.title -like "AzDO Issue*"
-if ($issueIsAzdoMirror) {
-	Write-Host "##vso[task.LogIssue type=warning;]Linked GitHub issue is a mirrored Azure DevOps workitem. Please ensure the workitem has release notes in it."
-	exit 0
-}
-
-Write-Host "##vso[task.LogIssue type=error;]Linked GitHub issue does not have release notes. Check failed."
-Write-Host "Ensure your issue has release notes. They should be in the following format:`n`n### Release Note Description`n<Stick your notes here>`n"
-Write-Host "For more information, see https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/983/ReleaseNotesGuidance?anchor=mechanics"
-exit 1
+exit 0


### PR DESCRIPTION
We will use the GitHub release notes (https://github.com/dotnet/arcade-services/issues/3633)
