### PR TITLE
Fixup darc command used for auth test

### DIFF
--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -197,11 +197,11 @@ stages:
     - powershell:
         az login --service-principal -u "$(GetAuthInfo.ServicePrincipalId)" --federated-token "$(GetAuthInfo.FederatedToken)" --tenant "$(GetAuthInfo.TenantId)" --allow-no-subscriptions 
         
-        .\darc\darc.exe get-subscriptions --ci --source-enabled true --bar-uri "$(GetAuthInfo.BarUri)" --debug
+        .\darc\darc.exe get-default-channels --source-repo arcade-services --ci --bar-uri "$(GetAuthInfo.BarUri)" --debug
       displayName: Test Azure CLI authentication
 
     - powershell:
-        .\darc\darc.exe get-subscriptions -t "$(GetAuthInfo.FederatedToken)" --source-enabled true --bar-uri "$(GetAuthInfo.BarUri)" --debug
+        .\darc\darc.exe get-default-channels --source-repo arcade-services -t "$(GetAuthInfo.FederatedToken)" --bar-uri "$(GetAuthInfo.BarUri)" --debug
       displayName: Test Federated token authentication
 
     - task: VSTest@2


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Discovered during first attempt of https://dev.azure.com/dnceng/internal/_build/results?buildId=2476622&view=logs&j=4d9f00d7-d155-5977-7b70-2e6b79720ff2&t=291400ad-67fd-572f-5af0-43735534953d

Use a different darc command for testing authentication as prod Maestro did not have any source-enabled subscriptions.