### PR TITLE
Make local darc settings available in DI

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/LocalSettings.cs
@@ -81,7 +81,7 @@ internal class LocalSettings
         {
             if (!options.IsCi && options.OutputFormat != DarcOutputType.json)
             {
-                logger.LogWarning(e, $"Failed to load the darc settings file, may be corrupted");
+                logger.LogInformation(e, $"Failed to load the darc settings file, may be corrupted");
             }
         }
 

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
@@ -26,15 +26,12 @@ internal class RemoteFactory : IRemoteFactory
     }
 
     public static IBarApiClient GetBarClient(ICommandLineOptions options, ILogger logger)
-    {
-        var settings = LocalSettings.GetSettings(options, logger);
-        return new BarApiClient(
-            settings?.BuildAssetRegistryToken,
-            options?.FederatedToken,
+        => new BarApiClient(
+            options.BuildAssetRegistryToken,
+            options.FederatedToken,
             managedIdentityId: null,
             options.IsCi,
-            settings?.BuildAssetRegistryBaseUri);
-    }
+            options.BuildAssetRegistryBaseUri);
 
     public Task<IRemote> GetRemoteAsync(string repoUrl, ILogger logger)
         => Task.FromResult(GetRemote(_options, repoUrl, logger));
@@ -47,8 +44,6 @@ internal class RemoteFactory : IRemoteFactory
 
     private static IRemoteGitRepo GetRemoteGitClient(ICommandLineOptions options, string repoUrl, ILogger logger)
     {
-        var darcSettings = LocalSettings.GetSettings(options, logger);
-
         string temporaryRepositoryRoot = Path.GetTempPath();
 
         var repoType = GitRepoUrlParser.ParseTypeFromUri(repoUrl);
@@ -58,7 +53,7 @@ internal class RemoteFactory : IRemoteFactory
             GitRepoType.GitHub =>
                 new GitHubClient(
                     options.GitLocation,
-                    darcSettings.GitHubToken,
+                    options.GitHubPat,
                     logger,
                     temporaryRepositoryRoot,
                     // Caching not in use for Darc local client.
@@ -67,7 +62,7 @@ internal class RemoteFactory : IRemoteFactory
             GitRepoType.AzureDevOps =>
                 new AzureDevOpsClient(
                     options.GitLocation,
-                    darcSettings.AzureDevOpsToken,
+                    options.AzureDevOpsPat,
                     logger,
                     temporaryRepositoryRoot),
 

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
@@ -213,9 +213,6 @@ internal class AddBuildToChannelOperation : Operation
             return Constants.SuccessCode;
         }
 
-        LocalSettings localSettings = LocalSettings.GetSettings(_options, Logger);
-        _options.AzureDevOpsPat = (string.IsNullOrEmpty(_options.AzureDevOpsPat)) ? localSettings.AzureDevOpsToken : _options.AzureDevOpsPat;
-
         if (string.IsNullOrEmpty(_options.AzureDevOpsPat))
         {
             Console.WriteLine($"Promoting build {build.Id} with the given parameters would require starting the Build Promotion pipeline, however an AzDO PAT was not found.");

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GatherDropOperation.cs
@@ -1072,12 +1072,6 @@ internal class GatherDropOperation : Operation
 
         var packageContentUrl = $"https://pkgs.dev.azure.com/{feedAccount}/{feedProject}_apis/packaging/feeds/{feedName}/nuget/packages/{assetName}/versions/{asset.Version}/content";
 
-        if (string.IsNullOrEmpty(_options.AzureDevOpsPat))
-        {
-            var localSettings = LocalSettings.GetSettings(_options, Logger);
-            _options.AzureDevOpsPat = localSettings.AzureDevOpsToken;
-        }
-
         var authHeader = new AuthenticationHeaderValue(
             "Basic",
             Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", _options.AzureDevOpsPat))));

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
@@ -42,9 +42,7 @@ public abstract class Operation : IDisposable
             throw new NotImplementedException($"Output format type '{options.OutputFormat}' not yet supported for this operation.\r\nPlease raise a new issue in https://github.com/dotnet/arcade/issues/.");
         }
 
-        var localSettings = LocalSettings.GetSettings(options, Logger);
-        options.AzureDevOpsPat ??= localSettings.AzureDevOpsToken;
-        options.GitHubPat ??= localSettings.GitHubToken;
+        options.InitializeFromSettings(Logger);
 
         services ??= new ServiceCollection();
         services.AddLogging(b => b

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
@@ -42,8 +42,6 @@ public abstract class Operation : IDisposable
             throw new NotImplementedException($"Output format type '{options.OutputFormat}' not yet supported for this operation.\r\nPlease raise a new issue in https://github.com/dotnet/arcade/issues/.");
         }
 
-        options.InitializeFromSettings(Logger);
-
         services ??= new ServiceCollection();
         services.AddLogging(b => b
             .AddConsole(o => o.FormatterName = CompactConsoleLoggerFormatter.FormatterName)
@@ -62,6 +60,7 @@ public abstract class Operation : IDisposable
 
         Provider = services.BuildServiceProvider();
         Logger = Provider.GetRequiredService<ILogger<Operation>>();
+        options.InitializeFromSettings(Logger);
     }
 
     public abstract Task<int> ExecuteAsync();

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
@@ -42,6 +42,10 @@ public abstract class Operation : IDisposable
             throw new NotImplementedException($"Output format type '{options.OutputFormat}' not yet supported for this operation.\r\nPlease raise a new issue in https://github.com/dotnet/arcade/issues/.");
         }
 
+        var localSettings = LocalSettings.GetSettings(options, Logger);
+        options.AzureDevOpsPat ??= localSettings.AzureDevOpsToken;
+        options.GitHubPat ??= localSettings.GitHubToken;
+
         services ??= new ServiceCollection();
         services.AddLogging(b => b
             .AddConsole(o => o.FormatterName = CompactConsoleLoggerFormatter.FormatterName)

--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using CommandLine;
+using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Operations;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Darc.Options;
 
@@ -56,5 +58,14 @@ public abstract class CommandLineOptions : ICommandLineOptions
     public RemoteConfiguration GetRemoteConfiguration()
     {
         return new RemoteConfiguration(GitHubPat, AzureDevOpsPat);
+    }
+
+    public void InitializeFromSettings(ILogger logger)
+    {
+        var localSettings = LocalSettings.GetSettings(this, logger);
+        AzureDevOpsPat ??= localSettings.AzureDevOpsToken;
+        GitHubPat ??= localSettings.GitHubToken;
+        BuildAssetRegistryBaseUri ??= localSettings.BuildAssetRegistryBaseUri;
+        BuildAssetRegistryToken ??= localSettings.BuildAssetRegistryToken;
     }
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.DotNet.Darc.Operations;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Darc.Options;
 public interface ICommandLineOptions
@@ -20,4 +21,9 @@ public interface ICommandLineOptions
 
     Operation GetOperation();
     RemoteConfiguration GetRemoteConfiguration();
+
+    /// <summary>
+    /// Reads missing options from the local settings.
+    /// </summary>
+    void InitializeFromSettings(ILogger logger);
 }


### PR DESCRIPTION
Fixes a bug when an AzDO PAT was not used from local settings.

The problem were commands that were more DI-based (we still have half and half unfortunately) and the DI didn't know about the local settings, only the PATs from the options directly.
We now stop reading the local settings in many places and let the options object initialize from there.

<!-- https://github.com/dotnet/arcade-services/issues/3658 -->