### PR TITLE
XmlSchema reorder

### DIFF
--- a/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ApplicationManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ApplicationTypeName="MaestroApplicationType" ApplicationTypeVersion="1.0.42" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+<ApplicationManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" ApplicationTypeName="MaestroApplicationType" ApplicationTypeVersion="1.0.42" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
     <Parameter Name="CoreHealthMonitor_InstanceCount" DefaultValue="-1" />
     <Parameter Name="DependencyUpdateErrorProcessor_MinReplicaSetSize" DefaultValue="3" />

--- a/src/Maestro/MaestroApplication/ApplicationParameters/Local.1Node.xml
+++ b/src/Maestro/MaestroApplication/ApplicationParameters/Local.1Node.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Application xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="fabric:/MaestroApplication" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+<Application xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="fabric:/MaestroApplication" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
     <Parameter Name="CoreHealthMonitor_InstanceCount" Value="1" />
     <Parameter Name="DependencyUpdateErrorProcessor_MinReplicaSetSize" Value="1" />

--- a/src/Maestro/MaestroApplication/ApplicationParameters/Local.5Node.xml
+++ b/src/Maestro/MaestroApplication/ApplicationParameters/Local.5Node.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Application xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="fabric:/MaestroApplication" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+<Application xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="fabric:/MaestroApplication" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
     <Parameter Name="CoreHealthMonitor_InstanceCount" Value="1" />
     <Parameter Name="DependencyUpdateErrorProcessor_MinReplicaSetSize" Value="3" />


### PR DESCRIPTION
Small reorder on the line in XML manifest files. As they are auto-generated every build they show as changed. This should fix them to the state after generation. Technically there is no change in the file, it is just about reordering namespace definition.