### PR TITLE
Remove AzDO tokens from Maestro

### DIFF
--- a/src/Maestro/Client/src/MaestroApiOptions.cs
+++ b/src/Maestro/Client/src/MaestroApiOptions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Maestro.Client
             : this(
                   new Uri(baseUri),
                   AppCredentialResolver.CreateCredential(
-                      new CredentialResolverOptions(EntraAppIds[(baseUri ?? ProductionBuildAssetRegistryBaseUri).TrimEnd('/')])
+                      new AppCredentialResolverOptions(EntraAppIds[(baseUri ?? ProductionBuildAssetRegistryBaseUri).TrimEnd('/')])
                       {
                           DisableInteractiveAuth = disableInteractiveAuth,
                           Token = accessToken,

--- a/src/Maestro/DependencyUpdater/.config/settings.Staging.json
+++ b/src/Maestro/DependencyUpdater/.config/settings.Staging.json
@@ -1,14 +1,19 @@
 {
-  "HealthReportSettings": {
-    "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
-    "TableName": "healthreport"
-  },
-  "KeyVaultUri": "https://maestroint.vault.azure.net/",
-  "BuildAssetRegistry": {
-    "ConnectionString": "Data Source=tcp:maestro-int-server.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
-  },
-  "Kusto": {
-    "Database": "engineeringdata",
-    "KustoClusterUri": "https://engdata.westus2.kusto.windows.net"
-  }
+    "HealthReportSettings": {
+        "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
+        "TableName": "healthreport"
+    },
+    "KeyVaultUri": "https://maestroint.vault.azure.net/",
+    "BuildAssetRegistry": {
+        "ConnectionString": "Data Source=tcp:maestro-int-server.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
+    },
+    "Kusto": {
+        "Database": "engineeringdata",
+        "KustoClusterUri": "https://engdata.westus2.kusto.windows.net"
+    },
+    "AzureDevOps": {
+        "ManagedIdentities": {
+            "default": "system"
+        }
+    }
 }

--- a/src/Maestro/DependencyUpdater/.config/settings.json
+++ b/src/Maestro/DependencyUpdater/.config/settings.json
@@ -1,22 +1,13 @@
 {
-  "GitHub": {
-    "GitHubAppId": "[vault(github-app-id)]",
-    "PrivateKey": "[vault(github-app-private-key)]"
-  },
-  "AzureDevOps": {
-    "Tokens": [
-      {
-        "Account": "dnceng",
-        "Token": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]"
-      },
-      {
-        "Account": "devdiv",
-        "Token": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]"
-      },
-      {
-        "Account": "domoreexp",
-        "Token": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
-      }
-    ]
-  }
+    "GitHub": {
+        "GitHubAppId": "[vault(github-app-id)]",
+        "PrivateKey": "[vault(github-app-private-key)]"
+    },
+    "AzureDevOps": {
+        "Tokens": {
+            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
+            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
+            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        }
+    }
 }

--- a/src/Maestro/DependencyUpdater/Program.cs
+++ b/src/Maestro/DependencyUpdater/Program.cs
@@ -46,21 +46,11 @@ public static class Program
                     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                     ?.InformationalVersion);
         });
-        services.Configure<GitHubTokenProviderOptions>("GitHub", (o, s) =>
-        {
-            s.Bind(o);
-        });
+        services.Configure<GitHubTokenProviderOptions>("GitHub", (o, s) => s.Bind(o));
         services.AddGitHubTokenProvider();
 
+        services.Configure<AzureDevOpsTokenProviderOptions>("AzureDevOps", (o, s) => s.Bind(o));
         services.AddAzureDevOpsTokenProvider();
-        services.Configure<AzureDevOpsTokenProviderOptions>("AzureDevOps:Tokens", (o, s) =>
-        {
-            var tokenMap = s.GetChildren();
-            foreach (IConfigurationSection token in tokenMap)
-            {
-                o.Tokens.Add(token.GetValue<string>("Account"), token.GetValue<string>("Token"));
-            }
-        });
 
         // We do not use AddMemoryCache here. We use our own cache because we wish to
         // use a sized cache and some components, such as EFCore, do not implement their caching

--- a/src/Maestro/FeedCleanerService/.config/settings.Staging.json
+++ b/src/Maestro/FeedCleanerService/.config/settings.Staging.json
@@ -1,10 +1,15 @@
 {
-  "HealthReportSettings": {
-    "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
-    "TableName": "healthreport"
-  },
-  "KeyVaultUri": "https://maestroint.vault.azure.net/",
-  "BuildAssetRegistry": {
-    "ConnectionString": "Data Source=tcp:maestro-int-server.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
-  }
+    "HealthReportSettings": {
+        "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
+        "TableName": "healthreport"
+    },
+    "KeyVaultUri": "https://maestroint.vault.azure.net/",
+    "BuildAssetRegistry": {
+        "ConnectionString": "Data Source=tcp:maestro-int-server.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
+    },
+    "AzureDevOps": {
+        "ManagedIdentities": {
+            "default": "system"
+        }
+    }
 }

--- a/src/Maestro/FeedCleanerService/.config/settings.json
+++ b/src/Maestro/FeedCleanerService/.config/settings.json
@@ -1,35 +1,32 @@
 {
-  "FeedCleaner": {
-    "Enabled": false,
-    "ReleasePackageFeeds": [
-      {
-        "Account": "dnceng",
-        "Project": "public",
-        "Name": "dotnet3"
-      },
-      {
-        "Account": "dnceng",
-        "Project": "public",
-        "Name": "dotnet3.1"
-      },
-      {
-        "Account": "dnceng",
-        "Project": "public",
-        "Name": "dotnet5"
-      },
-      {
-        "Account": "dnceng",
-        "Project": "public",
-        "Name": "dotnet-tools"
-      }
-    ]
-  },
-  "AzureDevOps": {
-    "Tokens": [
-      {
-        "Account": "dnceng",
-        "Token": "[vault(dn-bot-dnceng-packaging-rwm)]"
-      }
-    ]
-  }
+    "FeedCleaner": {
+        "Enabled": false,
+        "ReleasePackageFeeds": [
+            {
+                "Account": "dnceng",
+                "Project": "public",
+                "Name": "dotnet3"
+            },
+            {
+                "Account": "dnceng",
+                "Project": "public",
+                "Name": "dotnet3.1"
+            },
+            {
+                "Account": "dnceng",
+                "Project": "public",
+                "Name": "dotnet5"
+            },
+            {
+                "Account": "dnceng",
+                "Project": "public",
+                "Name": "dotnet-tools"
+            }
+        ]
+    },
+    "AzureDevOps": {
+        "Tokens": {
+            "dnceng": "[vault(dn-bot-dnceng-packaging-rwm)]"
+        }
+    }
 }

--- a/src/Maestro/FeedCleanerService/Program.cs
+++ b/src/Maestro/FeedCleanerService/Program.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Linq;
 using Maestro.Common.AzureDevOpsTokens;
 using Maestro.Data;
 using Microsoft.DncEng.Configuration.Extensions;
@@ -29,19 +31,20 @@ public static class Program
     {
         services.Configure<FeedCleanerOptions>((options, provider) =>
         {
-            var config1 = provider.GetRequiredService<IConfiguration>();
-            options.Enabled = config1.GetSection("FeedCleaner").GetValue<bool>("Enabled");
-            var releaseFeedsTokenMap = config1.GetSection("FeedCleaner:ReleasePackageFeeds").GetChildren();
+            var config = provider.GetRequiredService<IConfiguration>();
+            options.Enabled = config.GetSection("FeedCleaner").GetValue<bool>("Enabled");
+            var releaseFeedsTokenMap = config.GetSection("FeedCleaner:ReleasePackageFeeds").GetChildren();
             foreach (IConfigurationSection token1 in releaseFeedsTokenMap)
             {
                 options.ReleasePackageFeeds.Add((token1.GetValue<string>("Account"), token1.GetValue<string>("Project"), token1.GetValue<string>("Name")));
             }
 
-            var azdoAccountTokenMap = config1.GetSection("AzureDevOps:Tokens").GetChildren();
-            foreach (IConfigurationSection token2 in azdoAccountTokenMap)
-            {
-                options.AzdoAccounts.Add(token2.GetValue<string>("Account"));
-            }
+            AzureDevOpsTokenProviderOptions azdoConfig = new();
+            config.GetSection("AzureDevOps").Bind(azdoConfig);
+            IEnumerable<string> allOrgs = azdoConfig.Tokens.Keys
+                .Concat(azdoConfig.ManagedIdentities.Keys)
+                .Distinct();
+            options.AzdoAccounts.AddRange(allOrgs);
         });
         services.AddDefaultJsonConfiguration();
         services.AddBuildAssetRegistry((provider, options) =>
@@ -50,14 +53,6 @@ public static class Program
             options.UseSqlServerWithRetry(config.GetSection("BuildAssetRegistry")["ConnectionString"]);
         });
         services.AddAzureDevOpsTokenProvider();
-        services.Configure<AzureDevOpsTokenProviderOptions>((options, provider) =>
-        {
-            var config = provider.GetRequiredService<IConfiguration>();
-            var tokenMap = config.GetSection("AzureDevOps:Tokens").GetChildren();
-            foreach (IConfigurationSection token in tokenMap)
-            {
-                options.Tokens.Add(token.GetValue<string>("Account"), token.GetValue<string>("Token"));
-            }
-        });
+        services.Configure<AzureDevOpsTokenProviderOptions>("AzureDevOps", (o, s) => s.Bind(o));
     }
 }

--- a/src/Maestro/Maestro.Common/AppCredentials/AppCredentialResolver.cs
+++ b/src/Maestro/Maestro.Common/AppCredentials/AppCredentialResolver.cs
@@ -10,7 +10,7 @@ public static class AppCredentialResolver
     /// <summary>
     /// Creates a credential based on parameters provided.
     /// </summary>
-    public static TokenCredential CreateCredential(CredentialResolverOptions options)
+    public static TokenCredential CreateCredential(AppCredentialResolverOptions options)
     {
         // 1. BAR or Entra token that can directly be used to authenticate against a service
         if (!string.IsNullOrEmpty(options.Token))

--- a/src/Maestro/Maestro.Common/AppCredentials/AppCredentialResolverOptions.cs
+++ b/src/Maestro/Maestro.Common/AppCredentials/AppCredentialResolverOptions.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Maestro.Common.AppCredentials;
+
+public class AppCredentialResolverOptions : CredentialResolverOptions
+{
+    /// <summary>
+    /// Client ID of the Azure application to request the token for
+    /// </summary>
+    public string AppId { get; set; }
+
+    /// <summary>
+    /// User scope to request the token for (in case of user flows).
+    /// </summary>
+    public string UserScope { get; set; } = ".default";
+
+    public AppCredentialResolverOptions(string appId)
+    {
+        AppId = appId;
+    }
+}

--- a/src/Maestro/Maestro.Common/AppCredentials/CredentialResolverOptions.cs
+++ b/src/Maestro/Maestro.Common/AppCredentials/CredentialResolverOptions.cs
@@ -6,11 +6,6 @@ namespace Maestro.Common.AppCredentials;
 public class CredentialResolverOptions
 {
     /// <summary>
-    /// Client ID of the Azure application to request the token for
-    /// </summary>
-    public string AppId { get; set; }
-
-    /// <summary>
     /// Whether to include interactive login flows
     /// </summary>
     public bool DisableInteractiveAuth { get; set; }
@@ -29,14 +24,4 @@ public class CredentialResolverOptions
     /// Managed Identity to use for the auth
     /// </summary>
     public string? ManagedIdentityId { get; set; }
-
-    /// <summary>
-    /// User scope to request the token for (in case of user flows).
-    /// </summary>
-    public string UserScope { get; set; } = ".default";
-
-    public CredentialResolverOptions(string appId)
-    {
-        AppId = appId;
-    }
 }

--- a/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
+++ b/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
@@ -1,29 +1,67 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Azure.Core;
+using Azure.Identity;
 using Microsoft.Extensions.Options;
 
 namespace Maestro.Common.AzureDevOpsTokens;
 
+/// <summary>
+/// This token provider expects to have a token or an MI defined per each Azure DevOps account (dnceng, devdiv..).
+/// Token has precedence over MI.
+/// Example configuration:
+/// 
+/// {
+///   "Tokens": {
+///     "dnceng": "[some PAT]",
+///   },
+///   "ManagedIdentities": {
+///     "devdiv": "123b84ac-1321-425f-a117-222ca6974498",
+///     "default": "system", // Use the system-assigned identity for every other org not defined
+/// }
+///
+/// The config above will use PAT for dnceng, a specific MI for devdiv and the system-assigned MI for any other org.
+/// </summary>
 public class AzureDevOpsTokenProvider : IAzureDevOpsTokenProvider
 {
+    private const string AzureDevOpsScope = "499b84ac-1321-427f-aa17-267ca6975798/.default";
+
+    private readonly Dictionary<string, ManagedIdentityCredential> _tokenCredentials = [];
     private readonly IOptionsMonitor<AzureDevOpsTokenProviderOptions> _options;
 
     public AzureDevOpsTokenProvider(IOptionsMonitor<AzureDevOpsTokenProviderOptions> options)
     {
         _options = options;
+
+        foreach (var credential in options.CurrentValue.ManagedIdentities)
+        {
+            _tokenCredentials[credential.Key] = credential.Value == "system"
+                ? new ManagedIdentityCredential()
+                : new ManagedIdentityCredential(credential.Value);
+        }
     }
 
-    public Task<string> GetTokenForAccount(string account)
+    public async Task<string> GetTokenForAccount(string account)
     {
-        var options = _options.CurrentValue;
-        if (!options.Tokens.TryGetValue(account, out var pat) || string.IsNullOrEmpty(pat))
+        if (_options.CurrentValue.Tokens.TryGetValue(account, out var pat) && !string.IsNullOrEmpty(pat))
         {
-            throw new ArgumentOutOfRangeException(
-                $"Azure DevOps account {account} does not have a configured PAT. " +
-                $"Please ensure the 'Tokens' array in the 'AzureDevOps' section of settings.json contains a PAT for {account}");
+            return pat;
         }
 
-        return Task.FromResult(pat);
+        if (_tokenCredentials.TryGetValue(account, out var credential))
+        {
+            return (await credential.GetTokenAsync(new TokenRequestContext([AzureDevOpsScope]))).Token;
+        }
+
+        // We can also define just one MI for all accounts
+        if (_tokenCredentials.TryGetValue("default", out var defaultCredential))
+        {
+            return (await defaultCredential.GetTokenAsync(new TokenRequestContext([AzureDevOpsScope]))).Token;
+        }
+
+        throw new ArgumentOutOfRangeException(
+            $"Azure DevOps account {account} does not have a configured PAT or credential. " +
+            $"Please set the 'AzureDevOps.Tokens' or 'AzureDevOps.Credentials' configuration section");
     }
 }

--- a/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
+++ b/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
@@ -62,6 +62,6 @@ public class AzureDevOpsTokenProvider : IAzureDevOpsTokenProvider
 
         throw new ArgumentOutOfRangeException(
             $"Azure DevOps account {account} does not have a configured PAT or credential. " +
-            $"Please set the 'AzureDevOps.Tokens' or 'AzureDevOps.Credentials' configuration section");
+            $"Please add the account to the 'AzureDevOps.Tokens' or 'AzureDevOps.ManagedIdentities' configuration section");
     }
 }

--- a/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProviderOptions.cs
+++ b/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProviderOptions.cs
@@ -6,4 +6,6 @@ namespace Maestro.Common.AzureDevOpsTokens;
 public class AzureDevOpsTokenProviderOptions
 {
     public Dictionary<string, string> Tokens { get; } = [];
+
+    public Dictionary<string, string> ManagedIdentities { get; } = [];
 }

--- a/src/Maestro/Maestro.Web/.config/settings.Staging.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Staging.json
@@ -23,5 +23,10 @@
         "ClientId": "baf98f1b-374e-487d-af42-aa33807f11e4",
         "UserRole": "User",
         "RedirectUri": "https://maestro.int-dot.net/signin-oidc"
+    },
+    "AzureDevOps": {
+        "ManagedIdentities": {
+            "default": "system"
+        }
     }
 }

--- a/src/Maestro/Maestro.Web/.config/settings.json
+++ b/src/Maestro/Maestro.Web/.config/settings.json
@@ -1,43 +1,34 @@
 {
-  "GitHubAuthentication": {
-    "ClientId": "[vault(github-oauth-id)]",
-    "ClientSecret": "[vault(github-oauth-secret)]",
-    "SaveTokens": true,
-    "CallbackPath": "/signin/github",
-    "UserAgentProduct": "",
-    "ClaimsIssuer": "github"
-  },
-  "GitHub": {
-    "GitHubAppId": "[vault(github-app-id)]",
-    "PrivateKey": "[vault(github-app-private-key)]"
-  },
-  "AzureDevOps": {
-    "Tokens": [
-      {
-        "Account": "dnceng",
-        "Token": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]"
-      },
-      {
-        "Account": "devdiv",
-        "Token": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]"
-      },
-      {
-        "Account": "domoreexp",
-        "Token": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
-      }
-    ]
-  },
-  "WebHooks": {
-    "github": {
-      "SecretKey": {
-        "default": "[vault(github-app-webhook-secret)]"
-      }
-    }
-  },
-  "ApiRedirect": {
-    "uri": "https://maestro.dot.net/",
-    "token": "[vault(prod-maestro-token)]"
-  },
-  "GitDownloadLocation": "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/git/Git-2.32.0-64-bit.zip",
-  "EnableAutoBuildPromotion": "[config(FeatureManagement:AutoBuildPromotion)]"
+    "GitHubAuthentication": {
+        "ClientId": "[vault(github-oauth-id)]",
+        "ClientSecret": "[vault(github-oauth-secret)]",
+        "SaveTokens": true,
+        "CallbackPath": "/signin/github",
+        "UserAgentProduct": "",
+        "ClaimsIssuer": "github"
+    },
+    "GitHub": {
+        "GitHubAppId": "[vault(github-app-id)]",
+        "PrivateKey": "[vault(github-app-private-key)]"
+    },
+    "AzureDevOps": {
+        "Tokens": {
+            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
+            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
+            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        }
+    },
+    "WebHooks": {
+        "github": {
+            "SecretKey": {
+                "default": "[vault(github-app-webhook-secret)]"
+            }
+        }
+    },
+    "ApiRedirect": {
+        "uri": "https://maestro.dot.net/",
+        "token": "[vault(prod-maestro-token)]"
+    },
+    "GitDownloadLocation": "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/git/Git-2.32.0-64-bit.zip",
+    "EnableAutoBuildPromotion": "[config(FeatureManagement:AutoBuildPromotion)]"
 }

--- a/src/Maestro/Maestro.Web/Startup.cs
+++ b/src/Maestro/Maestro.Web/Startup.cs
@@ -235,16 +235,7 @@ public partial class Startup : StartupBase
         services.Configure<GitHubTokenProviderOptions>(Configuration.GetSection("GitHub"));
         services.AddAzureDevOpsTokenProvider();
 
-        services.RegisterOptionsForConfigurationChangeNotifications<AzureDevOpsTokenProviderOptions>(null, Configuration);
-        services.Configure<AzureDevOpsTokenProviderOptions>(
-            (options, provider) =>
-            {
-                var tokenMap = Configuration.GetSection("AzureDevOps:Tokens").GetChildren();
-                foreach (IConfigurationSection token in tokenMap)
-                {
-                    options.Tokens.Add(token.GetValue<string>("Account"), token.GetValue<string>("Token"));
-                }
-            });
+        services.Configure<AzureDevOpsTokenProviderOptions>("AzureDevOps", Configuration);
         services.AddKustoClientProvider("Kusto");
 
         // We do not use AddMemoryCache here. We use our own cache because we wish to

--- a/src/Maestro/SubscriptionActorService/.config/settings.json
+++ b/src/Maestro/SubscriptionActorService/.config/settings.json
@@ -1,22 +1,13 @@
 {
-  "GitHub": {
-    "GitHubAppId": "[vault(github-app-id)]",
-    "PrivateKey": "[vault(github-app-private-key)]"
-  },
-  "AzureDevOps": {
-    "Tokens": [
-      {
-        "Account": "dnceng",
-        "Token": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]"
-      },
-      {
-        "Account": "devdiv",
-        "Token": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]"
-      },
-      {
-        "Account": "domoreexp",
-        "Token": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
-      }
-    ]
-  }
+    "GitHub": {
+        "GitHubAppId": "[vault(github-app-id)]",
+        "PrivateKey": "[vault(github-app-private-key)]"
+    },
+    "AzureDevOps": {
+        "Tokens": {
+            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
+            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
+            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        }
+    }
 }

--- a/src/Maestro/SubscriptionActorService/Program.cs
+++ b/src/Maestro/SubscriptionActorService/Program.cs
@@ -70,14 +70,7 @@ public static class Program
                     ?.InformationalVersion);
         });
         services.Configure<GitHubTokenProviderOptions>("GitHub", (o, s) => s.Bind(o));
-        services.Configure<AzureDevOpsTokenProviderOptions>("AzureDevOps:Tokens", (o, s) =>
-        {
-            var tokenMap = s.GetChildren();
-            foreach (IConfigurationSection token in tokenMap)
-            {
-                o.Tokens.Add(token["Account"], token["Token"]);
-            }
-        });
+        services.Configure<AzureDevOpsTokenProviderOptions>("AzureDevOps", (o, s) => s.Bind(o));
         services.AddSingleton<IProductConstructionServiceApi>(s =>
         {
             var config = s.GetRequiredService<IConfiguration>();

--- a/src/ProductConstructionService/ProductConstructionService.Client/ProductConstructionServiceApiOptions.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Client/ProductConstructionServiceApiOptions.cs
@@ -26,7 +26,7 @@ namespace ProductConstructionService.Client
             : this(
                   new Uri(baseUri),
                   AppCredentialResolver.CreateCredential(
-                      new CredentialResolverOptions(EntraAppIds[baseUri.TrimEnd('/')])
+                      new AppCredentialResolverOptions(EntraAppIds[baseUri.TrimEnd('/')])
                       {
                           DisableInteractiveAuth = true, // the client is only used in Maestro for now
                           Token = accessToken,


### PR DESCRIPTION
This PR makes the Maestro cluster use its system-assigned managed identity for AzureDevOps communication.

It does not affect `darc` or `PCS` where `RemoteConfiguration` is still used.

https://dev.azure.com/dnceng/internal/_workitems/edit/6419
