### PR TITLE
Use MIs in staging Maestro instead of AzDO tokens

### DIFF
--- a/src/Maestro/DependencyUpdater/.config/settings.Development.json
+++ b/src/Maestro/DependencyUpdater/.config/settings.Development.json
@@ -1,15 +1,22 @@
 {
-  "HealthReportSettings": {
-    "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
-    "TableName": "healthreport"
-  },
-  "KeyVaultUri": "https://maestrolocal.vault.azure.net/",
-  "BuildAssetRegistry": {
-    "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
-  },
-  "Kusto": {
-    "Database": "engineeringdata",
-    "KustoClusterUri": "https://engdata.westus2.kusto.windows.net",
-    "UseAzCliAuthentication": true
-  }
+    "HealthReportSettings": {
+        "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
+        "TableName": "healthreport"
+    },
+    "KeyVaultUri": "https://maestrolocal.vault.azure.net/",
+    "BuildAssetRegistry": {
+        "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
+    },
+    "Kusto": {
+        "Database": "engineeringdata",
+        "KustoClusterUri": "https://engdata.westus2.kusto.windows.net",
+        "UseAzCliAuthentication": true
+    },
+    "AzureDevOps": {
+        "Tokens": {
+            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
+            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
+            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        }
+    }
 }

--- a/src/Maestro/DependencyUpdater/.config/settings.Production.json
+++ b/src/Maestro/DependencyUpdater/.config/settings.Production.json
@@ -1,14 +1,21 @@
 {
-  "HealthReportSettings": {
-    "StorageAccountTablesUri": "https://maestroprod1337.table.core.windows.net",
-    "TableName": "healthreport"
-  },
-  "KeyVaultUri": "https://maestroprod.vault.azure.net/",
-  "BuildAssetRegistry": {
-    "ConnectionString": "Data Source=tcp:maestro-prod.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
-  },
-  "Kusto": {
-    "Database": "engineeringdata",
-    "KustoClusterUri": "https://engsrvprod.westus.kusto.windows.net"
-  }
+    "HealthReportSettings": {
+        "StorageAccountTablesUri": "https://maestroprod1337.table.core.windows.net",
+        "TableName": "healthreport"
+    },
+    "KeyVaultUri": "https://maestroprod.vault.azure.net/",
+    "BuildAssetRegistry": {
+        "ConnectionString": "Data Source=tcp:maestro-prod.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
+    },
+    "Kusto": {
+        "Database": "engineeringdata",
+        "KustoClusterUri": "https://engsrvprod.westus.kusto.windows.net"
+    },
+    "AzureDevOps": {
+        "Tokens": {
+            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
+            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
+            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        }
+    }
 }

--- a/src/Maestro/DependencyUpdater/.config/settings.json
+++ b/src/Maestro/DependencyUpdater/.config/settings.json
@@ -2,12 +2,5 @@
     "GitHub": {
         "GitHubAppId": "[vault(github-app-id)]",
         "PrivateKey": "[vault(github-app-private-key)]"
-    },
-    "AzureDevOps": {
-        "Tokens": {
-            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
-            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
-            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
-        }
     }
 }

--- a/src/Maestro/FeedCleanerService/.config/settings.Development.json
+++ b/src/Maestro/FeedCleanerService/.config/settings.Development.json
@@ -1,10 +1,15 @@
 {
-  "HealthReportSettings": {
-    "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
-    "TableName": "healthreport"
-  },
-  "KeyVaultUri": "https://maestrolocal.vault.azure.net/",
-  "BuildAssetRegistry": {
-    "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
-  }
+    "HealthReportSettings": {
+        "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
+        "TableName": "healthreport"
+    },
+    "KeyVaultUri": "https://maestrolocal.vault.azure.net/",
+    "BuildAssetRegistry": {
+        "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
+    },
+    "AzureDevOps": {
+        "Tokens": {
+            "dnceng": "[vault(dn-bot-dnceng-packaging-rwm)]"
+        }
+    }
 }

--- a/src/Maestro/FeedCleanerService/.config/settings.Production.json
+++ b/src/Maestro/FeedCleanerService/.config/settings.Production.json
@@ -1,13 +1,18 @@
 {
-  "HealthReportSettings": {
-    "StorageAccountTablesUri": "https://maestroprod1337.table.core.windows.net",
-    "TableName": "healthreport"
-  },
-  "KeyVaultUri": "https://maestroprod.vault.azure.net/",
-  "FeedCleaner": {
-    "Enabled": true
-  },
-  "BuildAssetRegistry": {
-    "ConnectionString": "Data Source=tcp:maestro-prod.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
-  }
+    "HealthReportSettings": {
+        "StorageAccountTablesUri": "https://maestroprod1337.table.core.windows.net",
+        "TableName": "healthreport"
+    },
+    "KeyVaultUri": "https://maestroprod.vault.azure.net/",
+    "FeedCleaner": {
+        "Enabled": true
+    },
+    "BuildAssetRegistry": {
+        "ConnectionString": "Data Source=tcp:maestro-prod.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
+    },
+    "AzureDevOps": {
+        "Tokens": {
+            "dnceng": "[vault(dn-bot-dnceng-packaging-rwm)]"
+        }
+    }
 }

--- a/src/Maestro/FeedCleanerService/.config/settings.json
+++ b/src/Maestro/FeedCleanerService/.config/settings.json
@@ -23,10 +23,5 @@
                 "Name": "dotnet-tools"
             }
         ]
-    },
-    "AzureDevOps": {
-        "Tokens": {
-            "dnceng": "[vault(dn-bot-dnceng-packaging-rwm)]"
-        }
     }
 }

--- a/src/Maestro/Maestro.Web/.config/settings.Development.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Development.json
@@ -1,21 +1,28 @@
 {
-  "HealthReportSettings": {
-    "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
-    "TableName": "healthreport"
-  },
-  "KeyVaultUri": "https://maestrolocal.vault.azure.net/",
-  "AppConfigurationUri": "https://maestrolocal.azconfig.io/",
-  "BuildAssetRegistry": {
-    "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
-  },
-  "ForceLocalApi": false,
-  "DataProtection": {
-    "KeyFileUri": "",
-    "KeyIdentifier": ""
-  },
-  "Kusto": {
-    "Database": "engineeringdata",
-    "KustoClusterUri": "https://engdata.westus2.kusto.windows.net",
-    "UseAzCliAuthentication": true
-  }
+    "HealthReportSettings": {
+        "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
+        "TableName": "healthreport"
+    },
+    "KeyVaultUri": "https://maestrolocal.vault.azure.net/",
+    "AppConfigurationUri": "https://maestrolocal.azconfig.io/",
+    "BuildAssetRegistry": {
+        "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
+    },
+    "ForceLocalApi": false,
+    "DataProtection": {
+        "KeyFileUri": "",
+        "KeyIdentifier": ""
+    },
+    "Kusto": {
+        "Database": "engineeringdata",
+        "KustoClusterUri": "https://engdata.westus2.kusto.windows.net",
+        "UseAzCliAuthentication": true
+    },
+    "AzureDevOps": {
+        "Tokens": {
+            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
+            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
+            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        }
+    }
 }

--- a/src/Maestro/Maestro.Web/.config/settings.Production.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Production.json
@@ -27,5 +27,12 @@
         "ClientId": "54c17f3d-7325-4eca-9db7-f090bfc765a8",
         "UserRole": "User",
         "RedirectUri": "https://maestro.dot.net/signin-oidc"
+    },
+    "AzureDevOps": {
+        "Tokens": {
+            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
+            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
+            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        }
     }
 }

--- a/src/Maestro/Maestro.Web/.config/settings.json
+++ b/src/Maestro/Maestro.Web/.config/settings.json
@@ -11,13 +11,6 @@
         "GitHubAppId": "[vault(github-app-id)]",
         "PrivateKey": "[vault(github-app-private-key)]"
     },
-    "AzureDevOps": {
-        "Tokens": {
-            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
-            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
-            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
-        }
-    },
     "WebHooks": {
         "github": {
             "SecretKey": {

--- a/src/Maestro/SubscriptionActorService/.config/settings.Development.json
+++ b/src/Maestro/SubscriptionActorService/.config/settings.Development.json
@@ -1,19 +1,26 @@
 {
-  "HealthReportSettings": {
-    "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
-    "TableName": "healthreport"
-  },
-  "KeyVaultUri": "https://maestrolocal.vault.azure.net/",
-  "BuildAssetRegistry": {
-    "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
-  },
-  "ProductConstructionService": {
-    "Uri": "http://localhost:53181/",
-    "NoAuth": true
-  },
-  "Kusto": {
-    "Database": "engineeringdata",
-    "KustoClusterUri": "https://engdata.westus2.kusto.windows.net",
-    "UseAzCliAuthentication": true
-  }
+    "HealthReportSettings": {
+        "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
+        "TableName": "healthreport"
+    },
+    "KeyVaultUri": "https://maestrolocal.vault.azure.net/",
+    "BuildAssetRegistry": {
+        "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
+    },
+    "ProductConstructionService": {
+        "Uri": "http://localhost:53181/",
+        "NoAuth": true
+    },
+    "Kusto": {
+        "Database": "engineeringdata",
+        "KustoClusterUri": "https://engdata.westus2.kusto.windows.net",
+        "UseAzCliAuthentication": true
+    },
+    "AzureDevOps": {
+        "Tokens": {
+            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
+            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
+            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        }
+    }
 }

--- a/src/Maestro/SubscriptionActorService/.config/settings.Production.json
+++ b/src/Maestro/SubscriptionActorService/.config/settings.Production.json
@@ -1,19 +1,26 @@
 {
-  "HealthReportSettings": {
-    "StorageAccountTablesUri": "https://maestroprod1337.table.core.windows.net",
-    "TableName": "healthreport"
-  },
-  "KeyVaultUri": "https://maestroprod.vault.azure.net/",
-  "DarcTemporaryRepoRoot": "D:\\",
-  "ProductConstructionService": {
-    "Uri": "https://github.com/dotnet/arcade-services/issues/3183",
-    "NoAuth": true // TODO https://github.com/dotnet/arcade-services/issues/3183
-  },
-  "BuildAssetRegistry": {
-    "ConnectionString": "Data Source=tcp:maestro-prod.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
-  },
-  "Kusto": {
-    "Database": "engineeringdata",
-    "KustoClusterUri": "https://engsrvprod.westus.kusto.windows.net"
-  }
+    "HealthReportSettings": {
+        "StorageAccountTablesUri": "https://maestroprod1337.table.core.windows.net",
+        "TableName": "healthreport"
+    },
+    "KeyVaultUri": "https://maestroprod.vault.azure.net/",
+    "DarcTemporaryRepoRoot": "D:\\",
+    "ProductConstructionService": {
+        "Uri": "https://github.com/dotnet/arcade-services/issues/3183",
+        "NoAuth": true // TODO https://github.com/dotnet/arcade-services/issues/3183
+    },
+    "BuildAssetRegistry": {
+        "ConnectionString": "Data Source=tcp:maestro-prod.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
+    },
+    "Kusto": {
+        "Database": "engineeringdata",
+        "KustoClusterUri": "https://engsrvprod.westus.kusto.windows.net"
+    },
+    "AzureDevOps": {
+        "Tokens": {
+            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
+            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
+            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        }
+    }
 }

--- a/src/Maestro/SubscriptionActorService/.config/settings.Staging.json
+++ b/src/Maestro/SubscriptionActorService/.config/settings.Staging.json
@@ -1,18 +1,23 @@
 {
-  "HealthReportSettings": {
-    "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
-    "TableName": "healthreport"
-  },
-  "KeyVaultUri": "https://maestroint.vault.azure.net/",
-  "DarcTemporaryRepoRoot": "D:\\",
-  "ProductConstructionService": {
-    "Uri": "https://product-construction-int.wittytree-28a89311.westus2.azurecontainerapps.io/"
-  },
-  "BuildAssetRegistry": {
-    "ConnectionString": "Data Source=tcp:maestro-int-server.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
-  },
-  "Kusto": {
-    "Database": "engineeringdata",
-    "KustoClusterUri": "https://engdata.westus2.kusto.windows.net"
-  }
+    "HealthReportSettings": {
+        "StorageAccountTablesUri": "https://maestroint.table.core.windows.net",
+        "TableName": "healthreport"
+    },
+    "KeyVaultUri": "https://maestroint.vault.azure.net/",
+    "DarcTemporaryRepoRoot": "D:\\",
+    "ProductConstructionService": {
+        "Uri": "https://product-construction-int.wittytree-28a89311.westus2.azurecontainerapps.io/"
+    },
+    "BuildAssetRegistry": {
+        "ConnectionString": "Data Source=tcp:maestro-int-server.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
+    },
+    "Kusto": {
+        "Database": "engineeringdata",
+        "KustoClusterUri": "https://engdata.westus2.kusto.windows.net"
+    },
+    "AzureDevOps": {
+        "ManagedIdentities": {
+            "default": "system"
+        }
+    }
 }

--- a/src/Maestro/SubscriptionActorService/.config/settings.json
+++ b/src/Maestro/SubscriptionActorService/.config/settings.json
@@ -2,12 +2,5 @@
     "GitHub": {
         "GitHubAppId": "[vault(github-app-id)]",
         "PrivateKey": "[vault(github-app-private-key)]"
-    },
-    "AzureDevOps": {
-        "Tokens": {
-            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
-            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
-            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
-        }
     }
 }


### PR DESCRIPTION
The previous change https://github.com/dotnet/arcade-services/issues/3662 didn't take it because the settings layers merge together. So when `settings.json` had the `Tokens` defined, all other layers inherited this. We only want this in staging, so we need to define it in the env levels and not in `settings.json`.
