### PR TITLE
Stop using a deleted variable group

### DIFF
--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -135,9 +135,7 @@ stages:
   
   variables:
   - group: ${{ parameters.VariableGroup }}
-  # Secret-Manager-Scenario-Tests provides: secret-manager-scenario-tests-client-secret
-  - group: Secret-Manager-Scenario-Tests
-  
+
   jobs:
   - job: scenario
     displayName: Scenario tests


### PR DESCRIPTION
The builds are failing because the variable group was removed. However our secret validation is green

<!-- https://github.com/dotnet/arcade-services/issues/3672 -->