### PR TITLE
Unify AzDO token retrieval across Maestro and darc

### DIFF
--- a/src/Maestro/DependencyUpdater/.config/settings.Development.json
+++ b/src/Maestro/DependencyUpdater/.config/settings.Development.json
@@ -13,10 +13,14 @@
         "UseAzCliAuthentication": true
     },
     "AzureDevOps": {
-        "Tokens": {
-            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
-            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
-            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        "dnceng": {
+            "Token": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]"
+        },
+        "devdiv": {
+            "Token": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]"
+        },
+        "domoreexp": {
+            "Token": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
         }
     }
 }

--- a/src/Maestro/DependencyUpdater/.config/settings.Production.json
+++ b/src/Maestro/DependencyUpdater/.config/settings.Production.json
@@ -10,5 +10,10 @@
     "Kusto": {
         "Database": "engineeringdata",
         "KustoClusterUri": "https://engsrvprod.westus.kusto.windows.net"
+    },
+    "AzureDevOps": {
+        "default": {
+            "ManagedIdentityId": "system"
+        }
     }
 }

--- a/src/Maestro/DependencyUpdater/.config/settings.Staging.json
+++ b/src/Maestro/DependencyUpdater/.config/settings.Staging.json
@@ -10,5 +10,10 @@
     "Kusto": {
         "Database": "engineeringdata",
         "KustoClusterUri": "https://engdata.westus2.kusto.windows.net"
+    },
+    "AzureDevOps": {
+        "default": {
+            "ManagedIdentityId": "system"
+        }
     }
 }

--- a/src/Maestro/DependencyUpdater/.config/settings.json
+++ b/src/Maestro/DependencyUpdater/.config/settings.json
@@ -2,10 +2,5 @@
     "GitHub": {
         "GitHubAppId": "[vault(github-app-id)]",
         "PrivateKey": "[vault(github-app-private-key)]"
-    },
-    "AzureDevOps": {
-        "ManagedIdentities": {
-            "default": "system"
-        }
     }
 }

--- a/src/Maestro/DependencyUpdater/Program.cs
+++ b/src/Maestro/DependencyUpdater/Program.cs
@@ -7,6 +7,7 @@ using Maestro.Data;
 using Maestro.DataProviders;
 using Microsoft.DncEng.Configuration.Extensions;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.DotNet.Kusto;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
@@ -57,6 +58,7 @@ public static class Program
         // in such a way that will work with sizing.
         services.AddSingleton<DarcRemoteMemoryCache>();
 
+        services.AddTransient<IProcessManager>(sp => ActivatorUtilities.CreateInstance<ProcessManager>(sp, "git"));
         services.AddTransient<IVersionDetailsParser, VersionDetailsParser>();
         services.AddScoped<IRemoteFactory, DarcRemoteFactory>();
         services.AddTransient<IBasicBarClient, SqlBarClient>();

--- a/src/Maestro/FeedCleanerService/.config/settings.Development.json
+++ b/src/Maestro/FeedCleanerService/.config/settings.Development.json
@@ -8,8 +8,8 @@
         "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
     },
     "AzureDevOps": {
-        "Tokens": {
-            "dnceng": "[vault(dn-bot-dnceng-packaging-rwm)]"
+        "dnceng": {
+            "Token": "[vault(dn-bot-dnceng-packaging-rwm)]"
         }
     }
 }

--- a/src/Maestro/FeedCleanerService/.config/settings.Production.json
+++ b/src/Maestro/FeedCleanerService/.config/settings.Production.json
@@ -9,5 +9,10 @@
     },
     "BuildAssetRegistry": {
         "ConnectionString": "Data Source=tcp:maestro-prod.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
+    },
+    "AzureDevOps": {
+        "default": {
+            "ManagedIdentityId": "system"
+        }
     }
 }

--- a/src/Maestro/FeedCleanerService/.config/settings.Staging.json
+++ b/src/Maestro/FeedCleanerService/.config/settings.Staging.json
@@ -6,5 +6,10 @@
     "KeyVaultUri": "https://maestroint.vault.azure.net/",
     "BuildAssetRegistry": {
         "ConnectionString": "Data Source=tcp:maestro-int-server.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False;"
+    },
+    "AzureDevOps": {
+        "default": {
+            "ManagedIdentityId": "system"
+        }
     }
 }

--- a/src/Maestro/FeedCleanerService/.config/settings.json
+++ b/src/Maestro/FeedCleanerService/.config/settings.json
@@ -23,10 +23,5 @@
                 "Name": "dotnet-tools"
             }
         ]
-    },
-    "AzureDevOps": {
-        "ManagedIdentities": {
-            "default": "system"
-        }
     }
 }

--- a/src/Maestro/FeedCleanerService/Program.cs
+++ b/src/Maestro/FeedCleanerService/Program.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Maestro.Common.AzureDevOpsTokens;
 using Maestro.Data;
 using Microsoft.DncEng.Configuration.Extensions;
+using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -54,5 +55,6 @@ public static class Program
         });
         services.AddAzureDevOpsTokenProvider();
         services.Configure<AzureDevOpsTokenProviderOptions>("AzureDevOps", (o, s) => s.Bind(o));
+        services.AddTransient<IAzureDevOpsClient, AzureDevOpsClient>();
     }
 }

--- a/src/Maestro/FeedCleanerService/Program.cs
+++ b/src/Maestro/FeedCleanerService/Program.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Linq;
 using Maestro.Common.AzureDevOpsTokens;
 using Maestro.Data;
 using Microsoft.DncEng.Configuration.Extensions;
@@ -40,12 +38,9 @@ public static class Program
                 options.ReleasePackageFeeds.Add((token1.GetValue<string>("Account"), token1.GetValue<string>("Project"), token1.GetValue<string>("Name")));
             }
 
-            AzureDevOpsTokenProviderOptions azdoConfig = new();
+            AzureDevOpsTokenProviderOptions azdoConfig = [];
             config.GetSection("AzureDevOps").Bind(azdoConfig);
-            IEnumerable<string> allOrgs = azdoConfig.Tokens.Keys
-                .Concat(azdoConfig.ManagedIdentities.Keys)
-                .Distinct();
-            options.AzdoAccounts.AddRange(allOrgs);
+            options.AzdoAccounts.AddRange(azdoConfig.Keys);
         });
         services.AddDefaultJsonConfiguration();
         services.AddBuildAssetRegistry((provider, options) =>

--- a/src/Maestro/FeedCleanerService/Program.cs
+++ b/src/Maestro/FeedCleanerService/Program.cs
@@ -5,6 +5,7 @@ using Maestro.Common.AzureDevOpsTokens;
 using Maestro.Data;
 using Microsoft.DncEng.Configuration.Extensions;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -51,5 +52,6 @@ public static class Program
         services.AddAzureDevOpsTokenProvider();
         services.Configure<AzureDevOpsTokenProviderOptions>("AzureDevOps", (o, s) => s.Bind(o));
         services.AddTransient<IAzureDevOpsClient, AzureDevOpsClient>();
+        services.AddTransient<IProcessManager>(sp => ActivatorUtilities.CreateInstance<ProcessManager>(sp, "git"));
     }
 }

--- a/src/Maestro/Maestro.Common/AppCredentials/AppCredential.cs
+++ b/src/Maestro/Maestro.Common/AppCredentials/AppCredential.cs
@@ -20,7 +20,7 @@ public class AppCredential : TokenCredential
     private readonly TokenRequestContext _requestContext;
     private readonly TokenCredential _tokenCredential;
 
-    private AppCredential(TokenCredential credential, TokenRequestContext requestContext)
+    public AppCredential(TokenCredential credential, TokenRequestContext requestContext)
     {
         _requestContext = requestContext;
         _tokenCredential = credential;
@@ -42,9 +42,13 @@ public class AppCredential : TokenCredential
     /// Use this for user-based flows.
     /// </summary>
     public static AppCredential CreateUserCredential(string appId, string userScope = ".default")
-    {
-        var requestContext = new TokenRequestContext([$"api://{appId}/{userScope}"]);
+        => CreateUserCredential(appId, new TokenRequestContext([$"api://{appId}/{userScope}"]));
 
+    /// <summary>
+    /// Use this for user-based flows.
+    /// </summary>
+    public static AppCredential CreateUserCredential(string appId, TokenRequestContext requestContext)
+    {
         var authRecordPath = Path.Combine(AUTH_CACHE, $"{AUTH_RECORD_PREFIX}-{appId}");
         var credential = GetInteractiveCredential(appId, requestContext, authRecordPath);
 

--- a/src/Maestro/Maestro.Common/AppCredentials/AppCredential.cs
+++ b/src/Maestro/Maestro.Common/AppCredentials/AppCredential.cs
@@ -43,7 +43,7 @@ public class AppCredential : TokenCredential
     /// </summary>
     public static AppCredential CreateUserCredential(string appId, string userScope = ".default")
     {
-        var requestContext = new TokenRequestContext(new string[] { $"api://{appId}/{userScope}" });
+        var requestContext = new TokenRequestContext([$"api://{appId}/{userScope}"]);
 
         var authRecordPath = Path.Combine(AUTH_CACHE, $"{AUTH_RECORD_PREFIX}-{appId}");
         var credential = GetInteractiveCredential(appId, requestContext, authRecordPath);
@@ -122,7 +122,7 @@ public class AppCredential : TokenCredential
             appId,
             token => Task.FromResult(federatedToken));
 
-        var requestContext = new TokenRequestContext(new string[] { $"api://{appId}/.default" });
+        var requestContext = new TokenRequestContext([$"api://{appId}/.default"]);
         return new AppCredential(credential, requestContext);
     }
 
@@ -139,9 +139,9 @@ public class AppCredential : TokenCredential
         var appCredential = new ClientAssertionCredential(
             TENANT_ID,
             appId,
-            async (ct) => (await miCredential.GetTokenAsync(new TokenRequestContext(new string[] { "api://AzureADTokenExchange" }), ct)).Token);
+            async (ct) => (await miCredential.GetTokenAsync(new TokenRequestContext(["api://AzureADTokenExchange"]), ct)).Token);
 
-        var requestContext = new TokenRequestContext(new string[] { $"api://{appId}/.default" });
+        var requestContext = new TokenRequestContext([$"api://{appId}/.default"]);
         return new AppCredential(appCredential, requestContext);
     }
 
@@ -150,7 +150,7 @@ public class AppCredential : TokenCredential
     /// </summary>
     public static AppCredential CreateNonUserCredential(string appId)
     {
-        var requestContext = new TokenRequestContext(new string[] { $"{appId}/.default" });
+        var requestContext = new TokenRequestContext([$"{appId}/.default"]);
         var credential = new AzureCliCredential();
         return new AppCredential(credential, requestContext);
     }

--- a/src/Maestro/Maestro.Common/AppCredentials/AppCredentialResolverOptions.cs
+++ b/src/Maestro/Maestro.Common/AppCredentials/AppCredentialResolverOptions.cs
@@ -8,7 +8,7 @@ public class AppCredentialResolverOptions : CredentialResolverOptions
     /// <summary>
     /// Client ID of the Azure application to request the token for
     /// </summary>
-    public string AppId { get; set; }
+    public string AppId { get; }
 
     /// <summary>
     /// User scope to request the token for (in case of user flows).

--- a/src/Maestro/Maestro.Common/AppCredentials/ResolvedCredential.cs
+++ b/src/Maestro/Maestro.Common/AppCredentials/ResolvedCredential.cs
@@ -27,3 +27,28 @@ public class ResolvedCredential : TokenCredential
         return new ValueTask<AccessToken>(new AccessToken(Token, DateTimeOffset.MaxValue));
     }
 }
+
+/// <summary>
+/// Credential with a token that can expire on runtime.
+/// </summary>
+public class ResolvingCredential : TokenCredential
+{
+    private readonly Func<string> _tokenResolver;
+    private readonly TimeSpan _expiration;
+
+    public ResolvingCredential(Func<string> tokenResolver, TimeSpan expiration)
+    {
+        _tokenResolver = tokenResolver;
+        _expiration = expiration;
+    }
+
+    public override AccessToken GetToken(TokenRequestContext _, CancellationToken __)
+    {
+        return new AccessToken(_tokenResolver(), DateTimeOffset.Now + _expiration);
+    }
+
+    public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext _, CancellationToken __)
+    {
+        return new ValueTask<AccessToken>(new AccessToken(_tokenResolver(), DateTimeOffset.Now + _expiration));
+    }
+}

--- a/src/Maestro/Maestro.Common/AppCredentials/ResolvedCredential.cs
+++ b/src/Maestro/Maestro.Common/AppCredentials/ResolvedCredential.cs
@@ -8,47 +8,31 @@ namespace Maestro.Common.AppCredentials;
 /// <summary>
 /// Credential with a set token.
 /// </summary>
-public class ResolvedCredential : TokenCredential
+public class ResolvedCredential(string token) : TokenCredential
 {
-    public ResolvedCredential(string token)
-    {
-        Token = token;
-    }
-
-    public string Token { get; }
-
     public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
     {
-        return new AccessToken(Token, DateTimeOffset.MaxValue);
+        return new AccessToken(token, DateTimeOffset.MaxValue);
     }
 
     public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
     {
-        return new ValueTask<AccessToken>(new AccessToken(Token, DateTimeOffset.MaxValue));
+        return new ValueTask<AccessToken>(new AccessToken(token, DateTimeOffset.MaxValue));
     }
 }
 
 /// <summary>
-/// Credential with a token that can expire on runtime.
+/// Credential that resolves the token on each request.
 /// </summary>
-public class ResolvingCredential : TokenCredential
+public class ResolvingCredential(Func<string> tokenResolver) : TokenCredential
 {
-    private readonly Func<string> _tokenResolver;
-    private readonly TimeSpan _expiration;
-
-    public ResolvingCredential(Func<string> tokenResolver, TimeSpan expiration)
-    {
-        _tokenResolver = tokenResolver;
-        _expiration = expiration;
-    }
-
     public override AccessToken GetToken(TokenRequestContext _, CancellationToken __)
     {
-        return new AccessToken(_tokenResolver(), DateTimeOffset.Now + _expiration);
+        return new AccessToken(tokenResolver(), DateTimeOffset.UtcNow);
     }
 
     public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext _, CancellationToken __)
     {
-        return new ValueTask<AccessToken>(new AccessToken(_tokenResolver(), DateTimeOffset.Now + _expiration));
+        return new ValueTask<AccessToken>(new AccessToken(tokenResolver(), DateTimeOffset.UtcNow));
     }
 }

--- a/src/Maestro/Maestro.Common/AppCredentials/ResolvedCredential.cs
+++ b/src/Maestro/Maestro.Common/AppCredentials/ResolvedCredential.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
 using Azure.Core;
 
 namespace Maestro.Common.AppCredentials;
@@ -24,15 +25,15 @@ public class ResolvedCredential(string token) : TokenCredential
 /// <summary>
 /// Credential that resolves the token on each request.
 /// </summary>
-public class ResolvingCredential(Func<string> tokenResolver) : TokenCredential
+public class ResolvingCredential(Func<TokenRequestContext, CancellationToken, string> tokenResolver) : TokenCredential
 {
-    public override AccessToken GetToken(TokenRequestContext _, CancellationToken __)
+    public override AccessToken GetToken(TokenRequestContext context, CancellationToken cancellationToken)
     {
-        return new AccessToken(tokenResolver(), DateTimeOffset.UtcNow);
+        return new AccessToken(tokenResolver(context, cancellationToken), DateTimeOffset.UtcNow);
     }
 
-    public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext _, CancellationToken __)
+    public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext context, CancellationToken cancellationToken)
     {
-        return new ValueTask<AccessToken>(new AccessToken(tokenResolver(), DateTimeOffset.UtcNow));
+        return new ValueTask<AccessToken>(new AccessToken(tokenResolver(context, cancellationToken), DateTimeOffset.UtcNow));
     }
 }

--- a/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsCredentialResolverOptions.cs
+++ b/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsCredentialResolverOptions.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Maestro.Common.AppCredentials;
+
+namespace Maestro.Common.AzureDevOpsTokens;
+
+public class AzureDevOpsCredentialResolverOptions : AppCredentialResolverOptions
+{
+    public AzureDevOpsCredentialResolverOptions()
+        : base("499b84ac-1321-427f-aa17-267ca6975798")
+    {
+    }
+}

--- a/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
+++ b/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
@@ -34,16 +34,15 @@ public class AzureDevOpsTokenProvider : IAzureDevOpsTokenProvider
 
     public AzureDevOpsTokenProvider(IOptionsMonitor<AzureDevOpsTokenProviderOptions> options)
         // We don't mind locking down the current value of the option because non-token settings are not expected to change
+        // Tokens are always read fresh through the second argument
         : this(GetCredentials(options.CurrentValue, account => options.CurrentValue[account].Token!))
     {
     }
 
-    public AzureDevOpsTokenProvider(AzureDevOpsTokenProviderOptions options)
-        : this(GetCredentials(options, account => options[account].Token!))
-    {
-    }
+    public static AzureDevOpsTokenProvider FromStaticOptions(AzureDevOpsTokenProviderOptions options)
+        => new(GetCredentials(options, account => options[account].Token!));
 
-    public AzureDevOpsTokenProvider(Dictionary<string, TokenCredential> accountCredentials)
+    private AzureDevOpsTokenProvider(Dictionary<string, TokenCredential> accountCredentials)
     {
         _accountCredentials = accountCredentials;
     }
@@ -143,7 +142,7 @@ public class AzureDevOpsTokenProvider : IAzureDevOpsTokenProvider
             }
 
             // 5. Interactive login (user-based scenario)
-            credentials[account] = AppCredential.CreateUserCredential(option.AppId, option.UserScope);
+            credentials[account] = new DefaultAzureCredential(includeInteractiveCredentials: true);
         }
 
         return credentials;

--- a/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProviderOptions.cs
+++ b/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProviderOptions.cs
@@ -3,9 +3,6 @@
 
 namespace Maestro.Common.AzureDevOpsTokens;
 
-public class AzureDevOpsTokenProviderOptions
+public class AzureDevOpsTokenProviderOptions : Dictionary<string, AzureDevOpsCredentialResolverOptions>
 {
-    public Dictionary<string, string> Tokens { get; } = [];
-
-    public Dictionary<string, string> ManagedIdentities { get; } = [];
 }

--- a/src/Maestro/Maestro.Common/AzureDevOpsTokens/IAzureDevOpsTokenProvider.cs
+++ b/src/Maestro/Maestro.Common/AzureDevOpsTokens/IAzureDevOpsTokenProvider.cs
@@ -1,27 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.RegularExpressions;
-
 namespace Maestro.Common.AzureDevOpsTokens;
 
-public interface IAzureDevOpsTokenProvider
+public interface IAzureDevOpsTokenProvider : IRemoteTokenProvider
 {
-    Task<string> GetTokenForAccount(string account);
-}
+    string GetTokenForAccount(string account);
 
-public static class AzureDevOpsTokenProviderExtensions
-{
-    private static readonly Regex AccountNameRegex = new(@"^https://dev\.azure\.com/(?<account>[a-zA-Z0-9]+)/");
-
-    public static Task<string> GetTokenForRepository(this IAzureDevOpsTokenProvider that, string repositoryUrl)
-    {
-        Match m = AccountNameRegex.Match(repositoryUrl);
-        if (!m.Success)
-        {
-            throw new ArgumentException($"{repositoryUrl} is not a valid Azure DevOps repository URL");
-        }
-        var account = m.Groups["account"].Value;
-        return that.GetTokenForAccount(account);
-    }
+    Task<string> GetTokenForAccountAsync(string account);
 }

--- a/src/Maestro/Maestro.Common/AzureDevOpsTokens/MaestroAzureDevOpsServiceCollectionExtensions.cs
+++ b/src/Maestro/Maestro.Common/AzureDevOpsTokens/MaestroAzureDevOpsServiceCollectionExtensions.cs
@@ -7,8 +7,19 @@ namespace Maestro.Common.AzureDevOpsTokens;
 
 public static class MaestroAzureDevOpsServiceCollectionExtensions
 {
-    public static IServiceCollection AddAzureDevOpsTokenProvider(this IServiceCollection services)
+    /// <summary>
+    /// Registers the Azure DevOps token provider.
+    /// </summary>
+    /// <param name="staticOptions">If provided, will initialize these options. Otherwise will try to monitor configuration.</param>
+    public static IServiceCollection AddAzureDevOpsTokenProvider(
+        this IServiceCollection services,
+        AzureDevOpsTokenProviderOptions? staticOptions = null)
     {
+        if (staticOptions != null)
+        {
+            services.AddSingleton(staticOptions);
+        }
+
         return services.AddSingleton<IAzureDevOpsTokenProvider, AzureDevOpsTokenProvider>();
     }
 }

--- a/src/Maestro/Maestro.Common/IRemoteTokenProvider.cs
+++ b/src/Maestro/Maestro.Common/IRemoteTokenProvider.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Maestro.Common;
+
+public interface IRemoteTokenProvider
+{
+    string? GetTokenForRepository(string repoUri);
+
+    Task<string?> GetTokenForRepositoryAsync(string repoUri);
+}
+
+public class ResolvedTokenProvider : IRemoteTokenProvider
+{
+    private readonly string? _token;
+
+    public ResolvedTokenProvider(string? token)
+    {
+        _token = token;
+    }
+
+    public string? GetTokenForRepository(string repoUri)
+    {
+        return _token;
+    }
+
+    public Task<string?> GetTokenForRepositoryAsync(string repoUri)
+    {
+        return Task.FromResult(_token);
+    }
+}

--- a/src/Maestro/Maestro.Web/.config/settings.Development.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Development.json
@@ -19,10 +19,14 @@
         "UseAzCliAuthentication": true
     },
     "AzureDevOps": {
-        "Tokens": {
-            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
-            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
-            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        "dnceng": {
+            "Token": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]"
+        },
+        "devdiv": {
+            "Token": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]"
+        },
+        "domoreexp": {
+            "Token": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
         }
     }
 }

--- a/src/Maestro/Maestro.Web/.config/settings.Production.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Production.json
@@ -27,5 +27,10 @@
         "ClientId": "54c17f3d-7325-4eca-9db7-f090bfc765a8",
         "UserRole": "User",
         "RedirectUri": "https://maestro.dot.net/signin-oidc"
+    },
+    "AzureDevOps": {
+        "default": {
+            "ManagedIdentityId": "system"
+        }
     }
 }

--- a/src/Maestro/Maestro.Web/.config/settings.Staging.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Staging.json
@@ -23,5 +23,10 @@
         "ClientId": "baf98f1b-374e-487d-af42-aa33807f11e4",
         "UserRole": "User",
         "RedirectUri": "https://maestro.int-dot.net/signin-oidc"
+    },
+    "AzureDevOps": {
+        "default": {
+            "ManagedIdentityId": "system"
+        }
     }
 }

--- a/src/Maestro/Maestro.Web/.config/settings.json
+++ b/src/Maestro/Maestro.Web/.config/settings.json
@@ -11,11 +11,6 @@
         "GitHubAppId": "[vault(github-app-id)]",
         "PrivateKey": "[vault(github-app-private-key)]"
     },
-    "AzureDevOps": {
-        "ManagedIdentities": {
-            "default": "system"
-        }
-    },
     "WebHooks": {
         "github": {
             "SecretKey": {

--- a/src/Maestro/Maestro.Web/Controllers/AzDevController.cs
+++ b/src/Maestro/Maestro.Web/Controllers/AzDevController.cs
@@ -38,7 +38,7 @@ public class AzDevController : ControllerBase
     [HttpGet("build/status/{account}/{project}/{definitionId}/{*branch}")]
     public async Task<IActionResult> GetBuildStatus(string account, string project, int definitionId, string branch, int count, string status)
     {
-        string token = await TokenProvider.GetTokenForAccount(account);
+        string token = await TokenProvider.GetTokenForAccountAsync(account);
             
         return await HttpContext.ProxyRequestAsync(
             s_lazyClient.Value,

--- a/src/Maestro/Maestro.Web/Startup.cs
+++ b/src/Maestro/Maestro.Web/Startup.cs
@@ -48,6 +48,7 @@ using Newtonsoft.Json.Serialization;
 using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.Swagger;
 using Maestro.Common.AzureDevOpsTokens;
+using Microsoft.DotNet.DarcLib.Helpers;
 
 namespace Maestro.Web;
 
@@ -243,6 +244,7 @@ public partial class Startup : StartupBase
         // in such a way that will work with sizing.
         services.AddSingleton<DarcRemoteMemoryCache>();
 
+        services.AddTransient<IProcessManager>(sp => ActivatorUtilities.CreateInstance<ProcessManager>(sp, "git"));
         services.AddTransient<IVersionDetailsParser, VersionDetailsParser>();
         services.AddScoped<IRemoteFactory, DarcRemoteFactory>();
         services.AddTransient<IBasicBarClient, SqlBarClient>();

--- a/src/Maestro/SubscriptionActorService/.config/settings.Development.json
+++ b/src/Maestro/SubscriptionActorService/.config/settings.Development.json
@@ -17,10 +17,14 @@
         "UseAzCliAuthentication": true
     },
     "AzureDevOps": {
-        "Tokens": {
-            "dnceng": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]",
-            "devdiv": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]",
-            "domoreexp": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        "dnceng": {
+            "Token": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]"
+        },
+        "devdiv": {
+            "Token": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]"
+        },
+        "domoreexp": {
+            "Token": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
         }
     }
 }

--- a/src/Maestro/SubscriptionActorService/.config/settings.Production.json
+++ b/src/Maestro/SubscriptionActorService/.config/settings.Production.json
@@ -15,5 +15,10 @@
     "Kusto": {
         "Database": "engineeringdata",
         "KustoClusterUri": "https://engsrvprod.westus.kusto.windows.net"
+    },
+    "AzureDevOps": {
+        "default": {
+            "ManagedIdentityId": "system"
+        }
     }
 }

--- a/src/Maestro/SubscriptionActorService/.config/settings.Staging.json
+++ b/src/Maestro/SubscriptionActorService/.config/settings.Staging.json
@@ -14,5 +14,10 @@
     "Kusto": {
         "Database": "engineeringdata",
         "KustoClusterUri": "https://engdata.westus2.kusto.windows.net"
+    },
+    "AzureDevOps": {
+        "default": {
+            "ManagedIdentityId": "system"
+        }
     }
 }

--- a/src/Maestro/SubscriptionActorService/.config/settings.json
+++ b/src/Maestro/SubscriptionActorService/.config/settings.json
@@ -2,10 +2,5 @@
     "GitHub": {
         "GitHubAppId": "[vault(github-app-id)]",
         "PrivateKey": "[vault(github-app-private-key)]"
-    },
-    "AzureDevOps": {
-        "ManagedIdentities": {
-            "default": "system"
-        }
     }
 }

--- a/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
+++ b/src/Maestro/SubscriptionActorService/DarcRemoteFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Maestro.Common;
 using Maestro.Common.AzureDevOpsTokens;
 using Maestro.Data;
 using Microsoft.DotNet.DarcLib;
@@ -22,10 +23,10 @@ public class DarcRemoteFactory : IRemoteFactory
     private readonly IAzureDevOpsTokenProvider _azureDevOpsTokenProvider;
     private readonly BuildAssetRegistryContext _context;
     private readonly DarcRemoteMemoryCache _cache;
-
     private readonly TemporaryFiles _tempFiles;
     private readonly ILocalGit _localGit;
     private readonly IVersionDetailsParser _versionDetailsParser;
+    private readonly IProcessManager _processManager;
     private readonly OperationManager _operations;
 
     public DarcRemoteFactory(
@@ -37,11 +38,13 @@ public class DarcRemoteFactory : IRemoteFactory
         TemporaryFiles tempFiles,
         ILocalGit localGit,
         IVersionDetailsParser versionDetailsParser,
+        IProcessManager processManager,
         OperationManager operations)
     {
         _tempFiles = tempFiles;
         _localGit = localGit;
         _versionDetailsParser = versionDetailsParser;
+        _processManager = processManager;
         _operations = operations;
         _configuration = configuration;
         _gitHubTokenProvider = gitHubTokenProvider;
@@ -91,16 +94,6 @@ public class DarcRemoteFactory : IRemoteFactory
             throw new GithubApplicationInstallationException($"No installation is available for repository '{normalizedUrl}'");
         }
 
-        var remoteConfiguration = repoType switch
-        {
-            GitRepoType.GitHub => new RemoteTokenProvider(
-                gitHubToken: await _gitHubTokenProvider.GetTokenForInstallationAsync(installationId)),
-            GitRepoType.AzureDevOps => new RemoteTokenProvider(
-                azureDevOpsToken: await _azureDevOpsTokenProvider.GetTokenForRepository(normalizedUrl)),
-
-            _ => throw new NotImplementedException($"Unknown repo url type {normalizedUrl}"),
-        };
-
         var gitExe = _localGit.GetPathToLocalGit();
 
         return GitRepoUrlParser.ParseTypeFromUri(normalizedUrl) switch
@@ -108,15 +101,15 @@ public class DarcRemoteFactory : IRemoteFactory
             GitRepoType.GitHub => installationId == default
                 ? throw new GithubApplicationInstallationException($"No installation is available for repository '{normalizedUrl}'")
                 : new GitHubClient(
-                    gitExe,
-                    remoteConfiguration.GitHubToken,
+                    new ResolvedTokenProvider(await _gitHubTokenProvider.GetTokenForInstallationAsync(installationId)),
+                    _processManager,
                     logger,
                     temporaryRepositoryRoot,
                     _cache.Cache),
 
             GitRepoType.AzureDevOps => new AzureDevOpsClient(
-                gitExe,
-                remoteConfiguration.AzureDevOpsToken,
+                _azureDevOpsTokenProvider,
+                _processManager,
                 logger,
                 temporaryRepositoryRoot),
 

--- a/src/Maestro/SubscriptionActorService/Program.cs
+++ b/src/Maestro/SubscriptionActorService/Program.cs
@@ -8,6 +8,7 @@ using Maestro.DataProviders;
 using Maestro.MergePolicies;
 using Microsoft.DncEng.Configuration.Extensions;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.DotNet.Kusto;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
@@ -39,6 +40,7 @@ public static class Program
     public static void Configure(IServiceCollection services)
     {
         services.TryAddTransient<ILogger>(sp => sp.GetRequiredService<ILogger<SubscriptionActor>>());
+        services.AddTransient<IProcessManager>(sp => ActivatorUtilities.CreateInstance<ProcessManager>(sp, "git"));
         services.AddSingleton<IActionRunner, ActionRunner>();
         services.AddSingleton<IMergePolicyEvaluator, MergePolicyEvaluator>();
         services.AddTransient<ICoherencyUpdateResolver, CoherencyUpdateResolver>();

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Threading.Tasks;
-using Maestro.Common.AzureDevOpsTokens;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
@@ -53,7 +52,7 @@ internal class RemoteFactory : IRemoteFactory
         {
             GitRepoType.GitHub =>
                 new GitHubClient(
-                    options.GetRemoteTokenProvider(),
+                    options.GetGitHubTokenProvider(),
                     new ProcessManager(logger, options.GitLocation),
                     logger,
                     temporaryRepositoryRoot,
@@ -62,7 +61,7 @@ internal class RemoteFactory : IRemoteFactory
 
             GitRepoType.AzureDevOps =>
                 new AzureDevOpsClient(
-                    new AzureDevOpsTokenProvider(),
+                    options.GetAzdoTokenProvider(),
                     new ProcessManager(logger, options.GitLocation),
                     logger,
                     temporaryRepositoryRoot),

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Threading.Tasks;
+using Maestro.Common.AzureDevOpsTokens;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
@@ -52,8 +53,8 @@ internal class RemoteFactory : IRemoteFactory
         {
             GitRepoType.GitHub =>
                 new GitHubClient(
-                    options.GitLocation,
-                    options.GitHubPat,
+                    options.GetRemoteTokenProvider(),
+                    new ProcessManager(logger, options.GitLocation),
                     logger,
                     temporaryRepositoryRoot,
                     // Caching not in use for Darc local client.
@@ -61,8 +62,8 @@ internal class RemoteFactory : IRemoteFactory
 
             GitRepoType.AzureDevOps =>
                 new AzureDevOpsClient(
-                    options.GitLocation,
-                    options.AzureDevOpsPat,
+                    new AzureDevOpsTokenProvider(),
+                    new ProcessManager(logger, options.GitLocation),
                     logger,
                     temporaryRepositoryRoot),
 

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Maestro.Common.AzureDevOpsTokens;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
@@ -211,13 +212,6 @@ internal class AddBuildToChannelOperation : Operation
                 Console.WriteLine($"Build {build.Id} was assigned to channel '{targetChannel.Name}' bypassing the promotion pipeline.");
             }
             return Constants.SuccessCode;
-        }
-
-        if (string.IsNullOrEmpty(_options.AzureDevOpsPat))
-        {
-            Console.WriteLine($"Promoting build {build.Id} with the given parameters would require starting the Build Promotion pipeline, however an AzDO PAT was not found.");
-            Console.WriteLine("Either specify an AzDO PAT as a parameter or add the --skip-assets-publishing parameter when calling Darc add-build-to-channel.");
-            return Constants.ErrorCode;
         }
 
         var (arcadeSDKSourceBranch, arcadeSDKSourceSHA) = await GetSourceBranchInfoAsync(build).ConfigureAwait(false);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Maestro.Common.AzureDevOpsTokens;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
@@ -230,7 +230,7 @@ internal class AddBuildToChannelOperation : Operation
             return Constants.ErrorCode;
         }
 
-        var azdoClient = new AzureDevOpsClient(gitExecutable: null, _options.AzureDevOpsPat, Logger, temporaryRepositoryPath: null);
+        var azdoClient = Provider.GetRequiredService<AzureDevOpsClient>();
 
         var targetAzdoBuildStatus = await ValidateAzDOBuildAsync(azdoClient, build.AzureDevOpsAccount, build.AzureDevOpsProject, build.AzureDevOpsBuildId.Value)
             .ConfigureAwait(false);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddDependencyOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddDependencyOperation.cs
@@ -24,7 +24,7 @@ internal class AddDependencyOperation : Operation
     {
         DependencyType type = _options.Type.ToLower() == "toolset" ? DependencyType.Toolset : DependencyType.Product;
 
-        var local = new Local(_options.GetRemoteConfiguration(), Logger);
+        var local = new Local(_options.GetRemoteTokenProvider(), Logger);
 
         DependencyDetail dependency = new DependencyDetail
         {

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/CloneOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/CloneOperation.cs
@@ -79,7 +79,7 @@ internal class CloneOperation : Operation
 
             if (string.IsNullOrWhiteSpace(_options.RepoUri))
             {
-                var local = new Local(_options.GetRemoteConfiguration(), Logger);
+                var local = new Local(_options.GetRemoteTokenProvider(), Logger);
                 IEnumerable<DependencyDetail>  rootDependencies = await local.GetDependenciesAsync();
                 IEnumerable<StrippedDependency> stripped = rootDependencies.Select(StrippedDependency.GetDependency);
                 foreach (StrippedDependency d in stripped)
@@ -231,7 +231,7 @@ internal class CloneOperation : Operation
         if (Directory.Exists(repoPath))
         {
             Logger.LogDebug($"Repo path {repoPath} already exists, assuming we cloned already and skipping");
-            local = new Local(_options.GetRemoteConfiguration(), Logger, repoPath);
+            local = new Local(_options.GetRemoteTokenProvider(), Logger, repoPath);
         }
         else
         {
@@ -239,7 +239,7 @@ internal class CloneOperation : Operation
             Directory.CreateDirectory(repoPath);
             File.WriteAllText(Path.Combine(repoPath, ".git"), GetGitDirRedirectString(masterRepoGitDirPath));
             Logger.LogInformation($"Checking out {commit} in {repoPath}");
-            local = new Local(_options.GetRemoteConfiguration(), Logger, repoPath);
+            local = new Local(_options.GetRemoteTokenProvider(), Logger, repoPath);
             local.Checkout(commit, true);
         }
 
@@ -256,7 +256,7 @@ internal class CloneOperation : Operation
         {
             await HandleMasterCopyWithDefaultGitDir(remoteFactory, repoUrl, masterGitRepoPath, masterRepoGitDirPath);
         }
-        var local = new Local(_options.GetRemoteConfiguration(), Logger, masterGitRepoPath);
+        var local = new Local(_options.GetRemoteTokenProvider(), Logger, masterGitRepoPath);
         await local.AddRemoteIfMissingAsync(masterGitRepoPath, repoUrl);
     }
 
@@ -361,7 +361,7 @@ internal class CloneOperation : Operation
             Logger.LogDebug($"Master .gitdir exists and master folder {masterGitRepoPath} does not.  Creating master folder.");
             Directory.CreateDirectory(masterGitRepoPath);
             File.WriteAllText(Path.Combine(masterGitRepoPath, ".git"), gitDirRedirect);
-            var masterLocal = new Local(_options.GetRemoteConfiguration(), Logger, masterGitRepoPath);
+            var masterLocal = new Local(_options.GetRemoteTokenProvider(), Logger, masterGitRepoPath);
             Logger.LogDebug($"Checking out default commit in {masterGitRepoPath}");
             masterLocal.Checkout(null, true);
         }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependenciesOperation.cs
@@ -23,7 +23,7 @@ internal class GetDependenciesOperation : Operation
 
     public override async Task<int> ExecuteAsync()
     {
-        var local = new Local(_options.GetRemoteConfiguration(), Logger);
+        var local = new Local(_options.GetRemoteTokenProvider(), Logger);
 
         try
         {

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependencyGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependencyGraphOperation.cs
@@ -27,7 +27,7 @@ internal class GetDependencyGraphOperation : Operation
     {
         _options = options;
         _gitClient = new LocalLibGit2Client(
-            options.GetRemoteConfiguration(),
+            options.GetRemoteTokenProvider(),
             new NoTelemetryRecorder(),
             new ProcessManager(Logger, _options.GitLocation),
             new FileSystem(),
@@ -95,7 +95,7 @@ internal class GetDependencyGraphOperation : Operation
                     Console.WriteLine($"Getting root dependencies from local repository...");
 
                     // Grab root dependency set from local repo
-                    var local = new Local(_options.GetRemoteConfiguration(), Logger);
+                    var local = new Local(_options.GetRemoteTokenProvider(), Logger);
                     rootDependencies = await local.GetDependenciesAsync(
                         _options.AssetName);
                 }
@@ -131,7 +131,7 @@ internal class GetDependencyGraphOperation : Operation
             {
                 Console.WriteLine($"Getting root dependencies from local repository...");
 
-                var local = new Local(_options.GetRemoteConfiguration(), Logger);
+                var local = new Local(_options.GetRemoteTokenProvider(), Logger);
                 rootDependencies = await local.GetDependenciesAsync(
                     _options.AssetName);
 

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Maestro.Common;
+using Maestro.Common.AzureDevOpsTokens;
 using Microsoft.Arcade.Common;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
@@ -55,13 +56,16 @@ public abstract class Operation : IDisposable
         services.TryAddTransient<IProcessManager>(sp => ActivatorUtilities.CreateInstance<ProcessManager>(sp, options.GitLocation));
         services.TryAddSingleton(sp => RemoteFactory.GetBarClient(options, sp.GetRequiredService<ILogger<BarApiClient>>()));
         services.TryAddSingleton<IBasicBarClient>(sp => sp.GetRequiredService<IBarApiClient>());
-        services.TryAddSingleton<IRemoteTokenProvider>(options.GetRemoteTokenProvider());
         services.TryAddTransient<ILogger>(sp => sp.GetRequiredService<ILogger<Operation>>());
         services.TryAddTransient<ITelemetryRecorder, NoTelemetryRecorder>();
+        services.TryAddSingleton<AzureDevOpsClient>();
 
         Provider = services.BuildServiceProvider();
         Logger = Provider.GetRequiredService<ILogger<Operation>>();
         options.InitializeFromSettings(Logger);
+
+        services.TryAddSingleton<IAzureDevOpsTokenProvider>(options.GetAzdoTokenProvider());
+        services.TryAddSingleton<IRemoteTokenProvider>(options.GetRemoteTokenProvider());
     }
 
     public abstract Task<int> ExecuteAsync();

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Maestro.Common;
 using Microsoft.Arcade.Common;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Options;
@@ -54,7 +55,7 @@ public abstract class Operation : IDisposable
         services.TryAddTransient<IProcessManager>(sp => ActivatorUtilities.CreateInstance<ProcessManager>(sp, options.GitLocation));
         services.TryAddSingleton(sp => RemoteFactory.GetBarClient(options, sp.GetRequiredService<ILogger<BarApiClient>>()));
         services.TryAddSingleton<IBasicBarClient>(sp => sp.GetRequiredService<IBarApiClient>());
-        services.TryAddSingleton(options.GetRemoteConfiguration());
+        services.TryAddSingleton<IRemoteTokenProvider>(options.GetRemoteTokenProvider());
         services.TryAddTransient<ILogger>(sp => sp.GetRequiredService<ILogger<Operation>>());
         services.TryAddTransient<ITelemetryRecorder, NoTelemetryRecorder>();
 

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
@@ -41,7 +41,7 @@ internal class UpdateDependenciesOperation : Operation
             IBarApiClient barClient = Provider.GetRequiredService<IBarApiClient>();
             var coherencyUpdateResolver = new CoherencyUpdateResolver(barClient, Logger);
 
-            var local = new Local(_options.GetRemoteConfiguration(), Logger);
+            var local = new Local(_options.GetRemoteTokenProvider(), Logger);
             List<DependencyDetail> dependenciesToUpdate = [];
             bool someUpToDate = false;
             string finalMessage = $"Local dependencies updated from channel '{_options.Channel}'.";

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VerifyOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VerifyOperation.cs
@@ -26,7 +26,7 @@ internal class VerifyOperation : Operation
     /// <returns>Process exit code.</returns>
     public override async Task<int> ExecuteAsync()
     {
-        var local = new Local(_options.GetRemoteConfiguration(), Logger);
+        var local = new Local(_options.GetRemoteTokenProvider(), Logger);
 
         try
         {

--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using CommandLine;
+using Maestro.Common;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Operations;
 using Microsoft.DotNet.DarcLib;
@@ -55,9 +56,9 @@ public abstract class CommandLineOptions : ICommandLineOptions
 
     public abstract Operation GetOperation();
 
-    public RemoteTokenProvider GetRemoteConfiguration()
+    public IRemoteTokenProvider GetRemoteTokenProvider()
     {
-        return new RemoteTokenProvider(GitHubPat, AzureDevOpsPat);
+        return new RemoteTokenProvider(new ResolvedTokenProvider(AzureDevOpsPat), new ResolvedTokenProvider(GitHubPat));
     }
 
     public void InitializeFromSettings(ILogger logger)

--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -64,14 +64,14 @@ public abstract class CommandLineOptions : ICommandLineOptions
     {
         var azdoOptions = new AzureDevOpsTokenProviderOptions
         {
-            ["system"] = new AzureDevOpsCredentialResolverOptions
+            ["default"] = new AzureDevOpsCredentialResolverOptions
             {
                 Token = AzureDevOpsPat,
                 FederatedToken = FederatedToken,
                 DisableInteractiveAuth = IsCi,
             }
         };
-        return new AzureDevOpsTokenProvider(azdoOptions);
+        return AzureDevOpsTokenProvider.FromStaticOptions(azdoOptions);
     }
 
     public IRemoteTokenProvider GetGitHubTokenProvider() => new ResolvedTokenProvider(GitHubPat);

--- a/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
@@ -1,8 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Maestro.Common;
 using Microsoft.DotNet.Darc.Operations;
-using Microsoft.DotNet.DarcLib;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Darc.Options;
@@ -20,7 +20,7 @@ public interface ICommandLineOptions
     bool IsCi { get; set; }
 
     Operation GetOperation();
-    RemoteTokenProvider GetRemoteConfiguration();
+    IRemoteTokenProvider GetRemoteTokenProvider();
 
     /// <summary>
     /// Reads missing options from the local settings.

--- a/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/ICommandLineOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Maestro.Common;
+using Maestro.Common.AzureDevOpsTokens;
 using Microsoft.DotNet.Darc.Operations;
 using Microsoft.Extensions.Logging;
 
@@ -21,6 +22,8 @@ public interface ICommandLineOptions
 
     Operation GetOperation();
     IRemoteTokenProvider GetRemoteTokenProvider();
+    IAzureDevOpsTokenProvider GetAzdoTokenProvider();
+    IRemoteTokenProvider GetGitHubTokenProvider();
 
     /// <summary>
     /// Reads missing options from the local settings.

--- a/src/Microsoft.DotNet.Darc/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Actions/Local.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Maestro.Common;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models;
 using Microsoft.Extensions.Logging;
@@ -30,11 +31,11 @@ public class Local
     /// </summary>
     private const string GitExecutable = "git";
 
-    public Local(RemoteTokenProvider remoteConfiguration, ILogger logger, string overrideRootPath = null)
+    public Local(IRemoteTokenProvider tokenProvider, ILogger logger, string overrideRootPath = null)
     {
         _logger = logger;
         _versionDetailsParser = new VersionDetailsParser();
-        _gitClient = new LocalLibGit2Client(remoteConfiguration, new NoTelemetryRecorder(), new ProcessManager(logger, GitExecutable), new FileSystem(), logger);
+        _gitClient = new LocalLibGit2Client(tokenProvider, new NoTelemetryRecorder(), new ProcessManager(logger, GitExecutable), new FileSystem(), logger);
         _fileManager = new DependencyFileManager(_gitClient, _versionDetailsParser, logger);
 
         _repoRootDir = new(() => overrideRootPath ?? _gitClient.GetRootDirAsync().GetAwaiter().GetResult(), LazyThreadSafetyMode.PublicationOnly);

--- a/src/Microsoft.DotNet.Darc/DarcLib/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/AzureDevOpsClient.cs
@@ -59,6 +59,11 @@ public class AzureDevOpsClient : RemoteRepoBase, IRemoteGitRepo, IAzureDevOpsCli
     {
     }
 
+    public AzureDevOpsClient(IAzureDevOpsTokenProvider tokenProvider, IProcessManager processManager, ILogger<AzureDevOpsClient> logger)
+        : this(tokenProvider, processManager, (ILogger)logger)
+    {
+    }
+
     public AzureDevOpsClient(IAzureDevOpsTokenProvider tokenProvider, IProcessManager processManager, ILogger logger, string temporaryRepositoryPath)
         : base(tokenProvider, processManager, temporaryRepositoryPath, null, logger)
     {

--- a/src/Microsoft.DotNet.Darc/DarcLib/GitHubTokenProvider.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitHubTokenProvider.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Maestro.Common;
+using Microsoft.DotNet.GitHub.Authentication;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib;
+
+public class GitHubTokenProvider : IRemoteTokenProvider
+{
+    private readonly IGitHubTokenProvider _tokenProvider;
+
+    public GitHubTokenProvider(IGitHubTokenProvider tokenProvider)
+    {
+        _tokenProvider = tokenProvider;
+    }
+
+    public string? GetTokenForRepository(string repoUri)
+    {
+        return _tokenProvider.GetTokenForRepository(repoUri).GetAwaiter().GetResult();
+    }
+
+    public async Task<string?> GetTokenForRepositoryAsync(string repoUri)
+    {
+        return await _tokenProvider.GetTokenForRepository(repoUri);
+    }
+}

--- a/src/Microsoft.DotNet.Darc/DarcLib/GitHubTokenProvider.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitHubTokenProvider.cs
@@ -3,16 +3,15 @@
 
 using System.Threading.Tasks;
 using Maestro.Common;
-using Microsoft.DotNet.GitHub.Authentication;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib;
 
 public class GitHubTokenProvider : IRemoteTokenProvider
 {
-    private readonly IGitHubTokenProvider _tokenProvider;
+    private readonly GitHub.Authentication.IGitHubTokenProvider _tokenProvider;
 
-    public GitHubTokenProvider(IGitHubTokenProvider tokenProvider)
+    public GitHubTokenProvider(GitHub.Authentication.IGitHubTokenProvider tokenProvider)
     {
         _tokenProvider = tokenProvider;
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/GitNativeRepoCloner.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitNativeRepoCloner.cs
@@ -52,7 +52,7 @@ public class GitNativeRepoCloner : IGitRepoCloner
 
         var args = new List<string>();
         var envVars = new Dictionary<string, string>();
-        _localGitClient.AddGitAuthHeader(args, envVars, repoUri);
+        await _localGitClient.AddGitAuthHeader(args, envVars, repoUri);
 
         if (gitDirectory != null)
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/GitRepoCloner.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitRepoCloner.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using LibGit2Sharp;
+using Maestro.Common;
 using Microsoft.Extensions.Logging;
 
 #nullable enable
@@ -13,13 +14,13 @@ namespace Microsoft.DotNet.DarcLib;
 
 public class GitRepoCloner : IGitRepoCloner
 {
-    private readonly RemoteTokenProvider _remoteConfiguration;
+    private readonly IRemoteTokenProvider _remoteTokenProvider;
     private readonly ILocalLibGit2Client _localGitClient;
     private readonly ILogger _logger;
 
-    public GitRepoCloner(RemoteTokenProvider remoteConfiguration, ILocalLibGit2Client localGitClient, ILogger logger)
+    public GitRepoCloner(IRemoteTokenProvider remoteTokenProvider, ILocalLibGit2Client localGitClient, ILogger logger)
     {
-        _remoteConfiguration = remoteConfiguration;
+        _remoteTokenProvider = remoteTokenProvider;
         _localGitClient = localGitClient;
         _logger = logger;
     }
@@ -60,7 +61,7 @@ public class GitRepoCloner : IGitRepoCloner
                     // The PAT is actually the only thing that matters here, the username
                     // will be ignored.
                     Username = RemoteTokenProvider.GitRemoteUser,
-                    Password = _remoteConfiguration.GetTokenForUri(repoUri),
+                    Password = _remoteTokenProvider.GetTokenForRepository(repoUri),
                 },
         };
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
@@ -159,7 +159,7 @@ public interface ILocalGitClient
     /// </summary>
     /// <param name="args">Where to add the new argument into</param>
     /// <param name="envVars">Where to add the new variables into</param>
-    void AddGitAuthHeader(IList<string> args, IDictionary<string, string> envVars, string repoUri);
+    Task AddGitAuthHeader(IList<string> args, IDictionary<string, string> envVars, string repoUri);
 
     /// <summary>
     /// Gets a value of a given git configuration setting.

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using LibGit2Sharp;
+using Maestro.Common;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
 
@@ -20,14 +21,19 @@ namespace Microsoft.DotNet.DarcLib;
 /// </summary>
 public class LocalLibGit2Client : LocalGitClient, ILocalLibGit2Client
 {
-    private readonly RemoteTokenProvider _remoteConfiguration;
+    private readonly IRemoteTokenProvider _remoteTokenProvider;
     private readonly IProcessManager _processManager;
     private readonly ILogger _logger;
 
-    public LocalLibGit2Client(RemoteTokenProvider remoteConfiguration, ITelemetryRecorder telemetryRecorder, IProcessManager processManager, IFileSystem fileSystem, ILogger logger)
-        : base(remoteConfiguration, telemetryRecorder, processManager, fileSystem, logger)
+    public LocalLibGit2Client(
+        IRemoteTokenProvider remoteTokenProvider,
+        ITelemetryRecorder telemetryRecorder,
+        IProcessManager processManager,
+        IFileSystem fileSystem,
+        ILogger logger)
+        : base(remoteTokenProvider, telemetryRecorder, processManager, fileSystem, logger)
     {
-        _remoteConfiguration = remoteConfiguration;
+        _remoteTokenProvider = remoteTokenProvider;
         _processManager = processManager;
         _logger = logger;
     }
@@ -350,7 +356,7 @@ public class LocalLibGit2Client : LocalGitClient, ILocalLibGit2Client
             CredentialsProvider = (url, user, cred) =>
                 new UsernamePasswordCredentials
                 {
-                    Username = _remoteConfiguration.GetTokenForUri(remoteUrl),
+                    Username = _remoteTokenProvider.GetTokenForRepository(remoteUrl),
                     Password = string.Empty
                 }
         };

--- a/src/Microsoft.DotNet.Darc/DarcLib/Microsoft.DotNet.DarcLib.csproj
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Microsoft.DotNet.DarcLib.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="LibGit2Sharp" />
     <PackageReference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.DotNet.GitHub.Authentication" />
     <PackageReference Include="Microsoft.DotNet.Internal.Logging" />
     <PackageReference Include="Microsoft.DotNet.Services.Utility" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DependencyGraph.cs
@@ -782,7 +782,7 @@ public class DependencyGraph
                 // If a repo folder or a mapping was not set we use the current parent's 
                 // parent folder.
                 var gitClient = new LocalLibGit2Client(
-                    new RemoteTokenProvider(null, null),
+                    new RemoteTokenProvider((string)null, null),
                     new NoTelemetryRecorder(),
                     new ProcessManager(logger, gitExecutable),
                     new FileSystem(),

--- a/src/Microsoft.DotNet.Darc/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/RemoteRepoBase.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.DarcLib.Helpers;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,56 +8,42 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Maestro.Common;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.DarcLib;
 
 public class RemoteRepoBase : GitRepoCloner
 {
     private readonly ILogger _logger;
-    private readonly ProcessManager _processManager;
+    private readonly IProcessManager _processManager;
 
     protected RemoteRepoBase(
-        string gitExecutable,
+        IRemoteTokenProvider remoteConfiguration,
+        IProcessManager processManager,
         string temporaryRepositoryPath,
         IMemoryCache cache,
-        ILogger logger,
-        RemoteTokenProvider remoteConfiguration)
-        : this(gitExecutable, temporaryRepositoryPath, cache, logger, new ProcessManager(logger, gitExecutable), remoteConfiguration)
-    {
-    }
-
-    private RemoteRepoBase(
-        string gitExecutable,
-        string temporaryRepositoryPath,
-        IMemoryCache cache,
-        ILogger logger,
-        ProcessManager processManager,
-        RemoteTokenProvider remoteConfiguration)
+        ILogger logger)
         : base(remoteConfiguration, new LocalLibGit2Client(remoteConfiguration, new NoTelemetryRecorder(), processManager, new FileSystem(), logger), logger)
     {
         TemporaryRepositoryPath = temporaryRepositoryPath;
-        GitExecutable = gitExecutable;
         Cache = cache;
         _logger = logger;
         _processManager = processManager;
     }
 
     /// <summary>
-    ///     Location of the git executable. Can be "git" or full path to temporary download location
-    ///     used in the Maestro context.
-    /// </summary>
-    protected string GitExecutable { get; set; }
-
-    /// <summary>
     ///     Location where repositories should be cloned.
     /// </summary>
     protected string TemporaryRepositoryPath { get; set; }
-        
+
     /// <summary>
     /// Generic memory cache that may be supplied by the creator of the
     /// Remote for the purposes of caching remote responses.
     /// </summary>
-    protected IMemoryCache Cache { get; set;}
+    protected IMemoryCache Cache { get; set; }
 
     /// <summary>
     /// Cloning big repos takes a considerable amount of time when checking out the files. When

--- a/src/Microsoft.DotNet.Darc/DarcLib/RemoteRepoBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/RemoteRepoBase.cs
@@ -28,7 +28,7 @@ public class RemoteRepoBase : GitRepoCloner
         ILogger logger)
         : base(remoteConfiguration, new LocalLibGit2Client(remoteConfiguration, new NoTelemetryRecorder(), processManager, new FileSystem(), logger), logger)
     {
-        TemporaryRepositoryPath = temporaryRepositoryPath;
+        TemporaryRepositoryPath = temporaryRepositoryPath ?? Path.GetTempPath();
         Cache = cache;
         _logger = logger;
         _processManager = processManager;

--- a/src/Microsoft.DotNet.Darc/DarcLib/RemoteTokenProvider.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/RemoteTokenProvider.cs
@@ -1,35 +1,59 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System;
+using System.Threading.Tasks;
+using Maestro.Common;
+using Maestro.Common.AzureDevOpsTokens;
 using Microsoft.DotNet.DarcLib.Helpers;
 
+#nullable enable
 namespace Microsoft.DotNet.DarcLib;
 
-public class RemoteTokenProvider
+public class RemoteTokenProvider : IRemoteTokenProvider
 {
-    public RemoteTokenProvider(string? gitHubToken = null, string? azureDevOpsToken = null)
+    private readonly IRemoteTokenProvider _azdoTokenProvider;
+    private readonly IRemoteTokenProvider _gitHubTokenProvider;
+
+    public RemoteTokenProvider(
+        IRemoteTokenProvider azdoTokenProvider,
+        IRemoteTokenProvider gitHubTokenProvider)
     {
-        GitHubToken = gitHubToken;
-        AzureDevOpsToken = azureDevOpsToken;
+        _azdoTokenProvider = azdoTokenProvider;
+        _gitHubTokenProvider = gitHubTokenProvider;
+    }
+
+    public RemoteTokenProvider(
+        IAzureDevOpsTokenProvider azdoTokenProvider,
+        string? gitHubToken)
+    {
+        _azdoTokenProvider = azdoTokenProvider;
+        _gitHubTokenProvider = new ResolvedTokenProvider(gitHubToken);
     }
 
     public static string GitRemoteUser => Constants.GitHubBotUserName;
 
-    public string? GitHubToken { get; }
-
-
-    public string? AzureDevOpsToken { get; }
-
-    public string? GetTokenForUri(string repoUri)
+    public async Task<string?> GetTokenForRepositoryAsync(string repoUri)
     {
         var repoType = GitRepoUrlParser.ParseTypeFromUri(repoUri);
 
         return repoType switch
         {
-            GitRepoType.GitHub => GitHubToken,
-            GitRepoType.AzureDevOps => AzureDevOpsToken,
+            GitRepoType.GitHub => _gitHubTokenProvider.GetTokenForRepository(repoUri),
+            GitRepoType.AzureDevOps => await _azdoTokenProvider.GetTokenForRepositoryAsync(repoUri),
+            GitRepoType.Local => null,
+            _ => throw new NotImplementedException($"Unsupported repository remote {repoUri}"),
+        };
+    }
+
+    public string? GetTokenForRepository(string repoUri)
+    {
+        var repoType = GitRepoUrlParser.ParseTypeFromUri(repoUri);
+
+        return repoType switch
+        {
+            GitRepoType.GitHub => _gitHubTokenProvider.GetTokenForRepository(repoUri),
+            GitRepoType.AzureDevOps => _azdoTokenProvider.GetTokenForRepositoryAsync(repoUri).GetAwaiter().GetResult(),
             GitRepoType.Local => null,
             _ => throw new NotImplementedException($"Unsupported repository remote {repoUri}"),
         };

--- a/src/Microsoft.DotNet.Darc/DarcLib/RemoteTokenProvider.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/RemoteTokenProvider.cs
@@ -15,6 +15,12 @@ public class RemoteTokenProvider : IRemoteTokenProvider
     private readonly IRemoteTokenProvider _azdoTokenProvider;
     private readonly IRemoteTokenProvider _gitHubTokenProvider;
 
+    public RemoteTokenProvider()
+    {
+        _azdoTokenProvider = new ResolvedTokenProvider(null);
+        _gitHubTokenProvider = new ResolvedTokenProvider(null);
+    }
+
     public RemoteTokenProvider(
         IRemoteTokenProvider azdoTokenProvider,
         IRemoteTokenProvider gitHubTokenProvider)
@@ -28,6 +34,14 @@ public class RemoteTokenProvider : IRemoteTokenProvider
         string? gitHubToken)
     {
         _azdoTokenProvider = azdoTokenProvider;
+        _gitHubTokenProvider = new ResolvedTokenProvider(gitHubToken);
+    }
+
+    public RemoteTokenProvider(
+        string? azdoToken,
+        string? gitHubToken)
+    {
+        _azdoTokenProvider = new ResolvedTokenProvider(azdoToken);
         _gitHubTokenProvider = new ResolvedTokenProvider(gitHubToken);
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -29,7 +29,7 @@ public static class VmrRegistrations
     {
         // Configuration based registrations
         services.TryAddSingleton<IVmrInfo>(new VmrInfo(Path.GetFullPath(vmrPath), Path.GetFullPath(tmpPath)));
-        services.TryAddTransient<IRemoteTokenProvider>(sp =>
+        services.TryAddSingleton<IRemoteTokenProvider>(sp =>
         {
             if (!string.IsNullOrEmpty(azureDevOpsToken))
             {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -5,6 +5,8 @@ using System;
 using System.IO;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
+using Maestro.Common;
+using Maestro.Common.AzureDevOpsTokens;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,7 +29,16 @@ public static class VmrRegistrations
     {
         // Configuration based registrations
         services.TryAddSingleton<IVmrInfo>(new VmrInfo(Path.GetFullPath(vmrPath), Path.GetFullPath(tmpPath)));
-        services.TryAddSingleton(new RemoteTokenProvider(gitHubToken, azureDevOpsToken));
+        services.TryAddTransient<IRemoteTokenProvider>(sp =>
+        {
+            if (!string.IsNullOrEmpty(azureDevOpsToken))
+            {
+                return new RemoteTokenProvider(azureDevOpsToken, gitHubToken);
+            }
+
+            var azdoTokenProvider = sp.GetRequiredService<IAzureDevOpsTokenProvider>();
+            return new RemoteTokenProvider(azdoTokenProvider, gitHubToken);
+        });
         services.TryAddTransient<IProcessManager>(sp => ActivatorUtilities.CreateInstance<ProcessManager>(sp, gitLocation));
 
         services.TryAddTransient<ILogger>(sp => sp.GetRequiredService<ILogger<VmrManagerBase>>());

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -47,6 +47,7 @@ public static class VmrRegistrations
         services.TryAddTransient<ILocalGitRepoFactory, LocalGitRepoFactory>();
         services.TryAddTransient<ILocalGitClient, LocalGitClient>();
         services.TryAddTransient<ILocalLibGit2Client, LocalLibGit2Client>();
+        services.TryAddTransient<IAzureDevOpsClient, AzureDevOpsClient>();
         services.TryAddTransient<ISourceMappingParser, SourceMappingParser>();
         services.TryAddTransient<IVersionDetailsParser, VersionDetailsParser>();
         services.TryAddTransient<IVmrPatchHandler, VmrPatchHandler>();
@@ -71,6 +72,7 @@ public static class VmrRegistrations
         services.TryAddTransient<ITelemetryRecorder, NoTelemetryRecorder>();
         services.TryAddScoped<IVmrCloneManager, VmrCloneManager>();
         services.TryAddScoped<IRepositoryCloneManager, RepositoryCloneManager>();
+        services.TryAddSingleton<IAzureDevOpsTokenProvider, AzureDevOpsTokenProvider>();
 
         services.AddHttpClient("GraphQL", httpClient =>
         {

--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/PcsConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/PcsConfiguration.cs
@@ -7,6 +7,7 @@ using ProductConstructionService.Api.VirtualMonoRepo;
 using ProductConstructionService.Api.Queue;
 using ProductConstructionService.Api.Controllers;
 using Microsoft.DotNet.Maestro.Client;
+using Maestro.Common.AzureDevOpsTokens;
 
 namespace ProductConstructionService.Api.Configuration;
 
@@ -34,9 +35,9 @@ internal static class PcsConfiguration
     /// <param name="tmpPath">Path to the VMR tmp folder</param>
     /// <param name="vmrUri">Uri of the VMR</param>
     /// <param name="azureCredential">Credentials used to authenticate to Azure Resources</param>
-    /// <param name="databaseConnectionString">ConnectionString to the BAR database</param>
     /// <param name="initializeService">Run service initialization? Currently this just means cloning the VMR</param>
     /// <param name="addEndpointAuthentication">Add endpoint authentication?</param>
+    /// <param name="addSwagger">Add Swagger UI?</param>
     /// <param name="keyVaultUri">Uri to used KeyVault</param>
     public static void ConfigurePcs(
         this WebApplicationBuilder builder,
@@ -68,6 +69,7 @@ internal static class PcsConfiguration
         });
 
         builder.AddTelemetry();
+        builder.Services.Configure<AzureDevOpsTokenProviderOptions>("AzureDevOps", (o, s) => s.Bind(o));
         builder.AddVmrRegistrations(vmrPath, tmpPath);
         builder.AddGitHubClientFactory();
         builder.AddWorkitemQueues(azureCredential, waitForInitialization: initializeService);

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
@@ -21,5 +21,10 @@
         "ClientId": "baf98f1b-374e-487d-af42-aa33807f11e4",
         "UserRole": "User",
         "RedirectUri": "https://product-construction-int.wittytree-28a89311.westus2.azurecontainerapps.io/signin-oidc"
+    },
+    "AzureDevOps": {
+        "default": {
+            "ManagedIdentityId": "system"
+        }
     }
 }

--- a/test/FeedCleaner.Tests/FeedCleanerServiceTests.cs
+++ b/test/FeedCleaner.Tests/FeedCleanerServiceTests.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;
+using NuGet.Common;
 using NUnit.Framework;
 
 namespace FeedCleanerService.Tests;
@@ -66,7 +67,10 @@ public class FeedCleanerServiceTests : IDisposable
         services.Configure<AzureDevOpsTokenProviderOptions>(
             (options) =>
             {
-                options.Tokens.Add(SomeAccount, "someToken");
+                options[SomeAccount] = new()
+                {
+                    Token = "someToken"
+                };
             });
 
         _provider = services.BuildServiceProvider();
@@ -157,12 +161,7 @@ public class FeedCleanerServiceTests : IDisposable
 
     private FeedCleanerService ConfigureFeedCleaner()
     {
-        FeedCleanerService cleaner = ActivatorUtilities.CreateInstance<FeedCleanerService>(_scope.ServiceProvider);
-        cleaner.AzureDevOpsClients = new Dictionary<string, IAzureDevOpsClient>
-        {
-            { SomeAccount, _azdoMock.Object }
-        };
-        return cleaner;
+        return ActivatorUtilities.CreateInstance<FeedCleanerService>(_scope.ServiceProvider, _azdoMock.Object);
     }
 
     private static void MarkVersionAsDeleted(List<AzureDevOpsPackage> packages, string packageName, string version)

--- a/test/Microsoft.DotNet.DarcLib.Tests/GitHubClientTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/GitHubClientTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using FluentAssertions;
+using Maestro.Common;
+using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.Internal.Testing.Utility;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -146,7 +148,7 @@ internal class TestGitHubClient : GitHubClient
         }
     }
     public TestGitHubClient(string gitExecutable, string accessToken, ILogger logger, string temporaryRepositoryPath, IMemoryCache cache)
-        : base(gitExecutable, accessToken, logger, temporaryRepositoryPath, cache)
+        : base(new ResolvedTokenProvider(accessToken), new ProcessManager(logger, gitExecutable), logger, temporaryRepositoryPath, cache)
     {
     }
 }


### PR DESCRIPTION
In order to use the token credentials correctly and everywhere, we need to stop using hardcoded PATs and rather keep calling `GetToken()` every time we need to use it. The credentials can then either have a PAT inside (if we supply one in `darc` via args) or we will use `AzureCLI` or managed identities to obtain it.
The system of choosing the credential has now been also unified with how we handle Maestro API tokens.

This code change unifies the approach so that the `AzureDevOpsTokenProvider` is used everywhere for that purpose.
It also changes how we configure what kind of credential to use. Each AzDO account can still have it's own way.

Lastly, more classes become DI-friendly and easier to obtain/depend on (such as `AzureDevOpsClient`).

https://dev.azure.com/dnceng/internal/_workitems/edit/6419