### PR TITLE
Restore and re-apply all VMR patches always

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -394,11 +394,12 @@ public class LocalGitClient : ILocalGitClient
             "show"
         };
 
-        if (outputPath != null)
-        {
-            args.Add("--output");
-            args.Add(outputPath);
-        }
+        // This somehow stopped working for me
+        //if (outputPath != null)
+        //{
+        //    args.Add("--output");
+        //    args.Add(outputPath);
+        //}
 
         args.Add($"{revision}:{relativeFilePath.TrimStart('/')}");
 
@@ -407,6 +408,11 @@ public class LocalGitClient : ILocalGitClient
         if (!result.Succeeded)
         {
             return null;
+        }
+
+        if (outputPath != null)
+        {
+            _fileSystem.WriteToFile(outputPath, result.StandardOutput);
         }
 
         return result.StandardOutput;

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -391,8 +391,7 @@ public class LocalGitClient : ILocalGitClient
     {
         var args = new List<string>
         {
-            "show",
-            $"{revision}:{relativeFilePath.TrimStart('/')}"
+            "show"
         };
 
         if (outputPath != null)
@@ -400,6 +399,8 @@ public class LocalGitClient : ILocalGitClient
             args.Add("--output");
             args.Add(outputPath);
         }
+
+        args.Add($"{revision}:{relativeFilePath.TrimStart('/')}");
 
         var result = await _processManager.ExecuteGit(repoPath, args);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -394,12 +394,11 @@ public class LocalGitClient : ILocalGitClient
             "show"
         };
 
-        // This somehow stopped working for me
-        //if (outputPath != null)
-        //{
-        //    args.Add("--output");
-        //    args.Add(outputPath);
-        //}
+        if (outputPath != null)
+        {
+            args.Add("--output");
+            args.Add(outputPath);
+        }
 
         args.Add($"{revision}:{relativeFilePath.TrimStart('/')}");
 
@@ -408,11 +407,6 @@ public class LocalGitClient : ILocalGitClient
         if (!result.Succeeded)
         {
             return null;
-        }
-
-        if (outputPath != null)
-        {
-            _fileSystem.WriteToFile(outputPath, result.StandardOutput);
         }
 
         return result.StandardOutput;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -39,9 +39,11 @@ public interface IVmrPatchHandler
         UnixPath? applicationPath,
         CancellationToken cancellationToken);
 
-    IReadOnlyCollection<string> GetVmrPatches(SourceMapping mapping) => GetVmrPatches(mapping.Name);
+    Task<IReadOnlyCollection<VmrIngestionPatch>> GetVmrPatches(
+        string? patchVersion,
+        CancellationToken cancellationToken);
 
-    IReadOnlyCollection<string> GetVmrPatches(string mappingName);
-
-    Task<IReadOnlyCollection<UnixPath>> GetPatchedFiles(string patchPath, CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<UnixPath>> GetPatchedFiles(
+        string patchPath,
+        CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -89,6 +89,8 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
     {
         await _dependencyTracker.InitializeSourceMappings(sourceMappingsPath);
 
+        StartingVmrSha = await LocalVmr.GetGitCommitAsync();
+
         var mapping = _dependencyTracker.GetMapping(mappingName);
 
         if (_dependencyTracker.GetDependencyVersion(mapping) is not null)
@@ -212,17 +214,9 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         _logger.LogInformation("Initialization of {name} finished", update.Mapping.Name);
     }
 
-    protected override Task<IReadOnlyCollection<VmrIngestionPatch>> RestoreVmrPatchedFilesAsync(
-        SourceMapping mapping,
-        IReadOnlyCollection<VmrIngestionPatch> patches,
-        IReadOnlyCollection<AdditionalRemote> additionalRemotes,
-        CancellationToken cancellationToken)
+    protected override Task RestoreVmrPatchedFilesAsync(CancellationToken cancellationToken)
     {
-        // We only need to apply VMR patches that belong to the mapping, nothing to restore from before
-        IReadOnlyCollection<VmrIngestionPatch> vmrPatchesForMapping = _patchHandler.GetVmrPatches(mapping)
-            .Select(patch => new VmrIngestionPatch(patch, VmrInfo.GetRelativeRepoSourcesPath(mapping)))
-            .ToImmutableArray();
-
-        return Task.FromResult(vmrPatchesForMapping);
+        // No-op for first-time initialization
+        return Task.CompletedTask;
     }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
-using Octokit;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -68,7 +68,7 @@ public abstract class VmrManagerBase
         LocalVmr = localGitRepoFactory.Create(_vmrInfo.VmrPath);
     }
 
-    public async Task StageRepositoryUpdatesAsync(
+    protected async Task StageRepositoryUpdatesAsync(
         VmrDependencyUpdate update,
         ILocalGitRepo repoClone,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
@@ -344,7 +344,8 @@ public abstract class VmrManagerBase
     /// Takes a given commit message template and populates it with given values, URLs and others.
     /// </summary>
     /// <param name="template">Template into which the values are filled into</param>
-    /// <param name="mapping">Repository mapping</param>
+    /// <param name="name">Repository name</param>
+    /// <param name="remote">Remote URI of the repository</param>
     /// <param name="oldSha">SHA we are updating from</param>
     /// <param name="newSha">SHA we are updating to</param>
     /// <param name="additionalMessage">Additional message inserted in the commit body</param>

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -144,7 +144,7 @@ public abstract class VmrManagerBase
                 continue;
             }
 
-            await _patchHandler.ApplyPatch(patch, _vmrInfo.VmrPath, false, reverseApply: false, cancellationToken);
+            await _patchHandler.ApplyPatch(patch, _vmrInfo.VmrPath, removePatchAfter: false, reverseApply: false, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
             patchesApplied = true;
         }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -661,7 +661,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         }
 
         var patches = result.StandardOutput
-            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+            .Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
         var copiedPatches = new List<VmrIngestionPatch>();
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -142,7 +142,8 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             }
             else
             {
-                hadUpdates = await UpdateRepositoryInternal(
+                await RestoreVmrPatchedFilesAsync(cancellationToken);
+                hadUpdates = await UpdateRepository(
                     dependencyUpdate,
                     reapplyVmrPatches: true,
                     additionalRemotes,
@@ -151,10 +152,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                     generateCodeowners,
                     discardPatches,
                     cancellationToken);
-
-                await ReapplyVmrPatchesAsync(cancellationToken);
-                await CommitAsync("[VMR patches] Re-apply VMR patches");
-
             }
         }
         catch (EmptySyncException e)
@@ -166,7 +163,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         return hadUpdates;
     }
 
-    private async Task<bool> UpdateRepositoryInternal(
+    private async Task<bool> UpdateRepository(
         VmrDependencyUpdate update,
         bool reapplyVmrPatches,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
@@ -415,7 +412,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
             try
             {
-                await UpdateRepositoryInternal(
+                await UpdateRepository(
                     update,
                     reapplyVmrPatches: false,
                     additionalRemotes,

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchAddedTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchAddedTest.cs
@@ -1,0 +1,158 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using NUnit.Framework;
+
+namespace Microsoft.DotNet.Darc.Tests.VirtualMonoRepo;
+
+[TestFixture]
+internal class VmrPatchAddedTest : VmrTestsBase
+{
+    [Test]
+    public async Task PatchesAreAppliedTest()
+    {
+        var newPatchFileName = "new-patch.patch";
+        var vmrPatchesDir = VmrPath / VmrInfo.RelativeSourcesDir / Constants.InstallerRepoName / Constants.PatchesFolderName / Constants.ProductRepoName;
+        var patchPathInVmr = vmrPatchesDir / newPatchFileName;
+        var installerPatchesDir = InstallerRepoPath / Constants.PatchesFolderName / Constants.ProductRepoName;
+        var installerFilePathInVmr = VmrPath / VmrInfo.RelativeSourcesDir / Constants.InstallerRepoName / Constants.GetRepoFileName(Constants.InstallerRepoName);
+        var productRepoFilePathInVmr = VmrPath / VmrInfo.RelativeSourcesDir / Constants.ProductRepoName / Constants.GetRepoFileName(Constants.ProductRepoName);
+
+        await File.WriteAllTextAsync(ProductRepoPath / Constants.GetRepoFileName(Constants.ProductRepoName),
+            """
+            File in the test repo
+            patches will change the next lines
+            AAA
+            CCC
+            end of changes
+            """);
+        await GitOperations.CommitAll(ProductRepoPath, "Change file to CCC");
+
+        // Update dependent repo to the last commit
+        var productRepoSha = await GitOperations.GetRepoLastCommit(ProductRepoPath);
+        var productRepoDependency = string.Format(
+            Constants.DependencyTemplate,
+            Constants.ProductRepoName, ProductRepoPath, productRepoSha);
+
+        var versionDetails = string.Format(
+            Constants.VersionDetailsTemplate,
+            productRepoDependency);
+
+        await File.WriteAllTextAsync(InstallerRepoPath / VersionFiles.VersionDetailsXml, versionDetails);
+        await GitOperations.CommitAll(InstallerRepoPath, "Bump product repo to latest");
+
+        await InitializeRepoAtLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
+
+        CheckFileContents(productRepoFilePathInVmr, "AAA", "CCC");
+
+        await File.WriteAllTextAsync(ProductRepoPath / Constants.GetRepoFileName(Constants.ProductRepoName),
+            """
+            File in the test repo
+            patches will change the next lines
+            AAA
+            BBB
+            end of changes
+            """);
+        await GitOperations.CommitAll(ProductRepoPath, "Change file to BBB");
+
+        var expectedFilesFromRepos = new List<NativePath>
+        {
+            productRepoFilePathInVmr,
+            installerFilePathInVmr
+        };
+
+        var expectedFiles = GetExpectedFilesInVmr(
+            VmrPath,
+            [Constants.ProductRepoName, Constants.InstallerRepoName],
+            expectedFilesFromRepos
+        );
+
+        CheckDirectoryContents(VmrPath, expectedFiles);
+
+        // Add a new patch in installer
+        File.Copy(VmrTestsOneTimeSetUp.ResourcesPath / newPatchFileName, installerPatchesDir / newPatchFileName);
+
+        // Update dependent repo to the last commit
+        productRepoSha = await GitOperations.GetRepoLastCommit(ProductRepoPath);
+        productRepoDependency = string.Format(
+            Constants.DependencyTemplate,
+            Constants.ProductRepoName, ProductRepoPath, productRepoSha);
+
+        versionDetails = string.Format(
+            Constants.VersionDetailsTemplate,
+            productRepoDependency);
+
+        File.WriteAllText(InstallerRepoPath / VersionFiles.VersionDetailsXml, versionDetails);
+
+        await GitOperations.CommitAll(InstallerRepoPath, "Add a new patch file");
+        await UpdateRepoToLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
+
+        // Now we sync installer which means new patch + change in the product repo
+        // We must check that the patch is detected as being added and won't be restored during repo's sync
+        // The file will have AAA CCC in the beginning
+        // The repo change will change it to AAA BBB
+        // Then the patch will change it to TTT BBB
+        // If we tried to restore the patch before we sync the repo, the patch fails
+        // because it will find AAA CCC instead of AAA BBB (which it expects)
+        await UpdateRepoToLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
+
+        expectedFiles.Add(patchPathInVmr);
+        CheckDirectoryContents(VmrPath, expectedFiles);
+        CheckFileContents(productRepoFilePathInVmr, "TTT", "BBB");
+    }
+
+    protected override async Task CopyReposForCurrentTest()
+    {
+        var dependenciesMap = new Dictionary<string, List<string>>
+        {
+            { Constants.InstallerRepoName, new List<string> { Constants.ProductRepoName } },
+        };
+
+        await CopyRepoAndCreateVersionFiles(Constants.InstallerRepoName, dependenciesMap);
+    }
+
+    protected override async Task CopyVmrForCurrentTest()
+    {
+        CopyDirectory(VmrTestsOneTimeSetUp.CommonVmrPath, VmrPath);
+
+        var sourceMappings = new SourceMappingFile()
+        {
+            Mappings =
+            [
+                new SourceMappingSetting
+                {
+                    Name = Constants.InstallerRepoName,
+                    DefaultRemote = InstallerRepoPath
+                },
+                new SourceMappingSetting
+                {
+                    Name = Constants.ProductRepoName,
+                    DefaultRemote = ProductRepoPath
+                }
+            ],
+            PatchesPath = "src/installer/patches/"
+        };
+
+        await WriteSourceMappingsInVmr(sourceMappings);
+    }
+
+    private static void CheckFileContents(NativePath filePath, string line1, string line2)
+    {
+        CheckFileContents(filePath,
+            $"""
+            File in the test repo
+            patches will change the next lines
+            {line1}
+            {line2}
+            end of changes
+            """
+            );
+    }
+}

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
@@ -219,8 +219,18 @@ internal class VmrSyncRepoChangesTest :  VmrTestsBase
         // Remove submodule
 
         await GitOperations.RemoveSubmodule(ProductRepoPath, submoduleRelativePath);
-        await File.WriteAllTextAsync(VmrPath / VmrInfo.CodeownersPath, "My new content in the CODEOWNERS\n\n### CONTENT BELOW IS AUTO-GENERATED AND MANUAL CHANGES WILL BE OVERWRITTEN ###\n");
         await GitOperations.CommitAll(ProductRepoPath, "Remove the submodule");
+
+        // Change codeowners
+
+        await File.WriteAllTextAsync(VmrPath / VmrInfo.CodeownersPath,
+            """
+            My new content in the CODEOWNERS
+
+            ### CONTENT BELOW IS AUTO-GENERATED AND MANUAL CHANGES WILL BE OVERWRITTEN ###
+            """);
+        await GitOperations.CommitAll(VmrPath, "Updated codeowners");
+
         await UpdateRepoToLastCommit(Constants.ProductRepoName, ProductRepoPath, generateCodeowners: true);
 
         expectedFiles.Remove(submoduleFilePath);


### PR DESCRIPTION
Fixes a problem found in https://github.com/dotnet/sdk/issues/41793. The problem is that if SDK is the root repo where VMR patches are stored, and SDK gets pulled into the VMR, we must restore the previous versions of those VMR patches in the SDK before the new SDK changes were merged into the VMR.
This manifests in us trying to restore VMR patches that will only be added during the sync later.

The new code stops evaluating which VMR patches must be removed and strips all VMR patches always and then returns all back. So this simplifies the code a bit.

