### PR TITLE
Fix binding of AzDO configuration

### DIFF
--- a/src/Maestro/Maestro.Web/Startup.cs
+++ b/src/Maestro/Maestro.Web/Startup.cs
@@ -234,9 +234,10 @@ public partial class Startup : StartupBase
                     ?.InformationalVersion);
         });
         services.Configure<GitHubTokenProviderOptions>(Configuration.GetSection("GitHub"));
+
+        services.Configure<AzureDevOpsTokenProviderOptions>(Configuration.GetSection("AzureDevOps"));
         services.AddAzureDevOpsTokenProvider();
 
-        services.Configure<AzureDevOpsTokenProviderOptions>("AzureDevOps", Configuration);
         services.AddKustoClientProvider("Kusto");
 
         // We do not use AddMemoryCache here. We use our own cache because we wish to


### PR DESCRIPTION
We see exceptions like these:
> Specified argument was out of the range of valid values. (Parameter 'Azure DevOps account dnceng does not have a configured PAT or credential. Please add the account to the 'AzureDevOps.Tokens' or 'AzureDevOps.ManagedIdentities' configuration

Possibly introduced here:
https://github.com/dotnet/arcade-services/issues/3673



