### PR TITLE
Fixup AzDO client construction in DI

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
@@ -74,10 +74,7 @@ public abstract class Operation : IDisposable
                 s.GetRequiredService<ILogger>())
         );
         services.TryAddSingleton<IAzureDevOpsClient>(s =>
-            new AzureDevOpsClient(
-                s.GetRequiredService<IAzureDevOpsTokenProvider>(),
-                s.GetRequiredService<IProcessManager>(),
-                s.GetRequiredService<ILogger>())
+            s.GetRequiredService<AzureDevOpsClient>()
         );
 
         Provider = services.BuildServiceProvider();

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
@@ -66,9 +66,19 @@ public abstract class Operation : IDisposable
                 DisableInteractiveAuth = options.IsCi,
             };
         });
-        services.TryAddSingleton<AzureDevOpsClient>();
-        services.TryAddSingleton<IAzureDevOpsClient, AzureDevOpsClient>();
         services.TryAddSingleton<IAzureDevOpsTokenProvider, AzureDevOpsTokenProvider>();
+        services.TryAddSingleton(s =>
+            new AzureDevOpsClient(
+                s.GetRequiredService<IAzureDevOpsTokenProvider>(),
+                s.GetRequiredService<IProcessManager>(),
+                s.GetRequiredService<ILogger>())
+        );
+        services.TryAddSingleton<IAzureDevOpsClient>(s =>
+            new AzureDevOpsClient(
+                s.GetRequiredService<IAzureDevOpsTokenProvider>(),
+                s.GetRequiredService<IProcessManager>(),
+                s.GetRequiredService<ILogger>())
+        );
 
         Provider = services.BuildServiceProvider();
         Logger = Provider.GetRequiredService<ILogger<Operation>>();


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Resolves https://github.com/dotnet/arcade-services/issues/3718

Found by https://dev.azure.com/dnceng/internal/_build/results?buildId=2492728&view=results

DI is complaining about:
```
System.InvalidOperationException: Unable to activate type 'Microsoft.DotNet.DarcLib.AzureDevOpsClient'. The following constructors are ambiguous:
Void .ctor(Maestro.Common.AzureDevOpsTokens.IAzureDevOpsTokenProvider, Microsoft.DotNet.DarcLib.Helpers.IProcessManager, Microsoft.Extensions.Logging.ILogger`1[Microsoft.DotNet.DarcLib.AzureDevOpsClient])
Void .ctor(Maestro.Common.AzureDevOpsTokens.IAzureDevOpsTokenProvider, Microsoft.DotNet.DarcLib.Helpers.IProcessManager, Microsoft.Extensions.Logging.ILogger)
```

I couldn't find a way to remove one of the constructors and not break one of the services or Darc, so instead opted for manually constructing the AzDO client instance in DI.

Manually tested the command locally. Test build: https://dev.azure.com/dnceng/internal/_build?definitionId=252&_a=summary
