### PR TITLE
Use prod darc to validate darc

### DIFF
--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -204,12 +204,17 @@ stages:
       displayName: Test Federated token authentication
 
     - ${{ if in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production') }}:
-      - powershell: 
+      - task: AzureCLI@2
+      displayName: Test Darc add-build-to-channel
+      inputs:
+        azureSubscription: "Darc: Maestro Production"
+        scriptType: ps
+        scriptLocation: inlineScript
+        inlineScript: |
           $darcBuild = .\darc\darc.exe get-build `
             --repo "https://github.com/dotnet/arcade-services" `
             --commit $(Build.SourceVersion) `
             --ci `
-            -p $(GetAuthInfo.Token) `
             --output-format json |
             ConvertFrom-Json
 
@@ -217,8 +222,7 @@ stages:
             --id $darcBuild[0].id `
             --channel "General Testing"
             --ci `
-            -p $(GetAuthInfo.Token) `
-            --azdev-pat $(dn-bot-dnceng-build-rw-code-rw-release-rw) `
+            --azdev-pat $(dn-bot-dnceng-build-rw-code-rw-release-rw)
         displayName: Test Darc add-build-to-channel
 
     - task: VSTest@2


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
When we're trying to test `add-build-to-channel` we need to use the Prod Maestro, since that's where the 'General Testing' channel is, and where the build gets published

https://github.com/dotnet/arcade-services/issues/3724