### PR TITLE
Initialize IRemoteProvider when it's needed, not during DI registration

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
@@ -77,7 +77,7 @@ public abstract class Operation : IDisposable
         services.TryAddSingleton<IAzureDevOpsClient>(s =>
             s.GetRequiredService<AzureDevOpsClient>()
         );
-        services.TryAddSingleton<IRemoteTokenProvider>(new RemoteTokenProvider(options.AzureDevOpsPat, options.GitHubPat));
+        services.TryAddSingleton<IRemoteTokenProvider>(_ => new RemoteTokenProvider(options.AzureDevOpsPat, options.GitHubPat));
         Provider = services.BuildServiceProvider();
         Logger = Provider.GetRequiredService<ILogger<Operation>>();
         options.InitializeFromSettings(Logger);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/Operation.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Maestro.Common;
 using Maestro.Common.AzureDevOpsTokens;
 using Microsoft.Arcade.Common;
 using Microsoft.DotNet.Darc.Helpers;
@@ -76,7 +77,7 @@ public abstract class Operation : IDisposable
         services.TryAddSingleton<IAzureDevOpsClient>(s =>
             s.GetRequiredService<AzureDevOpsClient>()
         );
-
+        services.TryAddSingleton<IRemoteTokenProvider>(new RemoteTokenProvider(options.AzureDevOpsPat, options.GitHubPat));
         Provider = services.BuildServiceProvider();
         Logger = Provider.GetRequiredService<ILogger<Operation>>();
         options.InitializeFromSettings(Logger);


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/dnceng/issues/3470
In my previous PR I did the registration wrong, this fixes it