### PR TITLE
Use the right .NET installation in E2E tests

### DIFF
--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -165,9 +165,7 @@ stages:
 
     - powershell: |
         mkdir darc
-        
-        $dotnetDir = cmd /c "where dotnet"
-        Invoke-Expression "& '$dotnetDir' tool install Microsoft.DotNet.Darc --prerelease --tool-path .\darc --add-source $(Pipeline.Workspace)\PackageArtifacts" 
+        & .\.dotnet\dotnet tool install Microsoft.DotNet.Darc --prerelease --tool-path .\darc --add-source $(Pipeline.Workspace)\PackageArtifacts"
       displayName: Install Darc
 
     - task: AzureCLI@2


### PR DESCRIPTION
Fixes https://dev.azure.com/dnceng/internal/_build/results?buildId=2498289&view=logs&j=4d9f00d7-d155-5977-7b70-2e6b79720ff2&t=c5fa51d8-f4b1-5178-14fd-2c49e5155c0d

Probably it was using the global .NET?

<!-- https://github.com/dotnet/arcade-services/issues/3741 -->