### PR TITLE
Fix Maestro pushing empty commits to PRs

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -820,6 +820,13 @@ namespace SubscriptionActorService
             _logger.LogInformation("Found {count} required updates for Pull Request {url}", targetRepositoryUpdates.RequiredUpdates.Count, pr.Url);
 
             pr.RequiredUpdates = MergeExistingWithIncomingUpdates(pr.RequiredUpdates, targetRepositoryUpdates.RequiredUpdates);
+
+            if (pr.RequiredUpdates.Count < 1)
+            {
+                _logger.LogInformation("No new updates found for Pull Request {url}", pr.Url);
+                return;
+            }
+
             pr.CoherencyCheckSuccessful = targetRepositoryUpdates.CoherencyCheckSuccessful;
             pr.CoherencyErrors = targetRepositoryUpdates.CoherencyErrors;
 


### PR DESCRIPTION
Possibly a fix for https://github.com/dotnet/arcade-services/issues/3232 and https://github.com/dotnet/arcade-services/issues/3642 where Maestro pushes empty commits into PRs such as this: https://dev.azure.com/dnceng/internal/_git/dotnet-helix-service/pullrequest/40767?_a=commits
