### PR TITLE
Use local creds for maestro local development

### DIFF
--- a/src/Maestro/DependencyUpdater/.config/settings.Development.json
+++ b/src/Maestro/DependencyUpdater/.config/settings.Development.json
@@ -13,14 +13,8 @@
         "UseAzCliAuthentication": true
     },
     "AzureDevOps": {
-        "dnceng": {
-            "Token": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]"
-        },
-        "devdiv": {
-            "Token": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]"
-        },
-        "domoreexp": {
-            "Token": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        "default": {
+            "UseLocalCredentials": true
         }
     }
 }

--- a/src/Maestro/FeedCleanerService/.config/settings.Development.json
+++ b/src/Maestro/FeedCleanerService/.config/settings.Development.json
@@ -8,8 +8,8 @@
         "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
     },
     "AzureDevOps": {
-        "dnceng": {
-            "Token": "[vault(dn-bot-dnceng-packaging-rwm)]"
+        "default": {
+            "UseLocalCredentials": true
         }
     }
 }

--- a/src/Maestro/Maestro.Common/AppCredentials/CredentialResolverOptions.cs
+++ b/src/Maestro/Maestro.Common/AppCredentials/CredentialResolverOptions.cs
@@ -24,4 +24,9 @@ public class CredentialResolverOptions
     /// Managed Identity to use for the auth
     /// </summary>
     public string? ManagedIdentityId { get; set; }
+
+    /// <summary>
+    /// Whether to use local credentials
+    /// </summary>
+    public bool UseLocalCredentials { get; set; }
 }

--- a/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
+++ b/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
@@ -112,6 +112,7 @@ public class AzureDevOpsTokenProvider : IAzureDevOpsTokenProvider
             var account = pair.Key;
             var option = pair.Value;
 
+            // 0. Use localy-cached credentials for development flows
             if (option.UseLocalCredentials)
             {
                 credentials[account] = new LocalDevTokenCredential();

--- a/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
+++ b/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
@@ -6,6 +6,7 @@ using Azure.Core;
 using Azure.Identity;
 using Maestro.Common.AppCredentials;
 using Microsoft.Extensions.Options;
+using Microsoft.DncEng.Configuration.Extensions;
 
 namespace Maestro.Common.AzureDevOpsTokens;
 
@@ -110,6 +111,12 @@ public class AzureDevOpsTokenProvider : IAzureDevOpsTokenProvider
         {
             var account = pair.Key;
             var option = pair.Value;
+
+            if (option.UseLocalCredentials)
+            {
+                credentials[account] = new LocalDevTokenCredential();
+                continue;
+            }
 
             // 1. AzDO PAT from configuration
             if (!string.IsNullOrEmpty(option.Token))

--- a/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
+++ b/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
@@ -112,17 +112,17 @@ public class AzureDevOpsTokenProvider : IAzureDevOpsTokenProvider
             var account = pair.Key;
             var option = pair.Value;
 
-            // 0. Use localy-cached credentials for development flows
-            if (option.UseLocalCredentials)
-            {
-                credentials[account] = new LocalDevTokenCredential();
-                continue;
-            }
-
-            // 1. AzDO PAT from configuration
+            // 0. AzDO PAT from configuration
             if (!string.IsNullOrEmpty(option.Token))
             {
                 credentials[account] = new ResolvingCredential((context, cancellationToken) => patResolver(account, context, cancellationToken));
+                continue;
+            }
+
+            // 1. Use localy-cached credentials for development flows
+            if (option.UseLocalCredentials)
+            {
+                credentials[account] = new LocalDevTokenCredential();
                 continue;
             }
 

--- a/src/Maestro/Maestro.Common/Maestro.Common.csproj
+++ b/src/Maestro/Maestro.Common/Maestro.Common.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Microsoft.DncEng.Configuration.Extensions" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>

--- a/src/Maestro/Maestro.Web/.config/settings.Development.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Development.json
@@ -19,14 +19,8 @@
         "UseAzCliAuthentication": true
     },
     "AzureDevOps": {
-        "dnceng": {
-            "Token": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]"
-        },
-        "devdiv": {
-            "Token": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]"
-        },
-        "domoreexp": {
-            "Token": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        "default": {
+            "UseLocalCredentials": true
         }
     }
 }

--- a/src/Maestro/SubscriptionActorService/.config/settings.Development.json
+++ b/src/Maestro/SubscriptionActorService/.config/settings.Development.json
@@ -17,14 +17,8 @@
         "UseAzCliAuthentication": true
     },
     "AzureDevOps": {
-        "dnceng": {
-            "Token": "[vault(dn-bot-dnceng-build-rw-code-rw-release-rw)]"
-        },
-        "devdiv": {
-            "Token": "[vault(dn-bot-devdiv-build-rw-code-rw-release-rw)]"
-        },
-        "domoreexp": {
-            "Token": "[vault(dn-bot-domoreexp-build-rw-code-rw-release-rw)]"
+        "default": {
+            "UseLocalCredentials": true
         }
     }
 }


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Resolves https://dev.azure.com/dnceng/internal/_workitems/edit/6699/

In draft state as it depends on https://github.com/dotnet/dnceng-shared/pull/82

Re-uses `LocalDevTokenCredential` to fetch AzDO token in Maestro local development. This class is used by the [bootstrap script](https://github.com/dotnet/arcade-services/blob/main/src/Maestro/bootstrap.ps1) to obtain and cache login information of the developer's user. When use by Maestro, it reads the saved login information and uses it to obtain the token it needs for AzDO through its Azure app (the same way it does for other auth flows).

Since the information we need is already stored by the` LocalDevTokenCredential`, we don't need to change the bootstrap script in any way