### PR TITLE
Bump `Azure.Core` to `1.41.0`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure" Version="$(AspireVersion)" />
-    <PackageVersion Include="Azure.Core" Version="1.40.0" />
+    <PackageVersion Include="Azure.Core" Version="1.41.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />


### PR DESCRIPTION
Resolves https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-arcade-services/alert/10013733?typeId=6567134

<!-- https://github.com/dotnet/arcade-services/issues/3758 -->