### PR TITLE
Fix running `Maestro.Web` locally (outside of SF)

### DIFF
--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -33,7 +33,12 @@ It seems that calling `bootstrap.ps1` is not a one-time operation and needs to b
 
 ### Local developer workflow
 
-The guaranteed way (some steps might be extraneous but assured to work) to successfully (re-)deploy Maestro locally after you're iterating on the code is to:
+There are two main ways how you can run the Maestro application locally.
+
+The first one is to run the BarViz web application + Maestro API only. This can be done by F5-ing the `Maestro.Web` project directly from Visual Studio. This is suitable for testing the REST API and the front-end part of the web application (angular).
+
+The second way is to run the full Maestro in a local Service Fabric cluster. This takes a bit more time to start but will also run backend services like the dependency flow (pull request actos..).
+The guaranteed way (some steps might be extraneous but assured to work) to successfully (re-)deploy the Service Fabric cluster locally after you're iterating on the code is to:
 - Make sure you have run `bootstrap.ps1` after the last reboot
 - Reset the local SF cluster (`Service Fabric Local Cluster Manager` -> `Reset Local Cluster`)
 - Start the VS in Administrator mode

--- a/src/Maestro/Maestro.Web/Program.cs
+++ b/src/Maestro/Maestro.Web/Program.cs
@@ -1,14 +1,33 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.IO;
+using System.Linq;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
 
 namespace Maestro.Web;
 
 internal static class Program
 {
+    internal static int LocalHttpsPort => int.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_HTTPS_PORT") ?? "443");
+
+    /// <summary>
+    /// Path to the compiled static files for the Angular app.
+    /// This is required when running Maestro.Web locally, outside of Service Fabric.
+    /// </summary>
+    internal static string LocalCompiledStaticFilesPath => Path.Combine(Environment.CurrentDirectory, "..", "maestro-angular", "dist", "maestro-angular");
+
     private static void Main()
     {
-        ServiceHostWebSite<Startup>.Run("Maestro.WebType");
+        var options = new ServiceHostWebSiteOptions();
+
+        // Run local Maestro.Web (when outside of SF) on HTTPS too
+        if (!ServiceFabricHelpers.RunningInServiceFabric() && Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development")
+        {
+            options.Urls = options.Urls.Append($"https://localhost:{LocalHttpsPort}").ToList();
+        }
+
+        ServiceHostWebSite<Startup>.Run("Maestro.WebType", options);
     }
 }

--- a/src/Maestro/Maestro.Web/Properties/launchSettings.json
+++ b/src/Maestro/Maestro.Web/Properties/launchSettings.json
@@ -1,30 +1,14 @@
 {
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "api/values",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "Maestro.Web": {
       "commandName": "Project",
-      "commandLineArgs": "get-build",
       "launchBrowser": true,
-      "launchUrl": "api/values",
+      "launchUrl": "https://localhost:44321/",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44321"
       },
-      "applicationUrl": "http://localhost:59621/"
-    }
-  },
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:59620/",
-      "sslPort": 0
+      "applicationUrl": "http://localhost:44321/"
     }
   }
 }


### PR DESCRIPTION
This fixes some problems with static files and local usage of HTTPs so that it's possible to run the `Maestro.Web` project directly without needing to run Service Fabric. This can be used to develop the frontend web app (Angular..).

<!-- https://github.com/dotnet/arcade-services/issues/3763 -->
