### PR TITLE
Use Entra auth during API redirection

### DIFF
--- a/.vault-config/maestrolocal.yaml
+++ b/.vault-config/maestrolocal.yaml
@@ -19,11 +19,6 @@ secrets:
       hasWebhookSecret: false
       hasOAuthSecret: true
 
-  prod-maestro-token:
-    type: maestro-access-token
-    parameters:
-      environment: https://maestro.dot.net/
-
   dn-bot-dnceng-build-rw-code-rw-release-rw:
     type: azure-devops-access-token
     parameters:

--- a/.vault-config/shared/maestro-secrets.yaml
+++ b/.vault-config/shared/maestro-secrets.yaml
@@ -5,11 +5,6 @@ github:
     hasWebhookSecret: true
     hasOAuthSecret: true
 
-prod-maestro-token:
-  type: maestro-access-token
-  parameters:
-    environment: https://maestro.dot.net/
-
 dn-bot-dnceng-build-rw-code-rw-release-rw:
   type: azure-devops-access-token
   parameters:

--- a/src/Maestro/Maestro.Authentication/AuthenticationConfiguration.cs
+++ b/src/Maestro/Maestro.Authentication/AuthenticationConfiguration.cs
@@ -19,9 +19,17 @@ namespace Maestro.Authentication;
 
 public static class AuthenticationConfiguration
 {
+    public const string EntraAuthorizationPolicyName = "Entra";
     public const string MsftAuthorizationPolicyName = "msft";
 
     public const string AccountSignInRoute = "/Account/SignIn";
+
+    public static readonly string[] AuthenticationSchemes =
+    [
+        EntraAuthorizationPolicyName,
+        OpenIdConnectDefaults.AuthenticationScheme,
+        PersonalAccessTokenDefaults.AuthenticationScheme,
+    ];
 
     /// <summary>
     /// Sets up authentication and authorization services.
@@ -60,9 +68,8 @@ public static class AuthenticationConfiguration
 
         var openIdAuth = services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme);
 
-        const string entraScheme = "Entra";
         openIdAuth
-            .AddMicrosoftIdentityWebApi(entraAuthConfig, entraScheme);
+            .AddMicrosoftIdentityWebApi(entraAuthConfig, EntraAuthorizationPolicyName);
 
         openIdAuth
             .AddMicrosoftIdentityWebApp(entraAuthConfig);
@@ -83,10 +90,7 @@ public static class AuthenticationConfiguration
             {
                 options.AddPolicy(MsftAuthorizationPolicyName, policy =>
                 {
-                    policy.AddAuthenticationSchemes(
-                        entraScheme,
-                        OpenIdConnectDefaults.AuthenticationScheme,
-                        PersonalAccessTokenDefaults.AuthenticationScheme);
+                    policy.AddAuthenticationSchemes(AuthenticationSchemes);
                     policy.RequireAuthenticatedUser();
                     policy.RequireAssertion(context => context.User.IsInRole(entraRole));
                 });

--- a/src/Maestro/Maestro.Web/.config/settings.Development.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Development.json
@@ -9,10 +9,8 @@
         "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
     },
     "ApiRedirect": {
-        "uri": "https://maestro.dot.net/",
-        "token": "[vault(prod-maestro-token)]"
+        // "uri": "https://maestro.dot.net/"
     },
-    "ForceLocalApi": true,
     "DataProtection": {
         "KeyFileUri": "",
         "KeyIdentifier": ""

--- a/src/Maestro/Maestro.Web/.config/settings.Development.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Development.json
@@ -9,7 +9,7 @@
         "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
     },
     "ApiRedirect": {
-        // "uri": "https://maestro.dot.net/"
+        "uri": "https://maestro.dot.net/"
     },
     "DataProtection": {
         "KeyFileUri": "",

--- a/src/Maestro/Maestro.Web/.config/settings.Development.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Development.json
@@ -9,7 +9,7 @@
         "ConnectionString": "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true"
     },
     "ApiRedirect": {
-        "uri": "https://maestro.dot.net/"
+        "Uri": "https://maestro.dot.net/"
     },
     "DataProtection": {
         "KeyFileUri": "",

--- a/src/Maestro/Maestro.Web/.config/settings.Production.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Production.json
@@ -5,10 +5,6 @@
     },
     "KeyVaultUri": "https://maestroprod.vault.azure.net/",
     "AppConfigurationUri": "https://maestroprod.azconfig.io/",
-    "ApiRedirect": {
-        "uri": "",
-        "token": ""
-    },
     "DataProtection": {
         "KeyBlobUri": "https://maestroprod1337.blob.core.windows.net/dataprotection/keys.xml",
         "DataProtectionKeyUri": "https://maestroprod.vault.azure.net/keys/data-protection-encryption-key/"

--- a/src/Maestro/Maestro.Web/.config/settings.Staging.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Staging.json
@@ -27,7 +27,6 @@
         }
     },
     "ApiRedirect": {
-        "uri": "https://maestro.dot.net/",
-        "token": "[vault(prod-maestro-token)]"
+        "uri": "https://maestro.dot.net/"
     }
 }

--- a/src/Maestro/Maestro.Web/.config/settings.Staging.json
+++ b/src/Maestro/Maestro.Web/.config/settings.Staging.json
@@ -5,6 +5,9 @@
     },
     "KeyVaultUri": "https://maestroint.vault.azure.net/",
     "AppConfigurationUri": "https://maestroint.azconfig.io/",
+    "ApiRedirect": {
+        "Uri": "https://maestro.dot.net/"
+    },
     "DataProtection": {
         "KeyBlobUri": "https://maestroint.blob.core.windows.net/dataprotection/keys.xml",
         "DataProtectionKeyUri": "https://maestroint.vault.azure.net/keys/data-protection-encryption-key/"
@@ -25,8 +28,5 @@
         "default": {
             "ManagedIdentityId": "system"
         }
-    },
-    "ApiRedirect": {
-        "uri": "https://maestro.dot.net/"
     }
 }

--- a/src/Maestro/Maestro.Web/Startup.cs
+++ b/src/Maestro/Maestro.Web/Startup.cs
@@ -319,7 +319,7 @@ public partial class Startup : StartupBase
     // When we run outside of Service Fabric locally
     private bool IsLocalKestrelDevMode => HostingEnvironment.IsDevelopment() && !ServiceFabricHelpers.RunningInServiceFabric();
     private bool ApiRedirectionEnabled => !string.IsNullOrEmpty(ApiRedirectionTarget);
-    private string ApiRedirectionTarget => Configuration.GetSection("ApiRedirect")["uri"];
+    private string ApiRedirectionTarget => Configuration.GetSection("ApiRedirect")["Uri"];
 
     private async Task ApiRedirectHandler(HttpContext ctx)
     {

--- a/src/Maestro/Maestro.Web/Startup.cs
+++ b/src/Maestro/Maestro.Web/Startup.cs
@@ -11,7 +11,9 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
 using Azure.Identity;
 using EntityFrameworkCore.Triggers;
 using FluentValidation.AspNetCore;
@@ -35,6 +37,7 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.DotNet.Kusto;
+using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.ServiceFabric.ServiceHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -216,7 +219,7 @@ public partial class Startup : StartupBase
 
         services.AddSingleton(Configuration);
 
-        if (HostingEnvironment.IsDevelopment() && !ServiceFabricHelpers.RunningInServiceFabric())
+        if (IsLocalKestrelDevMode)
         {
             services.AddHttpsRedirection(options =>
             {
@@ -247,6 +250,18 @@ public partial class Startup : StartupBase
         services.AddSingleton<IAzureDevOpsTokenProvider, AzureDevOpsTokenProvider>();
 
         services.AddKustoClientProvider("Kusto");
+
+        if (ApiRedirectionEnabled)
+        {
+            var targetUri = ApiRedirectionTarget;
+            var token = Configuration.GetSection("ApiRedirect")["token"];
+            services.AddKeyedSingleton<IMaestroApi>(targetUri, MaestroApiFactory.GetAuthenticated(
+                targetUri,
+                accessToken: token,
+                managedIdentityId: Configuration["ManagedIdentityClientId"],
+                federatedToken: null,
+                disableInteractiveAuth: !IsLocalKestrelDevMode));
+        }
 
         // We do not use AddMemoryCache here. We use our own cache because we wish to
         // use a sized cache and some components, such as EFCore, do not implement their caching
@@ -301,14 +316,15 @@ public partial class Startup : StartupBase
             });
     }
 
-    private bool DoApiRedirect => !string.IsNullOrEmpty(ApiRedirectTarget);
-    private string ApiRedirectTarget => Configuration.GetSection("ApiRedirect")["uri"];
-    private string ApiRedirectToken => Configuration.GetSection("ApiRedirect")["token"];
+    // When we run outside of Service Fabric locally
+    private bool IsLocalKestrelDevMode => HostingEnvironment.IsDevelopment() && !ServiceFabricHelpers.RunningInServiceFabric();
+    private bool ApiRedirectionEnabled => !string.IsNullOrEmpty(ApiRedirectionTarget);
+    private string ApiRedirectionTarget => Configuration.GetSection("ApiRedirect")["uri"];
 
     private async Task ApiRedirectHandler(HttpContext ctx)
     {
         var logger = ctx.RequestServices.GetRequiredService<ILogger<Startup>>();
-        logger.LogInformation("Preparing for redirect: enabled: '{redirectEnabled}', uri: '{redirectUrl}'", DoApiRedirect, ApiRedirectTarget);
+        logger.LogDebug("Preparing for redirect: enabled: '{redirectEnabled}', uri: '{redirectUrl}'", ApiRedirectionEnabled, ApiRedirectionTarget);
         if (ctx.User == null)
         {
             logger.LogInformation("Rejecting redirect because of missing authentication");
@@ -328,7 +344,7 @@ public partial class Startup : StartupBase
         using (var client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }))
         {
             logger.LogInformation("Preparing proxy request to {proxyPath}", ctx.Request.Path);
-            var uri = new UriBuilder(ApiRedirectTarget)
+            var uri = new UriBuilder(ApiRedirectionTarget)
             {
                 Path = ctx.Request.Path,
                 Query = ctx.Request.QueryString.ToUriComponent(),
@@ -337,9 +353,11 @@ public partial class Startup : StartupBase
             string absoluteUri = uri.Uri.AbsoluteUri;
             logger.LogInformation("Service proxied request to {url}", absoluteUri);
             await ctx.ProxyRequestAsync(client, absoluteUri,
-                req =>
+                async req =>
                 {
-                    req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", ApiRedirectToken);
+                    var maestroApi = ctx.RequestServices.GetRequiredKeyedService<IMaestroApi>(ApiRedirectionTarget);
+                    AccessToken token = await maestroApi.Options.Credentials.GetTokenAsync(new(), CancellationToken.None);
+                    req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
                 });
         }
     }
@@ -351,19 +369,13 @@ public partial class Startup : StartupBase
         var logger = app.ApplicationServices.GetRequiredService<ILogger<Startup>>();
 
         logger.LogInformation(
-            "Configuring API, env: '{env}', isDev: {isDev}, inSF: {inSF}, forceLocal: '{forceLocal}'",
+            "Configuring API, env: '{env}', isDev: {isDev}, inSF: {inSF}, redirection: {redirection}",
             HostingEnvironment.EnvironmentName,
             HostingEnvironment.IsDevelopment(),
             ServiceFabricHelpers.RunningInServiceFabric(),
-            Configuration["ForceLocalApi"]
-        );
+            ApiRedirectionEnabled);
 
-        if (HostingEnvironment.IsDevelopment() &&
-            !ServiceFabricHelpers.RunningInServiceFabric() &&
-            !string.Equals(
-                Configuration["ForceLocalApi"],
-                true.ToString(),
-                StringComparison.OrdinalIgnoreCase))
+        if (IsLocalKestrelDevMode && ApiRedirectionEnabled)
         {
             // Redirect api requests to prod when running locally outside of service fabric
             // This is for the `ng serve` local debugging case for the website
@@ -401,7 +413,7 @@ public partial class Startup : StartupBase
 
             if (HostingEnvironment.IsDevelopment())
             {
-                e.MapControllers().AllowAnonymous();
+                e.MapControllers(); // TODO .AllowAnonymous();
             }
             else
             {
@@ -415,7 +427,7 @@ public partial class Startup : StartupBase
     {
         app.UseExceptionHandler(ConfigureApiExceptions);
 
-        if (DoApiRedirect)
+        if (ApiRedirectionEnabled)
         {
             app.MapWhen(ctx => !ctx.Request.Cookies.TryGetValue("Skip-Api-Redirect", out _),
                 a =>
@@ -436,7 +448,7 @@ public partial class Startup : StartupBase
         {
             if (HostingEnvironment.IsDevelopment())
             {
-                e.MapControllers().AllowAnonymous();
+                e.MapControllers(); // TODO .AllowAnonymous();
             }
             else
             {

--- a/src/Maestro/Maestro.Web/Startup.cs
+++ b/src/Maestro/Maestro.Web/Startup.cs
@@ -385,7 +385,7 @@ public partial class Startup : StartupBase
                        !ctx.Request.Path.Value.EndsWith("swagger.json"),
                 a =>
                 {
-                    app.UseAuthentication();
+                    a.UseAuthentication();
                     a.Run(ApiRedirectHandler);
                 });
         }
@@ -531,7 +531,7 @@ public partial class Startup : StartupBase
                 return next();
             });
 
-        if (HostingEnvironment.IsDevelopment() && !ServiceFabricHelpers.RunningInServiceFabric())
+        if (IsLocalKestrelDevMode)
         {
             // In local dev with the `ng serve` scenario, just redirect /_/api to /api
             app.UseRewriter(new RewriteOptions().AddRewrite("^_/(.*)", "$1", true));


### PR DESCRIPTION
Right now, redirection from local/INT to prod so that we can show prod data in the BarViz portal is using a BAR token too.
This PR switches to using the Maestro credential (so MI in a service and local credentials for local development).

The redirection was actually broken and this PR fixes it too. It also kills another boolean flag `ForceLocalApi` that was used for local development.

https://dev.azure.com/dnceng/internal/_workitems/edit/6740