### PR TITLE
Fix Maestro pushing empty commits to PRs

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -811,7 +811,7 @@ namespace SubscriptionActorService
             TargetRepoDependencyUpdate targetRepositoryUpdates =
                 await GetRequiredUpdates(updates, _remoteFactory, targetRepository, targetBranch);
 
-            if (targetRepositoryUpdates.CoherencyCheckSuccessful && targetRepositoryUpdates.RequiredUpdates.Count < 1)
+            if (targetRepositoryUpdates.RequiredUpdates.Count < 1)
             {
                 _logger.LogInformation("No updates found for Pull Request {url}", pr.Url);
                 return;


### PR DESCRIPTION
Possibly a fix for https://github.com/dotnet/arcade-services/issues/3232 and https://github.com/dotnet/arcade-services/issues/3642 where Maestro pushes empty commits into PRs such as this: https://dev.azure.com/dnceng/internal/_git/dotnet-helix-service/pullrequest/40767?_a=commits
