### PR TITLE
Fix Maestro pushing empty commits to PRs

### DIFF
--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -951,7 +951,7 @@ namespace SubscriptionActorService
             string? prBranch,
             string targetBranch)
         {
-            _logger.LogInformation("Getting Required Updates for {branch} to {targetRepository}", targetBranch, targetRepository);
+            _logger.LogInformation("Getting Required Updates for {branch} of {targetRepository}", targetBranch, targetRepository);
             // Get a remote factory for the target repo
             IRemote darc = await remoteFactory.GetRemoteAsync(targetRepository, _logger);
 
@@ -1030,7 +1030,7 @@ namespace SubscriptionActorService
                 repoDependencyUpdate.RequiredUpdates.Add((coherencyUpdateParameters, coherencyUpdates.ToList()));
             }
 
-            _logger.LogInformation("Finished getting Required Updates for {branch} to {targetRepository}", targetBranch, targetRepository);
+            _logger.LogInformation("Finished getting Required Updates for {branch} of {targetRepository}", targetBranch, targetRepository);
             return repoDependencyUpdate;
         }
 

--- a/test/SubscriptionActorService.Tests/PendingUpdatesTests.cs
+++ b/test/SubscriptionActorService.Tests/PendingUpdatesTests.cs
@@ -69,7 +69,7 @@ internal class PendingUpdatesTests : PendingUpdatePullRequestActorTests
             await WhenProcessPendingUpdatesAsyncIsCalled();
             ThenUpdateReminderIsRemoved();
             AndPendingUpdateIsRemoved();
-            ThenGetRequiredUpdatesShouldHaveBeenCalled(b);
+            ThenGetRequiredUpdatesShouldHaveBeenCalled(b, true);
             AndCommitUpdatesShouldHaveBeenCalled(b);
             AndUpdatePullRequestShouldHaveBeenCalled();
             AndShouldHavePullRequestCheckReminder();

--- a/test/SubscriptionActorService.Tests/PullRequestActorTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestActorTests.cs
@@ -122,14 +122,14 @@ internal abstract class PullRequestActorTests : SubscriptionOrPullRequestActorTe
         Reminders.Data[PullRequestActorImplementation.PullRequestCheckKey] = reminder;
     }
 
-    protected void ThenGetRequiredUpdatesShouldHaveBeenCalled(Build withBuild)
+    protected void ThenGetRequiredUpdatesShouldHaveBeenCalled(Build withBuild, bool prExists)
     {
         var assets = new List<IEnumerable<AssetData>>();
         var dependencies = new List<IEnumerable<DependencyDetail>>();
         _updateResolver
             .Verify(r => r.GetRequiredNonCoherencyUpdates(SourceRepo, NewCommit, Capture.In(assets), Capture.In(dependencies)));
         _darcRemotes[TargetRepo]
-            .Verify(r => r.GetDependenciesAsync(TargetRepo, TargetBranch, null));
+            .Verify(r => r.GetDependenciesAsync(TargetRepo, prExists ? InProgressPrHeadBranch : TargetBranch, null));
         _updateResolver
             .Verify(r => r.GetRequiredCoherencyUpdatesAsync(Capture.In(dependencies), _remoteFactory.Object));
         assets.Should()

--- a/test/SubscriptionActorService.Tests/UpdateAssetsTests.cs
+++ b/test/SubscriptionActorService.Tests/UpdateAssetsTests.cs
@@ -34,7 +34,7 @@ internal class UpdateAssetsTests : UpdateAssetsPullRequestActorTests
 
         await WhenUpdateAssetsAsyncIsCalled(b);
 
-        ThenGetRequiredUpdatesShouldHaveBeenCalled(b);
+        ThenGetRequiredUpdatesShouldHaveBeenCalled(b, false);
         AndCreateNewBranchShouldHaveBeenCalled();
         AndCommitUpdatesShouldHaveBeenCalled(b);
         AndCreatePullRequestShouldHaveBeenCalled();
@@ -62,7 +62,7 @@ internal class UpdateAssetsTests : UpdateAssetsPullRequestActorTests
         using (WithExistingPullRequest(SynchronizePullRequestResult.InProgressCanUpdate))
         {
             await WhenUpdateAssetsAsyncIsCalled(b);
-            ThenGetRequiredUpdatesShouldHaveBeenCalled(b);
+            ThenGetRequiredUpdatesShouldHaveBeenCalled(b, true);
             AndCommitUpdatesShouldHaveBeenCalled(b);
             AndUpdatePullRequestShouldHaveBeenCalled();
             AndShouldHavePullRequestCheckReminder();
@@ -110,7 +110,7 @@ internal class UpdateAssetsTests : UpdateAssetsPullRequestActorTests
 
         await WhenUpdateAssetsAsyncIsCalled(b);
 
-        ThenGetRequiredUpdatesShouldHaveBeenCalled(b);
+        ThenGetRequiredUpdatesShouldHaveBeenCalled(b, false);
         AndSubscriptionShouldBeUpdatedForMergedPullRequest(b);
     }
 
@@ -134,7 +134,7 @@ internal class UpdateAssetsTests : UpdateAssetsPullRequestActorTests
 
         await WhenUpdateAssetsAsyncIsCalled(b);
 
-        ThenGetRequiredUpdatesShouldHaveBeenCalled(b);
+        ThenGetRequiredUpdatesShouldHaveBeenCalled(b, false);
         AndCreateNewBranchShouldHaveBeenCalled();
         AndCommitUpdatesShouldHaveBeenCalled(b);
         AndCreatePullRequestShouldHaveBeenCalled();


### PR DESCRIPTION
Possibly a fix for https://github.com/dotnet/arcade-services/issues/3232 and https://github.com/dotnet/arcade-services/issues/3642 where Maestro pushes empty commits into PRs such as this: https://dev.azure.com/dnceng/internal/_git/dotnet-helix-service/pullrequest/40767?_a=commits
