### PR TITLE
Sort channel menu alphabetically in BarViz

### DIFF
--- a/src/Maestro/maestro-angular/src/app/services/channel.service.ts
+++ b/src/Maestro/maestro-angular/src/app/services/channel.service.ts
@@ -11,9 +11,9 @@ function channelSorter(a: Channel, b: Channel): number {
     return 0;
   }
   if (a.name! < b.name!) {
-    return 1;
+    return -1;
   }
-  return -1;
+  return 1;
 }
 
 function repoSorter(a: DefaultChannel, b: DefaultChannel): number {


### PR DESCRIPTION
Sorts channels a-z isntead of z-a in the right main channel menu of BarViz
