### PR TITLE
Add second build to channel before triggering the subscription

### DIFF
--- a/test/Maestro.ScenarioTests/EndToEndFlowLogic.cs
+++ b/test/Maestro.ScenarioTests/EndToEndFlowLogic.cs
@@ -320,6 +320,7 @@ internal class EndToEndFlowLogic : MaestroScenarioTestBase
 
                     TestContext.WriteLine("Set up another build for intake into target repository");
                     Build build2 = await CreateBuildAsync(sourceRepoUri, sourceBranch, TestRepository.CoherencyTestRepo2Commit, Source2BuildNumber, source1AssetsUpdated);
+                    await AddBuildToChannelAsync(build2.Id, testChannelName);
 
                     TestContext.WriteLine("Trigger the dependency update");
                     await TriggerSubscriptionAsync(subscription1Id.Value);


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
We were creating a second build but never assigning it to a channel, so when we triggered the subscription, there was nothing to update with
https://github.com/dotnet/arcade-services/issues/3786