### PR TITLE
Fix Maestro app ID reference conflict

### DIFF
--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -148,7 +148,7 @@ stages:
       value: https://maestro-prod.westus2.cloudapp.azure.com,https://maestro.dot.net
     - name: ScenarioTestSubscription
       value: "Darc: Maestro Production"
-    - name: MaestroAppClientId
+    - name: MaestroAppId
       value: $(MaestroAppClientId)
   - ${{ else }}:
     - group: MaestroInt KeyVault
@@ -156,7 +156,7 @@ stages:
       value: https://maestro-int.westus2.cloudapp.azure.com,https://maestro.int-dot.net
     - name: ScenarioTestSubscription
       value: "Darc: Maestro Staging"
-    - name: MaestroAppClientId
+    - name: MaestroAppId
       value: $(MaestroStagingAppClientId)
 
   jobs:
@@ -201,7 +201,7 @@ stages:
         scriptLocation: inlineScript
         inlineScript: |
           # Fetch token used for scenario tests
-          $token = (az account get-access-token --resource "${{ variables.MaestroAppClientId }}" | ConvertFrom-Json).accessToken
+          $token = (az account get-access-token --resource "${{ variables.MaestroAppId }}" | ConvertFrom-Json).accessToken
           echo "##vso[task.setvariable variable=Token;isOutput=true;isSecret=true]$token"
 
           # Set variables with auth info for tests below


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Fixes E2E break in CI caused by https://github.com/dotnet/arcade-services/issues/3820
Failing build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2514226&view=results

The pipeline variable and the secret for Maestro App ID have the same name in production, causing complaints from AzDO when downloading secrets from the key vault.

Backport of production hotfix from https://github.com/dotnet/arcade-services/pull/3826