### PR TITLE
Add Redis cache

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="$(AspireVersion)" />
     <PackageVersion Include="Azure.Core" Version="1.41.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.3" />
@@ -48,6 +49,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.WebHooks.Receivers.GitHub" Version="1.0.0-preview2-final" />
     <PackageVersion Include="Microsoft.AspNetCore.WebHooks.Receivers" Version="1.0.0-preview2-final" />
+    <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.1.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.3.2" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.3.2" />
@@ -118,6 +120,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.14" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="NRedisStack" Version="0.12.0" />
     <PackageVersion Include="NuGet.Configuration" Version="6.9.1" />
     <PackageVersion Include="NuGet.Packaging" Version="6.9.1" />
     <PackageVersion Include="NuGet.Protocol" Version="6.9.1" />

--- a/eng/service-templates/ProductConstructionService/provision.bicep
+++ b/eng/service-templates/ProductConstructionService/provision.bicep
@@ -767,7 +767,7 @@ resource redisCacheBuiltInAccessPolicyAssignment 'Microsoft.Cache/redis/accessPo
     name: guid(subscription().id, resourceGroup().id, 'pcsDataContributor')
     parent: redisCache
     properties: {
-        accessPolicyName: 'Data Owner'
+        accessPolicyName: 'Data Contributor'
         objectId: pcsIdentity.properties.principalId
         objectIdAlias: 'PCS Managed Identity'
     }

--- a/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
@@ -163,7 +163,7 @@ internal static class PcsStartup
 
         if (addRedis)
         {
-            await builder.Services.ConfigureRedis(builder.Configuration, isDevelopment);
+            await builder.Services.AddRedis(builder.Configuration, isDevelopment);
         }
 
         if (initializeService)

--- a/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
@@ -159,7 +159,7 @@ internal static class PcsStartup
         builder.Services.AddMergePolicies();
         builder.Services.Configure<SlaOptions>(builder.Configuration.GetSection(ConfigurationKeys.DependencyFlowSLAs));
 
-        await builder.Services.ConfigureRedis(builder.Configuration, isDevelopment, managedIdentityId);
+        await builder.Services.ConfigureRedis(builder.Configuration, isDevelopment);
 
         if (initializeService)
         {

--- a/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
@@ -108,10 +108,12 @@ internal static class PcsStartup
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="addKeyVault">Use KeyVault for secrets?</param>
+    /// <param name="addRedis">Use Redis for caching?</param>
     /// <param name="addSwagger">Add Swagger UI?</param>
     internal static async Task ConfigurePcs(
         this WebApplicationBuilder builder,
         bool addKeyVault,
+        bool addRedis,
         bool addSwagger)
     {
         bool isDevelopment = builder.Environment.IsDevelopment();
@@ -159,7 +161,10 @@ internal static class PcsStartup
         builder.Services.AddMergePolicies();
         builder.Services.Configure<SlaOptions>(builder.Configuration.GetSection(ConfigurationKeys.DependencyFlowSLAs));
 
-        await builder.Services.ConfigureRedis(builder.Configuration, isDevelopment);
+        if (addRedis)
+        {
+            await builder.Services.ConfigureRedis(builder.Configuration, isDevelopment);
+        }
 
         if (initializeService)
         {

--- a/src/ProductConstructionService/ProductConstructionService.Api/ProductConstructionService.Api.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.Api/ProductConstructionService.Api.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
-    <PackageReference Include="Microsoft.Azure.StackExchangeRedis" />
     <PackageReference Include="NRedisStack" />
   </ItemGroup>
 

--- a/src/ProductConstructionService/ProductConstructionService.Api/ProductConstructionService.Api.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.Api/ProductConstructionService.Api.csproj
@@ -35,6 +35,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
+    <PackageReference Include="Microsoft.Azure.StackExchangeRedis" />
+    <PackageReference Include="NRedisStack" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ProductConstructionService/ProductConstructionService.Api/Program.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Program.cs
@@ -16,6 +16,7 @@ bool useSwagger = isDevelopment;
 
 await builder.ConfigurePcs(
     addKeyVault: true,
+    addRedis: true,
     addSwagger: useSwagger);
 
 var app = builder.Build();

--- a/src/ProductConstructionService/ProductConstructionService.Api/Program.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Program.cs
@@ -14,9 +14,9 @@ var builder = WebApplication.CreateBuilder(args);
 bool isDevelopment = builder.Environment.IsDevelopment();
 bool useSwagger = isDevelopment;
 
-builder.ConfigurePcs(
+await builder.ConfigurePcs(
     addKeyVault: true,
-    initializeService: !isDevelopment,
+    isDevelopment: isDevelopment,
     addSwagger: useSwagger);
 
 var app = builder.Build();

--- a/src/ProductConstructionService/ProductConstructionService.Api/Program.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Program.cs
@@ -16,7 +16,6 @@ bool useSwagger = isDevelopment;
 
 await builder.ConfigurePcs(
     addKeyVault: true,
-    isDevelopment: isDevelopment,
     addSwagger: useSwagger);
 
 var app = builder.Build();

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
@@ -1,7 +1,8 @@
 {
     "KeyVaultName": "ProductConstructionInt",
     "ConnectionStrings": {
-        "queues": "https://productconstructionint.queue.core.windows.net"
+        "queues": "https://productconstructionint.queue.core.windows.net",
+        "redis": "prodconstaging.redis.cache.windows.net:6380"
     },
     "ManagedIdentityClientId": "1d43ba8a-c2a6-4fad-b064-6d8c16fc0745",
     "VmrUri": "https://github.com/maestro-auth-test/dnceng-vmr",

--- a/src/ProductConstructionService/ProductConstructionService.AppHost/ProductConstructionService.AppHost.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.AppHost/ProductConstructionService.AppHost.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Aspire.Hosting.Azure" />
     <PackageReference Include="Aspire.Hosting.Azure.Storage" />
     <PackageReference Include="Aspire.Azure.Storage.Queues" />
+    <PackageReference Include="Aspire.Hosting.Redis" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ProductConstructionService/ProductConstructionService.AppHost/Program.cs
+++ b/src/ProductConstructionService/ProductConstructionService.AppHost/Program.cs
@@ -3,11 +3,13 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+var redisCache = builder.AddRedis("redis");
 var queues = builder.AddAzureStorage("storage")
     .RunAsEmulator(emulator => emulator.WithImageTag("3.31.0")) // Workaround for https://github.com/dotnet/aspire/issues/5078
     .AddQueues("queues");
 
 builder.AddProject<Projects.ProductConstructionService_Api>("productConstructionServiceApi")
-    .WithReference(queues);
+    .WithReference(queues)
+    .WithReference(redisCache);
 
 builder.Build().Run();

--- a/src/ProductConstructionService/ProductConstructionService.Common/ConfigurationKeys.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/ConfigurationKeys.cs
@@ -1,8 +1,0 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-namespace ProductConstructionService.Common;
-public static class ConfigurationKeys
-{
-    public const string RedisConnectionString = "redis";
-}

--- a/src/ProductConstructionService/ProductConstructionService.Common/ConfigurationKeys.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/ConfigurationKeys.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace ProductConstructionService.Common;
+public static class ConfigurationKeys
+{
+    public const string RedisConnectionString = "redis";
+}

--- a/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionService.Common.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionService.Common.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Azure.StackExchangeRedis" />
+    <PackageReference Include="NRedisStack" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionServiceExtension.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionServiceExtension.cs
@@ -77,7 +77,7 @@ public static class ProductConstructionServiceExtension
         services.AddSingleton<IInstallationLookup, BuildAssetRegistryInstallationLookup>(); ;
     }
 
-    public static async Task ConfigureRedis(
+    public static async Task AddRedis(
         this IServiceCollection services,
         IConfiguration configuration,
         bool isDevelopment)
@@ -90,7 +90,7 @@ public static class ProductConstructionServiceExtension
         if (!isDevelopment)
         {
             AzureCacheOptions azureOptions = new();
-            if (managedIdentityId != null && !managedIdentityId.Equals("system"))
+            if (managedIdentityId != "system")
             {
                 azureOptions.ClientId = managedIdentityId;
             }

--- a/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionServiceExtension.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionServiceExtension.cs
@@ -21,6 +21,7 @@ namespace ProductConstructionService.Common;
 public static class ProductConstructionServiceExtension
 {
     private const string QueueConnectionString = "QueueConnectionString";
+    private const string RedisConnectionString = "redis";
     private const string ManagedIdentityClientId = "ManagedIdentityClientId";
     private const string SqlConnectionStringUserIdPlaceholder = "USER_ID_PLACEHOLDER";
     private const string DatabaseConnectionString = "BuildAssetRegistrySqlConnectionString";
@@ -79,11 +80,11 @@ public static class ProductConstructionServiceExtension
     public static async Task ConfigureRedis(
         this IServiceCollection services,
         IConfiguration configuration,
-        bool isDevelopment,
-        string? managedIdentityId)
+        bool isDevelopment)
     {
         var redisConfig = ConfigurationOptions.Parse(
-            configuration.GetSection("ConnectionStrings").GetRequiredValue(ConfigurationKeys.RedisConnectionString));
+            configuration.GetSection("ConnectionStrings").GetRequiredValue(RedisConnectionString));
+        var managedIdentityId = configuration[ManagedIdentityClientId];
 
         // Local redis instance should not need authentication
         if (!isDevelopment)

--- a/test/ProductConstructionService.Api.Tests/DependencyRegistrationTests.cs
+++ b/test/ProductConstructionService.Api.Tests/DependencyRegistrationTests.cs
@@ -13,7 +13,7 @@ namespace ProductConstructionService.Api.Tests;
 public class DependencyRegistrationTests
 {
     [Test]
-    public void AreDependenciesRegistered()
+    public async Task AreDependenciesRegistered()
     {
         Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", Environments.Staging);
 
@@ -28,8 +28,8 @@ public class DependencyRegistrationTests
         builder.Configuration["DataProtection:DataProtectionKeyUri"] = "https://keyvault.azure.com/secret/key";
         builder.Configuration["DataProtection:KeyBlobUri"] = "https://blobs.azure.com/secret/key";
 
-        builder.ConfigurePcs(
-            initializeService: true,
+        await builder.ConfigurePcs(
+            isDevelopment: false,
             addKeyVault: false,
             addSwagger: true);
 

--- a/test/ProductConstructionService.Api.Tests/DependencyRegistrationTests.cs
+++ b/test/ProductConstructionService.Api.Tests/DependencyRegistrationTests.cs
@@ -30,6 +30,7 @@ public class DependencyRegistrationTests
 
         await builder.ConfigurePcs(
             addKeyVault: false,
+            addRedis: false,
             addSwagger: true);
 
         DependencyInjectionValidation.IsDependencyResolutionCoherent(

--- a/test/ProductConstructionService.Api.Tests/DependencyRegistrationTests.cs
+++ b/test/ProductConstructionService.Api.Tests/DependencyRegistrationTests.cs
@@ -29,7 +29,6 @@ public class DependencyRegistrationTests
         builder.Configuration["DataProtection:KeyBlobUri"] = "https://blobs.azure.com/secret/key";
 
         await builder.ConfigurePcs(
-            isDevelopment: false,
             addKeyVault: false,
             addSwagger: true);
 


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Contributes to https://github.com/dotnet/arcade-services/issues/3805

Adds a Redis client to PCS for future use.

<details>
<summary>Example usage</summary>

```csharp
public class RedisController : Controller
{
    private readonly IDatabase _cache;

    public RedisController (IConnectionMultiplexer redis)
    {
        _cache = redis.GetDatabase();
    }

    [HttpPost("key")]
    public async Task SetCacheKey([FromBody, Required] CacheKey cacheKey)
    {
        await _cache.StringSetAsync(cacheKey.Key, cacheKey.Value);
    }

	[HttpGet("key/{key}")]
    public async Task<string> GetCacheKey(string key)
    {
        var value = await _cache.StringGetAsync(key);

        return value.ToString();
    }
}
```
</details>