### PR TITLE
Use same logic as add-build-to-channel when checking default channels

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -196,28 +196,12 @@ namespace Microsoft.DotNet.Maestro.Tasks
         private async Task<IEnumerable<DefaultChannel>> GetBuildDefaultChannelsAsync(IMaestroApi client,
             Client.Models.Build recordedBuild)
         {
-            var defaultChannels = new List<DefaultChannel>();
-            if (recordedBuild.GitHubBranch != null && recordedBuild.GitHubRepository != null)
-            {
-                defaultChannels.AddRange(
-                    await client.DefaultChannels.ListAsync(
-                        branch: recordedBuild.GitHubBranch,
-                        channelId: null,
-                        enabled: true,
-                        repository: recordedBuild.GitHubRepository
-                    ));
-            }
-
-            if (recordedBuild.AzureDevOpsBranch != null && recordedBuild.AzureDevOpsRepository != null)
-            {
-                defaultChannels.AddRange(
-                    await client.DefaultChannels.ListAsync(
-                        branch: recordedBuild.AzureDevOpsBranch,
-                        channelId: null,
-                        enabled: true,
-                        repository: recordedBuild.AzureDevOpsRepository
-                    ));
-            }
+            IEnumerable<DefaultChannel> defaultChannels = await client.DefaultChannels.ListAsync(
+                branch: recordedBuild.GetBranch(),
+                channelId: null,
+                enabled: true,
+                repository: recordedBuild.GetRepository()
+            );
 
             Log.LogMessage(MessageImportance.High, "Found the following default channels:");
             foreach (var defaultChannel in defaultChannels)


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/3844
this PR makes it so we use the same logic as in the `darc add-build-to-channel` command when determining the default channels of a build