### PR TITLE
Remove AzDO PAT from CI tests

### DIFF
--- a/.vault-config/maestrolocal.yaml
+++ b/.vault-config/maestrolocal.yaml
@@ -18,13 +18,3 @@ secrets:
       hasPrivateKey: true
       hasWebhookSecret: false
       hasOAuthSecret: true
-
-  dn-bot-dnceng-build-rw-code-rw-release-rw:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-        location: helixkv
-        name: dn-bot-account-redmond
-      organizations: dnceng
-      scopes: build_execute code_write release_execute

--- a/.vault-config/shared/maestro-secrets.yaml
+++ b/.vault-config/shared/maestro-secrets.yaml
@@ -4,13 +4,3 @@ github:
     hasPrivateKey: true
     hasWebhookSecret: true
     hasOAuthSecret: true
-
-dn-bot-dnceng-build-rw-code-rw-release-rw:
-  type: azure-devops-access-token
-  parameters:
-    domainAccountName: dn-bot
-    domainAccountSecret:
-      location: helixkv
-      name: dn-bot-account-redmond
-    organizations: dnceng
-    scopes: build_execute code_write release_execute

--- a/eng/templates/jobs/e2e-tests.yml
+++ b/eng/templates/jobs/e2e-tests.yml
@@ -96,6 +96,11 @@ jobs:
         .\darc\darc.exe get-default-channels --source-repo arcade-services --ci --password "$(GetAuthInfo.Token)" --bar-uri "$(GetAuthInfo.BarUri)" --debug
       displayName: Test BAR token auth
 
+  - template: /eng/common/templates-official/steps/get-federated-access-token.yml
+    parameters:
+      federatedServiceConnection: "ArcadeServicesInternal"
+      outputVariableName: "AzdoToken"
+
   - task: DotNetCoreCLI@2
     displayName: Run E2E tests
     inputs:
@@ -115,7 +120,7 @@ jobs:
       MAESTRO_BASEURIS: ${{ variables.MaestroTestEndpoints }}
       MAESTRO_TOKEN: $(GetAuthInfo.Token)
       GITHUB_TOKEN: $(maestro-scenario-test-github-token)
-      AZDO_TOKEN: $(dn-bot-dnceng-build-rw-code-rw-release-rw)
+      AZDO_TOKEN: $(AzdoToken)
       DARC_PACKAGE_SOURCE: $(Pipeline.Workspace)\PackageArtifacts
       DARC_DIR: $(Build.SourcesDirectory)\darc
       DARC_IS_CI: true

--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -3,7 +3,6 @@ parameters:
   type: boolean
 
 # --- Secret Variable group requirements ---
-# dn-bot-dnceng-build-rw-code-rw-release-rw
 # maestro-scenario-test-github-token
 
 stages:


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Contributes to https://dev.azure.com/dnceng/internal/_workitems/edit/6594/

Replaces AzDO PAT from a key vault with an MI token retrieved before the test run

Passing build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2524160&view=results