### PR TITLE
Print direct link to revision logs when deployment fails

### DIFF
--- a/azure-pipelines-product-construction-service.yml
+++ b/azure-pipelines-product-construction-service.yml
@@ -12,6 +12,7 @@ pr:
       - main
 
 variables:
+# https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=189
 - group: Publish-Build-Assets
 - name: resourceGroupName
   value: product-construction-service
@@ -20,7 +21,8 @@ variables:
 - name: diffFolder
   value: $(Build.ArtifactStagingDirectory)/diff
 - ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/production') }}:
-  # https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=189
+  - name: subscriptionId
+    value: e6b5f9f5-0ca4-4351-879b-014d78400ec2
   - name: containerappName
     value: product-construction-int
   - name: containerjobNames
@@ -29,6 +31,8 @@ variables:
     value: productconstructionint
   - name: containerappEnvironmentName
     value: product-construction-service-env-int
+  - name: containerappWorkspaceName
+    value: product-construction-service-workspace-int
   - name: dockerRegistryUrl
     value: productconstructionint.azurecr.io
   - name: serviceConnectionName
@@ -96,8 +100,10 @@ stages:
             scriptLocation: scriptPath
             scriptPath: $(Build.SourcesDirectory)/eng/deployment/product-construction-service-deploy.ps1
             arguments: >
+              -subscriptionId $(subscriptionId)
               -resourceGroupName $(resourceGroupName)
               -containerappName $(containerappName)
+              -workspaceName $(containerappWorkspaceName)
               -newImageTag $(DockerTag.newDockerImageTag)
               -containerRegistryName $(containerRegistryName)
               -imageName $(containerName)

--- a/eng/deployment/product-construction-service-deploy.ps1
+++ b/eng/deployment/product-construction-service-deploy.ps1
@@ -2,8 +2,10 @@
 # The script determines the color of the currently active revision, deactivates the old inactive revision, 
 # and deploys the new revision, switching all traffic to it if the health probes pass.
 param(
+    [Parameter(Mandatory=$true)][string]$subscriptionId,
     [Parameter(Mandatory=$true)][string]$resourceGroupName,
     [Parameter(Mandatory=$true)][string]$containerappName,
+    [Parameter(Mandatory=$true)][string]$workspaceName,
     [Parameter(Mandatory=$true)][string]$newImageTag,
     [Parameter(Mandatory=$true)][string]$containerRegistryName,
     [Parameter(Mandatory=$true)][string]$imageName,
@@ -52,12 +54,39 @@ function StopAndWait([string]$pcsStatusUrl, [string]$pcsStopUrl, [hashtable]$aut
     return
 }
 
+function GetLogsLink {
+    param (
+        [string]$revisionName,
+        [string]$resourceGroup,
+        [string]$workspaceName,
+        [string]$subscriptionId
+    )
+
+    $query = "ContainerAppConsoleLogs_CL `
+| where RevisionName_s == '$revisionName' `
+| project TimeGenerated, Log_s"
+
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($query)
+    $memoryStream = New-Object System.IO.MemoryStream
+    $compressedStream = New-Object System.IO.Compression.GZipStream($memoryStream, [System.IO.Compression.CompressionMode]::Compress, $true)
+
+    $compressedStream.Write($bytes, 0, $bytes.Length)
+    $compressedStream.Close()
+    $memoryStream.Seek(0, [System.IO.SeekOrigin]::Begin) | Out-Null
+    $data = $memoryStream.ToArray()
+    $encodedQuery = [Convert]::ToBase64String($data)
+    $encodedQuery = [System.Web.HttpUtility]::UrlEncode($encodedQuery)
+    return "https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/" +
+           "resourceId/%2Fsubscriptions%2F$subscriptionId%2FresourceGroups%2F$resourceGroup%2Fproviders%2FMicrosoft.OperationalInsights%2Fworkspaces%2F" +
+           "$workspaceName/source/LogsBlade.AnalyticsShareLinkToQuery/q/$encodedQuery/timespan/P1D/limit/1000"
+}
+
 az extension add --name containerapp --upgrade
 
 Write-Host "Fetching all revisions to determine the active label"
 $containerappTraffic = az containerapp ingress traffic show --name $containerappName --resource-group $resourceGroupName | ConvertFrom-Json
 # find the currently active revision
-$activeRevision = $containerappTraffic | Where-Object { $_.weight -eq 100 } 
+$activeRevision = $containerappTraffic | Where-Object { $_.weight -eq 100 }
 
 Write-Host "Currently active revision: $($activeRevision.revisionName) with label $($activeRevision.label)"
 
@@ -125,7 +154,16 @@ try
         Write-Host "All traffic has been redirected to label $inactiveLabel"
     }
     else {
-        Write-Warning "New revision is not running. Check revision $newRevisionName logs in the inactive revisions. Deactivating the new revision"
+        Write-Warning "New revision failed to start. Deactivating the new revision.."
+        $link = GetLogsLink `
+            -revisionName "$newRevisionName"    `
+            -subscriptionId "$subscriptionId"   `
+            -resourceGroup "$resourceGroupName" `
+            -workspaceName "$workspaceName"
+            
+        Write-Host " Check revision $newRevisionName logs in the inactive revision: `
+        $link"
+
         az containerapp revision deactivate --revision $newRevisionName --name $containerappName --resource-group $resourceGroupName
         exit 1
     }


### PR DESCRIPTION
Example: https://dev.azure.com/dnceng/internal/_build/results?buildId=2525411&view=logs&j=4032b39f-a33d-55dd-373e-29d781cedb05&t=580fbd09-8e6b-5a54-4d1f-785b8aacd3d3&l=116

<!-- https://github.com/dotnet/arcade-services/issues/3886 -->
