### PR TITLE
Load KV secrets into a dedicated config section

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/GitHubClientFactoryConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/GitHubClientFactoryConfiguration.cs
@@ -25,7 +25,7 @@ public static class GitHubClientFactoryConfiguration
         builder.Services.AddSingleton<IGitHubClientFactory, GitHubClientFactory>();
         builder.Services.Configure<GitHubTokenProviderOptions>(o =>
         {
-            o.GitHubAppId = int.Parse(appId);
+            o.GitHubAppId = !string.IsNullOrEmpty(appId) ? int.Parse(appId) : 0;
             o.PrivateKey = appSecret;
         });
     }

--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/GitHubClientFactoryConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/GitHubClientFactoryConfiguration.cs
@@ -10,8 +10,8 @@ public static class GitHubClientFactoryConfiguration
 {
     public static void AddGitHubClientFactory(
         this WebApplicationBuilder builder,
-        string appId,
-        string appSecret)
+        string? appId,
+        string? appSecret)
     {
         builder.Services.Configure<GitHubClientOptions>(o =>
         {

--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/GitHubClientFactoryConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/GitHubClientFactoryConfiguration.cs
@@ -8,9 +8,10 @@ namespace ProductConstructionService.Api.Configuration;
 
 public static class GitHubClientFactoryConfiguration
 {
-    private const string GitHubConfiguration = "GitHub";
-
-    public static void AddGitHubClientFactory(this WebApplicationBuilder builder)
+    public static void AddGitHubClientFactory(
+        this WebApplicationBuilder builder,
+        string appId,
+        string appSecret)
     {
         builder.Services.Configure<GitHubClientOptions>(o =>
         {
@@ -22,6 +23,10 @@ public static class GitHubClientFactoryConfiguration
         });
 
         builder.Services.AddSingleton<IGitHubClientFactory, GitHubClientFactory>();
-        builder.Services.Configure<GitHubTokenProviderOptions>(builder.Configuration.GetSection(GitHubConfiguration));
+        builder.Services.Configure<GitHubTokenProviderOptions>(o =>
+        {
+            o.GitHubAppId = int.Parse(appId);
+            o.PrivateKey = appSecret;
+        });
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/KeyVaultSecretsWithPrefix.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/KeyVaultSecretsWithPrefix.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Azure.Extensions.AspNetCore.Configuration.Secrets;
+using Azure.Security.KeyVault.Secrets;
+
+namespace ProductConstructionService.Api.Configuration;
+
+internal class KeyVaultSecretsWithPrefix(string prefix) : KeyVaultSecretManager
+{
+    private readonly string _prefix = prefix;
+
+    public override string GetKey(KeyVaultSecret secret)
+        => _prefix + secret.Name.Replace("--", ConfigurationPath.KeyDelimiter);
+}

--- a/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
@@ -177,8 +177,8 @@ internal static class PcsStartup
         builder.AddVmrRegistrations(gitHubToken);
         builder.AddMaestroApiClient(managedIdentityId);
         builder.AddGitHubClientFactory(
-            builder.Configuration.GetRequiredValue(ConfigurationKeys.GitHubClientId),
-            builder.Configuration.GetRequiredValue(ConfigurationKeys.GitHubClientSecret));
+            builder.Configuration[ConfigurationKeys.GitHubClientId],
+            builder.Configuration[ConfigurationKeys.GitHubClientSecret]);
         builder.Services.AddGitHubTokenProvider();
         builder.Services.AddScoped<IRemoteFactory, DarcRemoteFactory>();
         builder.Services.AddSingleton<Microsoft.Extensions.Internal.ISystemClock, Microsoft.Extensions.Internal.SystemClock>();

--- a/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
@@ -36,7 +36,6 @@ using ProductConstructionService.Api.Telemetry;
 using ProductConstructionService.Api.VirtualMonoRepo;
 using ProductConstructionService.Common;
 using ProductConstructionService.DependencyFlow.WorkItems;
-using ProductConstructionService.DependencyFlow.WorkItemProcessors;
 using ProductConstructionService.WorkItems;
 using ProductConstructionService.DependencyFlow;
 
@@ -48,13 +47,19 @@ internal static class PcsStartup
 
     private static class ConfigurationKeys
     {
+        // All secrets loaded from KeyVault will have this prefix
+        public const string KeyVaultSecretPrefix = "KeyVaultSecrets:";
+
+        // Secrets coming from the KeyVault
+        public const string GitHubClientId = $"{KeyVaultSecretPrefix}github-app-id";
+        public const string GitHubClientSecret = $"{KeyVaultSecretPrefix}github-app-private-key";
+        public const string GitHubToken = $"{KeyVaultSecretPrefix}BotAccount-dotnet-bot-repo-PAT";
+
+        // Configuration from appsettings.json
         public const string AzureDevOpsConfiguration = "AzureDevOps";
         public const string DatabaseConnectionString = "BuildAssetRegistrySqlConnectionString";
         public const string DependencyFlowSLAs = "DependencyFlowSLAs";
         public const string EntraAuthenticationKey = "EntraAuthentication";
-        public const string GitHubClientId = "github-oauth-id";
-        public const string GitHubClientSecret = "github-oauth-secret";
-        public const string GitHubToken = "BotAccount-dotnet-bot-repo-PAT";
         public const string KeyVaultName = "KeyVaultName";
         public const string ManagedIdentityId = "ManagedIdentityClientId";
     }
@@ -157,7 +162,10 @@ internal static class PcsStartup
         if (addKeyVault)
         {
             Uri keyVaultUri = new($"https://{builder.Configuration.GetRequiredValue(ConfigurationKeys.KeyVaultName)}.vault.azure.net/");
-            builder.Configuration.AddAzureKeyVault(keyVaultUri, azureCredential);
+            builder.Configuration.AddAzureKeyVault(
+                keyVaultUri,
+                azureCredential,
+                new KeyVaultSecretsWithPrefix(ConfigurationKeys.KeyVaultSecretPrefix));
         }
 
         // TODO (https://github.com/dotnet/arcade-services/issues/3880) - Remove subscriptionIdGenerator
@@ -168,7 +176,9 @@ internal static class PcsStartup
         builder.AddDependencyFlowProcessors();
         builder.AddVmrRegistrations(gitHubToken);
         builder.AddMaestroApiClient(managedIdentityId);
-        builder.AddGitHubClientFactory();
+        builder.AddGitHubClientFactory(
+        builder.Configuration.GetRequiredValue(ConfigurationKeys.GitHubClientId),
+        builder.Configuration.GetRequiredValue(ConfigurationKeys.GitHubClientSecret));
         builder.Services.AddGitHubTokenProvider();
         builder.Services.AddScoped<IRemoteFactory, DarcRemoteFactory>();
         builder.Services.AddSingleton<Microsoft.Extensions.Internal.ISystemClock, Microsoft.Extensions.Internal.SystemClock>();

--- a/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
@@ -177,8 +177,8 @@ internal static class PcsStartup
         builder.AddVmrRegistrations(gitHubToken);
         builder.AddMaestroApiClient(managedIdentityId);
         builder.AddGitHubClientFactory(
-        builder.Configuration.GetRequiredValue(ConfigurationKeys.GitHubClientId),
-        builder.Configuration.GetRequiredValue(ConfigurationKeys.GitHubClientSecret));
+            builder.Configuration.GetRequiredValue(ConfigurationKeys.GitHubClientId),
+            builder.Configuration.GetRequiredValue(ConfigurationKeys.GitHubClientSecret));
         builder.Services.AddGitHubTokenProvider();
         builder.Services.AddScoped<IRemoteFactory, DarcRemoteFactory>();
         builder.Services.AddSingleton<Microsoft.Extensions.Internal.ISystemClock, Microsoft.Extensions.Internal.SystemClock>();

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.json
@@ -1,8 +1,4 @@
 {
-    "GitHub": {
-        "GitHubAppId": "[vault(github-app-id)]",
-        "PrivateKey": "[vault(github-app-private-key)]"
-    },
     "Logging": {
         "LogLevel": {
             "Default": "Information",


### PR DESCRIPTION
Previously, the secrets would go to the top-level section of the config, potentially overriding configuration there

<!-- https://github.com/dotnet/arcade-services/issues/3893 -->