### PR TITLE
Update Aspire to 8.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <AspNetAzureVersion>3.1.24</AspNetAzureVersion>
     <AspNetCoreVersion>6.0.26</AspNetCoreVersion>
     <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>
-    <AspireVersion>8.1.0</AspireVersion>
+    <AspireVersion>8.2.0</AspireVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Redis" Version="$(AspireVersion)" />
-    <PackageVersion Include="Azure.Core" Version="1.41.0" />
+    <PackageVersion Include="Azure.Core" Version="1.42.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -150,6 +150,6 @@
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Verify.NUnit" Version="19.6" />
-    <PackageVersion Include="YamlDotNet" Version="15.1.2" />
+    <PackageVersion Include="YamlDotNet" Version="16.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
> ##[error].dotnet\packs\Aspire.Hosting.Sdk\8.2.0\Sdk\Sdk.targets(79,5): error : (NETCORE_ENGINEERING_TELEMETRY=Restore) ProductConstructionService.AppHost is a .NET Aspire AppHost project that needs a package reference to Aspire.Hosting.AppHost version 8.2.0 or above to work correctly. You are using version 8.1.0.

[[build]](https://dev.azure.com/dnceng/internal/_build/results?buildId=2526902&view=logs&j=bb592630-4b9d-53ad-3960-d954a70a95cf&t=6acf3fd6-22e8-5cce-cc91-f1b299977c9d&l=46)

<!-- https://github.com/dotnet/arcade-services/issues/3896 -->

