### PR TITLE
Use BuildDependency.DependentBuildId over BuildId in Incoming.cshtml.cs

### DIFF
--- a/src/Maestro/Maestro.Web/Pages/DependencyFlow/Incoming.cshtml.cs
+++ b/src/Maestro/Maestro.Web/Pages/DependencyFlow/Incoming.cshtml.cs
@@ -84,11 +84,11 @@ public class IncomingModel : PageModel
         var incoming = new List<IncomingRepo>();
         foreach (var dep in Build.DependentBuildIds)
         {
-            var lastConsumedBuildOfDependency = graph[dep.BuildId];
+            var lastConsumedBuildOfDependency = graph[dep.DependentBuildId];
 
             if (lastConsumedBuildOfDependency == null)
             {
-                _logger.LogWarning("Failed to find build with id '{BuildId}' in the graph", dep.BuildId);
+                _logger.LogWarning("Failed to find build with id '{DependentBuildId}' in the graph", dep.DependentBuildId);
                 continue;
             }
 


### PR DESCRIPTION
@premun I was able to modify the seed data to point to some real commits and demonstrate that it can indeed pick up out-of-date dependencies. I only bothered updating the seed data for the meastro-test1 dependency, but I think it's sufficient to prove the fix works.

![Screenshot fix](https://github.com/user-attachments/assets/010efab9-6c76-48e8-953b-297effb30e3d)

Fixes https://github.com/dotnet/arcade-services/issues/3898

