### PR TITLE
Put the correct MI ID for Sub triggerer

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.SubscriptionTriggerer/appsettings.Staging.json
+++ b/src/ProductConstructionService/ProductConstructionService.SubscriptionTriggerer/appsettings.Staging.json
@@ -2,7 +2,7 @@
     "ConnectionStrings": {
         "queues": "https://productconstructionint.queue.core.windows.net"
     },
-    "ManagedIdentityClientId": "9729e72a-f381-4d59-a958-8aa94a18a8d2",
+    "ManagedIdentityClientId": "244cbfa2-f4d6-4048-ba28-b9334cbddfa7",
     "BuildAssetRegistrySqlConnectionString": "Data Source=tcp:maestro-int-server.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False; User Id=USER_ID_PLACEHOLDER",
     "Kusto": {
         "Database": "engineeringdata",


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
Before we renamed the service to SubscriptionTriggerer, I created a different MI and put the MI ID. When I recreated the identity with a new name, I didn't change the ID.
This is the correct MI https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/e6b5f9f5-0ca4-4351-879b-014d78400ec2/resourceGroups/product-construction-service/providers/Microsoft.ManagedIdentity/userAssignedIdentities/SubscriptionTriggererInt/overview
https://github.com/dotnet/arcade-services/issues/3916