### PR TITLE
Do not log errors for expected cases

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/AzureDevOpsClient.cs
@@ -218,7 +218,8 @@ public class AzureDevOpsClient : RemoteRepoBase, IRemoteGitRepo, IAzureDevOpsCli
             projectName,
             $"_apis/git/repositories/{repoName}/refs?filter=heads/{branch}",
             _logger,
-            versionOverride: "7.0");
+            versionOverride: "7.0",
+            logFailure: false);
 
         var refs = ((JArray)content["value"]).ToObject<List<AzureDevOpsRef>>();
         return refs.Any(refs => refs.Name == $"refs/heads/{branch}");

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/HttpRequestManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/HttpRequestManager.cs
@@ -96,8 +96,11 @@ public class HttpRequestManager
                                 errorDetails = $"Error details: {errorDetails}";
                             }
 
-                            _logger.LogError($"A '{(int)response.StatusCode} - {response.StatusCode}' status was returned for a HTTP request. " +
-                                             $"We'll set the retries amount to 0. {errorDetails}");
+                            _logger.LogError(
+                                "A '{httpCode} - {status}' status was returned for a HTTP request. We'll set the retries amount to 0. {error}",
+                                (int)response.StatusCode,
+                                response.StatusCode,
+                                errorDetails);
                         }
 
                         retriesRemaining = 0;
@@ -125,14 +128,22 @@ public class HttpRequestManager
                     if (_logFailure)
                     {
                         _logger.LogError("There was an error executing method '{method}' against URI '{requestUri}' " +
-                                         "after {maxRetries} attempts. Exception: {exception}", _method, _requestUri, retryCount, ex);
+                                         "after {maxRetries} attempts. Exception: {exception}",
+                                         _method,
+                                         _requestUri,
+                                         retryCount,
+                                         ex);
                     }
                     throw;
                 }
                 else if (_logFailure)
                 {
                     _logger.LogWarning("There was an error executing method '{method}' against URI '{requestUri}'. " +
-                                       "{retriesRemaining} attempts remaining. Exception: {ex.ToString()}", _method, _requestUri, retriesRemaining, ex);
+                                       "{retriesRemaining} attempts remaining. Exception: {ex.ToString()}",
+                                       _method,
+                                       _requestUri,
+                                       retriesRemaining,
+                                       ex);
                 }
             }
             --retriesRemaining;


### PR DESCRIPTION
Clears the log from errors which are not real errors (checking if branch exists kinda expects 404 if we believe the branch should not be there). This will help debugging.

Also fixes some build messages around logging.

https://github.com/dotnet/arcade-services/issues/3807