### PR TITLE
Add default expiration to all cache entries

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Common/RedisCache.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/RedisCache.cs
@@ -18,7 +18,7 @@ public interface IRedisCache
 
 public class RedisCache : IRedisCache
 {
-    internal static readonly TimeSpan DefaultExpiration = TimeSpan.FromDays(90);
+    internal static readonly TimeSpan DefaultExpiration = TimeSpan.FromDays(180);
 
     private readonly string _stateKey;
     private readonly IConnectionMultiplexer _connection;

--- a/src/ProductConstructionService/ProductConstructionService.Common/RedisCache.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/RedisCache.cs
@@ -18,6 +18,8 @@ public interface IRedisCache
 
 public class RedisCache : IRedisCache
 {
+    internal static readonly TimeSpan DefaultExpiration = TimeSpan.FromDays(90);
+
     private readonly string _stateKey;
     private readonly IConnectionMultiplexer _connection;
 
@@ -31,7 +33,7 @@ public class RedisCache : IRedisCache
 
     public async Task SetAsync(string value, TimeSpan? expiration = null)
     {
-        await Cache.StringSetAsync(_stateKey, value, expiration);
+        await Cache.StringSetAsync(_stateKey, value, expiration ?? DefaultExpiration);
     }
 
     public async Task<string?> TryGetAsync()
@@ -94,7 +96,7 @@ public class RedisCache<T> : IRedisCache<T> where T : class
             return;
         }
 
-        await _stateManager.SetAsync(json, expiration);
+        await _stateManager.SetAsync(json, expiration ?? RedisCache.DefaultExpiration);
     }
 
     private async Task<T?> TryGetStateAsync(bool delete)


### PR DESCRIPTION
This is so that our cache just doesn't grow indefinitely. 90 days should be enough to complete a PR but it should be fine for Maestro to forget about it after that.

https://github.com/dotnet/arcade-services/issues/3805