### PR TITLE
Do not use GitHub PAT in VMR initialization

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
@@ -53,7 +53,6 @@ internal static class PcsStartup
         // Secrets coming from the KeyVault
         public const string GitHubClientId = $"{KeyVaultSecretPrefix}github-app-id";
         public const string GitHubClientSecret = $"{KeyVaultSecretPrefix}github-app-private-key";
-        public const string GitHubToken = $"{KeyVaultSecretPrefix}BotAccount-dotnet-bot-repo-PAT";
 
         // Configuration from appsettings.json
         public const string AzureDevOpsConfiguration = "AzureDevOps";
@@ -148,7 +147,6 @@ internal static class PcsStartup
         string? managedIdentityId = builder.Configuration[ConfigurationKeys.ManagedIdentityId];
         string databaseConnectionString = builder.Configuration.GetRequiredValue(ConfigurationKeys.DatabaseConnectionString)
             .Replace(SqlConnectionStringUserIdPlaceholder, managedIdentityId);
-        string? gitHubToken = builder.Configuration[ConfigurationKeys.GitHubToken];
         builder.Services.Configure<AzureDevOpsTokenProviderOptions>(ConfigurationKeys.AzureDevOpsConfiguration, (o, s) => s.Bind(o));
 
         DefaultAzureCredential azureCredential = new(new DefaultAzureCredentialOptions
@@ -174,7 +172,7 @@ internal static class PcsStartup
         builder.AddBuildAssetRegistry();
         builder.AddWorkItemQueues(azureCredential, waitForInitialization: initializeService);
         builder.AddDependencyFlowProcessors();
-        builder.AddVmrRegistrations(gitHubToken);
+        builder.AddVmrRegistrations();
         builder.AddMaestroApiClient(managedIdentityId);
         builder.AddGitHubClientFactory(
             builder.Configuration[ConfigurationKeys.GitHubClientId],

--- a/src/ProductConstructionService/ProductConstructionService.Api/VirtualMonoRepo/VmrConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/VirtualMonoRepo/VmrConfiguration.cs
@@ -14,12 +14,12 @@ internal static class VmrConfiguration
     private const string VmrReadyHealthCheckName = "VmrReady";
     private const string VmrReadyHealthCheckTag = "vmrReady";
 
-    public static void AddVmrRegistrations(this WebApplicationBuilder builder, string? gitHubToken)
+    public static void AddVmrRegistrations(this WebApplicationBuilder builder)
     {
         string vmrPath = builder.Configuration.GetRequiredValue(VmrPathKey);
         string tmpPath = builder.Configuration.GetRequiredValue(TmpPathKey);
 
-        builder.Services.AddVmrManagers("git", vmrPath, tmpPath, gitHubToken, azureDevOpsToken: null);
+        builder.Services.AddVmrManagers("git", vmrPath, tmpPath, gitHubToken: null, azureDevOpsToken: null);
     }
 
     public static void AddVmrInitialization(this WebApplicationBuilder builder)


### PR DESCRIPTION
PCS will no longer depend on this secret. It will clone the real VMR using the GitHub app

<!-- https://github.com/dotnet/arcade-services/issues/3926 -->