### PR TITLE
Make E2E Arcade tests use maestro-auth-test arcade

### DIFF
--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -22,8 +22,8 @@
   ```
 
 1. Run `.\Build.cmd -pack` at the root of the repo
-2. Get access to the [maestrolocal KeyVault](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cab65fc3-d077-467d-931f-3932eabf36d3/resourceGroups/maestro/providers/Microsoft.KeyVault/vaults/maestrolocal/overview)
-3. Get assigned to users of the [staging Maestro Entra application](https://ms.portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Users/objectId/8b6d0440-8a2f-438e-84b7-d6ffaa401ca3/appId/baf98f1b-374e-487d-af42-aa33807f11e4)
+1. Get access to the [maestrolocal KeyVault](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cab65fc3-d077-467d-931f-3932eabf36d3/resourceGroups/maestro/providers/Microsoft.KeyVault/vaults/maestrolocal/overview)
+1. Get assigned to users of the [staging Maestro Entra application](https://ms.portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Users/objectId/8b6d0440-8a2f-438e-84b7-d6ffaa401ca3/appId/baf98f1b-374e-487d-af42-aa33807f11e4)
 
 After successfully running `bootstrap.ps1` running the `MaestroApplication` project via F5 in VS (launch as elevated) will run the application on `http://localhost:8080`.
 

--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -17,12 +17,13 @@
       ('https://github.com/maestro-auth-test/maestro-test', 289474),
       ('https://github.com/maestro-auth-test/maestro-test2', 289474),
       ('https://github.com/maestro-auth-test/maestro-test3', 289474),
+      ('https://github.com/maestro-auth-test/arcade', 289474),
       ('https://github.com/maestro-auth-test/dnceng-vmr', 289474);
   ```
 
 1. Run `.\Build.cmd -pack` at the root of the repo
-1. Get access to the [maestrolocal KeyVault](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cab65fc3-d077-467d-931f-3932eabf36d3/resourceGroups/maestro/providers/Microsoft.KeyVault/vaults/maestrolocal/overview)
-1. Get assigned to users of the [staging Maestro Entra application](https://ms.portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Users/objectId/8b6d0440-8a2f-438e-84b7-d6ffaa401ca3/appId/baf98f1b-374e-487d-af42-aa33807f11e4)
+2. Get access to the [maestrolocal KeyVault](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cab65fc3-d077-467d-931f-3932eabf36d3/resourceGroups/maestro/providers/Microsoft.KeyVault/vaults/maestrolocal/overview)
+3. Get assigned to users of the [staging Maestro Entra application](https://ms.portal.azure.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Users/objectId/8b6d0440-8a2f-438e-84b7-d6ffaa401ca3/appId/baf98f1b-374e-487d-af42-aa33807f11e4)
 
 After successfully running `bootstrap.ps1` running the `MaestroApplication` project via F5 in VS (launch as elevated) will run the application on `http://localhost:8080`.
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -362,7 +362,7 @@ public class DependencyFileManager : IDependencyFileManager
     {
         try
         {
-            if (SemanticVersion.TryParse(globalJson.SelectToken("tools.dotnet").ToString(), out SemanticVersion repoDotnetVersion))
+            if (SemanticVersion.TryParse(globalJson.SelectToken("tools.dotnet")?.ToString(), out SemanticVersion repoDotnetVersion))
             {
                 if (repoDotnetVersion.CompareTo(incomingDotnetVersion) < 0)
                 {

--- a/src/ProductConstructionService/Readme.md
+++ b/src/ProductConstructionService/Readme.md
@@ -17,6 +17,7 @@
       ('https://github.com/maestro-auth-test/maestro-test', 289474),
       ('https://github.com/maestro-auth-test/maestro-test2', 289474),
       ('https://github.com/maestro-auth-test/maestro-test3', 289474),
+      ('https://github.com/maestro-auth-test/arcade', 289474),
       ('https://github.com/maestro-auth-test/dnceng-vmr', 289474);
   ```
 1. Install Docker Desktop: https://www.docker.com/products/docker-desktop

--- a/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
+++ b/test/Maestro.ScenarioTests/MaestroScenarioTestBase.cs
@@ -61,7 +61,7 @@ internal abstract class MaestroScenarioTestBase
     {
         Octokit.Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepo);
 
-        var attempts = 10;
+        var attempts = 20;
         while (attempts-- > 0)
         {
             IReadOnlyList<Octokit.PullRequest> prs = await GitHubApi.PullRequest.GetAllForRepository(repo.Id, new Octokit.PullRequestRequest
@@ -85,13 +85,13 @@ internal abstract class MaestroScenarioTestBase
                 throw new MaestroTestException($"More than one pull request found in {targetRepo} targeting {targetBranch}");
             }
 
-            await Task.Delay(TimeSpan.FromMinutes(1));
+            await Task.Delay(TimeSpan.FromSeconds(30));
         }
 
         throw new MaestroTestException($"No pull request was created in {targetRepo} targeting {targetBranch}");
     }
 
-    private async Task<Octokit.PullRequest> WaitForUpdatedPullRequestAsync(string targetRepo, string targetBranch, int attempts = 7)
+    private async Task<Octokit.PullRequest> WaitForUpdatedPullRequestAsync(string targetRepo, string targetBranch, int attempts = 20)
     {
         Octokit.Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepo);
         Octokit.PullRequest pr = await WaitForPullRequestAsync(targetRepo, targetBranch);
@@ -106,13 +106,13 @@ internal abstract class MaestroScenarioTestBase
                 return pr;
             }
 
-            await Task.Delay(TimeSpan.FromMinutes(1));
+            await Task.Delay(TimeSpan.FromSeconds(30));
         }
 
         throw new MaestroTestException($"The created pull request for {targetRepo} targeting {targetBranch} was not updated with subsequent subscriptions after creation");
     }
 
-    private async Task<bool> WaitForMergedPullRequestAsync(string targetRepo, string targetBranch, int attempts = 7)
+    private async Task<bool> WaitForMergedPullRequestAsync(string targetRepo, string targetBranch, int attempts = 20)
     {
         Octokit.Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepo);
         Octokit.PullRequest pr = await WaitForPullRequestAsync(targetRepo, targetBranch);
@@ -127,7 +127,7 @@ internal abstract class MaestroScenarioTestBase
                 return true;
             }
 
-            await Task.Delay(TimeSpan.FromMinutes(1));
+            await Task.Delay(TimeSpan.FromSeconds(30));
         }
 
         throw new MaestroTestException($"The created pull request for {targetRepo} targeting {targetBranch} was not merged within {attempts} minutes");
@@ -138,7 +138,7 @@ internal abstract class MaestroScenarioTestBase
         var searchBaseUrl = GetAzDoRepoUrl(targetRepoName);
         IEnumerable<int> prs = new List<int>();
 
-        var attempts = 10;
+        var attempts = 20;
         while (attempts-- > 0)
         {
             try
@@ -162,7 +162,7 @@ internal abstract class MaestroScenarioTestBase
                 throw new MaestroTestException($"More than one pull request found in {targetRepoName} targeting {targetBranch}");
             }
 
-            await Task.Delay(60 * 1000);
+            await Task.Delay(TimeSpan.FromSeconds(30));
         }
 
         throw new MaestroTestException($"No pull request was created in {searchBaseUrl} targeting {targetBranch}");
@@ -201,7 +201,7 @@ internal abstract class MaestroScenarioTestBase
             throw new Exception($"{nameof(expectedPRTitle)} must be defined for AzDo PRs that require an update");
         }
 
-        for (var tries = 10; tries > 0; tries--)
+        for (var tries = 20; tries > 0; tries--)
         {
             PullRequest pr = await AzDoClient.GetPullRequestAsync($"{apiBaseUrl}/pullRequests/{pullRequestId}");
             var trimmedTitle = Regex.Replace(pr.Title, @"\s+", " ");
@@ -230,7 +230,7 @@ internal abstract class MaestroScenarioTestBase
                 });
             }
 
-            await Task.Delay(TimeSpan.FromMinutes(1));
+            await Task.Delay(TimeSpan.FromSeconds(30));
         }
 
         throw new MaestroTestException($"The created pull request for {targetRepoName} targeting {targetBranch} was not updated with subsequent subscriptions after creation");
@@ -309,7 +309,7 @@ internal abstract class MaestroScenarioTestBase
         await CheckAzDoPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedDependencies, repoDirectory, false, isUpdated, expectedFeeds, notExpectedFeeds);
     }
 
-    protected async Task CheckAzDoPullRequest(
+    protected async Task<string> CheckAzDoPullRequest(
         string expectedPRTitle,
         string targetRepoName,
         string targetBranch,
@@ -348,6 +348,8 @@ internal abstract class MaestroScenarioTestBase
                 sources.Should().NotContain(notExpectedFeeds);
             }
         }
+
+        return pullRequest.Value.HeadBranch;
     }
 
     private async Task ValidatePullRequestDependencies(string pullRequestBaseBranch, List<DependencyDetail> expectedDependencies, int tries = 1)

--- a/test/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
+++ b/test/Maestro.ScenarioTests/ScenarioTests_SdkUpdate.cs
@@ -16,7 +16,7 @@ namespace Maestro.ScenarioTests;
 [TestFixture]
 [Category("PostDeployment")]
 [NonParallelizable]
-internal class ScenarioTests_SdkUpdate : ScenarioTestBase
+internal class ScenarioTests_SdkUpdate : MaestroScenarioTestBase
 {
     private TestParameters _parameters;
     private readonly Random _random = new();

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
@@ -55,7 +55,7 @@ internal abstract class ScenarioTestBase
     {
         Octokit.Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepo);
 
-        var attempts = 10;
+        var attempts = 20;
         while (attempts-- > 0)
         {
             IReadOnlyList<Octokit.PullRequest> prs = await GitHubApi.PullRequest.GetAllForRepository(repo.Id, new Octokit.PullRequestRequest
@@ -79,13 +79,13 @@ internal abstract class ScenarioTestBase
                 throw new ScenarioTestException($"More than one pull request found in {targetRepo} targeting {targetBranch}");
             }
 
-            await Task.Delay(TimeSpan.FromMinutes(1));
+            await Task.Delay(TimeSpan.FromSeconds(30));
         }
 
         throw new ScenarioTestException($"No pull request was created in {targetRepo} targeting {targetBranch}");
     }
 
-    private async Task<Octokit.PullRequest> WaitForUpdatedPullRequestAsync(string targetRepo, string targetBranch, int attempts = 7)
+    private async Task<Octokit.PullRequest> WaitForUpdatedPullRequestAsync(string targetRepo, string targetBranch, int attempts = 20)
     {
         Octokit.Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepo);
         Octokit.PullRequest pr = await WaitForPullRequestAsync(targetRepo, targetBranch);
@@ -100,13 +100,13 @@ internal abstract class ScenarioTestBase
                 return pr;
             }
 
-            await Task.Delay(TimeSpan.FromMinutes(1));
+            await Task.Delay(TimeSpan.FromSeconds(30));
         }
 
         throw new ScenarioTestException($"The created pull request for {targetRepo} targeting {targetBranch} was not updated with subsequent subscriptions after creation");
     }
 
-    private async Task<bool> WaitForMergedPullRequestAsync(string targetRepo, string targetBranch, int attempts = 7)
+    private async Task<bool> WaitForMergedPullRequestAsync(string targetRepo, string targetBranch, int attempts = 20)
     {
         Octokit.Repository repo = await GitHubApi.Repository.Get(_parameters.GitHubTestOrg, targetRepo);
         Octokit.PullRequest pr = await WaitForPullRequestAsync(targetRepo, targetBranch);
@@ -121,7 +121,7 @@ internal abstract class ScenarioTestBase
                 return true;
             }
 
-            await Task.Delay(TimeSpan.FromMinutes(1));
+            await Task.Delay(TimeSpan.FromSeconds(30));
         }
 
         throw new ScenarioTestException($"The created pull request for {targetRepo} targeting {targetBranch} was not merged within {attempts} minutes");
@@ -132,7 +132,7 @@ internal abstract class ScenarioTestBase
         var searchBaseUrl = GetAzDoRepoUrl(targetRepoName);
         IEnumerable<int> prs = new List<int>();
 
-        var attempts = 10;
+        var attempts = 20;
         while (attempts-- > 0)
         {
             try
@@ -156,7 +156,7 @@ internal abstract class ScenarioTestBase
                 throw new ScenarioTestException($"More than one pull request found in {targetRepoName} targeting {targetBranch}");
             }
 
-            await Task.Delay(60 * 1000);
+            await Task.Delay(TimeSpan.FromSeconds(30));
         }
 
         throw new ScenarioTestException($"No pull request was created in {searchBaseUrl} targeting {targetBranch}");
@@ -195,7 +195,7 @@ internal abstract class ScenarioTestBase
             throw new Exception($"{nameof(expectedPRTitle)} must be defined for AzDo PRs that require an update");
         }
 
-        for (var tries = 10; tries > 0; tries--)
+        for (var tries = 20; tries > 0; tries--)
         {
             PullRequest pr = await AzDoClient.GetPullRequestAsync($"{apiBaseUrl}/pullRequests/{pullRequestId}");
             var trimmedTitle = Regex.Replace(pr.Title, @"\s+", " ");
@@ -214,8 +214,8 @@ internal abstract class ScenarioTestBase
                                 projectName,
                                 $"_apis/git/repositories/{targetRepoName}/pullrequests/{pullRequestId}",
                                 new NUnitLogger(),
-                                "{ \"status\" : \"abandoned\"}"
-                                );
+                                "{ \"status\" : \"abandoned\"}",
+                                logFailure: false);
                     }
                     catch
                     {
@@ -224,7 +224,7 @@ internal abstract class ScenarioTestBase
                 });
             }
 
-            await Task.Delay(TimeSpan.FromMinutes(1));
+            await Task.Delay(TimeSpan.FromSeconds(30));
         }
 
         throw new ScenarioTestException($"The created pull request for {targetRepoName} targeting {targetBranch} was not updated with subsequent subscriptions after creation");
@@ -303,7 +303,7 @@ internal abstract class ScenarioTestBase
         await CheckAzDoPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedDependencies, repoDirectory, false, isUpdated, expectedFeeds, notExpectedFeeds);
     }
 
-    protected async Task CheckAzDoPullRequest(
+    protected async Task<string> CheckAzDoPullRequest(
         string expectedPRTitle,
         string targetRepoName,
         string targetBranch,
@@ -342,6 +342,8 @@ internal abstract class ScenarioTestBase
                 sources.Should().NotContain(notExpectedFeeds);
             }
         }
+
+        return pullRequest.Value.HeadBranch;
     }
 
     private async Task ValidatePullRequestDependencies(string pullRequestBaseBranch, List<DependencyDetail> expectedDependencies, int tries = 1)
@@ -889,7 +891,7 @@ internal abstract class ScenarioTestBase
         return await RunDarcAsync("get-repository-policies", "--all", "--repo", repoUri, "--branch", branchName);
     }
 
-    protected async Task WaitForMergedPullRequestAsync(string targetRepo, string targetBranch, Octokit.PullRequest pr, Octokit.Repository repo, int attempts = 7)
+    protected async Task WaitForMergedPullRequestAsync(string targetRepo, string targetBranch, Octokit.PullRequest pr, Octokit.Repository repo, int attempts = 20)
     {
         while (attempts-- > 0)
         {
@@ -901,7 +903,7 @@ internal abstract class ScenarioTestBase
                 return;
             }
 
-            await Task.Delay(TimeSpan.FromMinutes(1));
+            await Task.Delay(TimeSpan.FromSeconds(30));
         }
 
         throw new ScenarioTestException($"The created pull request for {targetRepo} targeting {targetBranch} was not merged within {attempts} minutes");


### PR DESCRIPTION
They were using real Arcade and the local dev Maestro app doesn't have access to it so these were never green even in old Maestro.

Also made the test check for PRs every 30 seconds instead of a minute to speed things up.

https://github.com/dotnet/arcade-services/issues/3922
