### PR TITLE
Fix repo merge policies E2E test

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
@@ -140,12 +140,6 @@ internal class SetRepositoryMergePoliciesOperation : Operation
         IRemote verifyRemote = RemoteFactory.GetRemote(_options, repository, _logger);
         IEnumerable<RepositoryBranch> targetRepository = await _barClient.GetRepositoriesAsync(repository, branch: null);
 
-        if (targetRepository == null || !targetRepository.Any())
-        {
-            Console.WriteLine($"The target repository '{repository}' doesn't have a Maestro installation. Aborting merge policy creation.");
-            return Constants.ErrorCode;
-        }
-
         if (!await UxHelpers.VerifyAndConfirmBranchExistsAsync(verifyRemote, repository, branch, !_options.Quiet))
         {
             Console.WriteLine("Aborting merge policy creation.");

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests_RepoPolicies.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests_RepoPolicies.cs
@@ -23,7 +23,7 @@ internal class ScenarioTests_RepoPolicies : ScenarioTestBase
     }
 
     [Test]
-    public async Task ArcadeRepoPolicies_EndToEnd()
+    public async Task RepoPolicies_EndToEnd()
     {
         TestContext.WriteLine("Repository merge policy handling");
         TestContext.WriteLine("Running tests...");


### PR DESCRIPTION
The way it's set up, if the repo never had any policies, it won't be able to get one (unless you trigger a subscription over the repo at least once). We're not actually querying repositories in the check but a repository branches instead.

https://github.com/dotnet/arcade-services/issues/3922