### PR TITLE
Fix measuring the queue wait time delay

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Common/MetricRecorder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/MetricRecorder.cs
@@ -8,7 +8,7 @@ namespace ProductConstructionService.Common;
 
 public interface IMetricRecorder
 {
-    void QueueMessageReceived(QueueMessage message, TimeSpan delay);
+    void QueueMessageReceived(QueueMessage message, int delayInSeconds);
 }
 
 public class MetricRecorder : IMetricRecorder
@@ -24,9 +24,9 @@ public class MetricRecorder : IMetricRecorder
         _queueWaitTimeCounter = meter.CreateCounter<int>(WaitTimeMetricName);
     }
 
-    public void QueueMessageReceived(QueueMessage message, TimeSpan delay)
+    public void QueueMessageReceived(QueueMessage message, int delayInSeconds)
     {
-        TimeSpan timeInQueue = DateTimeOffset.UtcNow - message.InsertedOn!.Value - delay;
-        _queueWaitTimeCounter.Add((int)timeInQueue.TotalSeconds);
+        TimeSpan timeInQueue = DateTimeOffset.UtcNow - message.InsertedOn!.Value;
+        _queueWaitTimeCounter.Add((int)timeInQueue.TotalSeconds - delayInSeconds);
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItem.cs
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItem.cs
@@ -16,5 +16,5 @@ public abstract class WorkItem
     /// Period of time before the WorkItem becomes visible in the queue.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault | JsonIgnoreCondition.WhenWritingNull)]
-    public TimeSpan? Delay { get; internal set; }
+    public int? Delay { get; internal set; }
 }

--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItemConsumer.cs
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItemConsumer.cs
@@ -70,17 +70,14 @@ internal class WorkItemConsumer(
         }
 
         string workItemType;
-        TimeSpan? delay;
+        int? delay;
         JsonNode node;
         try
         {
             node = JsonNode.Parse(message.Body)!;
             workItemType = node["type"]!.ToString();
 
-            var d = node["delay"]?.GetValue<int>();
-            delay = d.HasValue
-                ? TimeSpan.FromSeconds(d.Value)
-                : null;
+            delay = node["delay"]?.GetValue<int>();
         }
         catch (Exception ex)
         {
@@ -89,7 +86,7 @@ internal class WorkItemConsumer(
             return;
         }
 
-        _metricRecorder.QueueMessageReceived(message, delay ?? default);
+        _metricRecorder.QueueMessageReceived(message, delay ?? 0);
 
         try
         {

--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItemProducer.cs
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItemProducer.cs
@@ -31,7 +31,7 @@ public class WorkItemProducer<T>(QueueServiceClient queueServiceClient, string q
 
         if (delay != default)
         {
-            payload.Delay = delay;
+            payload.Delay = (int)delay.TotalSeconds;
         }
 
         var json = JsonSerializer.Serialize(payload, WorkItemConfiguration.JsonSerializerOptions);


### PR DESCRIPTION
There was a serialization problem - serializing `TimeSpan` and deserializing `int`

https://github.com/dotnet/arcade-services/issues/3933
