### PR TITLE
Support DependencyFlow in AzDO dasboard iframe

### DIFF
--- a/src/Maestro/Maestro.Authentication/AuthenticationConfiguration.cs
+++ b/src/Maestro/Maestro.Authentication/AuthenticationConfiguration.cs
@@ -50,7 +50,8 @@ public static class AuthenticationConfiguration
 
         services.Configure<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme, cookieAuthOptions =>
         {
-            // Allow /DependencyFlow pages to render for authenticated users in iframe on Azure DevOps dashboard.
+            // Allow /DependencyFlow pages to render for authenticated users in iframe on Azure DevOps dashboard
+            // with browsers that support third-party cookies.
             cookieAuthOptions.Cookie.SameSite = SameSiteMode.None;
         });
 

--- a/src/Maestro/Maestro.Authentication/AuthenticationConfiguration.cs
+++ b/src/Maestro/Maestro.Authentication/AuthenticationConfiguration.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Maestro.Data;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -45,6 +46,12 @@ public static class AuthenticationConfiguration
             options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
             // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
             options.HandleSameSiteCookieCompatibility();
+        });
+
+        services.Configure<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme, cookieAuthOptions =>
+        {
+            // Allow /DependencyFlow pages to render for authenticated users in iframe on Azure DevOps dashboard.
+            cookieAuthOptions.Cookie.SameSite = SameSiteMode.None;
         });
 
         // Support for old Maestro tokens

--- a/src/Maestro/Maestro.Web/Pages/Account/AccountController.cs
+++ b/src/Maestro/Maestro.Web/Pages/Account/AccountController.cs
@@ -4,6 +4,7 @@
 using System.Threading.Tasks;
 using Maestro.Authentication;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -14,18 +15,22 @@ public class AccountController : Controller
 {
     [HttpGet("/Account/SignOut")]
     [AllowAnonymous]
-    public new async Task<IActionResult> SignOut()
+    public new async Task SignOut()
     {
-        await HttpContext.SignOutAsync();
-        return Redirect($"{Request.Scheme}://{Request.Host}");
+        await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        await HttpContext.SignOutAsync(OpenIdConnectDefaults.AuthenticationScheme, new()
+        {
+            RedirectUri = "/"
+        });
     }
 
     [HttpGet(AuthenticationConfiguration.AccountSignInRoute)]
     [AllowAnonymous]
     public IActionResult SignIn(string returnUrl = null)
     {
+        returnUrl ??= "/";
         return Challenge(
-            new AuthenticationProperties() { RedirectUri = $"{Request.Scheme}://{Request.Host}" },
+            new AuthenticationProperties() { RedirectUri = returnUrl },
             OpenIdConnectDefaults.AuthenticationScheme);
     }
 }

--- a/src/Maestro/Maestro.Web/Pages/Error.cshtml
+++ b/src/Maestro/Maestro.Web/Pages/Error.cshtml
@@ -1,10 +1,22 @@
 @page
 @model Maestro.Web.Pages.ErrorModel
+@using System.Net
+@using Microsoft.AspNetCore.Http
 @{
     ViewBag.Title = "Error";
 }
 
-<div class="alert alert-danger">
-    <strong>@Model.StatusCode</strong> @Model.ErrorMessage
-</div>
+@if (Model.StatusCode == StatusCodes.Status401Unauthorized)
+{
+    <div>
+        Please <a href="/Account/SignIn?returnUrl=@WebUtility.UrlEncode(Model.ReturnUrl)">Sign In</a> to use this site. Make sure you have joined the
+        <a href="https://coreidentity.microsoft.com/manage/Entitlement/entitlement/dotnetesmaes-z54r" target="_blank">dotnetes-maestro-users group</a>.
+    </div>
+}
+else
+{
+    <div class="alert alert-danger">
+        <strong>@Model.StatusCode</strong> @Model.ErrorMessage
+    </div>
+}
 

--- a/src/Maestro/Maestro.Web/Pages/Error.cshtml.cs
+++ b/src/Maestro/Maestro.Web/Pages/Error.cshtml.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Maestro.Web.Pages;
@@ -10,6 +11,8 @@ public class ErrorModel : PageModel
     public new int StatusCode { get; set; }
 
     public string ErrorMessage { get; set; }
+
+    public string ReturnUrl => HttpContext.Features.Get<IStatusCodeReExecuteFeature>()?.OriginalPath;
 
     public void OnGet(int code)
     {

--- a/src/Maestro/Maestro.Web/Startup.cs
+++ b/src/Maestro/Maestro.Web/Startup.cs
@@ -534,7 +534,12 @@ public partial class Startup : StartupBase
                         ctx.Response.Headers.Add("X-XSS-Protection", "1");
                     }
 
-                    if (!ctx.Response.Headers.ContainsKey("X-Frame-Options"))
+                    if (ctx.Request.Path.StartsWithSegments("/DependencyFlow"))
+                    {
+                        // Allow DependencyFlow pages to be rendered on Azure DevOps dashboard
+                        ctx.Response.Headers.Add("Content-Security-Policy", "frame-ancestors https://dev.azure.com");
+                    }
+                    else if (!ctx.Response.Headers.ContainsKey("X-Frame-Options"))
                     {
                         ctx.Response.Headers.Add("X-Frame-Options", "DENY");
                     }

--- a/src/Maestro/Maestro.Web/Startup.cs
+++ b/src/Maestro/Maestro.Web/Startup.cs
@@ -534,16 +534,6 @@ public partial class Startup : StartupBase
                         ctx.Response.Headers.Add("X-XSS-Protection", "1");
                     }
 
-                    if (ctx.Request.Path.StartsWithSegments("/DependencyFlow"))
-                    {
-                        // Allow DependencyFlow pages to be rendered on Azure DevOps dashboard
-                        ctx.Response.Headers.Add("Content-Security-Policy", "frame-ancestors https://dev.azure.com");
-                    }
-                    else if (!ctx.Response.Headers.ContainsKey("X-Frame-Options"))
-                    {
-                        ctx.Response.Headers.Add("X-Frame-Options", "DENY");
-                    }
-
                     if (!ctx.Response.Headers.ContainsKey("X-Content-Type-Options"))
                     {
                         ctx.Response.Headers.Add("X-Content-Type-Options", "nosniff");
@@ -553,6 +543,9 @@ public partial class Startup : StartupBase
                     {
                         ctx.Response.Headers.Add("Referrer-Policy", "no-referrer-when-downgrade");
                     }
+
+                    // Only allow DependencyFlow pages to be rendered on Azure DevOps dashboard
+                    ctx.Response.Headers.Append("Content-Security-Policy", "frame-ancestors https://dev.azure.com");
 
                     return Task.CompletedTask;
                 });

--- a/src/ProductConstructionService/ProductConstructionService.Api/Controllers/AccountController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Controllers/AccountController.cs
@@ -3,6 +3,7 @@
 
 using Maestro.Authentication;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -13,18 +14,22 @@ public class AccountController : Controller
 {
     [HttpGet("/Account/SignOut")]
     [AllowAnonymous]
-    public new async Task<IActionResult> SignOut()
+    public new async Task SignOut()
     {
-        await HttpContext.SignOutAsync();
-        return Redirect($"{Request.Scheme}://{Request.Host}");
+        await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        await HttpContext.SignOutAsync(OpenIdConnectDefaults.AuthenticationScheme, new()
+        {
+            RedirectUri = "/"
+        });
     }
 
     [HttpGet(AuthenticationConfiguration.AccountSignInRoute)]
     [AllowAnonymous]
-    public IActionResult SignIn()
+    public IActionResult SignIn(string? returnUrl = null)
     {
+        returnUrl ??= "/";
         return Challenge(
-            new AuthenticationProperties() { RedirectUri = $"{Request.Scheme}://{Request.Host}" },
+            new AuthenticationProperties() { RedirectUri = returnUrl },
             OpenIdConnectDefaults.AuthenticationScheme);
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/Pages/Error.cshtml
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Pages/Error.cshtml
@@ -1,10 +1,21 @@
 @page
 @model ProductConstructionService.Api.Pages.ErrorModel
+@using System.Net
+@using Microsoft.AspNetCore.Http
 @{
     ViewBag.Title = "Error";
 }
 
-<div class="alert alert-danger">
-    <strong>@Model.StatusCode</strong> @Model.ErrorMessage
-</div>
-
+@if (Model.StatusCode == StatusCodes.Status401Unauthorized)
+{
+    <div>
+        Please <a href="/Account/SignIn?returnUrl=@WebUtility.UrlEncode(Model.ReturnUrl)">Sign In</a> to use this site. Make sure you have joined the
+        <a href="https://coreidentity.microsoft.com/manage/Entitlement/entitlement/dotnetesmaes-z54r" target="_blank">dotnetes-maestro-users group</a>.
+    </div>
+}
+else
+{
+    <div class="alert alert-danger">
+        <strong>@Model.StatusCode</strong> @Model.ErrorMessage
+    </div>
+}

--- a/src/ProductConstructionService/ProductConstructionService.Api/Pages/Error.cshtml.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Pages/Error.cshtml.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace ProductConstructionService.Api.Pages;
@@ -10,6 +11,8 @@ public class ErrorModel : PageModel
     public new int StatusCode { get; set; }
 
     public string? ErrorMessage { get; set; }
+
+    public string? ReturnUrl => HttpContext.Features.Get<IStatusCodeReExecuteFeature>()?.OriginalPath;
 
     public void OnGet(int code)
     {

--- a/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
@@ -311,6 +311,8 @@ internal static class PcsStartup
                 ctx.Response.Headers.TryAdd("X-Frame-Options", "DENY");
                 ctx.Response.Headers.TryAdd("X-Content-Type-Options", "nosniff");
                 ctx.Response.Headers.TryAdd("Referrer-Policy", "no-referrer-when-downgrade");
+                // Allow DependencyFlow pages to be rendered on Azure DevOps dashboard
+                ctx.Response.Headers.Append("Content-Security-Policy", "frame-ancestors https://dev.azure.com");
                 return Task.CompletedTask;
             });
 


### PR DESCRIPTION
Unlike the previous "dependency flow" pages which as of now are still hosted at https://dependencyflow.azurewebsites.net/ ([example](https://dependencyflow.azurewebsites.net/incoming/3883/dotnet/aspnetcore)), the same page on https://maestro.dot.net/DependencyFlow ([example](https://maestro.dot.net/DependencyFlow/incoming/3883/dotnet/aspnetcore)) cannot be rendered inside an iframe due to the `X-Frame-Options: Deny` response header and the `SameSite=Lax` cookies (as opposed to `SameSite=None`).

#### Before and after of dependency flow page being embedded into AzDO dashbaord

![Before and after of dependency flow page being embedded into AzDO dashbaord](https://github.com/user-attachments/assets/69407f5d-a669-4d79-b840-160e4873c8c6)

Fixes https://github.com/dotnet/arcade-services/issues/4004

Thanks again for all the help on this @premun!
