### PR TITLE
Add missing source mappings

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -187,9 +187,11 @@
       <package pattern="Microsoft.DotNet.Arcade.Sdk" />
       <package pattern="Microsoft.DotNet.Authentication.Algorithms" />
       <package pattern="Microsoft.DotNet.Build.Tasks.Feed" />
+      <package pattern="Microsoft.DotNet.Darc" />
       <package pattern="Microsoft.DotNet.GitHub.Authentication" />
       <package pattern="Microsoft.DotNet.Internal.*" />
       <package pattern="Microsoft.DotNet.Kusto" />
+      <package pattern="Microsoft.DotNet.Maestro.Tasks" />
       <package pattern="Microsoft.DotNet.Metrics" />
       <package pattern="Microsoft.DotNet.ServiceFabric.ServiceHost" />
       <package pattern="Microsoft.DotNet.Services.Utility" />


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
Some source mappings were missed in the original PR because we only restore these packages in the pipeline when publishing/testing, this should resolve the issue.
https://github.com/dotnet/arcade-services/issues/4017