### PR TITLE
Add Redis Mutex to all classes that are converted Maestro Actors

### DIFF
--- a/src/Maestro/Maestro.Data/Models/Build.cs
+++ b/src/Maestro/Maestro.Data/Models/Build.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection.Metadata.Ecma335;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Services.Utility;
 
@@ -114,6 +115,9 @@ public class Build
 
     [NotMapped]
     public List<BuildDependency> DependentBuildIds { get; set; }
+
+    public string GetRepository() => GitHubRepository ?? AzureDevOpsRepository;
+    public string GetBranch() => GitHubBranch ?? AzureDevOpsBranch;
 }
 
 public class BuildChannel

--- a/src/ProductConstructionService/ProductConstructionService.Common/RedisMutex.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/RedisMutex.cs
@@ -7,7 +7,7 @@ namespace ProductConstructionService.Common;
 
 public interface IRedisMutex
 {
-    public Task<T> EnterWhenAvailable<T>(string mutexName, Func<Task<T>> action, int lockTimeHours);
+    public Task<T> EnterWhenAvailable<T>(string mutexName, Func<Task<T>> action, int lockTimeHours = 1);
 }
 
 /// <summary>

--- a/src/ProductConstructionService/ProductConstructionService.Common/RedisMutex.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/RedisMutex.cs
@@ -7,11 +7,11 @@ namespace ProductConstructionService.Common;
 
 public interface IRedisMutex
 {
-    public Task<T> DoWhenReady<T>(string mutexName, Func<Task<T>> action);
+    public Task<T> ExecuteWhenReady<T>(string mutexName, Func<Task<T>> action);
 }
 
 /// <summary>
-/// Mutex implemented using a redis cache meant for synchronization between repplicas
+/// Mutex implemented using a redis cache meant for synchronization between replicas
 /// </summary>
 public class RedisMutex : IRedisMutex
 {
@@ -26,7 +26,7 @@ public class RedisMutex : IRedisMutex
         _logger = logger;
     }
 
-    public async Task<T> DoWhenReady<T>(string mutexName, Func<Task<T>> action)
+    public async Task<T> ExecuteWhenReady<T>(string mutexName, Func<Task<T>> action)
     {
         IRedisCache mutexCache = _cacheFactory.Create($"{mutexName}_mutex");
 

--- a/src/ProductConstructionService/ProductConstructionService.Common/RedisMutex.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/RedisMutex.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace ProductConstructionService.Common;
+
+public interface IRedisMutex
+{
+    public Task<T> DoWhenReady<T>(string mutexName, Func<Task<T>> action);
+}
+
+/// <summary>
+/// Mutex implemented using a redis cache meant for synchronization between repplicas
+/// </summary>
+public class RedisMutex : IRedisMutex
+{
+    private readonly IRedisCacheFactory _cacheFactory;
+    private readonly ILogger<RedisMutex> _logger;
+
+    private const int MutexWakeUpTimeSeconds = 5;
+
+    public RedisMutex(IRedisCacheFactory cacheFactory, ILogger<RedisMutex> logger)
+    {
+        _cacheFactory = cacheFactory;
+        _logger = logger;
+    }
+
+    public async Task<T> DoWhenReady<T>(string mutexName, Func<Task<T>> action)
+    {
+        IRedisCache mutexCache = _cacheFactory.Create($"{mutexName}_mutex");
+
+        try
+        {
+            // Check if a different replica is processing a subscription that belongs to the same batch
+            string? state;
+            do
+            {
+                state = await mutexCache.GetAsync();
+            } while (await Utility.SleepIfTrue(
+                () => !string.IsNullOrEmpty(state),
+                MutexWakeUpTimeSeconds,
+                () => _logger.LogInformation("Waiting for mutex {mutexName} mutexName to become available", mutexName)));
+            // Updating assets should never take more than an hour. If it does, it's possible something
+            // bad happened, so reset the mutex
+            _logger.LogInformation("Taking mutex {mutexName}", mutexName);
+            await mutexCache.SetAsync("busy", TimeSpan.FromHours(1));
+
+            return await action();
+        }
+        finally
+        {
+            _logger.LogInformation("Releasing mutex {mutexName}", mutexName);
+            // if something happens, we don't want this subscription to be blocked forever, reset the mutex
+            await mutexCache.TryDeleteAsync();
+        }
+    }
+}

--- a/src/ProductConstructionService/ProductConstructionService.Common/Utility.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/Utility.cs
@@ -19,6 +19,18 @@ public static class Utility
         return false;
     }
 
+    public static async Task<bool> SleepIfTrue(Func<bool> condition, int durationSeconds, Action falseAction)
+    {
+        if (condition())
+        {
+            falseAction();
+            await Task.Delay(TimeSpan.FromSeconds(durationSeconds));
+            return true;
+        }
+
+        return false;
+    }
+
     public static string ConvertStringToCompressedBase64EncodedQuery(string query)
     {
         var bytes = System.Text.Encoding.UTF8.GetBytes(query);

--- a/src/ProductConstructionService/ProductConstructionService.Common/Utility.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/Utility.cs
@@ -19,11 +19,14 @@ public static class Utility
         return false;
     }
 
-    public static async Task<bool> SleepIfTrue(Func<bool> condition, int durationSeconds, Action falseAction)
+    public static async Task<bool> SleepIfTrue(
+        Func<bool> condition,
+        int durationSeconds,
+        Action onFalseAction)
     {
         if (condition())
         {
-            falseAction();
+            onFalseAction();
             await Task.Delay(TimeSpan.FromSeconds(durationSeconds));
             return true;
         }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/BatchedPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/BatchedPullRequestUpdater.cs
@@ -18,9 +18,6 @@ internal class BatchedPullRequestUpdater : PullRequestUpdater
 {
     private readonly BatchedPullRequestUpdaterId _id;
     private readonly BuildAssetRegistryContext _context;
-    private readonly IRedisCache _batchedSubscriptionMutex;
-
-    private const int MutexWakeUpTimeSeconds = 10;
 
     public BatchedPullRequestUpdater(
         BatchedPullRequestUpdaterId id,
@@ -48,7 +45,6 @@ internal class BatchedPullRequestUpdater : PullRequestUpdater
     {
         _id = id;
         _context = context;
-        _batchedSubscriptionMutex = cacheFactory.Create($"{id}_mutex");
     }
 
     protected override Task<(string repository, string branch)> GetTargetAsync()
@@ -60,30 +56,5 @@ internal class BatchedPullRequestUpdater : PullRequestUpdater
     {
         RepositoryBranch? repositoryBranch = await _context.RepositoryBranches.FindAsync(_id.Repository, _id.Branch);
         return repositoryBranch?.PolicyObject?.MergePolicies ?? [];
-    }
-
-    public override async Task<bool> UpdateAssetsAsync(Guid subscriptionId, SubscriptionType type, int buildId, string sourceRepo, string sourceSha, List<Maestro.Contracts.Asset> assets)
-    {
-        try
-        {
-            // Check if a different replica is processing a subscription that belongs to the same batch
-            string? state;
-            do
-            {
-                state = await _batchedSubscriptionMutex.GetAsync();
-            } while (await Utility.SleepIfTrue(
-                () => !string.IsNullOrEmpty(state),
-                MutexWakeUpTimeSeconds));
-            // Updating assets should never take more than an hour. If it does, it's possible something
-            // bad happened, so reset the mutex
-            await _batchedSubscriptionMutex.SetAsync("busy", TimeSpan.FromHours(1));
-
-            return await base.UpdateAssetsAsync(subscriptionId, type, buildId, sourceRepo, sourceSha, assets);
-        }
-        finally
-        {
-            // if something happens, we don't want this subscription to be blocked forever, reset the mutex
-            await _batchedSubscriptionMutex.TryDeleteAsync();
-        }
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/DependencyFlowConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/DependencyFlowConfiguration.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using ProductConstructionService.Common;
 using ProductConstructionService.DependencyFlow.WorkItemProcessors;
 using ProductConstructionService.DependencyFlow.WorkItems;
 using ProductConstructionService.WorkItems;
@@ -24,6 +25,7 @@ public static class DependencyFlowConfiguration
         services.TryAddTransient<IPullRequestBuilder, PullRequestBuilder>();
         services.TryAddTransient<IPullRequestPolicyFailureNotifier, PullRequestPolicyFailureNotifier>();
         services.TryAddScoped<IBasicBarClient, SqlBarClient>();
+        services.TryAddSingleton<IRedisMutex, RedisMutex>();
 
         services.AddWorkItemProcessor<BuildCoherencyInfoWorkItem, BuildCoherencyInfoProcessor>();
         services.AddWorkItemProcessor<CodeFlowWorkItem, CodeFlowWorkItemProcessor>();

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/IPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/IPullRequestUpdater.cs
@@ -20,4 +20,6 @@ public interface IPullRequestUpdater
         string sourceRepo,
         string sourceSha,
         List<Maestro.Contracts.Asset> assets);
+
+    PullRequestUpdaterId Id { get; }
 }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -38,6 +38,8 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
     protected readonly IRedisCache<InProgressPullRequest> _pullRequestState;
     protected readonly IRedisCache<CodeFlowStatus> _codeFlowState;
 
+    public PullRequestUpdaterId Id { get { return _id; } }
+
     /// <summary>
     ///     Creates a new PullRequestActor
     /// </summary>
@@ -385,7 +387,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
     ///     PRs are marked as non-updateable so that we can allow pull request checks to complete on a PR prior
     ///     to pushing additional commits.
     /// </remarks>
-    public virtual async Task<bool> UpdateAssetsAsync(
+    public async Task<bool> UpdateAssetsAsync(
         Guid subscriptionId,
         SubscriptionType type,
         int buildId,

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/SubscriptionTriggerer.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/SubscriptionTriggerer.cs
@@ -6,6 +6,7 @@ using Maestro.Data;
 using Maestro.Data.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using ProductConstructionService.Common;
 using Asset = Maestro.Contracts.Asset;
 
 namespace ProductConstructionService.DependencyFlow;
@@ -16,17 +17,20 @@ internal class SubscriptionTriggerer : ISubscriptionTriggerer
     private readonly BuildAssetRegistryContext _context;
     private readonly ILogger<SubscriptionTriggerer> _logger;
     private readonly Guid _subscriptionId;
+    private readonly IRedisMutex _redisMutex;
 
     public SubscriptionTriggerer(
         BuildAssetRegistryContext context,
         IPullRequestUpdaterFactory updaterFactory,
         ILogger<SubscriptionTriggerer> logger,
-        Guid subscriptionId)
+        Guid subscriptionId,
+        IRedisMutex redisMutex)
     {
         _context = context;
         _updaterFactory = updaterFactory;
         _logger = logger;
         _subscriptionId = subscriptionId;
+        _redisMutex = redisMutex;
     }
 
     public async Task<bool> UpdateForMergedPullRequestAsync(int updateBuildId)
@@ -145,18 +149,25 @@ internal class SubscriptionTriggerer : ISubscriptionTriggerer
             })
             .ToList();
 
-        _logger.LogInformation("Running asset update for {subscriptionId}", _subscriptionId);
+        await _redisMutex.DoWhenReady(
+            pullRequestActor.Id.ToString(),
+            async () =>
+            {
+                _logger.LogInformation("Running asset update for {subscriptionId}", _subscriptionId);
 
-        await pullRequestActor.UpdateAssetsAsync(
-            _subscriptionId,
-            subscription.SourceEnabled
-                ? SubscriptionType.DependenciesAndSources
-                : SubscriptionType.Dependencies,
-            build.Id,
-            build.GitHubRepository ?? build.AzureDevOpsRepository,
-            build.Commit,
-            assets);
+                await pullRequestActor.UpdateAssetsAsync(
+                    _subscriptionId,
+                    subscription.SourceEnabled
+                        ? SubscriptionType.DependenciesAndSources
+                        : SubscriptionType.Dependencies,
+                    build.Id,
+                    build.GitHubRepository ?? build.AzureDevOpsRepository,
+                    build.Commit,
+                    assets);
 
-        _logger.LogInformation("Asset update complete for {subscriptionId}", _subscriptionId);
+                _logger.LogInformation("Asset update complete for {subscriptionId}", _subscriptionId);
+
+                return true;
+            });
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/SubscriptionTriggerer.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/SubscriptionTriggerer.cs
@@ -161,7 +161,7 @@ internal class SubscriptionTriggerer : ISubscriptionTriggerer
                         ? SubscriptionType.DependenciesAndSources
                         : SubscriptionType.Dependencies,
                     build.Id,
-                    build.GitHubRepository ?? build.AzureDevOpsRepository,
+                    build.GetRepository(),
                     build.Commit,
                     assets);
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/SubscriptionTriggerer.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/SubscriptionTriggerer.cs
@@ -149,7 +149,7 @@ internal class SubscriptionTriggerer : ISubscriptionTriggerer
             })
             .ToList();
 
-        await _redisMutex.ExecuteWhenReady(
+        await _redisMutex.EnterWhenAvailable(
             pullRequestActor.Id.ToString(),
             async () =>
             {

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/SubscriptionTriggerer.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/SubscriptionTriggerer.cs
@@ -149,7 +149,7 @@ internal class SubscriptionTriggerer : ISubscriptionTriggerer
             })
             .ToList();
 
-        await _redisMutex.DoWhenReady(
+        await _redisMutex.ExecuteWhenReady(
             pullRequestActor.Id.ToString(),
             async () =>
             {

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/BuildCoherencyInfoProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/BuildCoherencyInfoProcessor.cs
@@ -57,7 +57,7 @@ public class BuildCoherencyInfoProcessor : WorkItemProcessor<BuildCoherencyInfoW
             DependencyGraph graph = await DependencyGraph.BuildRemoteDependencyGraphAsync(
                 _remoteFactory,
                 _barClient,
-                build.GitHubRepository ?? build.AzureDevOpsRepository,
+                build.GetRepository(),
                 build.Commit,
                 graphBuildOptions,
                 _logger);

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/PullRequestCheckProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/PullRequestCheckProcessor.cs
@@ -22,7 +22,7 @@ public class PullRequestCheckProcessor : WorkItemProcessor<InProgressPullRequest
         InProgressPullRequest workItem,
         CancellationToken cancellationToken)
     {
-        return await _redisMutex.ExecuteWhenReady(
+        return await _redisMutex.EnterWhenAvailable(
             workItem.ActorId,
             async () =>
             {

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/PullRequestCheckProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/PullRequestCheckProcessor.cs
@@ -22,7 +22,7 @@ public class PullRequestCheckProcessor : WorkItemProcessor<InProgressPullRequest
         InProgressPullRequest workItem,
         CancellationToken cancellationToken)
     {
-        return await _redisMutex.DoWhenReady(
+        return await _redisMutex.ExecuteWhenReady(
             workItem.ActorId,
             async () =>
             {

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/PullRequestCheckProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/PullRequestCheckProcessor.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using ProductConstructionService.Common;
 using ProductConstructionService.DependencyFlow.WorkItems;
 using ProductConstructionService.WorkItems;
 
@@ -9,18 +10,25 @@ namespace ProductConstructionService.DependencyFlow.WorkItemProcessors;
 public class PullRequestCheckProcessor : WorkItemProcessor<InProgressPullRequest>
 {
     private readonly IPullRequestUpdaterFactory _updaterFactory;
+    private readonly IRedisMutex _redisMutex;
 
-    public PullRequestCheckProcessor(IPullRequestUpdaterFactory updaterFactory)
+    public PullRequestCheckProcessor(IPullRequestUpdaterFactory updaterFactory, IRedisMutex redisMutex)
     {
         _updaterFactory = updaterFactory;
+        _redisMutex = redisMutex;
     }
 
     public override async Task<bool> ProcessWorkItemAsync(
         InProgressPullRequest workItem,
         CancellationToken cancellationToken)
     {
-        var updater = _updaterFactory.CreatePullRequestUpdater(PullRequestUpdaterId.Parse(workItem.ActorId));
-        await updater.SynchronizeInProgressPullRequestAsync(workItem);
-        return true;
+        return await _redisMutex.DoWhenReady(
+            workItem.ActorId,
+            async () =>
+            {
+                var updater = _updaterFactory.CreatePullRequestUpdater(PullRequestUpdaterId.Parse(workItem.ActorId));
+                await updater.SynchronizeInProgressPullRequestAsync(workItem);
+                return true;
+            });
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/SubscriptionUpdateProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/SubscriptionUpdateProcessor.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using ProductConstructionService.Common;
 using ProductConstructionService.DependencyFlow.WorkItems;
 using ProductConstructionService.WorkItems;
 
@@ -9,18 +10,25 @@ namespace ProductConstructionService.DependencyFlow.WorkItemProcessors;
 public class SubscriptionUpdateProcessor : WorkItemProcessor<SubscriptionUpdateWorkItem>
 {
     private readonly IPullRequestUpdaterFactory _updaterFactory;
+    private readonly IRedisMutex _redisMutex;
 
-    public SubscriptionUpdateProcessor(IPullRequestUpdaterFactory updaterFactory)
+    public SubscriptionUpdateProcessor(IPullRequestUpdaterFactory updaterFactory, IRedisMutex redisMutex)
     {
         _updaterFactory = updaterFactory;
+        _redisMutex = redisMutex;
     }
 
     public override async Task<bool> ProcessWorkItemAsync(
         SubscriptionUpdateWorkItem workItem,
         CancellationToken cancellationToken)
     {
-        var updater = _updaterFactory.CreatePullRequestUpdater(PullRequestUpdaterId.Parse(workItem.ActorId));
-        await updater.ProcessPendingUpdatesAsync(workItem);
-        return true;
+        return await _redisMutex.DoWhenReady(
+            workItem.ActorId,
+            async () =>
+            {
+                var updater = _updaterFactory.CreatePullRequestUpdater(PullRequestUpdaterId.Parse(workItem.ActorId));
+                await updater.ProcessPendingUpdatesAsync(workItem);
+                return true;
+            }); 
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/SubscriptionUpdateProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/SubscriptionUpdateProcessor.cs
@@ -22,7 +22,7 @@ public class SubscriptionUpdateProcessor : WorkItemProcessor<SubscriptionUpdateW
         SubscriptionUpdateWorkItem workItem,
         CancellationToken cancellationToken)
     {
-        return await _redisMutex.DoWhenReady(
+        return await _redisMutex.ExecuteWhenReady(
             workItem.ActorId,
             async () =>
             {

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/SubscriptionUpdateProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/SubscriptionUpdateProcessor.cs
@@ -22,7 +22,7 @@ public class SubscriptionUpdateProcessor : WorkItemProcessor<SubscriptionUpdateW
         SubscriptionUpdateWorkItem workItem,
         CancellationToken cancellationToken)
     {
-        return await _redisMutex.ExecuteWhenReady(
+        return await _redisMutex.EnterWhenAvailable(
             workItem.ActorId,
             async () =>
             {

--- a/src/ProductConstructionService/ProductConstructionService.Deployment/Deployer.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Deployment/Deployer.cs
@@ -238,7 +238,7 @@ public class Deployer
     private async Task<ProcessExecutionResult> InvokeAzCLI(string[] command)
     {
         string[] fullCommand = [.. DefaultAzCliParameters, .. command];
-        _logger.LogInformation($"Invoking az cli command `{command}`", string.Join(' ', fullCommand));
+        _logger.LogInformation("Invoking az cli command `{command}`", string.Join(' ', fullCommand));
         return await _processManager.Execute(
             Path.GetFileName(_options.AzCliPath),
             fullCommand,

--- a/test/ProductConstructionService.DependencyFlow.Tests/SubscriptionUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/SubscriptionUpdaterTests.cs
@@ -34,7 +34,8 @@ internal class SubscriptionUpdaterTests : SubscriptionOrPullRequestUpdaterTests
             {
                 Mock<IPullRequestUpdater> mock = PullRequestUpdaters.GetOrAddValue(
                     updaterId,
-                    () => CreateMock<IPullRequestUpdater>());
+                    () => new Mock<IPullRequestUpdater>());
+                mock.Setup(updater => updater.Id).Returns(updaterId);
                 return mock.Object;
             });
 


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
Maestro Actors each have individual queues, and they process things one at a time. Because of this, calling trigger subscription twice fast doesn't create two PRs, the first item gets processed and then the second one sees the PR is already up and does nothing.
In PCS we now have multiple replicas working in parallel, all taking items from one queue. Because of this, we need to have some synchronization. 
https://github.com/dotnet/arcade-services/issues/3937