### PR TITLE
Clear reminders from cache upon receiving

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/PullRequestCheckProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/PullRequestCheckProcessor.cs
@@ -32,7 +32,7 @@ public class PullRequestCheckProcessor : WorkItemProcessor<PullRequestCheck>
             async () =>
             {
                 var reminders = _reminderFactory.CreateReminderManager<PullRequestCheck>(workItem.UpdaterId);
-                await reminders.UnsetReminderAsync();
+                await reminders.ReminderReceivedAsync();
 
                 var updater = _updaterFactory.CreatePullRequestUpdater(PullRequestUpdaterId.Parse(workItem.UpdaterId));
                 return await updater.CheckPullRequestAsync(workItem);

--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/ReminderManager.cs
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/ReminderManager.cs
@@ -10,6 +10,8 @@ public interface IReminderManager<T> where T : WorkItem
     Task SetReminderAsync(T reminder, TimeSpan dueTime);
 
     Task UnsetReminderAsync();
+
+    Task ReminderReceivedAsync();
 }
 
 public class ReminderManager<T> : IReminderManager<T> where T : WorkItem
@@ -43,6 +45,11 @@ public class ReminderManager<T> : IReminderManager<T> where T : WorkItem
 
         var client = _workItemProducerFactory.CreateProducer<T>();
         await client.DeleteWorkItemAsync(receipt.MessageId, receipt.PopReceipt);
+    }
+
+    public async Task ReminderReceivedAsync()
+    {
+        await _receiptCache.TryDeleteAsync();
     }
 
     private class ReminderArguments

--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/ReminderManager.cs
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/ReminderManager.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Azure;
 using ProductConstructionService.Common;
 
 namespace ProductConstructionService.WorkItems;
@@ -44,7 +45,15 @@ public class ReminderManager<T> : IReminderManager<T> where T : WorkItem
         }
 
         var client = _workItemProducerFactory.CreateProducer<T>();
-        await client.DeleteWorkItemAsync(receipt.MessageId, receipt.PopReceipt);
+
+        try
+        {
+            await client.DeleteWorkItemAsync(receipt.MessageId, receipt.PopReceipt);
+        }
+        catch (RequestFailedException e) when (e.Message.Contains("The specified message does not exist"))
+        {
+            // The message was already deleted, so we can ignore this exception.
+        }
     }
 
     public async Task ReminderReceivedAsync()

--- a/test/ProductConstructionService.DependencyFlow.Tests/MockReminderManager.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/MockReminderManager.cs
@@ -32,4 +32,10 @@ internal class MockReminderManager<T>
         Data.Remove(_key);
         return Task.CompletedTask;
     }
+
+    public Task ReminderReceivedAsync()
+    {
+        Data.Remove(_key);
+        return Task.CompletedTask;
+    }
 }


### PR DESCRIPTION
Fixes 2 problems:
1. When we receive a reminder from queue, we wanted to clear the cache but we also try to remove the queue message too which ends up throwing because message is not in the queue anymore.
2. When we try to unset a reminder, it might have just been processed and the message also won't be in the queue.

<!-- https://github.com/dotnet/arcade-services/issues/4042 -->