### PR TITLE
Fix `darc vmr forwardflow/backflow` commands

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
@@ -1,9 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.Logging;
@@ -15,23 +17,30 @@ internal class BackflowOperation(
     BackflowCommandLineOptions options,
     IVmrBackFlower vmrBackFlower,
     IVmrInfo vmrInfo,
+    IVmrDependencyTracker dependencyTracker,
+    ILocalGitRepoFactory localGitRepoFactory,
     ILogger<BackflowOperation> logger)
-    : CodeFlowOperation(options, vmrInfo, logger)
+    : CodeFlowOperation(options, vmrInfo, dependencyTracker, localGitRepoFactory, logger)
 {
     private readonly BackflowCommandLineOptions _options = options;
+    private readonly IVmrInfo _vmrInfo = vmrInfo;
 
     protected override async Task<bool> FlowAsync(
         string mappingName,
         NativePath targetDirectory,
-        string? shaToFlow,
+        string? targetRepoPath,
         CancellationToken cancellationToken)
-        => await vmrBackFlower.FlowBackAsync(
-                mappingName,
-                new NativePath(targetDirectory),
-                shaToFlow,
-                _options.Build,
-                _options.BranchName,
-                _options.BranchName,
-                _options.DiscardPatches,
-                cancellationToken);
+    {
+        targetRepoPath ??= Environment.CurrentDirectory!;
+        var targetRepo = new NativePath(targetRepoPath);
+        return await vmrBackFlower.FlowBackAsync(
+            mappingName,
+            targetRepo,
+            null,
+            _options.Build,
+            await GetBaseBranch(targetRepo),
+            await GetTargetBranch(_vmrInfo.VmrPath),
+            _options.DiscardPatches,
+            cancellationToken);
+    }
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/ForwardFlowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/ForwardFlowOperation.cs
@@ -1,9 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.Logging;
@@ -15,23 +17,29 @@ internal class ForwardFlowOperation(
     ForwardFlowCommandLineOptions options,
     IVmrForwardFlower vmrForwardFlower,
     IVmrInfo vmrInfo,
+    IVmrDependencyTracker dependencyTracker,
+    ILocalGitRepoFactory localGitRepoFactory,
     ILogger<ForwardFlowOperation> logger)
-    : CodeFlowOperation(options, vmrInfo, logger)
+    : CodeFlowOperation(options, vmrInfo, dependencyTracker, localGitRepoFactory, logger)
 {
     private readonly ForwardFlowCommandLineOptions _options = options;
 
     protected override async Task<bool> FlowAsync(
         string mappingName,
         NativePath targetDirectory,
-        string? shaToFlow,
+        string? sourceRepoPath,
         CancellationToken cancellationToken)
-        => await vmrForwardFlower.FlowForwardAsync(
-                mappingName,
-                new NativePath(targetDirectory),
-                shaToFlow,
-                _options.Build,
-                _options.BranchName,
-                _options.BranchName,
-                _options.DiscardPatches,
-                cancellationToken);
+    {
+        var sourceRepo = new NativePath(sourceRepoPath ?? Environment.CurrentDirectory!);
+
+        return await vmrForwardFlower.FlowForwardAsync(
+            mappingName,
+            sourceRepo,
+            null,
+            _options.Build,
+            await GetBaseBranch(new NativePath(_options.VmrPath)),
+            await GetTargetBranch(sourceRepo),
+            _options.DiscardPatches,
+            cancellationToken);
+    }
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/CodeFlowCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/CodeFlowCommandLineOptions.cs
@@ -40,7 +40,7 @@ internal abstract class CodeFlowCommandLineOptions<T> : VmrCommandLineOptions<T>
     [Option("commit", Required = false, HelpText = "If specified, flows the given commit. Cannot be used with --build.")]
     public string Commit { get; set; }
 
-    [Option("base-branch", Required = false, HelpText = "Name of the branch of the target repository to apply changes on top of. Defaults to checked out branch")]
+    [Option("base-branch", Required = false, HelpText = "Name of the branch of the target repository to apply changes on top of. Defaults to the checked out branch")]
     public string BaseBranch { get; set; }
 
     [Option("target-branch", Required = false, HelpText = "Name of the new branch that will be created in the target repository. Defaults to codeflow/SHA1-SHA2")]

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/CodeFlowCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/CodeFlowCommandLineOptions.cs
@@ -9,11 +9,12 @@ namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
 internal interface ICodeFlowCommandLineOptions : IBaseVmrCommandLineOptions
 {
-    string BranchName { get; set; }
     int? Build { get; set; }
     string Commit { get; set; }
     bool DiscardPatches { get; set; }
     string RepositoryDirectory { get; set; }
+    public string BaseBranch { get; set; }
+    public string TargetBranch { get; set; }
 }
 
 internal abstract class CodeFlowCommandLineOptions<T> : VmrCommandLineOptions<T>, IBaseVmrCommandLineOptions, ICodeFlowCommandLineOptions where T : Operation
@@ -39,6 +40,9 @@ internal abstract class CodeFlowCommandLineOptions<T> : VmrCommandLineOptions<T>
     [Option("commit", Required = false, HelpText = "If specified, flows the given commit. Cannot be used with --build.")]
     public string Commit { get; set; }
 
-    [Option("branch-name", Required = false, HelpText = "Name of the new branch that will be created in the target repository. Defaults to codeflow/backflow/SHA1-SHA2")]
-    public string BranchName { get; set; }
+    [Option("base-branch", Required = false, HelpText = "Name of the branch of the target repository to apply changes on top of. Defaults to checked out branch")]
+    public string BaseBranch { get; set; }
+
+    [Option("target-branch", Required = false, HelpText = "Name of the new branch that will be created in the target repository. Defaults to codeflow/SHA1-SHA2")]
+    public string TargetBranch { get; set; }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
@@ -184,4 +184,9 @@ public interface ILocalGitClient
         string repoPath,
         string[] args,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Gets the current checked out branch.
+    /// </summary>
+    Task<string> GetCheckedOutBranchAsync(NativePath path);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
@@ -120,6 +120,11 @@ public interface ILocalGitRepo
     Task<string> GetShaForRefAsync(string? gitRef = null);
 
     /// <summary>
+    ///     Gets the current checked out branch.
+    /// </summary>
+    Task<string> GetCheckedOutBranchAsync();
+
+    /// <summary>
     ///     Gets the type of a git object (e.g. commit, tree..).
     /// </summary>
     /// <param name="objectSha">SHA of the object</param>

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -193,6 +193,13 @@ public class LocalGitClient : ILocalGitClient
         return result.StandardOutput.Trim();
     }
 
+    public async Task<string> GetCheckedOutBranchAsync(NativePath repoPath)
+    {
+        var result = await _processManager.ExecuteGit(repoPath, "rev-parse", "--abbrev-ref", "HEAD");
+        result.ThrowIfFailed($"Failed to get current branch for {repoPath}");
+        return result.StandardOutput.Trim();
+    }
+
     public async Task<GitObjectType> GetObjectTypeAsync(string repoPath, string objectSha)
     {
         var args = new[]

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -196,7 +196,7 @@ public class LocalGitClient : ILocalGitClient
     public async Task<string> GetCheckedOutBranchAsync(NativePath repoPath)
     {
         var result = await _processManager.ExecuteGit(repoPath, "rev-parse", "--abbrev-ref", "HEAD");
-        result.ThrowIfFailed($"Failed to get current branch for {repoPath}");
+        result.ThrowIfFailed($"Failed to get the current branch for {repoPath}");
         return result.StandardOutput.Trim();
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitRepo.cs
@@ -62,6 +62,9 @@ public class LocalGitRepo(NativePath repoPath, ILocalGitClient localGitClient, I
     public async Task<string> GetShaForRefAsync(string? gitRef = null)
         => await _localGitClient.GetShaForRefAsync(Path, gitRef);
 
+    public async Task<string> GetCheckedOutBranchAsync()
+        => await _localGitClient.GetCheckedOutBranchAsync(Path);
+
     public async Task FetchAllAsync(IReadOnlyCollection<string> remoteUris, CancellationToken cancellationToken = default)
         => await _localGitClient.FetchAllAsync(Path, remoteUris, cancellationToken);
 


### PR DESCRIPTION
Dusting off some code that has never been exercised and making the VMR codeflow darc commands work again.
Right now, these commands will be just for testing purposes only but we want them working for our own purpose.

https://github.com/dotnet/arcade-services/issues/2995