### PR TITLE
Skip restoring projects during deployment

### DIFF
--- a/azure-pipelines-product-construction-service.yml
+++ b/azure-pipelines-product-construction-service.yml
@@ -203,9 +203,6 @@ stages:
               .\.dotnet\dotnet workload install aspire
             displayName: Install .NET and Aspire Workload
 
-          - powershell: .\eng\common\build.ps1 -restore
-            displayName: Install .NET
-
           # We'll need to give this service connection permission to get an auth token for PCS
           - task: AzureCLI@2
             inputs:


### PR DESCRIPTION
This shaves off another 2 minutes from the PCS deployment

<!--  -->
