### PR TITLE
Stop tracking GitHub bot PAT in secret manifests

### DIFF
--- a/.vault-config/maestroprod.yaml
+++ b/.vault-config/maestroprod.yaml
@@ -23,13 +23,3 @@ keys:
     size: 2048
 
 importSecretsFrom: shared/maestro-secrets.yaml
-
-secrets:
-  # Needed during Maestro rollouts to create GitHub releases in arcade-services
-  BotAccount-dotnet-bot-repo-PAT:
-    type: github-access-token
-    parameters:
-      gitHubBotAccountSecret: 
-        location: engkeyvault
-        name: BotAccount-dotnet-bot
-      gitHubBotAccountName: dotnet-bot

--- a/.vault-config/product-construction-dev.yaml
+++ b/.vault-config/product-construction-dev.yaml
@@ -18,13 +18,6 @@ references:
       name: engkeyvault
 
 secrets:
-  BotAccount-dotnet-bot-repo-PAT:
-    type: github-access-token
-    parameters:
-      gitHubBotAccountSecret: 
-        location: engkeyvault
-        name: BotAccount-dotnet-bot
-      gitHubBotAccountName: dotnet-bot
 
   github:
     type: github-app-secret

--- a/.vault-config/product-construction-prod.yaml
+++ b/.vault-config/product-construction-prod.yaml
@@ -12,14 +12,7 @@ references:
       name: engkeyvault
 
 secrets:
-  BotAccount-dotnet-bot-repo-PAT:
-    type: github-access-token
-    parameters:
-      gitHubBotAccountSecret: 
-        location: engkeyvault
-        name: BotAccount-dotnet-bot
-      gitHubBotAccountName: dotnet-bot
-      
+
   github:
     type: github-app-secret
     parameters:

--- a/.vault-config/vmr-synchronization.1.yaml
+++ b/.vault-config/vmr-synchronization.1.yaml
@@ -42,9 +42,3 @@ secrets:
       name: dn-bot-dnceng-build
       organizations: dnceng
       scopes: build_execute code_write
-
-  BotAccount-dotnet-bot-repo-PAT:
-    type: github-access-token
-    parameters:
-      gitHubBotAccountSecret: BotAccount-dotnet-bot
-      gitHubBotAccountName: dotnet-bot


### PR DESCRIPTION
https://github.com/dotnet/dnceng/issues/4141

We don't want to rotate this PAT by mistake because the same PAT is in another KeyVault used by Arcade infra. We agreed we will use a different one in this repo anyway.
