### PR TITLE
Replace GitHub tokens used in CI

### DIFF
--- a/.vault-config/product-construction-prod.yaml
+++ b/.vault-config/product-construction-prod.yaml
@@ -19,3 +19,19 @@ secrets:
       hasPrivateKey: true
       hasWebhookSecret: false
       hasOAuthSecret: true
+
+  dotnet-bot-arcade-services-content-rw:
+    type: github-access-token
+    parameters:
+      gitHubBotAccountSecret: 
+        location: engkeyvault
+        name: BotAccount-dotnet-bot
+      gitHubBotAccountName: dotnet-bot
+
+  dotnet-bot-maestro-auth-test-content-rw:
+    type: github-access-token
+    parameters:
+      gitHubBotAccountSecret: 
+        location: engkeyvault
+        name: BotAccount-dotnet-bot
+      gitHubBotAccountName: dotnet-bot

--- a/azure-pipelines-product-construction-service.yml
+++ b/azure-pipelines-product-construction-service.yml
@@ -12,6 +12,7 @@ pr:
 
 variables:
 # https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=189
+# Required for MaestroAppClientId, MaestroStagingAppClientId
 - group: Publish-Build-Assets
 - name: resourceGroupName
   value: product-construction-service

--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -176,7 +176,7 @@ If you change any settings in `ClusterManifestTemplate.json` run `Reset Local Cl
 
 ## Generating GitHub PAT for local scenario test runs
 
-The GitHub scenario tests are ran against a dedicated organization - [`maestro-auth-tests`](https://github.com/maestro-auth-test). As such, a PAT is with adequate permissions is required to run them locally.
+The GitHub scenario tests are ran against a dedicated organization - [`maestro-auth-tests`](https://github.com/maestro-auth-test). As such, a PAT with adequate permissions is required to run them locally.
 
 To generate one, navigate to https://github.com/settings/tokens and select the `Fine-grained tokens` sub-menu on the navigation bar. The token should be generated with the following settings:
   - Resource owner: `maestro-auth-test` (if this option is not available in the resource settings please ask the team to add you to the test organization)

--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -176,7 +176,7 @@ If you change any settings in `ClusterManifestTemplate.json` run `Reset Local Cl
 
 ## Generating GitHub PAT for local scenario test runs
 
-The GitHub scenario tests are ran against a dedicated organization the team uses for tests - [`maestro-auth-tests`](https://github.com/maestro-auth-test). As such, a PAT is with adequate permissions is required to run them locally.
+The GitHub scenario tests are ran against a dedicated organization - [`maestro-auth-tests`](https://github.com/maestro-auth-test). As such, a PAT is with adequate permissions is required to run them locally.
 
 To generate one, navigate to https://github.com/settings/tokens and select the `Fine-grained tokens` sub-menu on the navigation bar. The token should be generated with the following settings:
   - Resource owner: `maestro-auth-test` (if this option is not available in the resource settings please ask the team to add you to the test organization)

--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -82,7 +82,7 @@ You can deploy your branch to the staging environment where E2E tests can be run
 
 If you want to run the C# scenario tests (make sure that you followed the getting started steps before), you will need to set some environment variables:
 
-   1. GITHUB_TOKEN : Get a github PAT from https://github.com/settings/tokens
+   1. GITHUB_TOKEN : See [instructions](#generating-github-pat-for-local-scenario-test-runs) below
    1. DARC_PACKAGE_SOURCE : Get the path to the darc nuget package (which would be in `arcade-services\artifacts\packages\Debug\NonShipping\`, see below for getting this built)
    1. MAESTRO_BASEURIS : Run ngrok and get the https url
 
@@ -173,3 +173,14 @@ You can disable the DNS Service by deleting `DnsService` from the add-on feature
     ]
 ```
 If you change any settings in `ClusterManifestTemplate.json` run `Reset Local Cluster` from Service Fabric Local Cluster Manager to recreate the cluster configuration using the new settings
+
+## Generating GitHub PAT for local scenario test runs
+
+The GitHub scenario tests are ran against a dedicated organization the team uses for tests - [`maestro-auth-tests`](https://github.com/maestro-auth-test). As such, a PAT is with adequate permissions is required to run them locally.
+
+To generate one, navigate to https://github.com/settings/tokens and select the `Fine-grained tokens` sub-menu on the navigation bar. The token should be generated with the following settings:
+  - Resource owner: `maestro-auth-test` (if this option is not available in the resource settings please ask the team to add you to the test organization)
+  - Repository access: `All repositories`
+  - Repository permissions: `Contents` - `Access: Read and Write`
+
+This configuration will allow the tests to read and write to the test repos without any additional access to the org or the account itself.

--- a/eng/templates/jobs/e2e-pcs-tests.yml
+++ b/eng/templates/jobs/e2e-pcs-tests.yml
@@ -17,6 +17,9 @@ jobs:
     # https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=20&path=Publish-Build-Assets
     # Required for MaestroAppClientId, MaestroStagingAppClientId
     - group: Publish-Build-Assets
+    # https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=202&path=Arcade-Services-Scenario-Tests
+    # Required for dotnet-bot-maestro-auth-test-content-rw
+    - group: Arcade-Services-Scenario-Tests
     - ${{ if not(or(startsWith(variables['Build.SourceBranch'], 'refs/heads/production'), startsWith(variables['Build.SourceBranch'], 'refs/heads/production-'), eq(variables['Build.SourceBranch'], 'refs/heads/production'))) }}:
       - group: MaestroInt KeyVault
       - name: PcsTestEndpoint
@@ -106,7 +109,7 @@ jobs:
     env:
       PCS_BASEURI: ${{ variables.PcsTestEndpoint }}
       PCS_TOKEN: $(GetAuthInfo.Token)
-      GITHUB_TOKEN: $(maestro-scenario-test-github-token)
+      GITHUB_TOKEN: $(dotnet-bot-maestro-auth-test-content-rw)
       AZDO_TOKEN: $(AzdoToken)
       DARC_PACKAGE_SOURCE: $(Pipeline.Workspace)\PackageArtifacts
       DARC_DIR: $(Build.SourcesDirectory)\darc

--- a/eng/templates/jobs/e2e-tests.yml
+++ b/eng/templates/jobs/e2e-tests.yml
@@ -19,8 +19,10 @@ jobs:
     # https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=20&path=Publish-Build-Assets
     # Required for MaestroAppClientId, MaestroStagingAppClientId
     - group: Publish-Build-Assets
+    # https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=202&path=Arcade-Services-Scenario-Tests
+    # Required for dotnet-bot-maestro-auth-test-content-rw
+    - group: Arcade-Services-Scenario-Tests
     - ${{ if parameters.isProd }}:
-      - group: MaestroProd KeyVault
       - name: MaestroTestEndpoints
         value: https://maestro-prod.westus2.cloudapp.azure.com,https://maestro.dot.net
       - name: ScenarioTestSubscription
@@ -28,7 +30,6 @@ jobs:
       - name: MaestroAppId
         value: $(MaestroAppClientId)
     - ${{ else }}:
-      - group: MaestroInt KeyVault
       - name: MaestroTestEndpoints
         value: https://maestro-int.westus2.cloudapp.azure.com,https://maestro.int-dot.net
       - name: ScenarioTestSubscription
@@ -119,7 +120,7 @@ jobs:
     env:
       MAESTRO_BASEURIS: ${{ variables.MaestroTestEndpoints }}
       MAESTRO_TOKEN: $(GetAuthInfo.Token)
-      GITHUB_TOKEN: $(maestro-scenario-test-github-token)
+      GITHUB_TOKEN: $(dotnet-bot-maestro-auth-test-content-rw)
       AZDO_TOKEN: $(AzdoToken)
       DARC_PACKAGE_SOURCE: $(Pipeline.Workspace)\PackageArtifacts
       DARC_DIR: $(Build.SourcesDirectory)\darc

--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -2,9 +2,6 @@ parameters:
 - name: isProd
   type: boolean
 
-# --- Secret Variable group requirements ---
-# maestro-scenario-test-github-token
-
 stages:
 - template: /eng/templates/stages/secret-validation.yml@self
   parameters:
@@ -35,7 +32,9 @@ stages:
   
   variables:
   - ${{ if parameters.isProd }}:
-    - group: MaestroProd KeyVault
+    # https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=202&path=Arcade-Services-Scenario-Tests
+    # Required for dotnet-bot-arcade-services-content-write
+    - group: Arcade-Services-Release
     - name: PublishProfile
       value: Prod
     - name: Subscription
@@ -45,7 +44,6 @@ stages:
     - name: BarMigrationSubscription
       value: BarMigrationProd
   - ${{ else }}:
-    - group: MaestroInt KeyVault
     - name: PublishProfile
       value: Int
     - name: Subscription
@@ -131,7 +129,7 @@ stages:
             --repo dotnet/arcade-services
         displayName: Create GitHub release
         env:
-          GH_TOKEN: $(BotAccount-dotnet-bot-repo-PAT)
+          GH_TOKEN: $(dotnet-bot-arcade-services-content-write)
         continueOnError: true
 
 - stage: validateDeployment


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Contributes to https://github.com/dotnet/arcade-services/issues/4081

Replaces current GitHub PATs with fine-grained PATs that only have the required scopes for the operations performed.

Resource clean-up after this PR is merged is described in https://github.com/dotnet/arcade-services/issues/4081#issuecomment-2435688549

PCS build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2568184&view=results
Maestro build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2568257&view=results