### PR TITLE
Change how we deactivate all revisions

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Cli/Operations/DeploymentOperation.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Cli/Operations/DeploymentOperation.cs
@@ -48,7 +48,6 @@ internal class DeploymentOperation : IOperation
 
     public async Task<int> RunAsync()
     {
-        var a = _containerApp.GetContainerAppRevisions().ToList();
         var trafficWeights = _containerApp.Data.Configuration.Ingress.Traffic.ToList();
 
         var activeRevisionTrafficWeight = trafficWeights.FirstOrDefault(weight => weight.Weight == 100) ??

--- a/src/ProductConstructionService/ProductConstructionService.Cli/Operations/DeploymentOperation.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Cli/Operations/DeploymentOperation.cs
@@ -128,12 +128,9 @@ internal class DeploymentOperation : IOperation
 
     private async Task RemoveRevisionLabel(string revisionName, string label)
     {
-        var result = await InvokeAzCLI([
-                "containerapp", "revision", "label", "remove",
-                ],
-            [
-                "--label", label
-            ]);
+        var result = await InvokeAzCLI(
+            ["containerapp", "revision", "label", "remove"],
+            ["--label", label]);
         result.ThrowIfFailed($"Failed to remove label {label} from revision {revisionName}. Stderr: {result.StandardError}");
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.Cli/Operations/DeploymentOperation.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Cli/Operations/DeploymentOperation.cs
@@ -131,7 +131,7 @@ internal class DeploymentOperation : IOperation
         var result = await InvokeAzCLI(
             ["containerapp", "revision", "label", "remove"],
             ["--label", label]);
-        result.ThrowIfFailed($"Failed to remove label {label} from revision {revisionName}. Stderr: {result.StandardError}");
+        result.ThrowIfFailed($"Failed to remove label {label} from revision {revisionName}.");
     }
 
     private async Task CleanupRevisionsAsync(IEnumerable<ContainerAppRevisionTrafficWeight> revisionsTrafficWeight)


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
Improves the deployment command to clean all revisions that might have spawned when we changed the ACA configuration, removes labels before deactivating revisions
https://github.com/dotnet/arcade-services/issues/4103