### PR TITLE
Fix DI for the `darc vmr get-version` command

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/GetRepoVersionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/GetRepoVersionCommandLineOptions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using CommandLine;
 using Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
+using Microsoft.Extensions.DependencyInjection;
 
 #nullable enable
 namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
@@ -14,4 +15,10 @@ internal class GetRepoVersionCommandLineOptions : VmrCommandLineOptionsBase<GetR
 {
     [Value(0, HelpText = "Repository names (e.g. runtime) to get the versions for.")]
     public IEnumerable<string> Repositories { get; set; } = Array.Empty<string>();
+
+    public override IServiceCollection RegisterServices(IServiceCollection services)
+    {
+        RegisterVmrServices(services, tmpPath: null);
+        return base.RegisterServices(services);
+    }
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrCommandLineOptions.cs
@@ -1,15 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
 using CommandLine;
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
-using Microsoft.DotNet.DarcLib;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.DotNet.Darc.Operations;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 
@@ -20,31 +14,7 @@ internal abstract class VmrCommandLineOptions<T> : VmrCommandLineOptionsBase<T> 
 
     public override IServiceCollection RegisterServices(IServiceCollection services)
     {
-        string tmpPath = Path.GetFullPath(TmpPath ?? Path.GetTempPath());
-        LocalSettings localDarcSettings = null;
-
-        var gitHubToken = GitHubPat;
-        var azureDevOpsToken = AzureDevOpsPat;
-
-        // Read tokens from local settings if not provided
-        // We silence errors because the VMR synchronization often works with public repositories where tokens are not required
-        if (gitHubToken == null || azureDevOpsToken == null)
-        {
-            try
-            {
-                localDarcSettings = LocalSettings.GetSettings(this, NullLogger.Instance);
-            }
-            catch (DarcException)
-            {
-                // The VMR synchronization often works with public repositories where tokens are not required
-            }
-
-            gitHubToken ??= localDarcSettings?.GitHubToken;
-            azureDevOpsToken ??= localDarcSettings?.AzureDevOpsToken;
-        }
-
-        services.AddVmrManagers(GitLocation, VmrPath, tmpPath, gitHubToken, azureDevOpsToken);
-        services.TryAddTransient<IVmrScanner, VmrCloakedFileScanner>();
+        RegisterVmrServices(services, TmpPath);
         return base.RegisterServices(services);
     }
 }

--- a/test/Maestro.Web.Tests/TestDatabase.cs
+++ b/test/Maestro.Web.Tests/TestDatabase.cs
@@ -42,7 +42,7 @@ public static class SharedData
 public class TestDatabase : IDisposable
 {
     private const string TestDatabasePrefix = "TFD_";
-    private readonly Lazy<Task<string>> _connectionString = new(
+    private readonly Lazy<Task<string>> _databaseName = new(
         InitializeDatabaseAsync,
         LazyThreadSafetyMode.ExecutionAndPublication);
 
@@ -54,12 +54,12 @@ public class TestDatabase : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    public async Task<string> GetConnectionString() => await _connectionString.Value;
+    public async Task<string> GetConnectionString() => BuildAssetRegistryContextFactory.GetConnectionString(await _databaseName.Value);
 
     private static async Task<string> InitializeDatabaseAsync()
     {
         string databaseName = TestDatabasePrefix +
-            $"_{TestContext.CurrentContext.Test.ClassName.Split('.').Last()}" +
+            $"_{TestContext.CurrentContext.Test.ClassName!.Split('.').Last()}" +
             $"_{TestContext.CurrentContext.Test.MethodName}" +
             $"_{DateTime.Now:yyyyMMddHHmmss}";
 
@@ -90,7 +90,7 @@ public class TestDatabase : IDisposable
         await using ServiceProvider provider = collection.BuildServiceProvider();
         await provider.GetRequiredService<BuildAssetRegistryContext>().Database.MigrateAsync();
 
-        return BuildAssetRegistryContextFactory.GetConnectionString(databaseName);
+        return databaseName;
     }
 
     private static async Task DropAllTestDatabases(SqlConnection connection)

--- a/test/Microsoft.DotNet.Darc.Tests/DependencyRegistrationTests.cs
+++ b/test/Microsoft.DotNet.Darc.Tests/DependencyRegistrationTests.cs
@@ -20,14 +20,14 @@ public class DependencyRegistrationTests
     [Test]
     public void AreDarcOperationsRegistered()
     {
-        foreach (Type operationType in Program.GetOptions().Concat(Program.GetVmrOptions()))
+        foreach (Type optionType in Program.GetOptions().Concat(Program.GetVmrOptions()))
         {
             DependencyInjectionValidation.IsDependencyResolutionCoherent(services =>
             {
                 // Register the option type
-                services.AddTransient(operationType);
+                services.AddTransient(optionType);
 
-                var operationOption = (CommandLineOptions)Activator.CreateInstance(operationType);
+                var operationOption = (CommandLineOptions)Activator.CreateInstance(optionType);
                 // Set IsCi to true to avoid login pop up
                 operationOption.IsCi = true;
                 operationOption.RegisterServices(services);
@@ -35,7 +35,7 @@ public class DependencyRegistrationTests
 
                 // Verify we can create the operation
                 var operation = operationOption.GetOperation(provider);
-                operation.Should().NotBeNull($"Operation {operationType.Name} could not be created");
+                operation.Should().NotBeNull($"Operation for {optionType.Name} could not be created");
                 services.AddTransient(operation.GetType());
             },
             out string message).Should().BeTrue(message);


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4713

- Fixes the DI registatration for one of the VMR commands which inherits differently than the others
- Fixes the DI test to generate a test case per each darc operation so that the DI container is not re-used but gets created every time
- Also fixes flaky test DB setup in tests that has been bugging us for quite some time and have now been somehow more flaky with this PR