### PR TITLE
Parallelize feed cleaner

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/AzureDevOpsClient.cs
@@ -1328,14 +1328,15 @@ This pull request has not been merged because Maestro++ is waiting on the follow
     /// <param name="accountName">Azure DevOps account name</param>
     /// <param name="project">Project that the feed was created in</param>
     /// <param name="feedIdentifier">Name or id of the feed</param>
+    /// <param name="includeDeleted">Include deleted packages</param>
     /// <returns>List of packages in the feed</returns>
-    public async Task<List<AzureDevOpsPackage>> GetPackagesForFeedAsync(string accountName, string project, string feedIdentifier)
+    public async Task<List<AzureDevOpsPackage>> GetPackagesForFeedAsync(string accountName, string project, string feedIdentifier, bool includeDeleted = true)
     {
         JObject content = await ExecuteAzureDevOpsAPIRequestAsync(
             HttpMethod.Get,
             accountName,
             project,
-            $"_apis/packaging/feeds/{feedIdentifier}/packages?includeAllVersions=true&includeDeleted=true",
+            $"_apis/packaging/feeds/{feedIdentifier}/packages?includeAllVersions=true" + (includeDeleted ? "&includeDeleted=true" : string.Empty),
             _logger,
             versionOverride: "5.1-preview.1",
             baseAddressSubpath: "feeds.");

--- a/src/Microsoft.DotNet.Darc/DarcLib/IAzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IAzureDevOpsClient.cs
@@ -111,8 +111,11 @@ public interface IAzureDevOpsClient
     ///   Gets all Artifact feeds along with their packages in an Azure DevOps account.
     /// </summary>
     /// <param name="accountName">Azure DevOps account name.</param>
+    /// <param name="projectName">Azure DevOps project to get the ID for</param>
+    /// <param name="feedIdentifier">ID or name of the feed</param>
+    /// <param name="includeDeleted">Include deleted packages</param>
     /// <returns>List of Azure DevOps feeds in the account.</returns>
-    Task<List<AzureDevOpsPackage>> GetPackagesForFeedAsync(string accountName, string project, string feedIdentifier);
+    Task<List<AzureDevOpsPackage>> GetPackagesForFeedAsync(string accountName, string projectName, string feedIdentifier, bool includeDeleted = true);
 
     /// <summary>
     ///   Returns the project ID for a combination of Azure DevOps account and project name

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
@@ -13,7 +13,7 @@ using PackagesInReleaseFeeds = System.Collections.Generic.Dictionary<string, Sys
 
 namespace ProductConstructionService.FeedCleaner;
 
-public class FeedCleaner
+public class FeedCleaner : IDisposable
 {
     private readonly IAzureDevOpsClient _azureDevOpsClient;
     private readonly BuildAssetRegistryContext _context;
@@ -63,6 +63,12 @@ public class FeedCleaner
         {
             _logger.LogError(ex, "Something failed while trying to update the released packages in feed {feed}", feed.Name);
         }
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        _context.Dispose();
     }
 
     /// <summary>

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
@@ -93,8 +93,7 @@ public class FeedCleaner
 
             if (matchingAsset == null)
             {
-                _logger.LogError("Unable to find asset {package}.{version} in feed {feed} in BAR. " +
-                                 "Unable to determine if it was released or update its locations.",
+                _logger.LogInformation("Asset {package}.{version} from feed {feed} not found in BAR. Skipping...",
                     package.Name,
                     version.Version,
                     feed.Name);

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
@@ -13,7 +13,7 @@ using PackagesInReleaseFeeds = System.Collections.Generic.Dictionary<string, Sys
 
 namespace ProductConstructionService.FeedCleaner;
 
-public class FeedCleaner : IDisposable
+public class FeedCleaner
 {
     private readonly IAzureDevOpsClient _azureDevOpsClient;
     private readonly BuildAssetRegistryContext _context;
@@ -63,12 +63,6 @@ public class FeedCleaner : IDisposable
         {
             _logger.LogError(ex, "Something failed while trying to update the released packages in feed {feed}", feed.Name);
         }
-    }
-
-    public void Dispose()
-    {
-        GC.SuppressFinalize(this);
-        _context.Dispose();
     }
 
     /// <summary>
@@ -128,11 +122,10 @@ public class FeedCleaner : IDisposable
                     feedsWherePackageIsAvailable.Add(FeedConstants.NuGetOrgLocation);
                 }
             }
-            catch (HttpRequestException e)
+            catch (Exception e)
             {
-                _logger.LogWarning(e, "Failed to determine if package {package}.{version} is present in NuGet.org",
-                    package.Name,
-                    version.Version);
+                _logger.LogWarning(e, "Failed to determine if package is present in NuGet.org");
+                throw;
             }
 
             if (feedsWherePackageIsAvailable.Count <= 0)
@@ -243,6 +236,11 @@ public class FeedCleaner : IDisposable
         catch (HttpRequestException e) when (e.Message.Contains(((int)HttpStatusCode.NotFound).ToString()))
         {
             _logger.LogDebug("Package {package}.{version} not found on nuget.org", name, version);
+            return false;
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "Failed to determine if package {package}.{version} is present in NuGet.org", name, version);
             return false;
         }
     }

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
@@ -122,10 +122,11 @@ public class FeedCleaner
                     feedsWherePackageIsAvailable.Add(FeedConstants.NuGetOrgLocation);
                 }
             }
-            catch (Exception e)
+            catch (HttpRequestException e)
             {
-                _logger.LogWarning(e, "Failed to determine if package is present in NuGet.org");
-                throw;
+                _logger.LogWarning(e, "Failed to determine if package {package}.{version} is present in NuGet.org",
+                    package.Name,
+                    version.Version);
             }
 
             if (feedsWherePackageIsAvailable.Count <= 0)
@@ -236,11 +237,6 @@ public class FeedCleaner
         catch (HttpRequestException e) when (e.Message.Contains(((int)HttpStatusCode.NotFound).ToString()))
         {
             _logger.LogDebug("Package {package}.{version} not found on nuget.org", name, version);
-            return false;
-        }
-        catch (Exception e)
-        {
-            _logger.LogWarning(e, "Failed to determine if package {package}.{version} is present in NuGet.org", name, version);
             return false;
         }
     }

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
@@ -2,90 +2,36 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
-using System.Text.RegularExpressions;
 using Maestro.Data;
 using Maestro.Data.Models;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+
 using PackagesInReleaseFeeds = System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>>>;
 
 namespace ProductConstructionService.FeedCleaner;
 
 public class FeedCleaner
 {
-    private readonly BuildAssetRegistryContextFactory _contextFactory;
-    private readonly HttpClient _httpClient;
     private readonly IAzureDevOpsClient _azureDevOpsClient;
-    private readonly IOptions<FeedCleanerOptions> _options;
+    private readonly BuildAssetRegistryContext _context;
+    private readonly HttpClient _httpClient;
     private readonly ILogger<FeedCleaner> _logger;
 
     public FeedCleaner(
-        BuildAssetRegistryContextFactory contextFactory,
         IAzureDevOpsClient azureDevOpsClient,
-        IOptions<FeedCleanerOptions> options,
+        BuildAssetRegistryContext context,
         ILogger<FeedCleaner> logger)
     {
-        _contextFactory = contextFactory;
         _azureDevOpsClient = azureDevOpsClient;
-        _options = options;
+        _context = context;
         _logger = logger;
         _httpClient = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true });
     }
 
-    private FeedCleanerOptions Options => _options.Value;
-
-    public async Task CleanManagedFeedsAsync()
-    {
-        if (!Options.Enabled)
-        {
-            _logger.LogInformation("Feed cleaner service is disabled in this environment");
-            return;
-        }
-
-        _logger.LogInformation("Loading packages in release feeds...");
-
-        PackagesInReleaseFeeds packagesInReleaseFeeds = await GetPackagesForReleaseFeedsAsync();
-
-        _logger.LogInformation("Loaded {versionCount} versions of {packageCount} packages from {feedCount} feeds",
-            packagesInReleaseFeeds.Sum(feed => feed.Value.Sum(package => package.Value.Count)),
-            packagesInReleaseFeeds.Sum(feed => feed.Value.Keys.Count),
-            packagesInReleaseFeeds.Keys.Count);
-
-        foreach (var azdoAccount in Options.AzdoAccounts)
-        {
-            _logger.LogInformation("Processing feeds for {account}...", azdoAccount);
-
-            List<AzureDevOpsFeed> allFeeds;
-            try
-            {
-                allFeeds = await _azureDevOpsClient.GetFeedsAsync(azdoAccount);
-                _logger.LogInformation("Found {count} feeds for {account}...", allFeeds.Count, azdoAccount);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to get feeds for account {azdoAccount}", azdoAccount);
-                continue;
-            }
-
-            IEnumerable<AzureDevOpsFeed> managedFeeds = allFeeds.Where(f => Regex.IsMatch(f.Name, FeedConstants.MaestroManagedFeedNamePattern));
-
-            Parallel.ForEach(
-                managedFeeds,
-                new ParallelOptions
-                {
-                    MaxDegreeOfParallelism = 5
-                },
-                async feed =>
-                {
-                    await CleanFeedAsync(feed, packagesInReleaseFeeds);
-                });
-        }    
-    }
-
-    private async Task CleanFeedAsync(AzureDevOpsFeed feed, PackagesInReleaseFeeds packagesInReleaseFeeds)
+    public async Task CleanFeedAsync(AzureDevOpsFeed feed, PackagesInReleaseFeeds packagesInReleaseFeeds)
     {
         try
         {
@@ -94,11 +40,10 @@ public class FeedCleaner
             _logger.LogInformation("Cleaning feed {feed} with {count} packages...", feed.Name, packages.Count);
 
             var updatedCount = 0;
-            var barContext = _contextFactory.CreateDbContext([]);
 
             foreach (var package in packages)
             {
-                HashSet<string> updatedVersions = await UpdateReleasedVersionsForPackageAsync(barContext, feed, package, packagesInReleaseFeeds);
+                HashSet<string> updatedVersions = await UpdateReleasedVersionsForPackageAsync(feed, package, packagesInReleaseFeeds);
 
                 await DeletePackageVersionsFromFeedAsync(feed, package.Name, updatedVersions);
                 updatedCount += updatedVersions.Count;
@@ -121,57 +66,6 @@ public class FeedCleaner
     }
 
     /// <summary>
-    /// Get a mapping of feed -> (package, versions) for the release feeds so it
-    /// can be easily queried whether a version of a package is in a feed.
-    /// </summary>
-    /// <returns>Mapping of packages to versions for the release feeds.</returns>
-    private async Task<PackagesInReleaseFeeds> GetPackagesForReleaseFeedsAsync()
-    {
-        var packagesWithVersionsInReleaseFeeds = new PackagesInReleaseFeeds();
-        IEnumerable<ReleasePackageFeed> dotnetManagedFeeds = Options.ReleasePackageFeeds;
-        foreach ((string account, string project, string feedName) in dotnetManagedFeeds)
-        {
-            string readableFeedURL = ComputeAzureArtifactsNuGetFeedUrl(feedName, account, project);
-
-            packagesWithVersionsInReleaseFeeds[readableFeedURL] = await GetPackageVersionsForFeedAsync(account, project, feedName);
-        }
-        return packagesWithVersionsInReleaseFeeds;
-    }
-
-    /// <summary>
-    /// Construct a nuget feed URL for an Azure DevOps Artifact feed
-    /// </summary>
-    /// <param name="feedName">Name of the feed</param>
-    /// <param name="account">Azure DevOps Account where the feed is hosted</param>
-    /// <param name="project">Optional project for the feed.</param>
-    /// <returns>Url of the form https://pkgs.dev.azure.com/account/project/_packaging/feedName/nuget/v3/index.json </returns>
-    private static string ComputeAzureArtifactsNuGetFeedUrl(string feedName, string account, string project = "")
-    {
-        string projectSection = string.IsNullOrEmpty(project) ? "" : $"{project}/";
-        return $"https://pkgs.dev.azure.com/{account}/{projectSection}_packaging/{feedName}/nuget/v3/index.json";
-    }
-
-    /// <summary>
-    /// Gets a Mapping of package -> versions for an Azure DevOps feed.
-    /// </summary>
-    /// <param name="azdoClient">Azure DevOps client.</param>
-    /// <param name="account">Azure DevOps account.</param>
-    /// <param name="project">Azure DevOps project the feed is hosted in.</param>
-    /// <param name="feedName">Name of the feed</param>
-    /// <returns>Dictionary where the key is the package name, and the value is a HashSet of the versions of the package in the feed</returns>
-    private async Task<Dictionary<string, HashSet<string>>> GetPackageVersionsForFeedAsync(string account, string project, string feedName)
-    {
-        var packagesWithVersions = new Dictionary<string, HashSet<string>>();
-        List<AzureDevOpsPackage> packagesInFeed = await _azureDevOpsClient.GetPackagesForFeedAsync(account, project, feedName);
-        foreach (AzureDevOpsPackage package in packagesInFeed)
-        {
-            packagesWithVersions.Add(package.Name, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
-            packagesWithVersions[package.Name].UnionWith(package.Versions?.Where(v => !v.IsDeleted).Select(v => v.Version) ?? []);
-        }
-        return packagesWithVersions;
-    }
-
-    /// <summary>
     /// Updates the location for assets in the Database when 
     /// a version of an asset is found in the release feeds or in NuGet.org
     /// </summary>
@@ -180,7 +74,6 @@ public class FeedCleaner
     /// <param name="dotnetFeedsPackageMapping">Mapping of packages and their versions in the release feeds</param>
     /// <returns>Collection of versions that were updated for the package</returns>
     private async Task<HashSet<string>> UpdateReleasedVersionsForPackageAsync(
-        BuildAssetRegistryContext barContext,
         AzureDevOpsFeed feed,
         AzureDevOpsPackage package,
         PackagesInReleaseFeeds dotnetFeedsPackageMapping)
@@ -189,7 +82,7 @@ public class FeedCleaner
 
         foreach (var version in package.Versions)
         {
-            var matchingAssets = barContext.Assets
+            var matchingAssets = _context.Assets
                 .Include(a => a.Locations)
                 .Where(a => a.Name == package.Name &&
                             a.Version == version.Version)
@@ -257,7 +150,7 @@ public class FeedCleaner
                     Type = LocationType.NugetFeed
                 });
 
-                await barContext.SaveChangesAsync();
+                await _context.SaveChangesAsync();
             }
         }
 
@@ -270,7 +163,10 @@ public class FeedCleaner
     /// <param name="feed">Feed to delete the package from</param>
     /// <param name="packageName">package to delete</param>
     /// <param name="versionsToDelete">Collection of versions to delete</param>
-    private async Task DeletePackageVersionsFromFeedAsync(AzureDevOpsFeed feed, string packageName, HashSet<string> versionsToDelete)
+    private async Task DeletePackageVersionsFromFeedAsync(
+        AzureDevOpsFeed feed,
+        string packageName,
+        HashSet<string> versionsToDelete)
     {
         foreach (string version in versionsToDelete)
         {

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
@@ -73,8 +73,8 @@ public class FeedCleanerJob
 
             _logger.LogInformation("Found {totalCount} feeds for {account}. Will process {count} matching feeds",
                 allFeeds.Count,
-                managedFeeds.Count,
-                azdoAccount);
+                azdoAccount,
+                managedFeeds.Count);
 
             int feedsCleaned = 0;
 

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
+using Kusto.Cloud.Platform.Utils;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,13 +18,13 @@ public class FeedCleanerJob
     private readonly IServiceProvider _serviceProvider;
     private readonly IAzureDevOpsClient _azureDevOpsClient;
     private readonly IOptions<FeedCleanerOptions> _options;
-    private readonly ILogger<FeedCleanerJob> _logger;
+    private readonly Microsoft.Extensions.Logging.ILogger<FeedCleanerJob> _logger;
 
     public FeedCleanerJob(
         IServiceProvider serviceProvider,
         IAzureDevOpsClient azureDevOpsClient,
         IOptions<FeedCleanerOptions> options,
-        ILogger<FeedCleanerJob> logger)
+        Microsoft.Extensions.Logging.ILogger<FeedCleanerJob> logger)
     {
         _serviceProvider = serviceProvider;
         _azureDevOpsClient = azureDevOpsClient;
@@ -66,7 +67,9 @@ public class FeedCleanerJob
                 continue;
             }
 
-            IEnumerable<AzureDevOpsFeed> managedFeeds = allFeeds.Where(f => Regex.IsMatch(f.Name, FeedConstants.MaestroManagedFeedNamePattern));
+            IEnumerable<AzureDevOpsFeed> managedFeeds = allFeeds
+                .Where(f => Regex.IsMatch(f.Name, FeedConstants.MaestroManagedFeedNamePattern))
+                .Shuffle();
 
             Parallel.ForEach(
                 managedFeeds,

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
@@ -82,7 +82,7 @@ public class FeedCleanerJob
                     try
                     {
                         using var scope = _serviceProvider.CreateScope();
-                        var feedCleaner = scope.ServiceProvider.GetRequiredService<FeedCleaner>();
+                        using var feedCleaner = scope.ServiceProvider.GetRequiredService<FeedCleaner>();
                         await feedCleaner.CleanFeedAsync(feed, packagesInReleaseFeeds);
                     }
                     catch (Exception e)

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
@@ -76,9 +76,17 @@ public class FeedCleanerJob
                 },
                 async feed =>
                 {
-                    using var scope = _serviceProvider.CreateScope();
-                    var feedCleaner = scope.ServiceProvider.GetRequiredService<FeedCleaner>();
-                    await feedCleaner.CleanFeedAsync(feed, packagesInReleaseFeeds);
+                    try
+                    {
+                        using var scope = _serviceProvider.CreateScope();
+                        var feedCleaner = scope.ServiceProvider.GetRequiredService<FeedCleaner>();
+                        await feedCleaner.CleanFeedAsync(feed, packagesInReleaseFeeds);
+                    }
+                    catch (Exception e)
+                    {
+
+                        _logger.LogError(e, "Failed to clean feed {feed}", feed.Name);
+                    }
                 });
         }
     }

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
@@ -100,7 +100,7 @@ public class FeedCleanerJob
                 });
 
             _logger.Log(
-                feedsCleaned != managedFeeds.Count ? LogLevel.Warning : LogLevel.Error,
+                feedsCleaned != managedFeeds.Count ? LogLevel.Warning : LogLevel.Information,
                 "Successfully processed {count}/{totalCount} feeds for {account}",
                 feedsCleaned,
                 managedFeeds.Count,

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
@@ -1,0 +1,136 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using PackagesInReleaseFeeds = System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>>>;
+
+namespace ProductConstructionService.FeedCleaner;
+
+public class FeedCleanerJob
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAzureDevOpsClient _azureDevOpsClient;
+    private readonly IOptions<FeedCleanerOptions> _options;
+    private readonly ILogger<FeedCleanerJob> _logger;
+
+    public FeedCleanerJob(
+        IServiceProvider serviceProvider,
+        IAzureDevOpsClient azureDevOpsClient,
+        IOptions<FeedCleanerOptions> options,
+        ILogger<FeedCleanerJob> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _azureDevOpsClient = azureDevOpsClient;
+        _options = options;
+        _logger = logger;
+    }
+
+    private FeedCleanerOptions Options => _options.Value;
+
+    public async Task CleanManagedFeedsAsync()
+    {
+        if (!Options.Enabled)
+        {
+            _logger.LogInformation("Feed cleaner service is disabled in this environment");
+            return;
+        }
+
+        _logger.LogInformation("Loading packages in release feeds...");
+
+        PackagesInReleaseFeeds packagesInReleaseFeeds = await GetPackagesForReleaseFeedsAsync();
+
+        _logger.LogInformation("Loaded {versionCount} versions of {packageCount} packages from {feedCount} feeds",
+            packagesInReleaseFeeds.Sum(feed => feed.Value.Sum(package => package.Value.Count)),
+            packagesInReleaseFeeds.Sum(feed => feed.Value.Keys.Count),
+            packagesInReleaseFeeds.Keys.Count);
+
+        foreach (var azdoAccount in Options.AzdoAccounts)
+        {
+            _logger.LogInformation("Processing feeds for {account}...", azdoAccount);
+
+            List<AzureDevOpsFeed> allFeeds;
+            try
+            {
+                allFeeds = await _azureDevOpsClient.GetFeedsAsync(azdoAccount);
+                _logger.LogInformation("Found {count} feeds for {account}...", allFeeds.Count, azdoAccount);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get feeds for account {azdoAccount}", azdoAccount);
+                continue;
+            }
+
+            IEnumerable<AzureDevOpsFeed> managedFeeds = allFeeds.Where(f => Regex.IsMatch(f.Name, FeedConstants.MaestroManagedFeedNamePattern));
+
+            Parallel.ForEach(
+                managedFeeds,
+                new ParallelOptions
+                {
+                    MaxDegreeOfParallelism = 5
+                },
+                async feed =>
+                {
+                    using var scope = _serviceProvider.CreateScope();
+                    var feedCleaner = scope.ServiceProvider.GetRequiredService<FeedCleaner>();
+                    await feedCleaner.CleanFeedAsync(feed, packagesInReleaseFeeds);
+                });
+        }
+    }
+
+    /// <summary>
+    /// Get a mapping of feed -> (package, versions) for the release feeds so it
+    /// can be easily queried whether a version of a package is in a feed.
+    /// </summary>
+    /// <returns>Mapping of packages to versions for the release feeds.</returns>
+    private async Task<PackagesInReleaseFeeds> GetPackagesForReleaseFeedsAsync()
+    {
+        var packagesWithVersionsInReleaseFeeds = new PackagesInReleaseFeeds();
+        IEnumerable<ReleasePackageFeed> dotnetManagedFeeds = Options.ReleasePackageFeeds;
+        foreach ((string account, string project, string feedName) in dotnetManagedFeeds)
+        {
+            string readableFeedURL = ComputeAzureArtifactsNuGetFeedUrl(feedName, account, project);
+
+            packagesWithVersionsInReleaseFeeds[readableFeedURL] = await GetPackageVersionsForFeedAsync(account, project, feedName);
+        }
+        return packagesWithVersionsInReleaseFeeds;
+    }
+
+    /// <summary>
+    /// Construct a nuget feed URL for an Azure DevOps Artifact feed
+    /// </summary>
+    /// <param name="feedName">Name of the feed</param>
+    /// <param name="account">Azure DevOps Account where the feed is hosted</param>
+    /// <param name="project">Optional project for the feed.</param>
+    /// <returns>Url of the form https://pkgs.dev.azure.com/account/project/_packaging/feedName/nuget/v3/index.json </returns>
+    private static string ComputeAzureArtifactsNuGetFeedUrl(string feedName, string account, string project = "")
+    {
+        string projectSection = string.IsNullOrEmpty(project) ? "" : $"{project}/";
+        return $"https://pkgs.dev.azure.com/{account}/{projectSection}_packaging/{feedName}/nuget/v3/index.json";
+    }
+
+    /// <summary>
+    /// Gets a Mapping of package -> versions for an Azure DevOps feed.
+    /// </summary>
+    /// <param name="azdoClient">Azure DevOps client.</param>
+    /// <param name="account">Azure DevOps account.</param>
+    /// <param name="project">Azure DevOps project the feed is hosted in.</param>
+    /// <param name="feedName">Name of the feed</param>
+    /// <returns>Dictionary where the key is the package name, and the value is a HashSet of the versions of the package in the feed</returns>
+    private async Task<Dictionary<string, HashSet<string>>> GetPackageVersionsForFeedAsync(string account, string project, string feedName)
+    {
+        var packagesWithVersions = new Dictionary<string, HashSet<string>>();
+        List<AzureDevOpsPackage> packagesInFeed = await _azureDevOpsClient.GetPackagesForFeedAsync(account, project, feedName);
+        foreach (AzureDevOpsPackage package in packagesInFeed)
+        {
+            packagesWithVersions.Add(package.Name, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+            packagesWithVersions[package.Name].UnionWith(package.Versions?.Where(v => !v.IsDeleted).Select(v => v.Version) ?? []);
+        }
+        return packagesWithVersions;
+    }
+}

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
@@ -84,7 +84,6 @@ public class FeedCleanerJob
                     }
                     catch (Exception e)
                     {
-
                         _logger.LogError(e, "Failed to clean feed {feed}", feed.Name);
                     }
                 });

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
@@ -78,19 +78,20 @@ public class FeedCleanerJob
 
             int feedsCleaned = 0;
 
-            Parallel.ForEach(
+            await Parallel.ForEachAsync(
                 managedFeeds,
                 new ParallelOptions
                 {
                     MaxDegreeOfParallelism = 5
                 },
-                async (AzureDevOpsFeed feed) =>
+                async (AzureDevOpsFeed feed, CancellationToken cancellationToken) =>
                 {
                     using var scope = _serviceProvider.CreateScope();
-                    using var feedCleaner = scope.ServiceProvider.GetRequiredService<FeedCleaner>();
+                    var feedCleaner = scope.ServiceProvider.GetRequiredService<FeedCleaner>();
 
                     try
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
                         await feedCleaner.CleanFeedAsync(feed, packagesInReleaseFeeds);
                     }
                     catch (Exception e)

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
@@ -86,17 +86,19 @@ public class FeedCleanerJob
                 },
                 async (AzureDevOpsFeed feed) =>
                 {
+                    using var scope = _serviceProvider.CreateScope();
+                    using var feedCleaner = scope.ServiceProvider.GetRequiredService<FeedCleaner>();
+
                     try
                     {
-                        using var scope = _serviceProvider.CreateScope();
-                        using var feedCleaner = scope.ServiceProvider.GetRequiredService<FeedCleaner>();
                         await feedCleaner.CleanFeedAsync(feed, packagesInReleaseFeeds);
-                        Interlocked.Increment(ref feedsCleaned);
                     }
                     catch (Exception e)
                     {
                         _logger.LogError(e, "Failed to clean feed {feed}", feed.Name);
                     }
+
+                    Interlocked.Increment(ref feedsCleaned);
                 });
 
             _logger.Log(

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/Program.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/Program.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -9,14 +10,12 @@ InMemoryChannel telemetryChannel = new();
 try
 {
     var builder = Host.CreateApplicationBuilder();
-
     builder.ConfigureFeedCleaner(telemetryChannel);
 
     // We're registering BAR context as a scoped service, so we have to create a scope to resolve it
     var applicationScope = builder.Build().Services.CreateScope();
 
-    var cleaner = applicationScope.ServiceProvider.GetRequiredService<FeedCleaner>();
-
+    var cleaner = applicationScope.ServiceProvider.GetRequiredService<FeedCleanerJob>();
     await cleaner.CleanManagedFeedsAsync();
 }
 finally

--- a/test/FeedCleaner.Tests/FeedCleanerServiceTests.cs
+++ b/test/FeedCleaner.Tests/FeedCleanerServiceTests.cs
@@ -147,7 +147,7 @@ public class FeedCleanerServiceTests : IDisposable
     {
         var azdoClientMock = new Mock<IAzureDevOpsClient>(MockBehavior.Strict);
         azdoClientMock.Setup(a => a.GetFeedsAsync(SomeAccount)).ReturnsAsync(_feeds.Select(kvp => kvp.Value).ToList());
-        azdoClientMock.Setup(a => a.GetPackagesForFeedAsync(SomeAccount, It.IsAny<string>(), It.IsAny<string>()))
+        azdoClientMock.Setup(a => a.GetPackagesForFeedAsync(SomeAccount, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
             .Returns((string account, string project, string feed) => Task.FromResult(_feeds[feed].Packages));
         azdoClientMock.Setup(a => a.DeleteNuGetPackageVersionFromFeedAsync(SomeAccount, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .Callback<string, string, string, string, string>((account, project, feed, package, version) => MarkVersionAsDeleted(_feeds[feed].Packages, package, version))

--- a/test/FeedCleaner.Tests/FeedCleanerServiceTests.cs
+++ b/test/FeedCleaner.Tests/FeedCleanerServiceTests.cs
@@ -148,7 +148,7 @@ public class FeedCleanerServiceTests : IDisposable
         var azdoClientMock = new Mock<IAzureDevOpsClient>(MockBehavior.Strict);
         azdoClientMock.Setup(a => a.GetFeedsAsync(SomeAccount)).ReturnsAsync(_feeds.Select(kvp => kvp.Value).ToList());
         azdoClientMock.Setup(a => a.GetPackagesForFeedAsync(SomeAccount, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
-            .Returns((string account, string project, string feed) => Task.FromResult(_feeds[feed].Packages));
+            .Returns((string account, string project, string feed, bool includeDeleted) => Task.FromResult(_feeds[feed].Packages.Where(p => p.Versions.Any(v => !v.IsDeleted)).ToList()));
         azdoClientMock.Setup(a => a.DeleteNuGetPackageVersionFromFeedAsync(SomeAccount, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .Callback<string, string, string, string, string>((account, project, feed, package, version) => MarkVersionAsDeleted(_feeds[feed].Packages, package, version))
             .Returns(Task.CompletedTask);

--- a/test/ProductConstructionService.FeedCleaner.Tests/FeedCleanerTests.cs
+++ b/test/ProductConstructionService.FeedCleaner.Tests/FeedCleanerTests.cs
@@ -22,7 +22,7 @@ public class FeedCleanerTests
     private ServiceProvider? _provider;
     private IServiceScope _scope = new Mock<IServiceScope>().Object;
     private Dictionary<string, AzureDevOpsFeed> _feeds = [];
-    private FeedCleaner? _feedCleaner;
+    private FeedCleanerJob? _feedCleaner;
 
     private const string SomeAccount = "someAccount";
     private const string UnmanagedFeedName = "some-other-feed";
@@ -76,7 +76,7 @@ public class FeedCleanerTests
         _context = _scope.ServiceProvider.GetRequiredService<BuildAssetRegistryContext>();
 
         SetupAssetsFromFeeds();
-        _feedCleaner = ActivatorUtilities.CreateInstance<FeedCleaner>(_scope.ServiceProvider);
+        _feedCleaner = ActivatorUtilities.CreateInstance<FeedCleanerJob>(_scope.ServiceProvider);
     }
 
     [Test]

--- a/test/ProductConstructionService.FeedCleaner.Tests/FeedCleanerTests.cs
+++ b/test/ProductConstructionService.FeedCleaner.Tests/FeedCleanerTests.cs
@@ -164,7 +164,7 @@ public class FeedCleanerTests
     {
         var azdoClientMock = new Mock<IAzureDevOpsClient>(MockBehavior.Strict);
         azdoClientMock.Setup(a => a.GetFeedsAsync(SomeAccount)).ReturnsAsync(_feeds.Select(kvp => kvp.Value).ToList());
-        azdoClientMock.Setup(a => a.GetPackagesForFeedAsync(SomeAccount, It.IsAny<string>(), It.IsAny<string>()))
+        azdoClientMock.Setup(a => a.GetPackagesForFeedAsync(SomeAccount, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
             .Returns((string account, string project, string feed) => Task.FromResult(_feeds[feed].Packages));
         azdoClientMock.Setup(a => a.DeleteNuGetPackageVersionFromFeedAsync(SomeAccount, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .Callback<string, string, string, string, string>((account, project, feed, package, version) => MarkVersionAsDeleted(_feeds[feed].Packages, package, version))


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/4073

Resolves several issues in the feed cleaner:
- Already deleted (in recycle bin) feeds are re-scanned each time
- Feeds were processed one at a time and the feed cleaner runs too long (~20 hours). Parallelization was added and the time needed went down to 20 minutes.
- Feeds are shuffled so that they are not processed in the same order (so we never reach the tail)
- Logging is improved