### PR TITLE
Add policy for admin role

### DIFF
--- a/src/Maestro/Maestro.Authentication/AuthenticationConfiguration.cs
+++ b/src/Maestro/Maestro.Authentication/AuthenticationConfiguration.cs
@@ -111,6 +111,12 @@ public static class AuthenticationConfiguration
                             || context.User.IsInRole(prodconSvcsRole);
                     });
                 });
+                options.AddPolicy("RequireAdminAccess", policy =>
+                {
+                    policy.AddAuthenticationSchemes(AuthenticationSchemes);
+                    policy.RequireAuthenticatedUser();
+                    policy.RequireRole("Admin");
+                });
             });
 
         services.Configure<MvcOptions>(

--- a/src/Maestro/Maestro.Authentication/AuthenticationConfiguration.cs
+++ b/src/Maestro/Maestro.Authentication/AuthenticationConfiguration.cs
@@ -23,6 +23,7 @@ public static class AuthenticationConfiguration
 {
     public const string EntraAuthorizationPolicyName = "Entra";
     public const string MsftAuthorizationPolicyName = "msft";
+    public const string AdminAuthorizationPolicyName = "RequireAdminAccess";
 
     public const string AccountSignInRoute = "/Account/SignIn";
 
@@ -111,7 +112,7 @@ public static class AuthenticationConfiguration
                             || context.User.IsInRole(prodconSvcsRole);
                     });
                 });
-                options.AddPolicy("RequireAdminAccess", policy =>
+                options.AddPolicy(AdminAuthorizationPolicyName, policy =>
                 {
                     policy.AddAuthenticationSchemes(AuthenticationSchemes);
                     policy.RequireAuthenticatedUser();

--- a/src/ProductConstructionService/ProductConstructionService.Api/Controllers/StatusController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Controllers/StatusController.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using Maestro.Authentication;
 using Microsoft.AspNetCore.ApiVersioning;
 using Microsoft.AspNetCore.ApiVersioning.Swashbuckle;
 using Microsoft.AspNetCore.Authorization;
@@ -12,7 +13,7 @@ namespace ProductConstructionService.Api.Controllers;
 
 [Route("status")]
 [ApiVersion("2020-02-20")]
-[Authorize(Policy = "RequireAdminAccess")]
+[Authorize(Policy = AuthenticationConfiguration.AdminAuthorizationPolicyName)]
 public class StatusController(IReplicaWorkItemProcessorStateCacheFactory replicaWorkItemProcessorStateCacheFactory) : ControllerBase
 {
     private readonly IReplicaWorkItemProcessorStateCacheFactory _replicaWorkItemProcessorStateCacheFactory = replicaWorkItemProcessorStateCacheFactory;

--- a/src/ProductConstructionService/ProductConstructionService.Api/Controllers/StatusController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Controllers/StatusController.cs
@@ -12,6 +12,7 @@ namespace ProductConstructionService.Api.Controllers;
 
 [Route("status")]
 [ApiVersion("2020-02-20")]
+[Authorize(Policy = "RequireAdminAccess")]
 public class StatusController(IReplicaWorkItemProcessorStateCacheFactory replicaWorkItemProcessorStateCacheFactory) : ControllerBase
 {
     private readonly IReplicaWorkItemProcessorStateCacheFactory _replicaWorkItemProcessorStateCacheFactory = replicaWorkItemProcessorStateCacheFactory;


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Resolves https://github.com/dotnet/arcade-services/issues/4063

Adds an authentication policy for Admin role and assigns the policy to the `api/status` controller

The role already exists in `int`, will add it to `prod` and give it to the team + deployment MI once the PR is approved