### PR TITLE
Fixup invalid request response for subscription trigger

### DIFF
--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/SubscriptionsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Controllers/SubscriptionsController.cs
@@ -125,7 +125,7 @@ public class SubscriptionsController : Controller
         // TODO (https://github.com/dotnet/arcade-services/issues/3880) - Remove subscriptionIdGenerator
         if (!_subscriptionIdGenerator.ShouldTriggerSubscription(id))
         {
-            return BadRequest("Maestro shouldn't trigger PCS subscriptions");
+            return BadRequest(new ApiError("Maestro shouldn't trigger PCS subscriptions"));
         }
         Data.Models.Subscription subscription = await _context.Subscriptions.Include(sub => sub.LastAppliedBuild)
             .Include(sub => sub.Channel)
@@ -137,13 +137,13 @@ public class SubscriptionsController : Controller
             // Non-existent build
             if (build == null)
             {
-                return BadRequest($"Build {buildId} was not found");
+                return BadRequest(new ApiError($"Build {buildId} was not found"));
             }
             // Build doesn't match source repo
             if (!(build.GitHubRepository?.Equals(subscription.SourceRepository, StringComparison.InvariantCultureIgnoreCase) == true ||
                   build.AzureDevOpsRepository?.Equals(subscription.SourceRepository, StringComparison.InvariantCultureIgnoreCase) == true))
             {
-                return BadRequest($"Build {buildId} does not match source repo");
+                return BadRequest(new ApiError($"Build {buildId} does not match source repo"));
             }
         }
 

--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2018_07_16/Controllers/SubscriptionsController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2018_07_16/Controllers/SubscriptionsController.cs
@@ -119,7 +119,9 @@ public class SubscriptionsController : ControllerBase
         // TODO (https://github.com/dotnet/arcade-services/issues/3880) - Remove subscriptionIdGenerator
         if (!_subscriptionIdGenerator.ShouldTriggerSubscription(id))
         {
-            return BadRequest($"PCS can only trigger subscriptions which ids start with ${SubscriptionIdGenerator.PcsSubscriptionIdPrefix}");
+            return BadRequest(
+                new ApiError($"PCS can only trigger subscriptions which ids start with ${SubscriptionIdGenerator.PcsSubscriptionIdPrefix}")
+            );
         }
         Maestro.Data.Models.Subscription? subscription = await _context.Subscriptions.Include(sub => sub.LastAppliedBuild)
             .Include(sub => sub.Channel)
@@ -131,13 +133,13 @@ public class SubscriptionsController : ControllerBase
             // Non-existent build
             if (build == null)
             {
-                return BadRequest($"Build {buildId} was not found");
+                return BadRequest(new ApiError($"Build {buildId} was not found"));
             }
             // Build doesn't match source repo
             if (!(build.GitHubRepository?.Equals(subscription?.SourceRepository, StringComparison.InvariantCultureIgnoreCase) == true ||
                   build.AzureDevOpsRepository?.Equals(subscription?.SourceRepository, StringComparison.InvariantCultureIgnoreCase) == true))
             {
-                return BadRequest($"Build {buildId} does not match source repo");
+                return BadRequest(new ApiError($"Build {buildId} does not match source repo"));
             }
         }
 


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Resolves https://github.com/dotnet/arcade-services/issues/4128

Replaces the raw message string in `BadRequest` responses for subscription triggering with the expected `ApiError` object in line with how these types of responses are handled throughout Maestro / PCS

Example of the exception thrown by Darc after the change:
```
PS C:\Users\odidyk> darc trigger-subscriptions --bar-uri https://localhost:53180/ --id 00000000-d81a-43a9-ad8c-86b6fa5394ca
Will trigger the following 1 subscriptions...
  https://github.com/dotnet/dnceng (.NET Eng Services - Prod) ==> 'https://github.com/dotnet/arcade-services' ('main')
Continue? (y/n) y
Triggering 1 subscriptions...fail: Unexpected error while triggering subscriptions.
      Microsoft.DotNet.Maestro.Client.RestApiException`1[Microsoft.DotNet.Maestro.Client.Models.ApiError]: The response contained an invalid status code 400 Bad Request

Body: {"message":"PCS can only trigger subscriptions which ids start with $00000000","errors":null}
         at Microsoft.DotNet.Maestro.Client.Subscriptions.OnTriggerSubscriptionFailed(Request req, Response res) in /_/src/Maestro/Client/src/Generated/Subscriptions.cs:line 572
         at Microsoft.DotNet.Maestro.Client.Subscriptions.TriggerSubscriptionAsync(Int32 barBuildId, Guid id, CancellationToken cancellationToken) in /_/src/Maestro/Client/src/Generated/Subscriptions.cs:line 534
``` 