### PR TITLE
Minor BarViz improvements

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Components/BuildInfo.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Components/BuildInfo.razor
@@ -48,7 +48,7 @@ else
                     </FluentAnchor>
                 }
             </FluentStack>
-            <FluentLabel Typo="Typography.Body" Color="Color.Success">
+            <FluentLabel Typo="Typography.Body">
                 @DateFormatter.FormatDate(_build.DateProduced)
             </FluentLabel>
             <FluentLabel Typo="Typography.Body" Color="@GetSideIconColor()">

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Components/PinnedChannels.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Components/PinnedChannels.razor
@@ -30,24 +30,29 @@
     </FooterContent>
 </FluentAutocomplete>
 
-@foreach (var channel in Pins)
+@if (Pins.Any())
 {
-    <ChannelNavMenuItem Channel="@channel">
-        <CustomTitleTemplate>
-            <div class="fluent-nav-link notactive">
-                @channel.Name
+  <FluentNavMenu Id="pinned-channels-menu" Width="300" Collapsible="false" @bind-Expanded="expanded" CustomToggle="true">
+    @foreach (var channel in Pins)
+    {
+        <ChannelNavMenuItem Channel="@channel">
+            <CustomTitleTemplate>
+                <div class="fluent-nav-link notactive">
+                    @channel.Name
 
-                <div aria-hidden="true"
-                     class="expand-collapse-button"
-                     tabindex="-1"
-                     @onclick="@(() => RemoveFocus(channel))"
-                     @onclick:stopPropagation="true"
-                     @onclick:preventDefault="true">
-                    <FluentIcon Value="@(new Icons.Regular.Size12.Dismiss())" Color="@Color.Neutral" Class="fluent-nav-expand-icon" />
+                    <div aria-hidden="true"
+                         class="expand-collapse-button"
+                         tabindex="-1"
+                         @onclick="@(() => RemoveFocus(channel))"
+                         @onclick:stopPropagation="true"
+                         @onclick:preventDefault="true">
+                        <FluentIcon Value="@(new Icons.Regular.Size12.Dismiss())" Color="@Color.Neutral" Class="fluent-nav-expand-icon" />
+                    </div>
                 </div>
-            </div>
-        </CustomTitleTemplate>
-    </ChannelNavMenuItem>
+            </CustomTitleTemplate>
+        </ChannelNavMenuItem>
+    }
+  </FluentNavMenu>
 }
 
 @code {
@@ -56,6 +61,8 @@
 
     [Parameter]
     public List<Channel>? PrePinnedChannels { get; set; }
+
+    private bool expanded = true;
 
     private static readonly string SESSION_STORAGE_KEY = "pinned-channels";
 

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Components/PinnedChannels.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Components/PinnedChannels.razor
@@ -93,7 +93,7 @@
     private void OnSelection(IEnumerable<Channel> selectedChannels)
     {
         var newPinnedChannels = selectedChannels
-            .Where(c => !Pins.Contains(c))
+            .Where(c => !Pins.Any(p => p.Id == c.Id))
             .ToList();
 
         if (!newPinnedChannels.Any())

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Layout/NavMenu.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Layout/NavMenu.razor
@@ -8,12 +8,12 @@
 <div class="navmenu">
   <nav class="sitenav" aria-labelledby="main-menu">
     <input type="checkbox" title="Menu expand/collapse toggle" id="navmenu-toggle" class="navmenu-icon" />
-    <FluentNavMenu Id="main-menu" Width="300" Collapsible="false" Title="Navigation menu" @bind-Expanded="expanded" CustomToggle="true">
-      <PinnedChannels AvailableChannels="@AvailableChannels"
+
+    <PinnedChannels AvailableChannels="@AvailableChannels"
                       PrePinnedChannels="@PrePinnedChannels" />
+    <h4 class="navmenu-heading navmenu-heading-channels">Channels</h4>
 
-      <h4 class="navmenu-heading navmenu-heading-channels">Channels</h4>
-
+    <FluentNavMenu Id="main-menu" Width="300" Collapsible="false" Title="Navigation menu" @bind-Expanded="expanded" CustomToggle="true">
       @foreach (var category in Categories)
       {
         <FluentNavGroup Title="@category.Name" Icon="@(new Icons.Regular.Size20.FolderList())">


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Contributes to https://github.com/dotnet/arcade-services/issues/4048

Accessibility improvements:
  - fixes missing `aria` labels on non-interactable navigation menu items by moving them out of the navigation menu itself
  - fixes poor contrast on build date in the build info component

General fixes:
  - fixes being able to pin the same channel multiple times 