### PR TITLE
Fixup BarViz debugging

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,13 @@
     <LangVersion>latest</LangVersion>
     <IsShipping>false</IsShipping>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <!-- 
+      This compiler property is required for debugging the BarViz project locally.
+      
+      When set to `full`, all debugging information will be made available together with the built
+      artifacts. If not present, Visual Studio debugger will fail to connect to the browser during
+      the debugging session
+    -->
     <DebugType>Full</DebugType>
 
     <EnableCentralPackageVersions>true</EnableCentralPackageVersions>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,7 @@
     <LangVersion>latest</LangVersion>
     <IsShipping>false</IsShipping>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <DebugType>Full</DebugType>
 
     <EnableCentralPackageVersions>true</EnableCentralPackageVersions>
     <CentralPackagesFile>$(MSBuildThisFileDirectory)eng/Packages.props</CentralPackagesFile>


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Resolves issue found during work on https://github.com/dotnet/arcade-services/issues/4048

Adds back a property that was originally removed as it was breaking debugging of BarViz in PCS when the project was in its hackaton stage.

After the project was merged with the rest of the service, the debugging stopped working without this property being set.