### PR TITLE
Remove unused option in add-build-to-channel

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
@@ -256,7 +256,6 @@ internal class AddBuildToChannelOperation : Operation
             { "SigningValidationAdditionalParameters", _options.SigningValidationAdditionalParameters },
             { "EnableNugetValidation", _options.DoNuGetValidation.ToString() },
             { "EnableSourceLinkValidation", _options.DoSourcelinkValidation.ToString() },
-            { "PublishInstallersAndChecksums", true.ToString() },
             { "SymbolPublishingAdditionalParameters", _options.SymbolPublishingAdditionalParameters },
             { "ArtifactsPublishingAdditionalParameters", _options.ArtifactPublishingAdditionalParameters }
         };

--- a/src/Microsoft.DotNet.Darc/Darc/Options/AddBuildToChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/AddBuildToChannelCommandLineOptions.cs
@@ -58,9 +58,6 @@ internal class AddBuildToChannelCommandLineOptions : CommandLineOptions<AddBuild
     [RedactFromLogging]
     public string ArtifactPublishingAdditionalParameters { get; set; }
 
-    [Option("publish-installers-and-checksums", HelpText = "Whether installers and checksums should be published. This option is ignored")]
-    public bool PublishInstallersAndChecksums { get; set; }
-
     [Option("skip-assets-publishing", HelpText = "Add the build to the channel without publishing assets to the channel's feeds.")]
     public bool SkipAssetsPublishing { get; set; }
 


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Contributes to https://github.com/dotnet/arcade-services/issues/2508

The option is not referenced in any up-to-date repositories within `dotnet` org or internally. Existing references are just repositories using an old version of Arcade (~2years old) and should not be impacted by this change