### PR TITLE
Fix VMR patch re-application

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -39,9 +39,7 @@ public interface IVmrPatchHandler
         UnixPath? applicationPath,
         CancellationToken cancellationToken);
 
-    IReadOnlyCollection<string> GetVmrPatches(SourceMapping mapping) => GetVmrPatches(mapping.Name);
-
-    IReadOnlyCollection<string> GetVmrPatches(string mappingName);
+    IReadOnlyCollection<VmrIngestionPatch> GetVmrPatches();
 
     Task<IReadOnlyCollection<UnixPath>> GetPatchedFiles(string patchPath, CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PatchApplicationFailedException.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PatchApplicationFailedException.cs
@@ -10,8 +10,8 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 internal class PatchApplicationFailedException : Exception
 {
-    public PatchApplicationFailedException(VmrIngestionPatch patch, ProcessExecutionResult result)
-        : base($"Failed to apply the patch {Path.GetFileName(patch.Path)} to {patch.ApplicationPath ?? "/"}."
+    public PatchApplicationFailedException(VmrIngestionPatch patch, ProcessExecutionResult result, bool reverseApply)
+        : base($"Failed to {(reverseApply ? "reverse-apply" : "apply")} the patch {Path.GetFileName(patch.Path)} to {patch.ApplicationPath ?? "/"}."
             + Environment.NewLine
             + Environment.NewLine
             + result)

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -187,6 +187,8 @@ public abstract class VmrManagerBase
             cancellationToken.ThrowIfCancellationRequested();
         }
 
+        await CommitAsync("[VMR patches] Re-apply VMR patches");
+
         _logger.LogInformation("VMR patches re-applied back onto the VMR");
     }
 
@@ -196,7 +198,7 @@ public abstract class VmrManagerBase
 
         var watch = Stopwatch.StartNew();
 
-        await _localGitClient.CommitAsync(_vmrInfo.VmrPath, commitMessage, true, author);
+        await _localGitClient.CommitAsync(_vmrInfo.VmrPath, commitMessage, allowEmpty: true, author);
 
         _logger.LogInformation("Committed in {duration} seconds", (int) watch.Elapsed.TotalSeconds);
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -263,7 +263,7 @@ public class VmrPatchHandler : IVmrPatchHandler
             return;
         }
 
-        _logger.LogInformation("Applying patch {patchPath} to {path}...", patch.Path, patch.ApplicationPath ?? "root of the VMR");
+        _logger.LogInformation((reverseApply ? "Reverse-applying" : "Applying") + " patch {patchPath} to {path}...", patch.Path, patch.ApplicationPath ?? "root of the VMR");
 
         // This will help ignore some CR/LF issues (e.g. files with both endings)
         (await _processManager.ExecuteGit(targetDirectory, ["config", "apply.ignoreWhitespace", "change"], cancellationToken: cancellationToken))
@@ -307,7 +307,7 @@ public class VmrPatchHandler : IVmrPatchHandler
 
         if (!result.Succeeded)
         {
-            throw new PatchApplicationFailedException(patch, result);
+            throw new PatchApplicationFailedException(patch, result, reverseApply);
         }
 
         _logger.LogDebug("{output}", result.ToString());

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -144,7 +144,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             {
                 var patchesToReapply = await UpdateRepositoryInternal(
                     dependencyUpdate,
-                    reapplyVmrPatches: true,
+                    handleVmrPatches: true,
                     additionalRemotes,
                     componentTemplatePath,
                     tpnTemplatePath,
@@ -164,7 +164,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
     private async Task<IReadOnlyCollection<VmrIngestionPatch>> UpdateRepositoryInternal(
         VmrDependencyUpdate update,
-        bool reapplyVmrPatches,
+        bool handleVmrPatches,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? componentTemplatePath,
         string? tpnTemplatePath,
@@ -245,7 +245,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             currentVersion.Sha,
             author: null,
             commitMessage,
-            reapplyVmrPatches,
+            handleVmrPatches,
             componentTemplatePath,
             tpnTemplatePath,
             generateCodeowners,
@@ -338,7 +338,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             {
                 patchesToReapply = await UpdateRepositoryInternal(
                     update,
-                    false,
+                    handleVmrPatches: update.Parent == null,
                     additionalRemotes,
                     componentTemplatePath,
                     tpnTemplatePath,
@@ -404,53 +404,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 .AppendLine($"    {update.RemoteUri}/compare/{update.TargetVersion}..{update.TargetRevision}");
         }
 
-        if (vmrPatchesToReapply.Any())
-        {
-            try
-            {
-                await ReapplyVmrPatchesAsync(vmrPatchesToReapply.DistinctBy(p => p.Path).ToArray(), cancellationToken);
-            }
-            catch (Exception)
-            {
-                _logger.LogWarning(
-                    InterruptedSyncExceptionMessage,
-                    workBranch.OriginalBranch.StartsWith("sync") || workBranch.OriginalBranch.StartsWith("init")
-                        ? "the original"
-                        : workBranch.OriginalBranch);
-                throw;
-            }
-
-            await CommitAsync("[VMR patches] Re-apply VMR patches");
-
-            // TODO: Workaround for cases when we get CRLF problems on Windows
-            // We should figure out why restoring and reapplying VMR patches leaves working tree with EOL changes
-            // https://github.com/dotnet/arcade-services/issues/3277
-            if (vmrPatchesToReapply.Any() && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                if (await LocalVmr.HasWorkingTreeChangesAsync())
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await _localGitClient.CheckoutAsync(_vmrInfo.VmrPath, ".");
-
-                    // Sometimes not even checkout helps, so we check again
-                    if (await LocalVmr.HasWorkingTreeChangesAsync())
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        await _localGitClient.RunGitCommandAsync(
-                            _vmrInfo.VmrPath,
-                            ["add", "--u", "."],
-                            cancellationToken: default);
-
-                        await _localGitClient.RunGitCommandAsync(
-                            _vmrInfo.VmrPath,
-                            ["commit", "--amend", "--no-edit"],
-                            cancellationToken: default);
-                    }
-                }
-            }
-        }
+        await ReapplyVmrPatches(workBranch, vmrPatchesToReapply, cancellationToken);
 
         await CleanUpRemovedRepos(componentTemplatePath, tpnTemplatePath);
 
@@ -461,7 +415,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             originalRootSha,
             finalRootSha,
             summaryMessage.ToString());
-        
+
         await workBranch.MergeBackAsync(commitMessage);
 
         _logger.LogInformation("Recursive update for {repo} finished.{newLine}{message}",
@@ -472,6 +426,59 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         return updatedDependencies.Any();
     }
 
+    private async Task ReapplyVmrPatches(IWorkBranch workBranch, List<VmrIngestionPatch> vmrPatchesToReapply, CancellationToken cancellationToken)
+    {
+        if (!vmrPatchesToReapply.Any())
+        {
+            return;
+        }
+
+        try
+        {
+            await ReapplyVmrPatchesAsync(vmrPatchesToReapply.DistinctBy(p => p.Path).ToArray(), cancellationToken);
+        }
+        catch (Exception)
+        {
+            _logger.LogWarning(
+                InterruptedSyncExceptionMessage,
+                workBranch.OriginalBranch.StartsWith("sync") || workBranch.OriginalBranch.StartsWith("init")
+                    ? "the original"
+                    : workBranch.OriginalBranch);
+            throw;
+        }
+
+        await CommitAsync("[VMR patches] Re-apply VMR patches");
+
+        // TODO: Workaround for cases when we get CRLF problems on Windows
+        // We should figure out why restoring and reapplying VMR patches leaves working tree with EOL changes
+        // https://github.com/dotnet/arcade-services/issues/3277
+        if (vmrPatchesToReapply.Any() && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (await LocalVmr.HasWorkingTreeChangesAsync())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await _localGitClient.CheckoutAsync(_vmrInfo.VmrPath, ".");
+
+                // Sometimes not even checkout helps, so we check again
+                if (await LocalVmr.HasWorkingTreeChangesAsync())
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await _localGitClient.RunGitCommandAsync(
+                        _vmrInfo.VmrPath,
+                        ["add", "--u", "."],
+                        cancellationToken: default);
+
+                    await _localGitClient.RunGitCommandAsync(
+                        _vmrInfo.VmrPath,
+                        ["commit", "--amend", "--no-edit"],
+                        cancellationToken: default);
+                }
+            }
+        }
+    }
+
     /// <summary>
     /// Detects VMR patches affected by a given set of patches and restores files patched by these
     /// VMR patches into their original state.
@@ -480,13 +487,11 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
     /// <param name="updatedMapping">Mapping that is currently being updated (so we get its patches)</param>
     /// <param name="patches">Patches with incoming changes to be checked whether they affect some VMR patch</param>
     protected override async Task<IReadOnlyCollection<VmrIngestionPatch>> RestoreVmrPatchedFilesAsync(
-        SourceMapping updatedMapping,
         IReadOnlyCollection<VmrIngestionPatch> patches,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken)
     {
         IReadOnlyCollection<VmrIngestionPatch> vmrPatchesToRestore = await GetVmrPatchesToRestore(
-            updatedMapping,
             patches,
             cancellationToken);
 
@@ -521,8 +526,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
     }
 
     /// <summary>
-    /// Gets a list of VMR patches that need to be reverted for a given mapping update so that repo changes can be applied.
-    /// Usually, this just returns all VMR patches for that given mapping (e.g. for the aspnetcore returns all aspnetcore only patches).
+    /// Gets a list of all VMR patches so that they can be reverted before repo changes can be applied.
     /// 
     /// One exception is when the updated mapping is the one that the VMR patches come from into the VMR (e.g. dotnet/installer).
     /// In this case, we also check which VMR patches are modified by the change and we also returns those.
@@ -530,30 +534,24 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
     ///   - An aspnetcore VMR patch is removed from installer - we must remove it from the files it is applied to in the VMR.
     ///   - A new version of patch is synchronized from installer - we must remove the old version and apply the new.
     /// </summary>
-    /// <param name="updatedMapping">Currently synchronized mapping</param>
     /// <param name="patches">Patches of currently synchronized changes</param>
     private async Task<IReadOnlyCollection<VmrIngestionPatch>> GetVmrPatchesToRestore(
-        SourceMapping updatedMapping,
         IReadOnlyCollection<VmrIngestionPatch> patches,
         CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Getting a list of VMR patches to restore for {repo} before we ingest new changes...", updatedMapping.Name);
+        _logger.LogInformation("Getting a list of VMR patches to restore before we ingest new changes...");
 
+        // Always restore all patches
         var patchesToRestore = new List<VmrIngestionPatch>();
-
-        // Always restore all patches belonging to the currently updated mapping
-        foreach (var vmrPatch in _patchHandler.GetVmrPatches(updatedMapping))
-        {
-            patchesToRestore.Add(new VmrIngestionPatch(vmrPatch, updatedMapping));
-        }
+        patchesToRestore.AddRange(_patchHandler.GetVmrPatches());
 
         // If we are not updating the mapping that the VMR patches come from, we're done
-        if (_vmrInfo.PatchesPath == null || !_vmrInfo.PatchesPath.StartsWith(VmrInfo.GetRelativeRepoSourcesPath(updatedMapping)))
+        if (_vmrInfo.PatchesPath == null)
         {
             return patchesToRestore;
         }
 
-        _logger.LogInformation("Repo {repo} contains VMR patches, checking which VMR patches have changes...", updatedMapping.Name);
+        _logger.LogInformation("Checking which VMR patches have changes...");
 
         // Check which files are modified by every of the patches that bring new changes into the VMR
         foreach (var patch in patches)
@@ -562,7 +560,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
             IReadOnlyCollection<UnixPath> patchedFiles = await _patchHandler.GetPatchedFiles(patch.Path, cancellationToken);
             IEnumerable<LocalPath> affectedPatches = patchedFiles
-                .Select(path => VmrInfo.GetRelativeRepoSourcesPath(updatedMapping) / path)
                 .Where(path => path.Path.StartsWith(_vmrInfo.PatchesPath) && path.Path.EndsWith(".patch"))
                 .Select(path => _vmrInfo.VmrPath / path);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -559,7 +559,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
             IReadOnlyCollection<UnixPath> patchedFiles = await _patchHandler.GetPatchedFiles(patch.Path, cancellationToken);
             IEnumerable<LocalPath> affectedPatches = patchedFiles
-                .Select(path => patch.ApplicationPath! / path)
+                .Select(path => patch.ApplicationPath != null ? patch.ApplicationPath! / path : path)
                 .Where(path => path.Path.StartsWith(_vmrInfo.PatchesPath) && path.Path.EndsWith(".patch"))
                 .Select(path => _vmrInfo.VmrPath / path);
 

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchChangingFileTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchChangingFileTest.cs
@@ -23,12 +23,8 @@ internal class VmrPatchChangingFileTest : VmrPatchesTestsBase
     {
         var patchPathInVmr = VmrPatchesDir / PatchFileName;
         var productRepoFileName = Constants.GetRepoFileName(Constants.ProductRepoName);
-        var fileAfterPatch = "test-file-after-patch.txt";
-        var fileAfterChangedPatch = "test-file-after-changed-patch.txt";
-        var newPatchFileName = "new-patch.patch";
-        var fileAfterNewPatchName = "test-file-after-new-patch.txt";
 
-        // initialize repo with a vmr patch
+        // Initialize repo with a VMR patch (example.patch which changes BBB->CCC)
 
         await InitializeRepoAtLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
         await InitializeRepoAtLastCommit(Constants.ProductRepoName, ProductRepoPath);
@@ -47,21 +43,21 @@ internal class VmrPatchChangingFileTest : VmrPatchesTestsBase
         );
 
         CheckDirectoryContents(VmrPath, expectedFiles);
-        CompareFileContents(ProductRepoFilePathInVmr, fileAfterPatch);
+        CompareFileContents(ProductRepoFilePathInVmr, "test-file-after-patch.txt");
         await GitOperations.CheckAllIsCommitted(VmrPath);
 
-        // a change in the patch
+        // We change the patch to BBB->DDD
 
-        File.WriteAllText(
+        await File.WriteAllTextAsync(
             InstallerPatchesDir / PatchFileName,
-            File.ReadAllText(VmrTestsOneTimeSetUp.ResourcesPath / "changed-patch.patch"));
+            await File.ReadAllTextAsync(VmrTestsOneTimeSetUp.ResourcesPath / "changed-patch.patch"));
         await GitOperations.CommitAll(InstallerRepoPath, "Change the patch file");
         await UpdateRepoToLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
 
         CheckDirectoryContents(VmrPath, expectedFiles);
-        CompareFileContents(ProductRepoFilePathInVmr, fileAfterChangedPatch);
+        CompareFileContents(ProductRepoFilePathInVmr, "test-file-after-changed-patch.txt");
 
-        // remove the patch from installer
+        // Remove the patch from installer, file goes back to BBB
 
         File.Delete(InstallerPatchesDir / PatchFileName);
         await GitOperations.CommitAll(InstallerRepoPath, "Remove the patch file");
@@ -71,17 +67,18 @@ internal class VmrPatchChangingFileTest : VmrPatchesTestsBase
         CheckDirectoryContents(VmrPath, expectedFiles);
         CompareFileContents(ProductRepoFilePathInVmr, productRepoFileName);
 
-        // add a new patch in installer
+        // Add a new patch in installer which changes AAA->TTT (file should have BBB->TTT)
 
+        var newPatchFileName = "new-patch.patch";
         File.Copy(VmrTestsOneTimeSetUp.ResourcesPath / newPatchFileName, InstallerPatchesDir / newPatchFileName);
         await GitOperations.CommitAll(InstallerRepoPath, "Add a new patch file");
         await UpdateRepoToLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
 
         expectedFiles.Add(VmrPatchesDir / newPatchFileName);
         CheckDirectoryContents(VmrPath, expectedFiles);
-        CompareFileContents(ProductRepoFilePathInVmr, fileAfterNewPatchName);
+        CompareFileContents(ProductRepoFilePathInVmr, "test-file-after-new-patch.txt");
 
-        // change the file so the vmr patch cannot be applied
+        // Change the file so the VMR patch cannot be applied
 
         await File.WriteAllTextAsync(ProductRepoPath / productRepoFileName, "New content");
         await GitOperations.CommitAll(ProductRepoPath, "Change file in product repo");


### PR DESCRIPTION
Encountered problems like in https://github.com/dotnet/sdk/issues/44757 or https://github.com/dotnet/sdk/pull/44751 where a patch being applied together with incoming changes for a repo that is also being patched can end up with failures.

Instead of several rounds of restoring and reapplication of VMR patches, we strip all at the beginning and apply all at the end of the sync which makes it much simpler and less error prone.