### PR TITLE
Fixup removed promotion pipeline argument

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
@@ -256,6 +256,7 @@ internal class AddBuildToChannelOperation : Operation
             { "SigningValidationAdditionalParameters", _options.SigningValidationAdditionalParameters },
             { "EnableNugetValidation", _options.DoNuGetValidation.ToString() },
             { "EnableSourceLinkValidation", _options.DoSourcelinkValidation.ToString() },
+            { "PublishInstallersAndChecksums", true.ToString() },
             { "SymbolPublishingAdditionalParameters", _options.SymbolPublishingAdditionalParameters },
             { "ArtifactsPublishingAdditionalParameters", _options.ArtifactPublishingAdditionalParameters }
         };


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Contributes to https://github.com/dotnet/arcade-services/issues/2508

Fixes an issue introduced in https://github.com/dotnet/arcade-services/pull/4143

While named exactly like the command option, the promotion pipeline argument in `AddBuildToChannelOperation` is still a valid and actively used option and should not have been removed