### PR TITLE
Reduce logging verbosity for container jobs

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -418,7 +418,7 @@ public class VmrPatchHandler : IVmrPatchHandler
                 sha2,
                 fileName,
                 // Ignore all files except the one we're currently processing
-                [.. filters?.Except([GetInclusionRule("**/*")]) ],
+                [.. filters?.Except([GetInclusionRule("**/*")]) ?? []],
                 true,
                 workingDir,
                 applicationPath,

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/appsettings.json
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/appsettings.json
@@ -3,11 +3,7 @@
         "LogLevel": {
             "Default": "Information",
             "Azure.Core": "Warning",
-            "Azure.Identity": "Warning",
-            "Microsoft.AspNetCore": "Warning",
-            "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
-            "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
-            "Microsoft.IdentityModel.LoggingExtensions.IdentityLoggerAdapter": "Warning"
+            "Azure.Identity": "Warning"
         }
     },
     "FeedCleaner": {

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/appsettings.json
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/appsettings.json
@@ -1,4 +1,15 @@
 {
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Azure.Core": "Warning",
+            "Azure.Identity": "Warning",
+            "Microsoft.AspNetCore": "Warning",
+            "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
+            "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+            "Microsoft.IdentityModel.LoggingExtensions.IdentityLoggerAdapter": "Warning"
+        }
+    },
     "FeedCleaner": {
         "Enabled": false,
         "ReleasePackageFeeds": [

--- a/src/ProductConstructionService/ProductConstructionService.LongestBuildPathUpdater/appsettings.json
+++ b/src/ProductConstructionService/ProductConstructionService.LongestBuildPathUpdater/appsettings.json
@@ -1,1 +1,13 @@
-{}
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Azure.Core": "Warning",
+            "Azure.Identity": "Warning",
+            "Microsoft.AspNetCore": "Warning",
+            "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
+            "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+            "Microsoft.IdentityModel.LoggingExtensions.IdentityLoggerAdapter": "Warning"
+        }
+    }
+}

--- a/src/ProductConstructionService/ProductConstructionService.LongestBuildPathUpdater/appsettings.json
+++ b/src/ProductConstructionService/ProductConstructionService.LongestBuildPathUpdater/appsettings.json
@@ -3,11 +3,7 @@
         "LogLevel": {
             "Default": "Information",
             "Azure.Core": "Warning",
-            "Azure.Identity": "Warning",
-            "Microsoft.AspNetCore": "Warning",
-            "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
-            "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
-            "Microsoft.IdentityModel.LoggingExtensions.IdentityLoggerAdapter": "Warning"
+            "Azure.Identity": "Warning"
         }
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.SubscriptionTriggerer/appsettings.json
+++ b/src/ProductConstructionService/ProductConstructionService.SubscriptionTriggerer/appsettings.json
@@ -3,11 +3,7 @@
         "LogLevel": {
             "Default": "Information",
             "Azure.Core": "Warning",
-            "Azure.Identity": "Warning",
-            "Microsoft.AspNetCore": "Warning",
-            "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
-            "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
-            "Microsoft.IdentityModel.LoggingExtensions.IdentityLoggerAdapter": "Warning"
+            "Azure.Identity": "Warning"
         }
     },
     "DefaultWorkItemQueueName": "pcs-workitems",

--- a/src/ProductConstructionService/ProductConstructionService.SubscriptionTriggerer/appsettings.json
+++ b/src/ProductConstructionService/ProductConstructionService.SubscriptionTriggerer/appsettings.json
@@ -1,4 +1,15 @@
 {
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Azure.Core": "Warning",
+            "Azure.Identity": "Warning",
+            "Microsoft.AspNetCore": "Warning",
+            "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
+            "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+            "Microsoft.IdentityModel.LoggingExtensions.IdentityLoggerAdapter": "Warning"
+        }
+    },
     "DefaultWorkItemQueueName": "pcs-workitems",
     "CodeflowWorkItemQueueName": "pcs-codeflow-workitems"
 }


### PR DESCRIPTION
The logs are full of `Azure.Identity` logs when booting into the managed identity etc. [Example log](https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Ffbd6122a-9ad3-42e4-976e-bccb82486856%2FresourceGroups%2Fproduct-construction-service%2Fproviders%2FMicrosoft.OperationalInsights%2Fworkspaces%2Fproduct-construction-service-workspace-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAAzXKMQqAMAwAwN1XdHMqqKC4SgcX8QulYqhFbUoSKYKP18Wbz2AUFyLQkJLByHjAhJ6tmYpH5Q0IlPnLSHil2Z1gWbE4Es5BNlXytWih4P23SWeA%252Fbh1Ilx10%252FddW1dV%252BQIzK9f0ZwAAAA%253D%253D/timespan/P1Y/limit/30000)

<!--https://github.com/dotnet/arcade-services/issues/4160-->