### PR TITLE
Stop forward flow when target branch has conflicting changes

### DIFF
--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrBackflowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrBackflowTest.cs
@@ -296,7 +296,7 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         await GitOperations.MergePrBranch(VmrPath, branchName + "-ff");
 
         // Now we will change something in the VMR and flow it back to the repo
-        // Then we will change something in the VMR again but before we flow it back, we will update the repo package versions by running update-dependencies
+        // Then we will change something in the VMR again but before we flow it back, we will make a conflicting change in the VMR
         await File.WriteAllTextAsync(_productRepoVmrFilePath, "New content again in the VMR #1");
         await GitOperations.CommitAll(VmrPath, "Changing a VMR file again #1");
 
@@ -308,8 +308,6 @@ internal class VmrBackflowTest : VmrCodeFlowTests
             ("Package.D3", "1.0.5"),
         ]);
 
-        // Now we will change something in the VMR and flow it back to the repo
-        // Then we will change something in the VMR again but before we flow it back, we will change the PR branch so that there's a conflict
         await File.WriteAllTextAsync(_productRepoVmrFilePath, "New content again in the VMR #2");
         await GitOperations.CommitAll(VmrPath, "Changing a VMR file again #2");
 
@@ -355,6 +353,7 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         productRepo.Checkout(branchName + "-pr2");
         dependencies = await productRepo.GetDependenciesAsync();
         dependencies.Should().BeEquivalentTo(expectedDependencies);
+        CheckFileContents(_productRepoFilePath, "New content again but this time in the PR directly");
     }
 }
 

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrForwardFlowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrForwardFlowTest.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -82,25 +83,59 @@ internal class VmrForwardFlowTest : VmrCodeFlowTests
         await File.WriteAllTextAsync(_productRepoFilePath, "New content in the repository");
         await GitOperations.CommitAll(ProductRepoPath, "Changing a repo file");
 
-        var build = await CreateNewRepoBuild(
+        var build1 = await CreateNewRepoBuild(
         [
             ("Package.A1", "1.0.1"),
         ]);
 
-        var hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName, buildToFlow: build.Id);
+        var hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName, buildToFlow: build1.Id);
         hadUpdates.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName);
 
         // Verify that VMR's version files have the new versions
-        var vmrVersionDetails = new VersionDetailsParser()
-            .ParseVersionDetailsFile(VmrPath / VersionFiles.VersionDetailsXml);
-
-        vmrVersionDetails.Dependencies.Where(d => d.Name != DependencyFileManager.ArcadeSdkPackageName)
-            .Should().BeEquivalentTo(GetDependencies(build));
+        var vmr = GetLocal(VmrPath);
+        var dependencies = await vmr.GetDependenciesAsync();
+        dependencies.Where(d => d.Name != DependencyFileManager.ArcadeSdkPackageName)
+            .Should().BeEquivalentTo(GetDependencies(build1));
 
         var propName = VersionFiles.GetVersionPropsPackageVersionElementName("Package.A1");
         var vmrVersionProps = AllVersionsPropsFile.DeserializeFromXml(VmrPath / VersionFiles.VersionProps);
         vmrVersionProps.Versions[propName].Should().Be("1.0.1");
+
+        // Now we will change something in the repo and flow it to the VMR
+        // Then we will change something in the repo again but before we flow it, we will make a conflicting change in the repo
+        await File.WriteAllTextAsync(_productRepoFilePath, "New content again in the repo #1");
+        await GitOperations.CommitAll(ProductRepoPath, "Changing a repo file again #1");
+
+        var build2 = await CreateNewRepoBuild(
+        [
+            ("Package.A1", "1.0.5"),
+        ]);
+
+        await File.WriteAllTextAsync(_productRepoFilePath, "New content again in the repo #2");
+        await GitOperations.CommitAll(ProductRepoPath, "Changing a repo file again #2");
+
+        var build3 = await CreateNewRepoBuild(
+        [
+            ("Package.A1", "1.0.6"),
+        ]);
+
+        // Flow the first build
+        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName, buildToFlow: build2.Id);
+        hadUpdates.ShouldHaveUpdates();
+
+        // We make a conflicting change in the PR branch
+        await GitOperations.Checkout(VmrPath, branchName);
+        await File.WriteAllTextAsync(_productRepoVmrFilePath, "New content again but this time in the PR directly");
+        await GitOperations.CommitAll(VmrPath, "Changing a file in the PR");
+
+        // Flow the second build - this should throw as there's a conflict in the PR branch
+        await this.Awaiting(_ => CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName, buildToFlow: build3.Id))
+            .Should().ThrowAsync<ConflictInPrBranchException>();
+
+        // The state of the branch should be the same as before
+        vmr.Checkout(branchName);
+        CheckFileContents(_productRepoVmrFilePath, "New content again but this time in the PR directly");
     }
 }
 


### PR DESCRIPTION
Makes the codeflow respect conflicts with the target branch rather than backtracking and trying to flow from an older checkpoint.

Details in https://github.com/dotnet/arcade-services/issues/3352