### PR TITLE
Revert "Remove unused option in add-build-to-channel"

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Options/AddBuildToChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/AddBuildToChannelCommandLineOptions.cs
@@ -58,6 +58,9 @@ internal class AddBuildToChannelCommandLineOptions : CommandLineOptions<AddBuild
     [RedactFromLogging]
     public string ArtifactPublishingAdditionalParameters { get; set; }
 
+    [Option("publish-installers-and-checksums", HelpText = "Whether installers and checksums should be published. This option is ignored")]
+    public bool PublishInstallersAndChecksums { get; set; }
+
     [Option("skip-assets-publishing", HelpText = "Add the build to the channel without publishing assets to the channel's feeds.")]
     public bool SkipAssetsPublishing { get; set; }
 


### PR DESCRIPTION
Reverts https://github.com/dotnet/arcade-services/issues/4143

Seems like it is not as easy - we missed some servicing branches which are still using it.