### PR TITLE
Fix E2E code flow tests (fetching refs, updating version files)

### DIFF
--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -17,6 +17,7 @@
       ('https://github.com/maestro-auth-test/maestro-test', 289474),
       ('https://github.com/maestro-auth-test/maestro-test2', 289474),
       ('https://github.com/maestro-auth-test/maestro-test3', 289474),
+      ('https://github.com/maestro-auth-test/maestro-test-vmr', 289474),
       ('https://github.com/maestro-auth-test/arcade', 289474),
       ('https://github.com/maestro-auth-test/dnceng-vmr', 289474);
   ```

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
@@ -141,6 +141,14 @@ public interface ILocalGitClient
     Task<string[]> GetStagedFiles(string repoPath);
 
     /// <summary>
+    ///     Determines if a given path is a git repository.
+    /// </summary>
+    /// <param name="repoPath">Path to a git repository</param>
+    /// <param name="gitRef">Git reference to check for</param>
+    /// <returns>True if the path is a git repository, false otherwise</returns>
+    Task<bool> GitRefExists(string repoPath, string gitRef, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Fetches from all remotes.
     /// </summary>
     /// <param name="repoPath">Path to a git repository</param>

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
@@ -79,14 +80,13 @@ public abstract class CloneManager
             var missingCommit = false;
 
             // Verify that all requested commits are available
-            foreach (string commit in refsToVerify.ToArray())
+            foreach (string gitRef in refsToVerify.ToArray())
             {
                 try
                 {
-                    var objectType = await _localGitRepo.GetObjectTypeAsync(path, commit);
-                    if (objectType == GitObjectType.Commit)
+                    if (await _localGitRepo.GitRefExists(path, gitRef, cancellationToken))
                     {
-                        refsToVerify.Remove(commit);
+                        refsToVerify.Remove(gitRef);
                     }
                 }
                 catch

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
@@ -45,7 +45,6 @@ public class VmrDependencyTracker : IVmrDependencyTracker
 {
     private readonly AllVersionsPropsFile _repoVersions;
     private readonly ISourceManifest _sourceManifest;
-    private readonly LocalPath _allVersionsFilePath;
     private readonly IVmrInfo _vmrInfo;
     private readonly IFileSystem _fileSystem;
     private readonly ISourceMappingParser _sourceMappingParser;
@@ -63,7 +62,6 @@ public class VmrDependencyTracker : IVmrDependencyTracker
         ISourceManifest sourceManifest)
     {
         _vmrInfo = vmrInfo;
-        _allVersionsFilePath = vmrInfo.VmrPath / VmrInfo.GitInfoSourcesDir / AllVersionsPropsFile.FileName;
         _sourceManifest = sourceManifest;
         _repoVersions = new AllVersionsPropsFile(sourceManifest.Repositories);
         _fileSystem = fileSystem;
@@ -94,7 +92,7 @@ public class VmrDependencyTracker : IVmrDependencyTracker
     public void UpdateDependencyVersion(VmrDependencyUpdate update)
     {
         _repoVersions.UpdateVersion(update.Mapping.Name, update.TargetRevision, update.TargetVersion);
-        _repoVersions.SerializeToXml(_allVersionsFilePath);
+        _repoVersions.SerializeToXml(_vmrInfo.AllVersionsFilePath);
 
         _sourceManifest.UpdateVersion(update.Mapping.Name, update.RemoteUri, update.TargetRevision, update.TargetVersion);
         _fileSystem.WriteToFile(_vmrInfo.SourceManifestPath, _sourceManifest.ToJson());
@@ -126,7 +124,7 @@ public class VmrDependencyTracker : IVmrDependencyTracker
 
         if (_repoVersions.DeleteVersion(repo))
         {
-            _repoVersions.SerializeToXml(_allVersionsFilePath);
+            _repoVersions.SerializeToXml(_vmrInfo.AllVersionsFilePath);
             hasChanges = true;
         }
         

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -59,6 +59,11 @@ public interface IVmrInfo
     /// Gets a full path leading to sources belonging to a given repo
     /// </summary>
     NativePath GetRepoSourcesPath(string mappingName);
+
+    /// <summary>
+    /// Path to the AllRepoVersions.props
+    /// </summary>
+    NativePath AllVersionsFilePath { get; }
 }
 
 public class VmrInfo : IVmrInfo
@@ -137,4 +142,6 @@ public class VmrInfo : IVmrInfo
     public static UnixPath GetRelativeRepoSourcesPath(string mappingName) => RelativeSourcesDir / mappingName;
 
     public NativePath SourceManifestPath { get; private set; }
+
+    public NativePath AllVersionsFilePath => VmrPath / GitInfoSourcesDir / AllVersionsPropsFile.FileName;
 }

--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/ReminderManager.cs
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/ReminderManager.cs
@@ -50,7 +50,8 @@ public class ReminderManager<T> : IReminderManager<T> where T : WorkItem
         {
             await client.DeleteWorkItemAsync(receipt.MessageId, receipt.PopReceipt);
         }
-        catch (RequestFailedException e) when (e.Message.Contains("The specified message does not exist") || e.Message.Contains("did not match the pop receipt"))
+        catch (RequestFailedException e) when (e.Message.Contains("The specified message does not exist")
+                                            || e.Message.Contains("did not match the pop receipt"))
         {
             // The message was already deleted, so we can ignore this exception.
         }

--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/ReminderManager.cs
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/ReminderManager.cs
@@ -50,8 +50,7 @@ public class ReminderManager<T> : IReminderManager<T> where T : WorkItem
         {
             await client.DeleteWorkItemAsync(receipt.MessageId, receipt.PopReceipt);
         }
-        catch (RequestFailedException e) when (e.Message.Contains("The specified message does not exist")
-                                            || e.Message.Contains("did not match the pop receipt"))
+        catch (RequestFailedException e) when (e.ErrorCode == "MessageNotFound" || e.ErrorCode == "PopReceiptMismatch")
         {
             // The message was already deleted, so we can ignore this exception.
         }

--- a/src/ProductConstructionService/Readme.md
+++ b/src/ProductConstructionService/Readme.md
@@ -17,6 +17,7 @@
       ('https://github.com/maestro-auth-test/maestro-test', 289474),
       ('https://github.com/maestro-auth-test/maestro-test2', 289474),
       ('https://github.com/maestro-auth-test/maestro-test3', 289474),
+      ('https://github.com/maestro-auth-test/maestro-test-vmr', 289474),
       ('https://github.com/maestro-auth-test/arcade', 289474),
       ('https://github.com/maestro-auth-test/dnceng-vmr', 289474);
   ```

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTwoWayCodeflowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTwoWayCodeflowTest.cs
@@ -124,8 +124,8 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
           │ x─┘ 5.       7. x   │   
           │ │               │   │   
         6.O◄┘               └──►O 8.
-          │   9.                │   
-          │    ◄────────────────┤   
+          │                     │   
+          |────────────────────►O 9.
           │                     │   
      */
     [Test]
@@ -178,7 +178,9 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         // While the VMR accepted the content from the repo but it will get overriden by the VMR content again
         var hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branch: forwardBranchName);
         hadUpdates.ShouldHaveUpdates();
-        await GitOperations.MergePrBranch(VmrPath, forwardBranchName);
+        await GitOperations.VerifyMergeConflict(VmrPath, forwardBranchName,
+            mergeTheirs: true,
+            expectedConflictingFile: VmrInfo.SourcesDir / Constants.ProductRepoName / _productRepoFileName);
 
         // Both VMR and repo need to have the version from the VMR as it flowed to the repo and back
         CheckFileContents(_productRepoFilePath, "New content from the VMR #2");


### PR DESCRIPTION
Fixes problems introduced in #4181

- Fix how we look for git refs after we fetch from all remotes
- Fix getting the path to the `AllRepoVersions.props` file

https://github.com/dotnet/arcade-services/issues/3942