### PR TITLE
Propagate build info from BAR to VMR outputs

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
@@ -1,10 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.Logging;
@@ -16,15 +19,18 @@ internal class InitializeOperation : VmrOperationBase
 {
     private readonly InitializeCommandLineOptions _options;
     private readonly IVmrInitializer _vmrInitializer;
+    private readonly IBarApiClient _barClient;
 
     public InitializeOperation(
         InitializeCommandLineOptions options,
         IVmrInitializer vmrInitializer,
-        ILogger<InitializeOperation> logger)
+        ILogger<InitializeOperation> logger,
+        IBarApiClient barClient)
         : base(options, logger)
     {
         _options = options;
         _vmrInitializer = vmrInitializer;
+        _barClient = barClient;
     }
 
     protected override async Task ExecuteInternalAsync(
@@ -34,8 +40,8 @@ internal class InitializeOperation : VmrOperationBase
         CancellationToken cancellationToken)
         => await _vmrInitializer.InitializeRepository(
             repoName,
-            targetRevision,
-            null,
+            (await _barClient.GetBuildsAsync(repoName, targetRevision)).SingleOrDefault()
+                ?? throw new Exception($"Failed to, or found multiple builds for {repoName}/{targetRevision}"),
             _options.Recursive,
             new NativePath(_options.SourceMappings),
             additionalRemotes,

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -240,6 +240,7 @@ public class DependencyFileManager : IDependencyFileManager
 
             SetAttribute(versionDetails, sourceNode, VersionDetailsParser.UriElementName, sourceDependency.Uri);
             SetAttribute(versionDetails, sourceNode, VersionDetailsParser.ShaElementName, sourceDependency.Sha);
+            SetAttribute(versionDetails, sourceNode, VersionDetailsParser.BarIdElementName, sourceDependency.BarId.ToString());
         }
 
         foreach (DependencyDetail itemToUpdate in itemsToUpdate)

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/VersionDetailsParser.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/VersionDetailsParser.cs
@@ -28,6 +28,7 @@ public class VersionDetailsParser : IVersionDetailsParser
     public const string VersionPropsAlternateVersionElementSuffix = "Version";
     public const string ShaElementName = "Sha";
     public const string UriElementName = "Uri";
+    public const string BarIdElementName = "Bar";
     public const string DependencyElementName = "Dependency";
     public const string DependenciesElementName = "Dependencies";
     public const string NameAttributeName = "Name";
@@ -158,7 +159,12 @@ public class VersionDetailsParser : IVersionDetailsParser
         var sha = sourceNode.Attributes[ShaElementName]?.Value?.Trim()
             ?? throw new DarcException($"Malformed {SourceElementName} section - expected {ShaElementName} attribute");
 
-        return new SourceDependency(uri, sha);
+        var barId = int.Parse(
+            sourceNode.Attributes[BarIdElementName]?.Value?.Trim()
+                // TODO throw an exception here. We can't throw it in the beginning since we'll never be able to parse it
+                ?? "0");
+
+        return new SourceDependency(uri, sha, barId);
     }
 
     private static bool ParseBooleanAttribute(XmlAttributeCollection attributes, string attributeName)

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VersionDetails.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VersionDetails.cs
@@ -11,5 +11,5 @@ public record VersionDetails(
     IReadOnlyCollection<DependencyDetail> Dependencies,
     SourceDependency? Source);
 
-public record SourceDependency(string Uri, string Sha);
+public record SourceDependency(string Uri, string Sha, int BarId);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/AllVersionsPropsFile.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/AllVersionsPropsFile.cs
@@ -12,7 +12,7 @@ public interface IAllVersionsPropsFile : IMsBuildPropsFile
 {
     Dictionary<string, string> Versions { get; }
 
-    void UpdateVersion(string repository, string sha, string packageVersion);
+    void UpdateVersion(string repository, string sha);
 
     bool DeleteVersion(string repository);
 }
@@ -35,32 +35,26 @@ public class AllVersionsPropsFile : MsBuildPropsFile, IAllVersionsPropsFile
         Versions = versions;
     }
 
-    public AllVersionsPropsFile(IReadOnlyCollection<IVersionedSourceComponent> repositoryRecords)
+    public AllVersionsPropsFile(IReadOnlyCollection<ISourceComponent> repositoryRecords)
         : base(orderPropertiesAscending: true)
     {
         Versions = [];
         foreach (var repo in repositoryRecords)
         {
-            UpdateVersion(repo.Path, repo.CommitSha, repo.PackageVersion);
+            UpdateVersion(repo.Path, repo.CommitSha);
         }
     }
 
-    public void UpdateVersion(string repository, string sha, string? packageVersion)
+    public void UpdateVersion(string repository, string sha)
     {
         var key = SanitizePropertyName(repository);
         Versions[key + ShaPropertyName] = sha;
-
-        if (packageVersion != null)
-        {
-            Versions[key + PackageVersionPropertyName] = packageVersion;
-        }
     }
 
     public bool DeleteVersion(string repository)
     {
         var key = SanitizePropertyName(repository);
         var deleted = Versions.Remove(key + ShaPropertyName);
-        deleted |= Versions.Remove(key + PackageVersionPropertyName);
         return deleted;
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/GitInfoFile.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/GitInfoFile.cs
@@ -27,9 +27,6 @@ public class GitInfoFile : MsBuildPropsFile
 {
     public string GitCommitHash { get; set; }
     public string OfficialBuildId { get; set; }
-    public string OutputPackageVersion { get; set; }
-    public string PreReleaseVersionLabel { get; set; }
-    public bool IsStable { get; set; }
     public int? GitCommitCount { get; set; }
 
     public GitInfoFile()
@@ -42,10 +39,7 @@ public class GitInfoFile : MsBuildPropsFile
         var properties = new Dictionary<string, string>
         {
             [nameof(GitCommitHash)] = GitCommitHash,
-            [nameof(OfficialBuildId)] = OfficialBuildId,
-            [nameof(OutputPackageVersion)] = OutputPackageVersion,
-            [nameof(PreReleaseVersionLabel)] = PreReleaseVersionLabel,
-            [nameof(IsStable)] = IsStable ? "true" : "false",
+            [nameof(OfficialBuildId)] = OfficialBuildId
         };
 
         if (GitCommitCount.HasValue)
@@ -63,9 +57,6 @@ public class GitInfoFile : MsBuildPropsFile
         {
             GitCommitHash = properties[nameof(GitCommitHash)],
             OfficialBuildId = properties[nameof(OfficialBuildId)],
-            OutputPackageVersion = properties[nameof(OutputPackageVersion)],
-            PreReleaseVersionLabel = properties[nameof(PreReleaseVersionLabel)],
-            IsStable = properties[nameof(IsStable)] == "true",
             GitCommitCount = properties.TryGetValue(nameof(GitCommitCount), out var count) ? int.Parse(count) : null,
         };
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/ManifestRecord.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/ManifestRecord.cs
@@ -53,16 +53,11 @@ public interface ISourceComponent
     }
 }
 
-public interface IVersionedSourceComponent : ISourceComponent
-{
-    string? PackageVersion { get; }
-}
-
 /// <summary>
 /// Represents a record in the source-manifest.json file which VMR uses to keep track of
 /// synchronized sources
 /// </summary>
-public abstract class ManifestRecord : IComparable<ISourceComponent>, ISourceComponent
+public class ManifestRecord : IComparable<ISourceComponent>, ISourceComponent
 {
     public string Path { get; set; }
     public string RemoteUri { get; set; }
@@ -84,17 +79,6 @@ public abstract class ManifestRecord : IComparable<ISourceComponent>, ISourceCom
 
         return Path.CompareTo(other.Path);
     }
-}
-
-public class RepositoryRecord : ManifestRecord, IVersionedSourceComponent
-{
-    public RepositoryRecord(string path, string remoteUri, string commitSha, string? packageVersion)
-        : base(path, remoteUri, commitSha)
-    {
-        PackageVersion = packageVersion;
-    }
-
-    public string? PackageVersion { get; set; }
 }
 
 public class SubmoduleRecord : ManifestRecord

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/ManifestRecord.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/ManifestRecord.cs
@@ -80,11 +80,3 @@ public class ManifestRecord : IComparable<ISourceComponent>, ISourceComponent
         return Path.CompareTo(other.Path);
     }
 }
-
-public class SubmoduleRecord : ManifestRecord
-{
-    public SubmoduleRecord(string path, string remoteUri, string commitSha)
-        : base(path, remoteUri, commitSha)
-    {
-    }
-}

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
@@ -19,8 +19,8 @@ public interface ISourceManifest
 
     string ToJson();
     void RemoveRepository(string repository);
-    void RemoveSubmodule(SubmoduleRecord submodule);
-    void UpdateSubmodule(SubmoduleRecord submodule);
+    void RemoveSubmodule(ManifestRecord submodule);
+    void UpdateSubmodule(ManifestRecord submodule);
     void UpdateVersion(string repository, string uri, string sha);
     string? GetVersion(string repository);
     bool TryGetRepoVersion(string mappingName, [NotNullWhen(true)] out ISourceComponent? mapping);
@@ -35,13 +35,13 @@ public interface ISourceManifest
 public class SourceManifest : ISourceManifest
 {
     private SortedSet<ManifestRecord> _repositories;
-    private SortedSet<SubmoduleRecord> _submodules;
+    private SortedSet<ManifestRecord> _submodules;
 
     public IReadOnlyCollection<ISourceComponent> Repositories => _repositories;
 
     public IReadOnlyCollection<ISourceComponent> Submodules => _submodules;
 
-    public SourceManifest(IEnumerable<ManifestRecord> repositories, IEnumerable<SubmoduleRecord> submodules)
+    public SourceManifest(IEnumerable<ManifestRecord> repositories, IEnumerable<ManifestRecord> submodules)
     {
         _repositories = [.. repositories];
         _submodules = [.. submodules];
@@ -72,7 +72,7 @@ public class SourceManifest : ISourceManifest
         _submodules.RemoveWhere(s => s.Path.StartsWith(repository + "/"));
     }
 
-    public void RemoveSubmodule(SubmoduleRecord submodule)
+    public void RemoveSubmodule(ManifestRecord submodule)
     {
         var repo = _submodules.FirstOrDefault(r => r.Path == submodule.Path);
         if (repo != null)
@@ -81,7 +81,7 @@ public class SourceManifest : ISourceManifest
         }
     }
 
-    public void UpdateSubmodule(SubmoduleRecord submodule)
+    public void UpdateSubmodule(ManifestRecord submodule)
     {
         var repo = _submodules.FirstOrDefault(r => r.Path == submodule.Path);
         if (repo != null)
@@ -172,6 +172,6 @@ public class SourceManifest : ISourceManifest
     private class SourceManifestWrapper
     {
         public ICollection<ManifestRecord> Repositories { get; init; } = [];
-        public ICollection<SubmoduleRecord> Submodules { get; init; } = [];
+        public ICollection<ManifestRecord> Submodules { get; init; } = [];
     }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.Maestro.Client.Models;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
@@ -27,8 +28,7 @@ public interface IVmrInitializer
     /// <param name="discardPatches">Whether to clean up genreated .patch files after their used</param>
     Task InitializeRepository(
         string mappingName,
-        string? targetRevision,
-        string? targetVersion,
+        Build build,
         bool initializeDependencies,
         LocalPath sourceMappingsPath,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Maestro.Client.Models;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
@@ -14,9 +15,7 @@ public interface IVmrUpdater
     /// Updates repo in the VMR to given revision.
     /// </summary>
     /// <param name="mappingName">Name of a repository mapping</param>
-    /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
-    /// <param name="targetVersion">Version of packages, that the SHA we're updating to, produced</param>
-    /// <param name="noSquash">Whether to pull changes commit by commit instead of squashing all updates into one</param>
+    /// <param name="build">Build from which the code is being flown</param>
     /// <param name="updateDependencies">When true, updates dependencies (from Version.Details.xml) recursively</param>
     /// <param name="additionalRemotes">Additional git remotes to use when fetching</param>
     /// <param name="componentTemplatePath">Path to VMR's Component.md template</param>
@@ -27,8 +26,7 @@ public interface IVmrUpdater
     /// <returns>True if the repository was updated, false if it was already up to date</returns>
     Task<bool> UpdateRepository(
         string mappingName,
-        string? targetRevision,
-        string? targetVersion,
+        Build build,
         bool updateDependencies,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         string? componentTemplatePath,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
@@ -93,24 +93,25 @@ public class VmrDependencyTracker : IVmrDependencyTracker
 
     public void UpdateDependencyVersion(VmrDependencyUpdate update)
     {
-        _repoVersions.UpdateVersion(update.Mapping.Name, update.TargetRevision, update.TargetVersion);
+        // TODO remove the versions
+        _repoVersions.UpdateVersion(update.Mapping.Name, update.Commit, string.Empty);
         _repoVersions.SerializeToXml(_allVersionsFilePath);
 
-        _sourceManifest.UpdateVersion(update.Mapping.Name, update.RemoteUri, update.TargetRevision, update.TargetVersion);
+        // TODO remove the versions
+        _sourceManifest.UpdateVersion(update.Mapping.Name, update.Repository, update.Commit, string.Empty);
         _fileSystem.WriteToFile(_vmrInfo.SourceManifestPath, _sourceManifest.ToJson());
 
         // Root repository of an update does not have a package version associated with it
         // For installer, we leave whatever was there (e.g. 8.0.100)
         // For one-off non-recursive updates of repositories, we keep the previous
-        string packageVersion = update.TargetVersion
-            ?? _sourceManifest.GetVersion(update.Mapping.Name)?.PackageVersion
-            ?? "0.0.0";
+        // TODO remove the versions
+        string packageVersion = "0.0.0";
 
         var (buildId, releaseLabel) = VersionFiles.DeriveBuildInfo(update.Mapping.Name, packageVersion);
         
         var gitInfo = new GitInfoFile
         {
-            GitCommitHash = update.TargetRevision,
+            GitCommitHash = update.Commit,
             OfficialBuildId = buildId,
             PreReleaseVersionLabel = releaseLabel,
             IsStable = string.IsNullOrWhiteSpace(releaseLabel),

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyTracker.cs
@@ -30,7 +30,7 @@ public interface IVmrDependencyTracker
 
     void UpdateDependencyVersion(VmrDependencyUpdate update);
 
-    void UpdateSubmodules(List<SubmoduleRecord> submodules);
+    void UpdateSubmodules(List<ManifestRecord> submodules);
 
     bool RemoveRepositoryVersion(string repo);
 
@@ -128,7 +128,7 @@ public class VmrDependencyTracker : IVmrDependencyTracker
         return hasChanges;
     }
 
-    public void UpdateSubmodules(List<SubmoduleRecord> submodules)
+    public void UpdateSubmodules(List<ManifestRecord> submodules)
     {
         foreach (var submodule in submodules)
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyUpdate.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrDependencyUpdate.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
+using Microsoft.DotNet.Maestro.Client.Models;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
@@ -16,7 +17,9 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 /// <param name="Parent">Parent dependency in the dependency tree that caused this update,null for root (installer)</param>
 public record VmrDependencyUpdate(
     SourceMapping Mapping,
-    string RemoteUri,
-    string TargetRevision,
-    string? TargetVersion,
-    SourceMapping? Parent);
+    Build build,
+    SourceMapping? Parent)
+{
+    public string Repository => build.GetRepository();
+    public string Commit => build.Commit;
+}

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -93,7 +93,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
 
         var mapping = _dependencyTracker.GetMapping(mappingName);
 
-        if (_dependencyTracker.GetDependencyVersion(mapping) is not null)
+        if (_dependencyTracker.GetDependencyCommit(mapping) is not null)
         {
             throw new EmptySyncException($"Repository {mapping.Name} already exists");
         }
@@ -118,7 +118,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
                 var sourcesPath = _vmrInfo.GetRepoSourcesPath(update.Mapping);
                 if (_fileSystem.DirectoryExists(sourcesPath) && _fileSystem.GetFiles(sourcesPath).Length > 1)
                 {
-                    if (_dependencyTracker.GetDependencyVersion(update.Mapping) == null)
+                    if (_dependencyTracker.GetDependencyCommit(update.Mapping) == null)
                     {
                         throw new InvalidOperationException(
                             $"Sources for {update.Mapping.Name} already exists but repository is not initialized properly. " +
@@ -149,7 +149,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
             throw;
         }
 
-        string newSha = _dependencyTracker.GetDependencyVersion(mapping)?.Sha
+        string newSha = _dependencyTracker.GetDependencyCommit(mapping)
             ?? throw new Exception($"Repository {mapping.Name} was supposed to be but has not been initialized! " +
                                     "Please make sure the sources folder is empty!");
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -225,6 +225,8 @@ public abstract class VmrManagerBase
         reposToScan.Enqueue(transitiveDependencies.Values.Single());
 
         _logger.LogInformation("Finding transitive dependencies for {mapping}:{revision}..", root.Mapping.Name, root.Commit);
+        // IBasicBarClient only gets registered in darc. This works because the recursive updates are only called from darc
+        var barClient = _serviceProvider.GetRequiredService<IBasicBarClient>();
 
         while (reposToScan.TryDequeue(out var repo))
         {
@@ -275,8 +277,6 @@ public abstract class VmrManagerBase
                         $"for a {VersionFiles.VersionDetailsXml} dependency of {dependency.Name}");
                 }
 
-                // IBarApiClient only gets registered in darc. This works because the recursive updates are only called from darc
-                var barClient = _serviceProvider.GetRequiredService<IBarApiClient>();
                 var build = (await barClient.GetBuildsAsync(dependency.RepoUri, dependency.Commit)).SingleOrDefault()
                     ?? throw new Exception($"Failed to, or found multiple builds for repo {dependency.RepoUri}/{dependency.Commit}");
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -111,7 +111,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         List<SubmoduleChange> submoduleChanges = await GetSubmoduleChanges(clone, sha1, sha2);
 
         var changedRecords = submoduleChanges
-            .Select(c => new SubmoduleRecord(relativePath / c.Path, c.Url, c.After))
+            .Select(c => new ManifestRecord(relativePath / c.Path, c.Url, c.After))
             .ToList();
 
         _dependencyTracker.UpdateSubmodules(changedRecords);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRepoVersionResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRepoVersionResolver.cs
@@ -32,7 +32,7 @@ internal class VmrRepoVersionResolver : IVmrRepoVersionResolver
 
         SourceMapping mapping = _dependencyTracker.GetMapping(mappingName);
 
-        return _dependencyTracker.GetDependencyVersion(mapping)?.Sha
+        return _dependencyTracker.GetDependencyCommit(mapping)
             ?? throw new Exception($"Mapping {mappingName} has not been initialized yet");
     }
 }

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/LoadSourceMappingsFromInstallerTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/LoadSourceMappingsFromInstallerTest.cs
@@ -116,6 +116,7 @@ internal class LoadSourceMappingsFromInstallerTest : VmrTestsBase
 
         await GitOperations.CommitAll(InstallerRepoPath, "Added new dependency");
 
+        await CreateNewBuild(ProductRepoPath, []);
         // We will sync new installer, which should bring in the new product repo
         await UpdateRepoToLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
 

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrMultipleRemotesTests.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrMultipleRemotesTests.cs
@@ -41,6 +41,8 @@ internal class VmrMultipleRemotesTests : VmrTestsBase
         await File.WriteAllTextAsync(versionDetailsPath, versionDetailsContent);
         await GitOperations.CommitAll(InstallerRepoPath, "Point VersionDetails.xml to first location");
 
+        await CreateNewBuild(FirstDependencyPath, []);
+        await CreateNewBuild(SecondDependencyPath, []);
         await InitializeRepoAtLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
 
         var expectedFilesFromRepos = new List<NativePath>
@@ -76,6 +78,8 @@ internal class VmrMultipleRemotesTests : VmrTestsBase
         versionDetailsContent = versionDetailsContent.Replace(oldSha, newSha);
         await File.WriteAllTextAsync(versionDetailsPath, versionDetailsContent);
         await GitOperations.CommitAll(InstallerRepoPath, "Point VersionDetails.xml to second location");
+        await CreateNewBuild(FirstDependencyPath, []);
+        await CreateNewBuild(SecondDependencyPath, []);
         await UpdateRepoToLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
 
         CheckFileContents(dependencyFilePath, "New content only in the second folder now");

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrMultipleRemotesTests.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrMultipleRemotesTests.cs
@@ -119,7 +119,7 @@ internal class VmrMultipleRemotesTests : VmrTestsBase
             new AdditionalRemote(Constants.DependencyRepoName,  SecondDependencyPath)
         };
 
-        await CallDarcUpdate(Constants.DependencyRepoName, newSha, additionalRemotes);
+        await CallDarcUpdate(Constants.DependencyRepoName, await CreateNewBuild(SecondDependencyPath, []), additionalRemotes);
 
         CheckFileContents(dependencyFilePath, "New content only in the second folder now");
     }

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchAddingSubmoduleFileTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchAddingSubmoduleFileTest.cs
@@ -97,7 +97,7 @@ internal class VmrPatchAddingSubmoduleFileTest : VmrPatchesTestsBase
         // Move submodule to a new commit and verify it breaks the patch
 
         await GitOperations.UpdateSubmodule(ProductRepoPath, submoduleRelativePath);
-        var commit = await GitOperations.GetRepoLastCommit(ProductRepoPath);
-        await this.Awaiting(_ => CallDarcUpdate(Constants.ProductRepoName, commit)).Should().ThrowAsync<Exception>();
+        var build = await CreateNewBuild(ProductRepoPath, []);
+        await this.Awaiting(_ => CallDarcUpdate(Constants.ProductRepoName, build)).Should().ThrowAsync<Exception>();
     }
 }

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchChangingFileTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrPatchChangingFileTest.cs
@@ -82,7 +82,7 @@ internal class VmrPatchChangingFileTest : VmrPatchesTestsBase
 
         await File.WriteAllTextAsync(ProductRepoPath / productRepoFileName, "New content");
         await GitOperations.CommitAll(ProductRepoPath, "Change file in product repo");
-        var commit = await GitOperations.GetRepoLastCommit(ProductRepoPath);
-        await this.Awaiting(_ => CallDarcUpdate(Constants.ProductRepoName, commit)).Should().ThrowAsync<Exception>();
+        var build = await CreateNewBuild(ProductRepoPath, []);
+        await this.Awaiting(_ => CallDarcUpdate(Constants.ProductRepoName, build)).Should().ThrowAsync<Exception>();
     }
 }

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrRecursiveSyncTests.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrRecursiveSyncTests.cs
@@ -27,15 +27,20 @@ internal class VmrRecursiveSyncTests : VmrTestsBase
         /* 
          *  The dependency tree looks like:
          *
-         *  └── installer           1.0.0 *
+         *  └── installer
          *      ├── product-repo1   1.0.0 *
          *      │   └── dependency  1.0.0 *
-         *      └── product-repo2   1.0.0 *
-         *          └── dependency  1.0.0
+         *      ├── product-repo2   1.0.0 *
+         *      │   └── dependency  1.0.0 
+         *      └── sync-disabled-repo  1.0.0 *
          *
          *  (* marks which version will be in the VMR)
          */
 
+        await CreateNewBuild(ProductRepoPath, []);
+        await CreateNewBuild(DependencyRepoPath, []);
+        await CreateNewBuild(SecondRepoPath, []);
+        await CreateNewBuild(SyncDisabledRepoPath, []);
         await InitializeRepoAtLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
 
         var expectedFilesFromRepos = new List<NativePath>
@@ -117,14 +122,19 @@ internal class VmrRecursiveSyncTests : VmrTestsBase
 
         /* 
          *  The dependency tree should look like this:
-         *
-         *    └── installer           1.0.1 *
-         *        ├── product-repo1   1.0.0 *
-         *        │   └── dependency  1.0.0 *
-         *        └── product-repo2   1.0.1 *
-         *            └── dependency  1.0.1     < This bump is ignored because product-repo1 depends on 1.0.0
-        */
+         *  
+         *    └── installer             1.0.1 *    
+         *          ├── product-repo1   1.0.0 *
+         *          │   └── dependency  1.0.0 *
+         *          ├── product-repo2   1.0.1 * 
+         *          │   └── dependency  1.0.1   < This bump is ignored because product-repo1 depends on 1.0.0
+         *          └── sync-disabled-repo  1.0.0 * < This repo didn't get bumped because syncronization for it is disabled
+         */
 
+        await CreateNewBuild(ProductRepoPath, []);
+        await CreateNewBuild(DependencyRepoPath, []);
+        await CreateNewBuild(SecondRepoPath, []);
+        await CreateNewBuild(SyncDisabledRepoPath, []);
         await UpdateRepoToLastCommit(Constants.InstallerRepoName, InstallerRepoPath);
 
         CheckFileContents(installerFilePath, "New version of installer file");

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
@@ -58,41 +58,6 @@ internal class VmrSyncRepoChangesTest : VmrTestsBase
     }
 
     [Test]
-    public async Task PackageVersionIsUpdatedOnlyTest()
-    {
-        await EnsureTestRepoIsInitialized();
-
-        // Update version of dependent repo to 8.0.1
-        var versionDetails = await File.ReadAllTextAsync(ProductRepoPath / VersionFiles.VersionDetailsXml);
-        versionDetails = versionDetails.Replace("8.0.0", "8.0.1");
-        await File.WriteAllTextAsync(ProductRepoPath / VersionFiles.VersionDetailsXml, versionDetails);
-        await GitOperations.CommitAll(ProductRepoPath, "Changing SHA");
-
-        await UpdateRepoToLastCommit(Constants.ProductRepoName, ProductRepoPath);
-
-        var expectedFilesFromRepos = new List<NativePath>
-        {
-            _productRepoFilePath,
-            _dependencyRepoFilePath
-        };
-
-        var expectedFiles = GetExpectedFilesInVmr(
-            VmrPath,
-            [Constants.ProductRepoName, Constants.DependencyRepoName],
-            expectedFilesFromRepos
-        );
-
-        CheckDirectoryContents(VmrPath, expectedFiles);
-        CheckFileContents(_productRepoPath / VersionFiles.VersionDetailsXml, versionDetails, removeEmptyLines: false);
-        await GitOperations.CheckAllIsCommitted(VmrPath);
-        var sourceManifest = SourceManifest.FromJson(VmrPath / VmrInfo.DefaultRelativeSourceManifestPath);
-
-        sourceManifest.GetVersion(Constants.DependencyRepoName)!.PackageVersion.Should().Be("8.0.1");
-        (await File.ReadAllTextAsync(VmrPath / VmrInfo.GitInfoSourcesDir / Constants.DependencyRepoName + ".props")).Should().Contain("8.0.1");
-        (await File.ReadAllTextAsync(VmrPath / VmrInfo.GitInfoSourcesDir / AllVersionsPropsFile.FileName)).Should().Contain("8.0.1");
-    }
-
-    [Test]
     public async Task FileIsIncludedTest()
     {
         var excludedDir = ProductRepoPath / "excluded";

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrSyncRepoChangesTest.cs
@@ -352,6 +352,8 @@ internal class VmrSyncRepoChangesTest : VmrTestsBase
 
     private async Task EnsureTestRepoIsInitialized()
     {
+        await CreateNewBuild(ProductRepoPath, []);
+        await CreateNewBuild(DependencyRepoPath, []);
         await InitializeRepoAtLastCommit(Constants.ProductRepoName, ProductRepoPath);
 
         var expectedFilesFromRepos = new List<NativePath>

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -163,34 +163,34 @@ internal abstract class VmrTestsBase
 
     protected async Task InitializeRepoAtLastCommit(string repoName, NativePath repoPath, LocalPath? sourceMappingsPath = null)
     {
-        var commit = await GitOperations.GetRepoLastCommit(repoPath);
+        var build = await CreateNewBuild(repoPath, []);
         var sourceMappings = sourceMappingsPath ?? VmrPath / VmrInfo.DefaultRelativeSourceMappingsPath;
-        await CallDarcInitialize(repoName, commit, sourceMappings);
+        await CallDarcInitialize(repoName, build, sourceMappings);
     }
 
     protected async Task UpdateRepoToLastCommit(string repoName, NativePath repoPath, bool generateCodeowners = false, bool generateCredScanSuppressions = false)
     {
-        var commit = await GitOperations.GetRepoLastCommit(repoPath);
-        await CallDarcUpdate(repoName, commit, generateCodeowners, generateCredScanSuppressions);
+        var build = await CreateNewBuild(repoPath, []);
+        await CallDarcUpdate(repoName, build, generateCodeowners, generateCredScanSuppressions);
     }
 
-    private async Task CallDarcInitialize(string repository, string commit, LocalPath sourceMappingsPath)
+    private async Task CallDarcInitialize(string repository, Build build, LocalPath sourceMappingsPath)
     {
         using var scope = ServiceProvider.CreateScope();
         var vmrInitializer = scope.ServiceProvider.GetRequiredService<IVmrInitializer>();
-        await vmrInitializer.InitializeRepository(repository, commit, null, true, sourceMappingsPath, Array.Empty<AdditionalRemote>(), null, null, false, false, true, _cancellationToken.Token);
+        await vmrInitializer.InitializeRepository(repository, build, true, sourceMappingsPath, Array.Empty<AdditionalRemote>(), null, null, false, false, true, _cancellationToken.Token);
     }
 
-    protected async Task CallDarcUpdate(string repository, string commit, bool generateCodeowners = false, bool generateCredScanSuppressions = false)
+    protected async Task CallDarcUpdate(string repository, Build build, bool generateCodeowners = false, bool generateCredScanSuppressions = false)
     {
-        await CallDarcUpdate(repository, commit, [], generateCodeowners, generateCredScanSuppressions);
+        await CallDarcUpdate(repository, build, [], generateCodeowners, generateCredScanSuppressions);
     }
 
-    protected async Task CallDarcUpdate(string repository, string commit, AdditionalRemote[] additionalRemotes, bool generateCodeowners = false, bool generateCredScanSuppressions = false)
+    protected async Task CallDarcUpdate(string repository, Build build, AdditionalRemote[] additionalRemotes, bool generateCodeowners = false, bool generateCredScanSuppressions = false)
     {
         using var scope = ServiceProvider.CreateScope();
         var vmrUpdater = scope.ServiceProvider.GetRequiredService<IVmrUpdater>();
-        await vmrUpdater.UpdateRepository(repository, commit, null, true, additionalRemotes, null, null, generateCodeowners, generateCredScanSuppressions, true, _cancellationToken.Token);
+        await vmrUpdater.UpdateRepository(repository, build, true, additionalRemotes, null, null, generateCodeowners, generateCredScanSuppressions, true, _cancellationToken.Token);
     }
 
     protected async Task<bool> CallDarcBackflow(

--- a/test/Microsoft.DotNet.DarcLib.Tests/Models/VirtualMonoRepo/GitInfoFileTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Models/VirtualMonoRepo/GitInfoFileTests.cs
@@ -44,10 +44,7 @@ public class GitInfoFileTests
         {
             GitCommitHash = "4ee620cc1b57da45d93135e064d43a83e65bbb6e",
             OfficialBuildId = "20220803.1",
-            OutputPackageVersion = "7.0.0-beta.22403.1",
-            PreReleaseVersionLabel = "beta",
-            GitCommitCount = 1432,
-            IsStable = true,
+            GitCommitCount = 1432
         };
 
         // Act
@@ -62,9 +59,6 @@ public class GitInfoFileTests
               <PropertyGroup>
                 <GitCommitHash>4ee620cc1b57da45d93135e064d43a83e65bbb6e</GitCommitHash>
                 <OfficialBuildId>20220803.1</OfficialBuildId>
-                <OutputPackageVersion>7.0.0-beta.22403.1</OutputPackageVersion>
-                <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
-                <IsStable>true</IsStable>
                 <GitCommitCount>1432</GitCommitCount>
               </PropertyGroup>
             </Project>
@@ -74,9 +68,6 @@ public class GitInfoFileTests
         
         gitInfoFile.GitCommitHash.Should().Be("4ee620cc1b57da45d93135e064d43a83e65bbb6e");
         gitInfoFile.OfficialBuildId.Should().Be("20220803.1");
-        gitInfoFile.OutputPackageVersion.Should().Be("7.0.0-beta.22403.1");
-        gitInfoFile.PreReleaseVersionLabel.Should().Be("beta");
         gitInfoFile.GitCommitCount.Should().Be(1432);
-        gitInfoFile.IsStable.Should().BeTrue();
     }
 }

--- a/test/Microsoft.DotNet.DarcLib.Tests/Models/VirtualMonoRepo/ManifestRecordTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Models/VirtualMonoRepo/ManifestRecordTests.cs
@@ -14,19 +14,17 @@ public class ManifestRecordTests
     [Test]
     public void GitHubCommitUrlIsConstructedTest()
     {
-        ISourceComponent record = new RepositoryRecord(
+        ISourceComponent record = new ManifestRecord(
             path: "arcade",
             remoteUri: "https://github.com/dotnet/arcade",
-            commitSha: "4ee620cc1b57da45d93135e064d43a83e65bbb6e",
-            packageVersion: "5.0.0");
+            commitSha: "4ee620cc1b57da45d93135e064d43a83e65bbb6e");
 
         record.GetPublicUrl().Should().Be("https://github.com/dotnet/arcade/tree/4ee620cc1b57da45d93135e064d43a83e65bbb6e");
 
-        record = new RepositoryRecord(
+        record = new ManifestRecord(
             path: "arcade",
             remoteUri: "https://github.com/dotnet/some.git.repo.git",
-            commitSha: "4ee620cc1b57da45d93135e064d43a83e65bbb6e",
-            packageVersion: "5.0.0");
+            commitSha: "4ee620cc1b57da45d93135e064d43a83e65bbb6e");
 
         record.GetPublicUrl().Should().Be("https://github.com/dotnet/some.git.repo/tree/4ee620cc1b57da45d93135e064d43a83e65bbb6e");
     }
@@ -34,11 +32,10 @@ public class ManifestRecordTests
     [Test]
     public void AzDOCommitUrlIsConstructedTest()
     {
-        ISourceComponent record = new RepositoryRecord(
+        ISourceComponent record = new ManifestRecord(
             path: "command-line-api",
             remoteUri: "https://dev.azure.com/dnceng/internal/_git/dotnet-command-line-api",
-            commitSha: "4ee620cc1b57da45d93135e064d43a83e65bbb6e",
-            packageVersion: "5.0.0");
+            commitSha: "4ee620cc1b57da45d93135e064d43a83e65bbb6e");
 
         record.GetPublicUrl().Should().Be("https://dev.azure.com/dnceng/internal/_git/dotnet-command-line-api/?version=GC4ee620cc1b57da45d93135e064d43a83e65bbb6e");
     }

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -194,7 +194,7 @@ public class VmrPatchHandlerTests
                 It.IsAny<CancellationToken>()),
                 Times.Once);
         
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<SubmoduleRecord>>(l => l.Count == 0)), Times.Once);
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<ManifestRecord>>(l => l.Count == 0)), Times.Once);
 
         patches.Should().ContainSingle();
         patches.Single().Should().Be(new VmrIngestionPatch(expectedPatchName, RepoVmrPath));
@@ -302,7 +302,7 @@ public class VmrPatchHandlerTests
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<SubmoduleRecord>>(l => l.Count == 0)), Times.Once);
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<ManifestRecord>>(l => l.Count == 0)), Times.Once);
 
         patches.Should().Equal(
             new VmrIngestionPatch(expectedPatchName1, RepoVmrPath),
@@ -353,11 +353,11 @@ public class VmrPatchHandlerTests
         patches.Should().ContainSingle();
         patches.Single().Should().Be(new VmrIngestionPatch(expectedPatchName, RepoVmrPath));
 
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(1));
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<ManifestRecord>>()), Times.Exactly(1));
 
         _dependencyTracker.Verify(
             x => x.UpdateSubmodules(
-                It.Is<List<SubmoduleRecord>>(
+                It.Is<List<ManifestRecord>>(
                     l => l[0].CommitSha == _submoduleInfo.Commit 
                         && l[0].RemoteUri == _submoduleInfo.Url
                         && l[0].Path == IndividualRepoName + '/' + _submoduleInfo.Path)), Times.Once);
@@ -421,18 +421,18 @@ public class VmrPatchHandlerTests
         _cloneManager
             .Verify(x => x.PrepareCloneAsync(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(2));
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<ManifestRecord>>()), Times.Exactly(2));
 
         _dependencyTracker.Verify(
             x => x.UpdateSubmodules(
-                It.Is<List<SubmoduleRecord>>(
+                It.Is<List<ManifestRecord>>(
                     l => l.Count == 1
                         && l[0].CommitSha == _submoduleInfo.Commit
                         && l[0].RemoteUri == _submoduleInfo.Url
                         && l[0].Path == IndividualRepoName + '/' + _submoduleInfo.Path)),
             Times.Once);
 
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<SubmoduleRecord>>(l => l.Count == 0)), Times.Once);
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<ManifestRecord>>(l => l.Count == 0)), Times.Once);
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
@@ -531,11 +531,11 @@ public class VmrPatchHandlerTests
         _cloneManager
             .Verify(x => x.PrepareCloneAsync(nestedSubmoduleInfo.Url, nestedSubmoduleSha1, It.IsAny<CancellationToken>()), Times.Once);
 
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(3));
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<ManifestRecord>>()), Times.Exactly(3));
 
         _dependencyTracker.Verify(
             x => x.UpdateSubmodules(
-                It.Is<List<SubmoduleRecord>>(
+                It.Is<List<ManifestRecord>>(
                     l => l.Count == 1
                         && l[0].CommitSha == nestedSubmoduleInfo.Commit
                         && l[0].RemoteUri == nestedSubmoduleInfo.Url
@@ -544,14 +544,14 @@ public class VmrPatchHandlerTests
 
         _dependencyTracker.Verify(
             x => x.UpdateSubmodules(
-                It.Is<List<SubmoduleRecord>>(
+                It.Is<List<ManifestRecord>>(
                     l => l.Count == 1
                         && l[0].CommitSha == _submoduleInfo.Commit
                         && l[0].RemoteUri == _submoduleInfo.Url
                         && l[0].Path == IndividualRepoName + '/' + _submoduleInfo.Path)),
             Times.Once);
 
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<SubmoduleRecord>>(l => l.Count == 0)), Times.Once);
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<ManifestRecord>>(l => l.Count == 0)), Times.Once);
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
@@ -619,18 +619,18 @@ public class VmrPatchHandlerTests
         _cloneManager
             .Verify(x => x.PrepareCloneAsync(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(2));
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<ManifestRecord>>()), Times.Exactly(2));
 
         _dependencyTracker.Verify(
             x => x.UpdateSubmodules(
-                It.Is<List<SubmoduleRecord>>(
+                It.Is<List<ManifestRecord>>(
                     l => l.Count == 1
                         && l[0].CommitSha == Constants.EmptyGitObject
                         && l[0].RemoteUri == _submoduleInfo.Url
                         && l[0].Path == IndividualRepoName + '/' + _submoduleInfo.Path)),
             Times.Once);
 
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<SubmoduleRecord>>(l => l.Count == 0)), Times.Once);
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<ManifestRecord>>(l => l.Count == 0)), Times.Once);
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
@@ -696,18 +696,18 @@ public class VmrPatchHandlerTests
         _cloneManager
             .Verify(x => x.PrepareCloneAsync(_submoduleInfo.Url, SubmoduleSha1, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(2));
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<ManifestRecord>>()), Times.Exactly(2));
 
         _dependencyTracker.Verify(
             x => x.UpdateSubmodules(
-                It.Is<List<SubmoduleRecord>>(
+                It.Is<List<ManifestRecord>>(
                     l => l.Count == 1
                         && l[0].CommitSha == SubmoduleSha2
                         && l[0].RemoteUri == _submoduleInfo.Url
                         && l[0].Path == IndividualRepoName + '/' + _submoduleInfo.Path)),
             Times.Once);
 
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<SubmoduleRecord>>(l => l.Count == 0)), Times.Once);
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<ManifestRecord>>(l => l.Count == 0)), Times.Once);
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
@@ -792,11 +792,11 @@ public class VmrPatchHandlerTests
         _cloneManager
             .Verify(x => x.PrepareCloneAsync("https://github.com/dotnet/external-2", SubmoduleSha2, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
 
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<SubmoduleRecord>>()), Times.Exactly(3));
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.IsAny<List<ManifestRecord>>()), Times.Exactly(3));
 
         _dependencyTracker.Verify(
             x => x.UpdateSubmodules(
-                It.Is<List<SubmoduleRecord>>(
+                It.Is<List<ManifestRecord>>(
                     l => l.Count == 2 
                     && l.Any(
                         r => r.CommitSha == Constants.EmptyGitObject 
@@ -808,7 +808,7 @@ public class VmrPatchHandlerTests
                         && r.Path == IndividualRepoName + '/' + _submoduleInfo.Path))),
             Times.Once);
 
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<SubmoduleRecord>>(l => l.Count == 0)), Times.Exactly(2));
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<ManifestRecord>>(l => l.Count == 0)), Times.Exactly(2));
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {
@@ -937,7 +937,7 @@ public class VmrPatchHandlerTests
                 It.IsAny<CancellationToken>()),
                 Times.Once);
 
-        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<SubmoduleRecord>>(l => l.Count == 0)), Times.Once);
+        _dependencyTracker.Verify(x => x.UpdateSubmodules(It.Is<List<ManifestRecord>>(l => l.Count == 0)), Times.Once);
 
         patches.Should().BeEquivalentTo(new List<VmrIngestionPatch>
         {

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPusherTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPusherTests.cs
@@ -32,10 +32,10 @@ public class VmrPusherTests
     [SetUp]
     public void SetUp()
     {
-        var repo = new RepositoryRecord("some-repo", "https://github.com/org/some-repo", Sha, "8.0");
+        var repo = new ManifestRecord("some-repo", "https://github.com/org/some-repo", Sha);
 
         _sourceManifest.Reset();
-        _sourceManifest.SetupGet(s => s.Repositories).Returns(new List<RepositoryRecord>() { repo });
+        _sourceManifest.SetupGet(s => s.Repositories).Returns(new List<ManifestRecord>() { repo });
     }
 
     [Test]

--- a/test/ProductConstructionService.ScenarioTests/CodeFlowScenarioTestBase.cs
+++ b/test/ProductConstructionService.ScenarioTests/CodeFlowScenarioTestBase.cs
@@ -47,7 +47,8 @@ internal class CodeFlowScenarioTestBase : ScenarioTestBase
         string targetBranch,
         string[] testFiles,
         Dictionary<string, string> testFilePatches,
-        string commitSha)
+        string commitSha,
+        int buildId)
     {
         var expectedPRTitle = GetCodeFlowPRName(targetBranch, sourceRepoName);
 
@@ -56,7 +57,7 @@ internal class CodeFlowScenarioTestBase : ScenarioTestBase
 
         var versionDetailsFile = files.FirstOrDefault(file => file.FileName == "eng/Version.Details.xml");
         versionDetailsFile.Should().NotBeNull();
-        versionDetailsFile!.Patch.Should().Contain(GetExpectedCodeFlowDependencyVersionEntry(sourceRepoName, commitSha));
+        versionDetailsFile!.Patch.Should().Contain(GetExpectedCodeFlowDependencyVersionEntry(sourceRepoName, commitSha, buildId));
 
         // Verify new files are in the PR
         foreach (var testFile in testFiles)

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
@@ -247,8 +247,8 @@ internal abstract partial class ScenarioTestBase
     }
 
     protected static string GetCodeFlowPRName(string targetBranch, string sourceRepoName) => $"[{targetBranch}] Source code changes from {TestParameters.GitHubTestOrg}/{sourceRepoName}";
-    protected static string GetExpectedCodeFlowDependencyVersionEntry(string repo, string sha) =>
-        $"Source Uri=\"{GetGitHubRepoUrl(repo)}\" Sha=\"{sha}\" />";
+    protected static string GetExpectedCodeFlowDependencyVersionEntry(string repo, string sha, int buildId) =>
+        $"Source Uri=\"{GetGitHubRepoUrl(repo)}\" Sha=\"{sha}\" Bar=\"{buildId}\" />";
 
     protected async Task CheckGitHubPullRequest(string expectedPRTitle, string targetRepoName, string targetBranch,
         List<DependencyDetail> expectedDependencies, string repoDirectory, bool isCompleted, bool isUpdated)

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlow.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlow.cs
@@ -151,7 +151,7 @@ internal class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
                         await TriggerSubscriptionAsync(subscriptionId.Value);
 
                         TestContext.WriteLine("Verifying subscription PR");
-                        await CheckBackwardFlowGitHubPullRequest(TestRepository.VmrTestRepoName, TestRepository.TestRepo1Name, targetBranchName, [TestFileName], TestFilePatches, repoSha);
+                        await CheckBackwardFlowGitHubPullRequest(TestRepository.VmrTestRepoName, TestRepository.TestRepo1Name, targetBranchName, [TestFileName], TestFilePatches, repoSha, build.Id);
                     }
                 }
             }


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4166
https://github.com/dotnet/arcade-services/issues/4165

This PR makes it so the VMR flows BAR builds. Flowing commits from local repositories won't work anymore.
This is done primarily by changing the `VmrDependencyUpdate` to get most of its information from the build.
The PR also removes package versions, PreReleaseVersionLabel, and `IsStable` properties from the git-info