### PR TITLE
Make darc verify codeflow subscriptions not sourcing/targeting VMRs correctly

### DIFF
--- a/src/Maestro/DependencyUpdater/Program.cs
+++ b/src/Maestro/DependencyUpdater/Program.cs
@@ -60,7 +60,7 @@ public static class Program
 
         services.AddTransient<IProcessManager>(sp => ActivatorUtilities.CreateInstance<ProcessManager>(sp, "git"));
         services.AddTransient<IVersionDetailsParser, VersionDetailsParser>();
-        services.AddScoped<IRemoteFactory, DarcRemoteFactory>();
+        services.AddScoped<IRemoteFactory, RemoteFactory>();
         services.AddTransient<IBasicBarClient, SqlBarClient>();
         services.AddKustoClientProvider("Kusto");
         // TODO (https://github.com/dotnet/arcade-services/issues/3880) - Remove subscriptionIdGenerator

--- a/src/Maestro/Maestro.DataProviders/RemoteFactory.cs
+++ b/src/Maestro/Maestro.DataProviders/RemoteFactory.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Maestro.DataProviders;
 
-public class DarcRemoteFactory : IRemoteFactory
+public class RemoteFactory : IRemoteFactory
 {
     private readonly IVersionDetailsParser _versionDetailsParser;
     private readonly OperationManager _operations;
@@ -24,7 +24,7 @@ public class DarcRemoteFactory : IRemoteFactory
     private readonly IGitHubTokenProvider _gitHubTokenProvider;
     private readonly IAzureDevOpsTokenProvider _azdoTokenProvider;
 
-    public DarcRemoteFactory(
+    public RemoteFactory(
         BuildAssetRegistryContext context,
         IGitHubTokenProvider gitHubTokenProvider,
         IAzureDevOpsTokenProvider azdoTokenProvider,
@@ -84,10 +84,13 @@ public class DarcRemoteFactory : IRemoteFactory
                 : new GitHubClient(
                     new Microsoft.DotNet.DarcLib.GitHubTokenProvider(_gitHubTokenProvider),
                     _processManager,
-                    _loggerFactory.CreateLogger<IRemote>(),
+                    _loggerFactory.CreateLogger<GitHubClient>(),
                     _cache.Cache),
 
-            GitRepoType.AzureDevOps => new AzureDevOpsClient(_azdoTokenProvider, _processManager, _loggerFactory.CreateLogger<IRemote>()),
+            GitRepoType.AzureDevOps => new AzureDevOpsClient(
+                _azdoTokenProvider,
+                _processManager,
+                _loggerFactory.CreateLogger<AzureDevOpsClient>()),
 
             _ => throw new NotImplementedException($"Unknown repo url type {normalizedUrl}"),
         };

--- a/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/BuildsController.cs
+++ b/src/Maestro/Maestro.Web/Api/v2020_02_20/Controllers/BuildsController.cs
@@ -182,7 +182,7 @@ public class BuildsController : v2019_01_16.Controllers.BuildsController
             return NotFound();
         }
 
-        IRemote remote = await Factory.GetRemoteAsync(build.AzureDevOpsRepository ?? build.GitHubRepository, null);
+        IRemote remote = await Factory.CreateRemoteAsync(build.AzureDevOpsRepository ?? build.GitHubRepository);
         Microsoft.DotNet.DarcLib.Commit commit = await remote.GetCommitAsync(build.AzureDevOpsRepository ?? build.GitHubRepository, build.Commit);
         return Ok(new Maestro.Api.Model.v2020_02_20.Commit(commit.Author, commit.Sha, commit.Message));
     }

--- a/src/Maestro/Maestro.Web/Startup.cs
+++ b/src/Maestro/Maestro.Web/Startup.cs
@@ -277,7 +277,7 @@ public partial class Startup : StartupBase
                 sp.GetRequiredService<ILogger<ProcessManager>>(),
                 "git"));
         services.AddTransient<IVersionDetailsParser, VersionDetailsParser>();
-        services.AddScoped<IRemoteFactory, DarcRemoteFactory>();
+        services.AddScoped<IRemoteFactory, RemoteFactory>();
         services.AddTransient<IBasicBarClient, SqlBarClient>();
         services.AddSingleton(typeof(IActorProxyFactory<>), typeof(ActorProxyFactory<>));
 

--- a/src/Maestro/SubscriptionActorService/PullRequestActor.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestActor.cs
@@ -425,7 +425,7 @@ namespace SubscriptionActorService
             }
 
             (string targetRepository, _) = await GetTargetAsync();
-            IRemote remote = await _remoteFactory.GetRemoteAsync(targetRepository, _logger);
+            IRemote remote = await _remoteFactory.CreateRemoteAsync(targetRepository);
 
             _logger.LogInformation("Getting status for Pull Request: {url}", prUrl);
             PrStatus status = await remote.GetPullRequestStatusAsync(prUrl);
@@ -704,7 +704,7 @@ namespace SubscriptionActorService
         {
             (string targetRepository, string targetBranch) = await GetTargetAsync();
 
-            IRemote darcRemote = await _remoteFactory.GetRemoteAsync(targetRepository, _logger);
+            IRemote darcRemote = await _remoteFactory.CreateRemoteAsync(targetRepository);
 
             TargetRepoDependencyUpdate repoDependencyUpdate =
                 await GetRequiredUpdates(updates, _remoteFactory, targetRepository, prBranch: null, targetBranch);
@@ -805,7 +805,7 @@ namespace SubscriptionActorService
 
             _logger.LogInformation("Updating Pull Request {url} branch {targetBranch} in {targetRepository}", pr.Url, targetBranch, targetRepository);
 
-            IRemote darcRemote = await _remoteFactory.GetRemoteAsync(targetRepository, _logger);
+            IRemote darcRemote = await _remoteFactory.CreateRemoteAsync(targetRepository);
             PullRequest pullRequest = await darcRemote.GetPullRequestAsync(pr.Url);
 
             TargetRepoDependencyUpdate targetRepositoryUpdates =
@@ -955,7 +955,7 @@ namespace SubscriptionActorService
         {
             _logger.LogInformation("Getting Required Updates for {branch} of {targetRepository}", targetBranch, targetRepository);
             // Get a remote factory for the target repo
-            IRemote darc = await remoteFactory.GetRemoteAsync(targetRepository, _logger);
+            IRemote darc = await remoteFactory.CreateRemoteAsync(targetRepository);
 
             TargetRepoDependencyUpdate repoDependencyUpdate = new();
 

--- a/src/Maestro/SubscriptionActorService/PullRequestBuilder.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestBuilder.cs
@@ -122,7 +122,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
         (UpdateAssetsParameters update, List<DependencyUpdate> deps) coherencyUpdate =
             requiredUpdates.Where(u => u.update.IsCoherencyUpdate).SingleOrDefault();
 
-        IRemote remote = await _remoteFactory.GetRemoteAsync(targetRepository, _logger);
+        IRemote remote = await _remoteFactory.CreateRemoteAsync(targetRepository);
         var locationResolver = new AssetLocationResolver(_barClient);
 
         // To keep a PR to as few commits as possible, if the number of

--- a/src/Maestro/SubscriptionActorService/PullRequestPolicyFailureNotifier.cs
+++ b/src/Maestro/SubscriptionActorService/PullRequestPolicyFailureNotifier.cs
@@ -65,7 +65,7 @@ public class PullRequestPolicyFailureNotifier : IPullRequestPolicyFailureNotifie
             return;
         }
 
-        var darcRemote = await _remoteFactory.GetRemoteAsync($"https://github.com/{owner}/{repo}", _logger);
+        var darcRemote = await _remoteFactory.CreateRemoteAsync($"https://github.com/{owner}/{repo}");
         var darcSubscriptionObject = await _barClient.GetSubscriptionAsync(subscriptionFromPr.SubscriptionId);
         string sourceRepository = darcSubscriptionObject.SourceRepository;
         string targetRepository = darcSubscriptionObject.TargetRepository;

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/UxManager.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/UxManager.cs
@@ -36,7 +36,7 @@ public class UxManager
     /// </summary>
     /// <param name="popUp">Popup to run</param>
     /// <returns>Success or error code</returns>
-    public int ReadFromStdIn(EditorPopUp popUp)
+    public async Task<int> ReadFromStdIn(EditorPopUp popUp)
     {
         int result;
         try
@@ -46,7 +46,7 @@ public class UxManager
             string dirPath = Path.GetDirectoryName(path);
 
             Directory.CreateDirectory(dirPath);
-            using (StreamWriter streamWriter = new StreamWriter(path))
+            using (var streamWriter = new StreamWriter(path))
             {
                 string line;
                 while ((line = Console.ReadLine()) != null)
@@ -57,7 +57,7 @@ public class UxManager
 
             // Now run the closed event and process the contents
             IList<Line> contents = EditorPopUp.OnClose(path);
-            result = popUp.ProcessContents(contents);
+            result = await popUp.ProcessContents(contents);
             Directory.Delete(dirPath, true);
             if (result != Constants.SuccessCode)
             {
@@ -107,11 +107,11 @@ public class UxManager
                 {
                     _popUpClosed = false;
                     process.EnableRaisingEvents = true;
-                    process.Exited += (sender, e) =>
+                    process.Exited += async (sender, e) =>
                     {
                         IList<Line> contents = EditorPopUp.OnClose(path);
 
-                        result = popUp.ProcessContents(contents);
+                        result = await popUp.ProcessContents(contents);
 
                         // If succeeded, delete the temp file, otherwise keep it around
                         // for another popup iteration.

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AddSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AddSubscriptionPopUp.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
@@ -18,7 +19,8 @@ public class AddSubscriptionPopUp : SubscriptionPopUp
 
     public AddSubscriptionPopUp(
         string path,
-        IRemoteFactory remoteFactory,
+        bool forceCreation,
+        IGitRepoFactory gitRepoFactory,
         ILogger logger,
         string channel,
         string sourceRepository,
@@ -36,7 +38,7 @@ public class AddSubscriptionPopUp : SubscriptionPopUp
         string? sourceDirectory,
         string? targetDirectory,
         List<string> excludedAssets)
-        : base(path, suggestedChannels, suggestedRepositories, availableMergePolicyHelp, logger, remoteFactory,
+        : base(path, forceCreation, suggestedChannels, suggestedRepositories, availableMergePolicyHelp, logger, gitRepoFactory,
             new SubscriptionData
             {
                 Channel = GetCurrentSettingForDisplay(channel, "<required>", false),
@@ -78,7 +80,7 @@ public class AddSubscriptionPopUp : SubscriptionPopUp
         _logger = logger;
     }
 
-    public override int ProcessContents(IList<Line> contents)
+    public override async Task<int> ProcessContents(IList<Line> contents)
     {
         SubscriptionData outputYamlData;
 
@@ -97,7 +99,7 @@ public class AddSubscriptionPopUp : SubscriptionPopUp
             return Constants.ErrorCode;
         }
 
-        var result = ParseAndValidateData(outputYamlData);
+        var result = await ParseAndValidateData(outputYamlData);
 
         _data.TargetRepository = ParseSetting(outputYamlData.TargetRepository, _data.TargetRepository, false);
         if (string.IsNullOrEmpty(_data.TargetRepository))

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AddSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AddSubscriptionPopUp.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using YamlDotNet.Serialization;
@@ -17,6 +18,7 @@ public class AddSubscriptionPopUp : SubscriptionPopUp
 
     public AddSubscriptionPopUp(
         string path,
+        IRemoteFactory remoteFactory,
         ILogger logger,
         string channel,
         string sourceRepository,
@@ -34,7 +36,7 @@ public class AddSubscriptionPopUp : SubscriptionPopUp
         string? sourceDirectory,
         string? targetDirectory,
         List<string> excludedAssets)
-        : base(path, suggestedChannels, suggestedRepositories, availableMergePolicyHelp, logger,
+        : base(path, suggestedChannels, suggestedRepositories, availableMergePolicyHelp, logger, remoteFactory,
             new SubscriptionData
             {
                 Channel = GetCurrentSettingForDisplay(channel, "<required>", false),

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AuthenticateEditorPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AuthenticateEditorPopUp.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.Extensions.Logging;
 
@@ -63,7 +64,7 @@ internal class AuthenticateEditorPopUp : EditorPopUp
 
     public LocalSettings settings { get; set; }
 
-    public override int ProcessContents(IList<Line> contents)
+    public override Task<int> ProcessContents(IList<Line> contents)
     {
         foreach (Line line in contents)
         {
@@ -95,6 +96,6 @@ internal class AuthenticateEditorPopUp : EditorPopUp
             }
         }
 
-        return settings.SaveSettingsFile(_logger);
+        return Task.FromResult(settings.SaveSettingsFile(_logger));
     }
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/EditorPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/EditorPopUp.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 #nullable enable
@@ -34,7 +35,7 @@ public abstract class EditorPopUp
         return GetContentValues(updatedFileContents);
     }
 
-    public abstract int ProcessContents(IList<Line> contents);
+    public abstract Task<int> ProcessContents(IList<Line> contents);
 
     private static List<Line> GetContentValues(IEnumerable<string> contents)
     {

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SetRepositoryMergePoliciesPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SetRepositoryMergePoliciesPopUp.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using YamlDotNet.Serialization;
@@ -62,7 +63,7 @@ internal class SetRepositoryMergePoliciesPopUp : EditorPopUp
         }
     }
 
-    public override int ProcessContents(IList<Line> contents)
+    public override Task<int> ProcessContents(IList<Line> contents)
     {
         RepositoryPoliciesData outputYamlData;
 
@@ -76,13 +77,13 @@ internal class SetRepositoryMergePoliciesPopUp : EditorPopUp
         catch (Exception e)
         {
             _logger.LogError(e, "Failed to parse input yaml.  Please see help for correct format.");
-            return Constants.ErrorCode;
+            return Task.FromResult(Constants.ErrorCode);
         }
 
         // Validate the merge policies
         if (!MergePoliciesPopUpHelpers.ValidateMergePolicies(MergePoliciesPopUpHelpers.ConvertMergePolicies(outputYamlData.MergePolicies), _logger))
         {
-            return Constants.ErrorCode;
+            return Task.FromResult(Constants.ErrorCode);
         }
 
         _yamlData.MergePolicies = outputYamlData.MergePolicies;
@@ -91,17 +92,17 @@ internal class SetRepositoryMergePoliciesPopUp : EditorPopUp
         if (string.IsNullOrEmpty(_yamlData.Repository))
         {
             _logger.LogError("Repository URL must be non-empty");
-            return Constants.ErrorCode;
+            return Task.FromResult(Constants.ErrorCode);
         }
 
         _yamlData.Branch = ParseSetting(outputYamlData.Branch, _yamlData.Branch, false);
         if (string.IsNullOrEmpty(_yamlData.Branch))
         {
             _logger.LogError("Branch must be non-empty");
-            return Constants.ErrorCode;
+            return Task.FromResult(Constants.ErrorCode);
         }
 
-        return Constants.SuccessCode;
+        return Task.FromResult(Constants.SuccessCode);
     }
 
     private class RepositoryPoliciesData

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using YamlDotNet.Serialization;
@@ -34,6 +35,7 @@ public abstract class SubscriptionPopUp : EditorPopUp
     private readonly IEnumerable<string> _suggestedRepositories;
     private readonly IEnumerable<string> _availableMergePolicyHelp;
     private readonly ILogger _logger;
+    private readonly IRemoteFactory _remoteFactory;
 
     public string Channel => _data.Channel;
     public string SourceRepository => _data.SourceRepository;
@@ -54,6 +56,7 @@ public abstract class SubscriptionPopUp : EditorPopUp
         IEnumerable<string> suggestedRepositories,
         IEnumerable<string> availableMergePolicyHelp,
         ILogger logger,
+        IRemoteFactory remoteFactory,
         SubscriptionData data,
         IEnumerable<Line> header)
         : base(path)
@@ -63,7 +66,7 @@ public abstract class SubscriptionPopUp : EditorPopUp
         _suggestedRepositories = suggestedRepositories;
         _availableMergePolicyHelp = availableMergePolicyHelp;
         _logger = logger;
-
+        _remoteFactory = remoteFactory;
         GeneratePopUpContent(header);
     }
 
@@ -175,6 +178,12 @@ public abstract class SubscriptionPopUp : EditorPopUp
             {
                 _logger.LogError("Only one of source or target directory can be provided for source-enabled subscriptions");
                 return Constants.ErrorCode;
+            }
+
+            if (!string.IsNullOrEmpty(outputYamlData.TargetDirectory))
+            {
+                var remote = _remoteFactory.CreateRemoteAsync(outputYamlData.TargetRepository);
+                ...
             }
         }
 

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
@@ -190,12 +190,12 @@ public abstract class SubscriptionPopUp : EditorPopUp
             {
                 if (!string.IsNullOrEmpty(outputYamlData.TargetDirectory) && !_forceCreation)
                 {
-                    await CheckIfVmr(outputYamlData.TargetRepository, outputYamlData.TargetBranch);
+                    await CheckIfRepoIsVmr(outputYamlData.TargetRepository, outputYamlData.TargetBranch);
                 }
 
                 if (!string.IsNullOrEmpty(outputYamlData.SourceDirectory) && !_forceCreation)
                 {
-                    await CheckIfVmr(outputYamlData.SourceRepository, "main");
+                    await CheckIfRepoIsVmr(outputYamlData.SourceRepository, "main");
                 }
             }
             catch (DarcException e)
@@ -220,7 +220,7 @@ public abstract class SubscriptionPopUp : EditorPopUp
         return Constants.SuccessCode;
     }
 
-    private async Task CheckIfVmr(string repoUri, string branch)
+    private async Task CheckIfRepoIsVmr(string repoUri, string branch)
     {
         try
         {

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
 using YamlDotNet.Serialization;
@@ -22,13 +23,14 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
 
     private UpdateSubscriptionPopUp(
         string path,
+        IRemoteFactory remoteFactory,
         ILogger logger,
         Subscription subscription,
         IEnumerable<string> suggestedChannels,
         IEnumerable<string> suggestedRepositories,
         IEnumerable<string> availableMergePolicyHelp,
         SubscriptionUpdateData data)
-        : base(path, suggestedChannels, suggestedRepositories, availableMergePolicyHelp, logger, data,
+        : base(path, suggestedChannels, suggestedRepositories, availableMergePolicyHelp, logger, remoteFactory, data,
             header: [
                 new Line($"Use this form to update the values of subscription '{subscription.Id}'.", true),
                 new Line($"Note that if you are setting 'Is batchable' to true you need to remove all Merge Policies.", true),
@@ -48,6 +50,7 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
 
     public UpdateSubscriptionPopUp(
         string path,
+        IRemoteFactory remoteFactory,
         ILogger logger,
         Subscription subscription,
         IEnumerable<string> suggestedChannels,
@@ -59,7 +62,7 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
         string sourceDirectory,
         string targetDirectory,
         List<string> excludedAssets)
-        : this(path, logger, subscription, suggestedChannels, suggestedRepositories, availableMergePolicyHelp,
+        : this(path, remoteFactory, logger, subscription, suggestedChannels, suggestedRepositories, availableMergePolicyHelp,
               new SubscriptionUpdateData
               {
                   Id = GetCurrentSettingForDisplay(subscription.Id.ToString(), subscription.Id.ToString(), false),

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
@@ -23,14 +24,15 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
 
     private UpdateSubscriptionPopUp(
         string path,
-        IRemoteFactory remoteFactory,
+        bool forceCreation,
+        IGitRepoFactory gitRepoFactory,
         ILogger logger,
         Subscription subscription,
         IEnumerable<string> suggestedChannels,
         IEnumerable<string> suggestedRepositories,
         IEnumerable<string> availableMergePolicyHelp,
         SubscriptionUpdateData data)
-        : base(path, suggestedChannels, suggestedRepositories, availableMergePolicyHelp, logger, remoteFactory, data,
+        : base(path, forceCreation, suggestedChannels, suggestedRepositories, availableMergePolicyHelp, logger, gitRepoFactory, data,
             header: [
                 new Line($"Use this form to update the values of subscription '{subscription.Id}'.", true),
                 new Line($"Note that if you are setting 'Is batchable' to true you need to remove all Merge Policies.", true),
@@ -50,7 +52,8 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
 
     public UpdateSubscriptionPopUp(
         string path,
-        IRemoteFactory remoteFactory,
+        bool forceCreation,
+        IGitRepoFactory gitRepoFactory,
         ILogger logger,
         Subscription subscription,
         IEnumerable<string> suggestedChannels,
@@ -62,7 +65,7 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
         string sourceDirectory,
         string targetDirectory,
         List<string> excludedAssets)
-        : this(path, remoteFactory, logger, subscription, suggestedChannels, suggestedRepositories, availableMergePolicyHelp,
+        : this(path, forceCreation, gitRepoFactory, logger, subscription, suggestedChannels, suggestedRepositories, availableMergePolicyHelp,
               new SubscriptionUpdateData
               {
                   Id = GetCurrentSettingForDisplay(subscription.Id.ToString(), subscription.Id.ToString(), false),
@@ -83,7 +86,7 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
     {
     }
 
-    public override int ProcessContents(IList<Line> contents)
+    public override async Task<int> ProcessContents(IList<Line> contents)
     {
         SubscriptionUpdateData outputYamlData;
 
@@ -99,7 +102,7 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
             return Constants.ErrorCode;
         }
 
-        var result = ParseAndValidateData(outputYamlData);
+        var result = await ParseAndValidateData(outputYamlData);
 
         if (!bool.TryParse(outputYamlData.Enabled, out bool enabled))
         {

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
@@ -54,18 +54,21 @@ internal class AddBuildToChannelOperation : Operation
     private readonly AddBuildToChannelCommandLineOptions _options;
     private readonly ILogger<AddBuildToChannelOperation> _logger;
     private readonly IAzureDevOpsClient _azdoClient;
+    private readonly IRemoteFactory _remoteFactory;
     private readonly IBarApiClient _barClient;
 
     public AddBuildToChannelOperation(
         AddBuildToChannelCommandLineOptions options,
         IBarApiClient barClient,
         IAzureDevOpsClient azdoClient,
+        IRemoteFactory remoteFactory,
         ILogger<AddBuildToChannelOperation> logger)
     {
         _options = options;
         _barClient = barClient;
         _logger = logger;
         _azdoClient = azdoClient;
+        _remoteFactory = remoteFactory;
     }
 
     /// <summary>
@@ -409,7 +412,7 @@ internal class AddBuildToChannelOperation : Operation
             build.AzureDevOpsRepository :
             build.GitHubRepository;
 
-        IRemote repoRemote = RemoteFactory.GetRemote(_options, sourceBuildRepo, _logger);
+        IRemote repoRemote = await _remoteFactory.CreateRemoteAsync(sourceBuildRepo);
 
         IEnumerable<DependencyDetail> sourceBuildDependencies = await repoRemote.GetDependenciesAsync(sourceBuildRepo, build.Commit)
             .ConfigureAwait(false);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddDefaultChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddDefaultChannelOperation.cs
@@ -17,22 +17,25 @@ internal class AddDefaultChannelOperation : Operation
     private readonly AddDefaultChannelCommandLineOptions _options;
     private readonly ILogger<AddDefaultChannelOperation> _logger;
     private readonly IBarApiClient _barClient;
+    private readonly IRemoteFactory _remoteFactory;
 
     public AddDefaultChannelOperation(
         AddDefaultChannelCommandLineOptions options,
         ILogger<AddDefaultChannelOperation> logger,
-        IBarApiClient barClient)
+        IBarApiClient barClient,
+        IRemoteFactory remoteFactory)
     {
         _options = options;
         _logger = logger;
         _barClient = barClient;
+        _remoteFactory = remoteFactory;
     }
 
     public override async Task<int> ExecuteAsync()
     {
         try
         {
-            IRemote repoRemote = RemoteFactory.GetRemote(_options, _options.Repository, _logger);
+            IRemote repoRemote = await _remoteFactory.CreateRemoteAsync(_options.Repository);
 
             // Users can ignore the flag and pass in -regex: but to prevent typos we'll avoid that.
             _options.Branch = _options.UseBranchAsRegex ? $"-regex:{_options.Branch}" : GitHelpers.NormalizeBranchName(_options.Branch);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
@@ -25,17 +25,20 @@ internal class AddSubscriptionOperation : Operation
     private readonly ILogger<AddSubscriptionOperation> _logger;
     private readonly IBarApiClient _barClient;
     private readonly IRemoteFactory _remoteFactory;
+    private readonly IGitRepoFactory _gitRepoFactory;
 
     public AddSubscriptionOperation(
         AddSubscriptionCommandLineOptions options,
         ILogger<AddSubscriptionOperation> logger,
         IBarApiClient barClient,
-        IRemoteFactory remoteFactory)
+        IRemoteFactory remoteFactory,
+        IGitRepoFactory gitRepoFactory)
     {
         _options = options;
         _logger = logger;
         _barClient = barClient;
         _remoteFactory = remoteFactory;
+        _gitRepoFactory = gitRepoFactory;
     }
 
     /// <summary>
@@ -170,7 +173,8 @@ internal class AddSubscriptionOperation : Operation
             // Help the user along with a form.  We'll use the API to gather suggested values
             // from existing subscriptions based on the input parameters.
             var addSubscriptionPopup = new AddSubscriptionPopUp("add-subscription/add-subscription-todo",
-                _remoteFactory,
+                _options.ForceCreation,
+                _gitRepoFactory,
                 _logger,
                 channel,
                 sourceRepository,
@@ -191,7 +195,7 @@ internal class AddSubscriptionOperation : Operation
 
             var uxManager = new UxManager(_options.GitLocation, _logger);
             int exitCode = _options.ReadStandardIn
-                ? uxManager.ReadFromStdIn(addSubscriptionPopup)
+                ? await uxManager.ReadFromStdIn(addSubscriptionPopup)
                 : uxManager.PopUp(addSubscriptionPopup);
 
             if (exitCode != Constants.SuccessCode)

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/CloneOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/CloneOperation.cs
@@ -274,7 +274,7 @@ internal class CloneOperation : Operation
         if (!Directory.Exists(masterGitRepoPath))
         {
             _logger.LogInformation($"Cloning master copy of {repoUrl} into {masterGitRepoPath}");
-            IRemote repoRemote = await remoteFactory.GetRemoteAsync(repoUrl, _logger);
+            IRemote repoRemote = await remoteFactory.CreateRemoteAsync(repoUrl);
             await repoRemote.CloneAsync(repoUrl, null, masterGitRepoPath, checkoutSubmodules: true, masterRepoGitDirPath);
         }
         // The master folder already exists.  We are probably resuming with a different --git-dir-parent setting, or the .gitdir parent was cleaned.
@@ -315,7 +315,7 @@ internal class CloneOperation : Operation
         if (!Directory.Exists(masterGitRepoPath))
         {
             _logger.LogInformation($"Cloning master copy of {repoUrl} into {masterGitRepoPath} with .gitdir path {masterRepoGitDirPath}");
-            IRemote repoRemote = await remoteFactory.GetRemoteAsync(repoUrl, _logger);
+            IRemote repoRemote = await remoteFactory.CreateRemoteAsync(repoUrl);
             await repoRemote.CloneAsync(repoUrl, null, masterGitRepoPath, checkoutSubmodules: true, masterRepoGitDirPath);
         }
         // The master folder already exists.  We are probably resuming with a different --git-dir-parent setting, or the .gitdir parent was cleaned.

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GatherDropOperation.cs
@@ -172,7 +172,7 @@ internal class GatherDropOperation : Operation
     private async Task<IEnumerable<DependencyDetail>> GetBuildDependenciesAsync(Build build)
     {
         var repoUri = build.GetRepository();
-        IRemote remote = RemoteFactory.GetRemote(_options, repoUri, _logger);
+        IRemote remote = await _remoteFactory.CreateRemoteAsync(repoUri);
         return await remote.GetDependenciesAsync(repoUri, build.Commit);
     }
 

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependencyGraphOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GetDependencyGraphOperation.cs
@@ -88,7 +88,7 @@ internal class GetDependencyGraphOperation : Operation
 
                     // Grab root dependency set. The graph build can do this, but
                     // if an original asset name is passed, then this will do the initial filtering.
-                    IRemote rootRepoRemote = await _remoteFactory.GetRemoteAsync(_options.RepoUri, _logger);
+                    IRemote rootRepoRemote = await _remoteFactory.CreateRemoteAsync(_options.RepoUri);
                     rootDependencies = await rootRepoRemote.GetDependenciesAsync(
                         _options.RepoUri,
                         _options.Version,

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
@@ -23,15 +23,18 @@ internal class SetRepositoryMergePoliciesOperation : Operation
 {
     private readonly SetRepositoryMergePoliciesCommandLineOptions _options;
     private readonly IBarApiClient _barClient;
+    private readonly IRemoteFactory _remoteFactory;
     private readonly ILogger<SetRepositoryMergePoliciesOperation> _logger;
 
     public SetRepositoryMergePoliciesOperation(
         SetRepositoryMergePoliciesCommandLineOptions options,
         IBarApiClient barClient,
+        IRemoteFactory remoteFactory,
         ILogger<SetRepositoryMergePoliciesOperation> logger)
     {
         _options = options;
         _barClient = barClient;
+        _remoteFactory = remoteFactory;
         _logger = logger;
     }
 
@@ -137,7 +140,7 @@ internal class SetRepositoryMergePoliciesOperation : Operation
             mergePolicies = initEditorPopUp.MergePolicies;
         }
 
-        IRemote verifyRemote = RemoteFactory.GetRemote(_options, repository, _logger);
+        IRemote verifyRemote = await _remoteFactory.CreateRemoteAsync(repository);
 
         if (!await UxHelpers.VerifyAndConfirmBranchExistsAsync(verifyRemote, repository, branch, !_options.Quiet))
         {
@@ -147,8 +150,7 @@ internal class SetRepositoryMergePoliciesOperation : Operation
 
         try
         {
-            await _barClient.SetRepositoryMergePoliciesAsync(
-                repository, branch, mergePolicies);
+            await _barClient.SetRepositoryMergePoliciesAsync(repository, branch, mergePolicies);
             Console.WriteLine($"Successfully updated merge policies for {repository}@{branch}.");
             return Constants.SuccessCode;
         }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateSubscriptionOperation.cs
@@ -21,17 +21,20 @@ internal class UpdateSubscriptionOperation : Operation
     private readonly UpdateSubscriptionCommandLineOptions _options;
     private readonly IBarApiClient _barClient;
     private readonly IRemoteFactory _remoteFactory;
+    private readonly IGitRepoFactory _gitRepoFactory;
     private readonly ILogger<UpdateSubscriptionOperation> _logger;
 
     public UpdateSubscriptionOperation(
         UpdateSubscriptionCommandLineOptions options,
         IBarApiClient barClient,
         IRemoteFactory remoteFactory,
+        IGitRepoFactory gitRepoFactory,
         ILogger<UpdateSubscriptionOperation> logger)
     {
         _options = options;
         _barClient = barClient;
         _remoteFactory = remoteFactory;
+        _gitRepoFactory = gitRepoFactory;
         _logger = logger;
     }
 
@@ -116,7 +119,8 @@ internal class UpdateSubscriptionOperation : Operation
         {
             var updateSubscriptionPopUp = new UpdateSubscriptionPopUp(
                 "update-subscription/update-subscription-todo",
-                _remoteFactory,
+                _options.ForceCreation,
+                _gitRepoFactory,
                 _logger,
                 subscription,
                 (await suggestedChannels).Select(suggestedChannel => suggestedChannel.Name),

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateSubscriptionOperation.cs
@@ -20,15 +20,18 @@ internal class UpdateSubscriptionOperation : Operation
 {
     private readonly UpdateSubscriptionCommandLineOptions _options;
     private readonly IBarApiClient _barClient;
+    private readonly IRemoteFactory _remoteFactory;
     private readonly ILogger<UpdateSubscriptionOperation> _logger;
 
     public UpdateSubscriptionOperation(
         UpdateSubscriptionCommandLineOptions options,
         IBarApiClient barClient,
+        IRemoteFactory remoteFactory,
         ILogger<UpdateSubscriptionOperation> logger)
     {
         _options = options;
         _barClient = barClient;
+        _remoteFactory = remoteFactory;
         _logger = logger;
     }
 
@@ -113,6 +116,7 @@ internal class UpdateSubscriptionOperation : Operation
         {
             var updateSubscriptionPopUp = new UpdateSubscriptionPopUp(
                 "update-subscription/update-subscription-todo",
+                _remoteFactory,
                 _logger,
                 subscription,
                 (await suggestedChannels).Select(suggestedChannel => suggestedChannel.Name),

--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -55,7 +55,8 @@ public abstract class CommandLineOptions : ICommandLineOptions
 
     [Option("output-format", Default = DarcOutputType.text,
         HelpText = "Desired output type of darc. Valid values are 'json' and 'text'. Case sensitive.")]
-    public DarcOutputType OutputFormat {
+    public DarcOutputType OutputFormat
+    {
         get
         {
             return _outputFormat;
@@ -142,7 +143,11 @@ public abstract class CommandLineOptions : ICommandLineOptions
         services.TryAddSingleton<IFileSystem, FileSystem>();
         services.TryAddSingleton<IRemoteFactory, RemoteFactory>();
         services.TryAddTransient<IProcessManager>(sp => new ProcessManager(sp.GetRequiredService<ILogger<ProcessManager>>(), GitLocation));
-        services.TryAddSingleton(sp => RemoteFactory.GetBarClient(this));
+        services.TryAddSingleton(sp => new BarApiClient(
+            BuildAssetRegistryToken,
+            managedIdentityId: null,
+            disableInteractiveAuth: IsCi,
+            BuildAssetRegistryBaseUri));
         services.TryAddSingleton<IBasicBarClient>(sp => sp.GetRequiredService<IBarApiClient>());
         services.TryAddTransient<ILogger>(sp => sp.GetRequiredService<ILogger<Operation>>());
         services.TryAddTransient<ITelemetryRecorder, NoTelemetryRecorder>();

--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -143,7 +143,7 @@ public abstract class CommandLineOptions : ICommandLineOptions
         services.TryAddSingleton<IFileSystem, FileSystem>();
         services.TryAddSingleton<IRemoteFactory, RemoteFactory>();
         services.TryAddTransient<IProcessManager>(sp => new ProcessManager(sp.GetRequiredService<ILogger<ProcessManager>>(), GitLocation));
-        services.TryAddSingleton(sp => new BarApiClient(
+        services.TryAddSingleton<IBarApiClient>(sp => new BarApiClient(
             BuildAssetRegistryToken,
             managedIdentityId: null,
             disableInteractiveAuth: IsCi,

--- a/src/Microsoft.DotNet.Darc/Darc/Options/SubscriptionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/SubscriptionCommandLineOptions.cs
@@ -22,4 +22,7 @@ internal abstract class SubscriptionCommandLineOptions<T> : CommandLineOptions<T
 
     [Option("excluded-assets", HelpText = "Semicolon-delineated list of asset filters (package name with asterisks allowed) to be excluded from source-enabled code flow.")]
     public string ExcludedAssets { get; set; }
+
+    [Option('f', "force", HelpText = "Force subscription creation even when some checks fail.")]
+    public bool ForceCreation { get; set; }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/CoherencyUpdateResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/CoherencyUpdateResolver.cs
@@ -189,7 +189,7 @@ public class CoherencyUpdateResolver : ICoherencyUpdateResolver
                 if (!dependenciesCache.TryGetValue(parentCoherentDependencyCacheKey,
                         out IEnumerable<DependencyDetail> coherentParentsDependencies))
                 {
-                    IRemote remoteClient = await remoteFactory.GetRemoteAsync(parentCoherentDependency.RepoUri, _logger);
+                    IRemote remoteClient = await remoteFactory.CreateRemoteAsync(parentCoherentDependency.RepoUri);
                     coherentParentsDependencies = await remoteClient.GetDependenciesAsync(
                         parentCoherentDependency.RepoUri,
                         parentCoherentDependency.Commit);
@@ -389,7 +389,7 @@ public class CoherencyUpdateResolver : ICoherencyUpdateResolver
             // coherent asset itself.
             if (!nugetConfigCache.TryGetValue(parentCoherentDependencyCacheKey, out IEnumerable<string> nugetFeeds))
             {
-                IRemote remoteClient = await remoteFactory.GetRemoteAsync(parentCoherentDependency.RepoUri, _logger);
+                IRemote remoteClient = await remoteFactory.CreateRemoteAsync(parentCoherentDependency.RepoUri);
                 nugetFeeds = await remoteClient.GetPackageSourcesAsync(parentCoherentDependency.RepoUri, parentCoherentDependency.Commit);
             }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/HealthMetrics/ProductDependencyCyclesHealthMetric.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/HealthMetrics/ProductDependencyCyclesHealthMetric.cs
@@ -56,7 +56,7 @@ public class ProductDependencyCyclesHealthMetric : HealthMetric
         };
 
         // Evaluate and find out what the latest is on the branch
-        var remote = await _remoteFactory.GetRemoteAsync(_repository, _logger);
+        var remote = await _remoteFactory.CreateRemoteAsync(_repository);
         var commit = await remote.GetLatestCommitAsync(_repository, _branch);
 
         if (commit == null)

--- a/src/Microsoft.DotNet.Darc/DarcLib/HealthMetrics/SubscriptionHealthMetric.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/HealthMetrics/SubscriptionHealthMetric.cs
@@ -91,7 +91,7 @@ public class SubscriptionHealthMetric : HealthMetric
     /// <returns>True if the metric passed, false otherwise</returns>
     public override async Task EvaluateAsync()
     {
-        IRemote remote = await _remoteFactory.GetRemoteAsync(Repository, _logger);
+        IRemote remote = await _remoteFactory.CreateRemoteAsync(Repository);
 
         _logger.LogInformation("Evaluating subscription health metrics for {repo}@{branch}", Repository, Branch);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/IRemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IRemoteFactory.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.DarcLib.Helpers;
-using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.DarcLib;
@@ -13,7 +12,7 @@ namespace Microsoft.DotNet.DarcLib;
 /// </summary>
 public interface IRemoteFactory
 {
-    Task<IRemote> GetRemoteAsync(string repoUrl, ILogger logger);
+    Task<IRemote> CreateRemoteAsync(string repoUrl);
 
-    Task<IDependencyFileManager> GetDependencyFileManagerAsync(string repoUrl, ILogger logger);
+    Task<IDependencyFileManager> CreateDependencyFileManagerAsync(string repoUrl);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Local.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Local.cs
@@ -84,7 +84,7 @@ public class Local
         {
             try
             {
-                IRemote arcadeRemote = await remoteFactory.GetRemoteAsync(arcadeItem.RepoUri, _logger);
+                IRemote arcadeRemote = await remoteFactory.CreateRemoteAsync(arcadeItem.RepoUri);
                 List<GitFile> engCommonFiles = await arcadeRemote.GetCommonScriptFilesAsync(arcadeItem.RepoUri, arcadeItem.Commit);
                 filesToUpdate.AddRange(engCommonFiles);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DependencyGraph.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DependencyGraph.cs
@@ -311,7 +311,7 @@ public class DependencyGraph
                     // Perform diff if there is a latest commit.
                     if (!string.IsNullOrEmpty(latestCommit))
                     {
-                        IRemote repoRemote = await remoteFactory.GetRemoteAsync(node.Repository, logger);
+                        IRemote repoRemote = await remoteFactory.CreateRemoteAsync(node.Repository);
                         // This will return a no-diff if latestCommit == node.Commit
                         node.DiffFrom = await repoRemote.GitDiffAsync(node.Repository, latestCommit, node.Commit);
                     }
@@ -369,7 +369,7 @@ public class DependencyGraph
                 // Compare all other nodes to the latest
                 foreach (DependencyGraphNode node in nodes)
                 {
-                    IRemote repoRemote = await remoteFactory.GetRemoteAsync(node.Repository, logger);
+                    IRemote repoRemote = await remoteFactory.CreateRemoteAsync(node.Repository);
                     // If node == newestNode, returns no diff.
                     node.DiffFrom = await repoRemote.GitDiffAsync(node.Repository, newestNode.Commit, node.Commit);
                 }
@@ -836,10 +836,8 @@ public class DependencyGraph
             }
             else if (remote)
             {
-                IRemote remoteClient = await remoteFactory.GetRemoteAsync(repoUri, logger);
-                dependencies = await remoteClient.GetDependenciesAsync(
-                    repoUri,
-                    commit);
+                IRemote remoteClient = await remoteFactory.CreateRemoteAsync(repoUri);
+                dependencies = await remoteClient.GetDependenciesAsync(repoUri, commit);
             }
             else
             {

--- a/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
@@ -191,7 +191,7 @@ public sealed class Remote : IRemote
 
         if (mayNeedArcadeUpdate)
         {
-            IDependencyFileManager arcadeFileManager = await remoteFactory.GetDependencyFileManagerAsync(arcadeItem.RepoUri, _logger);
+            IDependencyFileManager arcadeFileManager = await remoteFactory.CreateDependencyFileManagerAsync(arcadeItem.RepoUri);
             targetDotNetVersion = await arcadeFileManager.ReadToolsDotnetVersionAsync(arcadeItem.RepoUri, arcadeItem.Commit);
         }
 
@@ -209,7 +209,7 @@ public sealed class Remote : IRemote
         {
             // Files in the source arcade repo. We use the remote factory because the
             // arcade repo may be in github while this remote is targeted at AzDO.
-            IRemote arcadeRemote = await remoteFactory.GetRemoteAsync(arcadeItem.RepoUri, _logger);
+            IRemote arcadeRemote = await remoteFactory.CreateRemoteAsync(arcadeItem.RepoUri);
             List<GitFile> engCommonFiles = await arcadeRemote.GetCommonScriptFilesAsync(arcadeItem.RepoUri, arcadeItem.Commit);
             filesToCommit.AddRange(engCommonFiles);
 

--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/BuildsController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/BuildsController.cs
@@ -177,7 +177,7 @@ public class BuildsController : v2019_01_16.Controllers.BuildsController
             return NotFound();
         }
 
-        IRemote remote = await _factory.GetRemoteAsync(build.AzureDevOpsRepository ?? build.GitHubRepository, null);
+        IRemote remote = await _factory.CreateRemoteAsync(build.AzureDevOpsRepository ?? build.GitHubRepository);
         Microsoft.DotNet.DarcLib.Commit commit = await remote.GetCommitAsync(build.AzureDevOpsRepository ?? build.GitHubRepository, build.Commit);
         return Ok(new Maestro.Api.Model.v2020_02_20.Commit(commit.Author, commit.Sha, commit.Message));
     }

--- a/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
@@ -196,7 +196,7 @@ internal static class PcsStartup
             builder.Configuration[ConfigurationKeys.GitHubClientId],
             builder.Configuration[ConfigurationKeys.GitHubClientSecret]);
         builder.Services.AddGitHubTokenProvider();
-        builder.Services.AddScoped<IRemoteFactory, DarcRemoteFactory>();
+        builder.Services.AddScoped<IRemoteFactory, RemoteFactory>();
         builder.Services.AddSingleton<Microsoft.Extensions.Internal.ISystemClock, Microsoft.Extensions.Internal.SystemClock>();
         builder.Services.AddSingleton<ExponentialRetry>();
         builder.Services.Configure<ExponentialRetryOptions>(_ => { });

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -117,7 +117,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
         (SubscriptionUpdateWorkItem update, List<DependencyUpdate> deps) coherencyUpdate =
             requiredUpdates.Where(u => u.update.IsCoherencyUpdate).SingleOrDefault();
 
-        IRemote remote = await _remoteFactory.GetRemoteAsync(targetRepository, _logger);
+        IRemote remote = await _remoteFactory.CreateRemoteAsync(targetRepository);
         var locationResolver = new AssetLocationResolver(_barClient);
 
         // To keep a PR to as few commits as possible, if the number of

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestPolicyFailureNotifier.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestPolicyFailureNotifier.cs
@@ -67,7 +67,7 @@ internal class PullRequestPolicyFailureNotifier : IPullRequestPolicyFailureNotif
             return;
         }
 
-        var darcRemote = await _remoteFactory.GetRemoteAsync($"https://github.com/{owner}/{repo}", _logger);
+        var darcRemote = await _remoteFactory.CreateRemoteAsync($"https://github.com/{owner}/{repo}");
         var darcSubscriptionObject = await _barClient.GetSubscriptionAsync(subscriptionFromPr.SubscriptionId);
         var sourceRepository = darcSubscriptionObject.SourceRepository;
         var targetRepository = darcSubscriptionObject.TargetRepository;

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -191,7 +191,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         _logger.LogInformation("Querying status for pull request {prUrl}", pr.Url);
 
         (var targetRepository, _) = await GetTargetAsync();
-        IRemote remote = await _remoteFactory.GetRemoteAsync(targetRepository, _logger);
+        IRemote remote = await _remoteFactory.CreateRemoteAsync(targetRepository);
 
         PrStatus status = await remote.GetPullRequestStatusAsync(pr.Url);
         _logger.LogInformation("Pull request {url} is {status}", pr.Url, status);
@@ -492,7 +492,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         (var targetRepository, var targetBranch) = await GetTargetAsync();
         bool isCodeFlow = update.SubscriptionType == SubscriptionType.DependenciesAndSources;
 
-        IRemote darcRemote = await _remoteFactory.GetRemoteAsync(targetRepository, _logger);
+        IRemote darcRemote = await _remoteFactory.CreateRemoteAsync(targetRepository);
 
         TargetRepoDependencyUpdate repoDependencyUpdate =
             await GetRequiredUpdates(update, _remoteFactory, targetRepository, prBranch: null, targetBranch);
@@ -598,7 +598,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
 
         _logger.LogInformation("Updating pull request {url} branch {targetBranch} in {targetRepository}", pr.Url, targetBranch, targetRepository);
 
-        IRemote darcRemote = await _remoteFactory.GetRemoteAsync(targetRepository, _logger);
+        IRemote darcRemote = await _remoteFactory.CreateRemoteAsync(targetRepository);
         PullRequest pullRequest = await darcRemote.GetPullRequestAsync(pr.Url);
 
         TargetRepoDependencyUpdate targetRepositoryUpdates =
@@ -747,7 +747,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
     {
         _logger.LogInformation("Getting Required Updates for {branch} of {targetRepository}", targetBranch, targetRepository);
         // Get a remote factory for the target repo
-        IRemote darc = await remoteFactory.GetRemoteAsync(targetRepository, _logger);
+        IRemote darc = await remoteFactory.CreateRemoteAsync(targetRepository);
 
         TargetRepoDependencyUpdate repoDependencyUpdate = new();
 
@@ -1054,7 +1054,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         var title = await _pullRequestBuilder.GenerateCodeFlowPRTitleAsync(update, subscription.TargetBranch);
         var description = await _pullRequestBuilder.GenerateCodeFlowPRDescriptionAsync(update);
 
-        var remote = await _remoteFactory.GetRemoteAsync(subscription.TargetRepository, _logger);
+        var remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
         await remote.UpdatePullRequestAsync(pullRequest.Url, new PullRequest
         {
             Title = title,
@@ -1160,7 +1160,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         string targetBranch)
     {
         bool isCodeFlow = update.SubscriptionType == SubscriptionType.DependenciesAndSources;
-        IRemote darcRemote = await _remoteFactory.GetRemoteAsync(targetRepository, _logger);
+        IRemote darcRemote = await _remoteFactory.CreateRemoteAsync(targetRepository);
 
         try
         {

--- a/test/Maestro.Web.Tests/BuildController20200914Tests.cs
+++ b/test/Maestro.Web.Tests/BuildController20200914Tests.cs
@@ -91,7 +91,7 @@ public partial class BuildController20200914Tests
 
             var mockIRemoteFactory = new Mock<IRemoteFactory>();
             var mockIRemote = new Mock<IRemote>();
-            mockIRemoteFactory.Setup(f => f.GetRemoteAsync(Repository, It.IsAny<ILogger>())).ReturnsAsync(mockIRemote.Object);
+            mockIRemoteFactory.Setup(f => f.CreateRemoteAsync(Repository)).ReturnsAsync(mockIRemote.Object);
             mockIRemote.Setup(f => f.GetCommitAsync(Repository, CommitHash)).ReturnsAsync(new Microsoft.DotNet.DarcLib.Commit(Account, CommitHash, CommitMessage));
 
             collection.AddSingleton(mockIRemote.Object);

--- a/test/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
+++ b/test/Microsoft.DotNet.Darc.Tests/DependencyCoherencyTests.cs
@@ -187,7 +187,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(dependencyGraphRemoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(dependencyGraphRemoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -272,7 +272,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(dependencyGraphRemoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(dependencyGraphRemoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -334,7 +334,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(dependencyGraphRemoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(dependencyGraphRemoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -393,7 +393,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(dependencyGraphRemoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(dependencyGraphRemoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: pinHead);
@@ -464,7 +464,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(dependencyGraphRemoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(dependencyGraphRemoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: pinHead);
@@ -555,7 +555,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -602,7 +602,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -637,7 +637,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -673,7 +673,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -713,7 +713,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -768,7 +768,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -831,7 +831,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -877,7 +877,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -927,7 +927,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -985,7 +985,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -1052,7 +1052,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -1118,7 +1118,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -1190,7 +1190,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -1263,7 +1263,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -1334,7 +1334,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);
@@ -1377,7 +1377,7 @@ public class DependencyCoherencyTests
 
         // Always return the main remote.
         var remoteFactoryMock = new Mock<IRemoteFactory>();
-        remoteFactoryMock.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(remoteMock.Object);
+        remoteFactoryMock.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(remoteMock.Object);
 
         List<DependencyDetail> existingDetails = [];
         DependencyDetail depA = AddDependency(existingDetails, "depA", "v1", "repoA", "commit1", pinned: false);

--- a/test/ProductConstructionService.Api.Tests/BuildController20200914Tests.cs
+++ b/test/ProductConstructionService.Api.Tests/BuildController20200914Tests.cs
@@ -94,7 +94,7 @@ public partial class BuildController20200914Tests
             var mockWorkItemProducerFactory = new Mock<IWorkItemProducerFactory>();
             var mockWorkItemProducer = new Mock<IWorkItemProducer<BuildCoherencyInfoWorkItem>>();
             mockWorkItemProducerFactory.Setup(f => f.CreateProducer<BuildCoherencyInfoWorkItem>(false)).Returns(mockWorkItemProducer.Object);
-            mockIRemoteFactory.Setup(f => f.GetRemoteAsync(Repository, It.IsAny<ILogger>())).ReturnsAsync(mockIRemote.Object);
+            mockIRemoteFactory.Setup(f => f.CreateRemoteAsync(Repository)).ReturnsAsync(mockIRemote.Object);
             mockIRemote.Setup(f => f.GetCommitAsync(Repository, CommitHash)).ReturnsAsync(new Microsoft.DotNet.DarcLib.Commit(Account, CommitHash, CommitMessage));
 
             collection.AddSingleton(mockIRemote.Object);

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -36,7 +36,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
 
     protected override void RegisterServices(IServiceCollection services)
     {
-        _remoteFactory.Setup(f => f.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>()))
+        _remoteFactory.Setup(f => f.CreateRemoteAsync(It.IsAny<string>()))
             .ReturnsAsync(
                 (string repo, ILogger logger) =>
                     _darcRemotes.GetOrAddValue(repo, () => CreateMock<IRemote>()).Object);

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -36,10 +36,9 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
 
     protected override void RegisterServices(IServiceCollection services)
     {
-        _remoteFactory.Setup(f => f.CreateRemoteAsync(It.IsAny<string>()))
-            .ReturnsAsync(
-                (string repo, ILogger logger) =>
-                    _darcRemotes.GetOrAddValue(repo, () => CreateMock<IRemote>()).Object);
+        _remoteFactory
+            .Setup(f => f.CreateRemoteAsync(It.IsAny<string>()))
+            .ReturnsAsync((string repo) => _darcRemotes.GetOrAddValue(repo, () => CreateMock<IRemote>()).Object);
 
         services.AddSingleton(_remoteFactory.Object);
         services.AddSingleton(_barClient.Object);

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -94,7 +94,7 @@ internal class PullRequestPolicyFailureNotifierTests
         MockRemote = new Remote(GitRepo.Object, new VersionDetailsParser(), NullLogger.Instance);
 
         RemoteFactory = new Mock<IRemoteFactory>(MockBehavior.Strict);
-        RemoteFactory.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(MockRemote);
+        RemoteFactory.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(MockRemote);
 
         Provider = services.BuildServiceProvider();
         Scope = Provider.CreateScope();

--- a/test/ProductConstructionService.DependencyFlow.Tests/UpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/UpdaterTests.cs
@@ -8,7 +8,6 @@ using Microsoft.DotNet.Internal.Logging;
 using Microsoft.DotNet.Kusto;
 using Microsoft.DotNet.Services.Utility;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Services.Common;
 using Moq;
 using NUnit.Framework;

--- a/test/ProductConstructionService.DependencyFlow.Tests/UpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/UpdaterTests.cs
@@ -64,7 +64,7 @@ internal abstract class UpdaterTests : TestsWithServices
         services.AddSingleton(workItemProducerFactoryMock.Object);
 
         RemoteFactory
-            .Setup(f => f.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>()))
+            .Setup(f => f.CreateRemoteAsync(It.IsAny<string>()))
             .ReturnsAsync((string repo, ILogger logger) =>
                 DarcRemotes.GetOrAddValue(repo, () => CreateMock<IRemote>()).Object);
     }

--- a/test/ProductConstructionService.DependencyFlow.Tests/UpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/UpdaterTests.cs
@@ -65,8 +65,7 @@ internal abstract class UpdaterTests : TestsWithServices
 
         RemoteFactory
             .Setup(f => f.CreateRemoteAsync(It.IsAny<string>()))
-            .ReturnsAsync((string repo, ILogger logger) =>
-                DarcRemotes.GetOrAddValue(repo, () => CreateMock<IRemote>()).Object);
+            .ReturnsAsync((string repo) => DarcRemotes.GetOrAddValue(repo, () => CreateMock<IRemote>()).Object);
     }
 
     [SetUp]

--- a/test/SubscriptionActorService.Tests/PullRequestActorTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestActorTests.cs
@@ -84,10 +84,9 @@ internal abstract class PullRequestActorTests : SubscriptionOrPullRequestActorTe
         services.AddSingleton(_updateResolver.Object);
         services.AddSingleton(Mock.Of<IProductConstructionServiceApi>());
 
-        _remoteFactory.Setup(f => f.CreateRemoteAsync(It.IsAny<string>()))
-            .ReturnsAsync(
-                (string repo, ILogger logger) =>
-                    _darcRemotes.GetOrAddValue(repo, () => CreateMock<IRemote>()).Object);
+        _remoteFactory
+            .Setup(f => f.CreateRemoteAsync(It.IsAny<string>()))
+            .ReturnsAsync((string repo) => _darcRemotes.GetOrAddValue(repo, () => CreateMock<IRemote>()).Object);
         services.AddSingleton(_remoteFactory.Object);
 
         base.RegisterServices(services);

--- a/test/SubscriptionActorService.Tests/PullRequestActorTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestActorTests.cs
@@ -84,7 +84,7 @@ internal abstract class PullRequestActorTests : SubscriptionOrPullRequestActorTe
         services.AddSingleton(_updateResolver.Object);
         services.AddSingleton(Mock.Of<IProductConstructionServiceApi>());
 
-        _remoteFactory.Setup(f => f.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>()))
+        _remoteFactory.Setup(f => f.CreateRemoteAsync(It.IsAny<string>()))
             .ReturnsAsync(
                 (string repo, ILogger logger) =>
                     _darcRemotes.GetOrAddValue(repo, () => CreateMock<IRemote>()).Object);

--- a/test/SubscriptionActorService.Tests/PullRequestBuilderTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestBuilderTests.cs
@@ -40,7 +40,7 @@ public class PullRequestBuilderTests : SubscriptionOrPullRequestActorTests
 
     protected override void RegisterServices(IServiceCollection services)
     {
-        _remoteFactory.Setup(f => f.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>()))
+        _remoteFactory.Setup(f => f.CreateRemoteAsync(It.IsAny<string>()))
             .ReturnsAsync(
                 (string repo, ILogger logger) =>
                     _darcRemotes.GetOrAddValue(repo, () => CreateMock<IRemote>()).Object);

--- a/test/SubscriptionActorService.Tests/PullRequestBuilderTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestBuilderTests.cs
@@ -12,7 +12,6 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Models.Darc;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Services.Common;
 using Moq;
 using NUnit.Framework;
@@ -40,10 +39,9 @@ public class PullRequestBuilderTests : SubscriptionOrPullRequestActorTests
 
     protected override void RegisterServices(IServiceCollection services)
     {
-        _remoteFactory.Setup(f => f.CreateRemoteAsync(It.IsAny<string>()))
-            .ReturnsAsync(
-                (string repo, ILogger logger) =>
-                    _darcRemotes.GetOrAddValue(repo, () => CreateMock<IRemote>()).Object);
+        _remoteFactory
+            .Setup(f => f.CreateRemoteAsync(It.IsAny<string>()))
+            .ReturnsAsync((string repo) => _darcRemotes.GetOrAddValue(repo, () => CreateMock<IRemote>()).Object);
 
         services.AddSingleton(_remoteFactory.Object);
         services.AddSingleton(_barClient.Object);

--- a/test/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/test/SubscriptionActorService.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -99,7 +99,7 @@ public class PullRequestPolicyFailureNotifierTests
         MockRemote = new Remote(GitRepo.Object, new VersionDetailsParser(), NullLogger.Instance);
 
         RemoteFactory = new Mock<IRemoteFactory>(MockBehavior.Strict);
-        RemoteFactory.Setup(m => m.GetRemoteAsync(It.IsAny<string>(), It.IsAny<ILogger>())).ReturnsAsync(MockRemote);
+        RemoteFactory.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(MockRemote);
 
         Provider = services.BuildServiceProvider();
         Scope = Provider.CreateScope();


### PR DESCRIPTION

- Blocks the user from making a mistake when creating codeflow subscriptions and not sourcing/targeting a VMR correctly.
- Stops requiring a logger when creating remotes.
- Uses DI in Darc to obtain a remote factory.

Resolves https://github.com/dotnet/arcade-services/issues/4174