### PR TITLE
Allow skipping BAR build look-up (+fix how we do it)

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
-using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.Logging;
@@ -18,18 +16,15 @@ internal class InitializeOperation : VmrOperationBase
 {
     private readonly InitializeCommandLineOptions _options;
     private readonly IVmrInitializer _vmrInitializer;
-    private readonly IBarApiClient _barClient;
 
     public InitializeOperation(
         InitializeCommandLineOptions options,
         IVmrInitializer vmrInitializer,
-        ILogger<InitializeOperation> logger,
-        IBarApiClient barClient)
+        ILogger<InitializeOperation> logger)
         : base(options, logger)
     {
         _options = options;
         _vmrInitializer = vmrInitializer;
-        _barClient = barClient;
     }
 
     protected override async Task ExecuteInternalAsync(
@@ -38,19 +33,10 @@ internal class InitializeOperation : VmrOperationBase
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken)
     {
-        Maestro.Client.Models.Build? build = null;
-
-        if (_options.EnableBuildLookUp)
-        {
-            build = (await _barClient.GetBuildsAsync(repoName, targetRevision)).FirstOrDefault();
-        }
-
         await _vmrInitializer.InitializeRepository(
             repoName,
             targetRevision,
             null,
-            build?.AzureDevOpsBuildNumber,
-            build?.Id,
             _options.Recursive,
             new NativePath(_options.SourceMappings),
             additionalRemotes,

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
@@ -59,6 +59,7 @@ internal class InitializeOperation : VmrOperationBase
             _options.GenerateCodeowners,
             _options.GenerateCredScanSuppressions,
             _options.DiscardPatches,
+            _options.EnableBuildLookUp,
             cancellationToken);
     }
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
@@ -38,7 +38,13 @@ internal class InitializeOperation : VmrOperationBase
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken)
     {
-        var build = (await _barClient.GetBuildsAsync(repoName, targetRevision)).SingleOrDefault();
+        Maestro.Client.Models.Build? build = null;
+
+        if (_options.NoBuildLookUp)
+        {
+            build = (await _barClient.GetBuildsAsync(repoName, targetRevision)).FirstOrDefault();
+        }
+
         await _vmrInitializer.InitializeRepository(
             repoName,
             targetRevision,

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
@@ -40,7 +40,7 @@ internal class InitializeOperation : VmrOperationBase
     {
         Maestro.Client.Models.Build? build = null;
 
-        if (_options.NoBuildLookUp)
+        if (_options.EnableBuildLookUp)
         {
             build = (await _barClient.GetBuildsAsync(repoName, targetRevision)).FirstOrDefault();
         }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
@@ -36,6 +36,8 @@ internal class UpdateOperation : VmrOperationBase
             repoName,
             targetRevision,
             targetVersion: null,
+            officialBuildId: null,
+            barId: null,
             _options.Recursive,
             additionalRemotes,
             _options.ComponentTemplate,

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
@@ -58,6 +58,7 @@ internal class UpdateOperation : VmrOperationBase
             _options.GenerateCredScanSuppressions,
             _options.DiscardPatches,
             reapplyVmrPatches: false,
+            _options.EnableBuildLookUp,
             cancellationToken);
     }
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
-using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.Logging;
 
@@ -17,18 +15,15 @@ internal class UpdateOperation : VmrOperationBase
 {
     private readonly UpdateCommandLineOptions _options;
     private readonly IVmrUpdater _vmrUpdater;
-    private readonly IBarApiClient _barClient;
 
     public UpdateOperation(
         UpdateCommandLineOptions options,
         IVmrUpdater vmrUpdater,
-        ILogger<UpdateOperation> logger,
-        IBarApiClient barClient)
+        ILogger<UpdateOperation> logger)
         : base(options, logger)
     {
         _options = options;
         _vmrUpdater = vmrUpdater;
-        _barClient = barClient;
     }
 
     protected override async Task ExecuteInternalAsync(
@@ -37,19 +32,10 @@ internal class UpdateOperation : VmrOperationBase
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken)
     {
-        Maestro.Client.Models.Build? build = null;
-
-        if (_options.EnableBuildLookUp)
-        {
-            build = (await _barClient.GetBuildsAsync(repoName, targetRevision)).FirstOrDefault();
-        }
-
         await _vmrUpdater.UpdateRepository(
             repoName,
             targetRevision,
             targetVersion: null,
-            build?.AzureDevOpsBuildNumber,
-            build?.Id,
             _options.Recursive,
             additionalRemotes,
             _options.ComponentTemplate,

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
@@ -37,7 +37,12 @@ internal class UpdateOperation : VmrOperationBase
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,
         CancellationToken cancellationToken)
     {
-        var build = (await _barClient.GetBuildsAsync(repoName, targetRevision)).SingleOrDefault();
+        Maestro.Client.Models.Build? build = null;
+
+        if (_options.NoBuildLookUp)
+        {
+            build = (await _barClient.GetBuildsAsync(repoName, targetRevision)).FirstOrDefault();
+        }
 
         await _vmrUpdater.UpdateRepository(
             repoName,

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
@@ -39,7 +39,7 @@ internal class UpdateOperation : VmrOperationBase
     {
         Maestro.Client.Models.Build? build = null;
 
-        if (_options.NoBuildLookUp)
+        if (_options.EnableBuildLookUp)
         {
             build = (await _barClient.GetBuildsAsync(repoName, targetRevision)).FirstOrDefault();
         }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/InitializeCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/InitializeCommandLineOptions.cs
@@ -16,4 +16,7 @@ internal class InitializeCommandLineOptions : VmrSyncCommandLineOptions<Initiali
 
     [Option("source-mappings", Required = true, HelpText = $"A path to the {VmrInfo.SourceMappingsFileName} file to be used for syncing.")]
     public string SourceMappings { get; set; }
+
+    [Option("no-build-lookup", Required = false, HelpText = "Do not look up package versions and build number from BAR")]
+    public bool NoBuildLookUp { get; set; } = false;
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/InitializeCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/InitializeCommandLineOptions.cs
@@ -17,6 +17,6 @@ internal class InitializeCommandLineOptions : VmrSyncCommandLineOptions<Initiali
     [Option("source-mappings", Required = true, HelpText = $"A path to the {VmrInfo.SourceMappingsFileName} file to be used for syncing.")]
     public string SourceMappings { get; set; }
 
-    [Option("no-build-lookup", Required = false, HelpText = "Do not look up package versions and build number from BAR")]
-    public bool NoBuildLookUp { get; set; } = false;
+    [Option("enable-build-lookup", Required = false, HelpText = "Look up package versions and build number from BAR when populating version files.")]
+    public bool EnableBuildLookUp { get; set; } = false;
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/UpdateCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/UpdateCommandLineOptions.cs
@@ -13,6 +13,6 @@ internal class UpdateCommandLineOptions : VmrSyncCommandLineOptions<UpdateOperat
     [Option('r', "recursive", Required = false, HelpText = $"Process also dependencies (from {VersionFiles.VersionDetailsXml}) recursively.")]
     public bool Recursive { get; set; } = false;
 
-    [Option("no-build-lookup", Required = false, HelpText = "Do not look up package versions and build number from BAR")]
-    public bool NoBuildLookUp { get; set; } = false;
+    [Option("enable-build-lookup", Required = false, HelpText = "Look up package versions and build number from BAR when populating version files.")]
+    public bool EnableBuildLookUp { get; set; } = false;
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/UpdateCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/UpdateCommandLineOptions.cs
@@ -12,4 +12,7 @@ internal class UpdateCommandLineOptions : VmrSyncCommandLineOptions<UpdateOperat
 {
     [Option('r', "recursive", Required = false, HelpText = $"Process also dependencies (from {VersionFiles.VersionDetailsXml}) recursively.")]
     public bool Recursive { get; set; } = false;
+
+    [Option("no-build-lookup", Required = false, HelpText = "Do not look up package versions and build number from BAR")]
+    public bool NoBuildLookUp { get; set; } = false;
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
@@ -27,6 +27,7 @@ public interface IVmrInitializer
     /// <param name="generateCodeowners">Whether to generate a CODEOWNERS file</param>
     /// <param name="generateCredScanSuppressions">Whether to generate a .config/CredScanSuppressions.json file</param>
     /// <param name="discardPatches">Whether to clean up genreated .patch files after their used</param>
+    /// <param name="lookUpBuilds">Whether to look up package versions and build number from BAR when populating version files</param>
     Task InitializeRepository(
         string mappingName,
         string? targetRevision,
@@ -41,5 +42,6 @@ public interface IVmrInitializer
         bool generateCodeowners,
         bool generateCredScanSuppressions,
         bool discardPatches,
+        bool lookUpBuilds,
         CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrInitializer.cs
@@ -17,8 +17,6 @@ public interface IVmrInitializer
     /// <param name="mappingName">Name of a repository mapping</param>
     /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
     /// <param name="targetVersion">Version of packages, that the SHA we're updating to, produced</param>
-    /// <param name="officialBuildId">Azdo build id of the build that's being flown, if applicable</param>
-    /// <param name="barId">Bar id of the build that's being flown, if applicable</param>
     /// <param name="initializeDependencies">When true, initializes dependencies (from Version.Details.xml) recursively</param>
     /// <param name="sourceMappingsPath">Path to the source-mappings.json file</param>
     /// <param name="additionalRemotes">Additional git remotes to use when fetching</param>
@@ -32,8 +30,6 @@ public interface IVmrInitializer
         string mappingName,
         string? targetRevision,
         string? targetVersion,
-        string? officialBuildId,
-        int? barId,
         bool initializeDependencies,
         LocalPath sourceMappingsPath,
         IReadOnlyCollection<AdditionalRemote> additionalRemotes,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
@@ -26,6 +26,7 @@ public interface IVmrUpdater
     /// <param name="generateCredScanSuppressions">Whether to generate a .config/CredScanSuppressions.json file</param>
     /// <param name="discardPatches">Whether to clean up genreated .patch files after their used</param>
     /// <param name="reapplyVmrPatches">Whether to reapply patches stored in the VMR</param>
+    /// <param name="lookUpBuilds">Whether to look up package versions and build number from BAR when populating version files</param>
     /// <returns>True if the repository was updated, false if it was already up to date</returns>
     Task<bool> UpdateRepository(
         string mappingName,
@@ -41,5 +42,6 @@ public interface IVmrUpdater
         bool generateCredScanSuppressions,
         bool discardPatches,
         bool reapplyVmrPatches,
+        bool lookUpBuilds,
         CancellationToken cancellationToken);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -253,6 +253,7 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 generateCredScanSuppressions: true,
                 discardPatches,
                 reapplyVmrPatches: true,
+                lookUpBuilds: true,
                 cancellationToken);
         }
         catch (PatchApplicationFailedException e)
@@ -308,6 +309,7 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 generateCredScanSuppressions: false,
                 discardPatches,
                 reapplyVmrPatches: true,
+                lookUpBuilds: true,
                 cancellationToken);
         }
 
@@ -383,6 +385,7 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             generateCredScanSuppressions: true,
             discardPatches,
             reapplyVmrPatches: true,
+            lookUpBuilds: true,
             cancellationToken);
     }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -39,7 +39,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         """;
 
     private readonly IVmrInfo _vmrInfo;
-    private readonly IBarApiClient _barClient;
+    private readonly IBasicBarClient _barClient;
     private readonly IVmrDependencyTracker _dependencyTracker;
     private readonly IVmrPatchHandler _patchHandler;
     private readonly IRepositoryCloneManager _cloneManager;
@@ -60,7 +60,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         ILocalGitRepoFactory localGitRepoFactory,
         IDependencyFileManager dependencyFileManager,
         IWorkBranchFactory workBranchFactory,
-        IBarApiClient barClient,
+        IBasicBarClient barClient,
         IFileSystem fileSystem,
         ILogger<VmrUpdater> logger,
         ISourceManifest sourceManifest,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -89,6 +89,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         bool generateCodeowners,
         bool generateCredScanSuppressions,
         bool discardPatches,
+        bool lookUpBuilds,
         CancellationToken cancellationToken)
     {
         await _dependencyTracker.RefreshMetadata(sourceMappingsPath);
@@ -120,7 +121,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
         try
         {
             IEnumerable<VmrDependencyUpdate> updates = initializeDependencies
-                ? await GetAllDependenciesAsync(rootUpdate, additionalRemotes, cancellationToken)
+                ? await GetAllDependenciesAsync(rootUpdate, additionalRemotes, lookUpBuilds, cancellationToken)
                 : [rootUpdate];
 
             foreach (var update in updates)

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -35,7 +35,7 @@ public abstract class VmrManagerBase
     private readonly ILocalGitClient _localGitClient;
     private readonly ILocalGitRepoFactory _localGitRepoFactory;
     private readonly IDependencyFileManager _dependencyFileManager;
-    private readonly IBarApiClient _barClient;
+    private readonly IBasicBarClient _barClient;
     private readonly IFileSystem _fileSystem;
     private readonly ILogger _logger;
 
@@ -54,7 +54,7 @@ public abstract class VmrManagerBase
         ILocalGitClient localGitClient,
         ILocalGitRepoFactory localGitRepoFactory,
         IDependencyFileManager dependencyFileManager,
-        IBarApiClient barClient,
+        IBasicBarClient barClient,
         IFileSystem fileSystem,
         ILogger<VmrUpdater> logger)
     {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -12,7 +12,6 @@ using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models;
 using Microsoft.DotNet.DarcLib.Models.Darc;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 #nullable enable
@@ -20,7 +19,7 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 
 public abstract class VmrManagerBase
 {
-    protected const string InterruptedSyncExceptionMessage = 
+    protected const string InterruptedSyncExceptionMessage =
         "A new branch was created for the sync and didn't get merged as the sync " +
         "was interrupted. A new sync should start from {original} branch.";
 
@@ -36,9 +35,9 @@ public abstract class VmrManagerBase
     private readonly ILocalGitClient _localGitClient;
     private readonly ILocalGitRepoFactory _localGitRepoFactory;
     private readonly IDependencyFileManager _dependencyFileManager;
+    private readonly IBarApiClient _barClient;
     private readonly IFileSystem _fileSystem;
     private readonly ILogger _logger;
-    private readonly IServiceProvider _serviceProvider;
 
     protected ILocalGitRepo GetLocalVmr() => _localGitRepoFactory.Create(_vmrInfo.VmrPath);
 
@@ -55,9 +54,9 @@ public abstract class VmrManagerBase
         ILocalGitClient localGitClient,
         ILocalGitRepoFactory localGitRepoFactory,
         IDependencyFileManager dependencyFileManager,
+        IBarApiClient barClient,
         IFileSystem fileSystem,
-        ILogger<VmrUpdater> logger,
-        IServiceProvider serviceProvider)
+        ILogger<VmrUpdater> logger)
     {
         _logger = logger;
         _vmrInfo = vmrInfo;
@@ -72,8 +71,8 @@ public abstract class VmrManagerBase
         _localGitClient = localGitClient;
         _localGitRepoFactory = localGitRepoFactory;
         _dependencyFileManager = dependencyFileManager;
+        _barClient = barClient;
         _fileSystem = fileSystem;
-        _serviceProvider = serviceProvider;
     }
 
     public async Task<IReadOnlyCollection<VmrIngestionPatch>> UpdateRepoToRevisionAsync(
@@ -205,7 +204,7 @@ public abstract class VmrManagerBase
 
         await _localGitClient.CommitAsync(_vmrInfo.VmrPath, commitMessage, allowEmpty: true, author);
 
-        _logger.LogInformation("Committed in {duration} seconds", (int) watch.Elapsed.TotalSeconds);
+        _logger.LogInformation("Committed in {duration} seconds", (int)watch.Elapsed.TotalSeconds);
     }
 
     /// <summary>
@@ -226,8 +225,6 @@ public abstract class VmrManagerBase
         reposToScan.Enqueue(transitiveDependencies.Values.Single());
 
         _logger.LogInformation("Finding transitive dependencies for {mapping}:{revision}..", root.Mapping.Name, root.TargetRevision);
-
-        var barClient = _serviceProvider.GetRequiredService<IBasicBarClient>();
 
         while (reposToScan.TryDequeue(out var repo))
         {
@@ -281,7 +278,7 @@ public abstract class VmrManagerBase
                 Maestro.Client.Models.Build? build = null;
                 if (lookUpBuilds)
                 {
-                    var builds = (await barClient.GetBuildsAsync(dependency.RepoUri, dependency.Commit))
+                    var builds = (await _barClient.GetBuildsAsync(dependency.RepoUri, dependency.Commit))
                         .OrderByDescending(b => b.DateProduced)
                         .ToList();
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -51,7 +51,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
     private readonly IRepositoryCloneManager _cloneManager;
     private readonly IVmrPatchHandler _patchHandler;
     private readonly IFileSystem _fileSystem;
-    private readonly IBarApiClient _barClient;
+    private readonly IBasicBarClient _barClient;
     private readonly ILogger<VmrUpdater> _logger;
     private readonly ISourceManifest _sourceManifest;
     private readonly IThirdPartyNoticesGenerator _thirdPartyNoticesGenerator;
@@ -75,7 +75,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         IGitRepoFactory gitRepoFactory,
         IWorkBranchFactory workBranchFactory,
         IFileSystem fileSystem,
-        IBarApiClient barClient,
+        IBasicBarClient barClient,
         ILogger<VmrUpdater> logger,
         ISourceManifest sourceManifest,
         IVmrInfo vmrInfo)

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -108,6 +108,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         bool generateCredScanSuppressions,
         bool discardPatches,
         bool reapplyVmrPatches,
+        bool lookUpBuilds,
         CancellationToken cancellationToken)
     {
         await _dependencyTracker.RefreshMetadata();
@@ -142,6 +143,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 generateCodeowners,
                 generateCredScanSuppressions,
                 discardPatches,
+                lookUpBuilds,
                 cancellationToken);
         }
         else
@@ -286,6 +288,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         bool generateCodeowners,
         bool generateCredScanSuppressions,
         bool discardPatches,
+        bool lookUpBuilds,
         CancellationToken cancellationToken)
     {
         string originalRootSha = GetCurrentVersion(rootUpdate.Mapping);
@@ -296,7 +299,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             Constants.Arrow,
             rootUpdate.TargetRevision);
 
-        var updates = (await GetAllDependenciesAsync(rootUpdate, additionalRemotes, cancellationToken)).ToList();
+        var updates = (await GetAllDependenciesAsync(rootUpdate, additionalRemotes, lookUpBuilds, cancellationToken)).ToList();
 
         var extraneousMappings = _dependencyTracker.Mappings
             .Where(mapping => !updates.Any(update => update.Mapping == mapping) && !mapping.DisableSynchronization)

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -171,23 +171,53 @@ internal abstract class VmrTestsBase
         await CallDarcUpdate(repoName, commit, generateCodeowners, generateCredScanSuppressions);
     }
 
-    private async Task CallDarcInitialize(string repository, string commit, LocalPath sourceMappingsPath)
+    private async Task CallDarcInitialize(string mapping, string commit, LocalPath sourceMappingsPath)
     {
         using var scope = ServiceProvider.CreateScope();
         var vmrInitializer = scope.ServiceProvider.GetRequiredService<IVmrInitializer>();
-        await vmrInitializer.InitializeRepository(repository, commit, null, null, null, true, sourceMappingsPath, Array.Empty<AdditionalRemote>(), null, null, false, false, true, _cancellationToken.Token);
+        await vmrInitializer.InitializeRepository(
+            mappingName: mapping,
+            targetRevision: commit,
+            targetVersion: null,
+            officialBuildId: null,
+            barId: null,
+            initializeDependencies: true,
+            sourceMappingsPath: sourceMappingsPath,
+            additionalRemotes: Array.Empty<AdditionalRemote>(),
+            componentTemplatePath: null,
+            tpnTemplatePath: null,
+            generateCodeowners: false,
+            generateCredScanSuppressions: false,
+            discardPatches: true,
+            lookUpBuilds: false,
+            cancellationToken: _cancellationToken.Token);
     }
 
-    protected async Task CallDarcUpdate(string repository, string commit, bool generateCodeowners = false, bool generateCredScanSuppressions = false)
+    protected async Task CallDarcUpdate(string mapping, string commit, bool generateCodeowners = false, bool generateCredScanSuppressions = false)
     {
-        await CallDarcUpdate(repository, commit, [], generateCodeowners, generateCredScanSuppressions);
+        await CallDarcUpdate(mapping, commit, [], generateCodeowners, generateCredScanSuppressions);
     }
 
-    protected async Task CallDarcUpdate(string repository, string commit, AdditionalRemote[] additionalRemotes, bool generateCodeowners = false, bool generateCredScanSuppressions = false)
+    protected async Task CallDarcUpdate(string mapping, string commit, AdditionalRemote[] additionalRemotes, bool generateCodeowners = false, bool generateCredScanSuppressions = false)
     {
         using var scope = ServiceProvider.CreateScope();
         var vmrUpdater = scope.ServiceProvider.GetRequiredService<IVmrUpdater>();
-        await vmrUpdater.UpdateRepository(repository, commit, null, null, null, true, additionalRemotes, null, null, generateCodeowners, generateCredScanSuppressions, discardPatches: true, reapplyVmrPatches: false, _cancellationToken.Token);
+        await vmrUpdater.UpdateRepository(
+            mappingName: mapping,
+            targetRevision: commit,
+            targetVersion: null,
+            officialBuildId: null,
+            barId: null,
+            updateDependencies: true,
+            additionalRemotes: additionalRemotes,
+            componentTemplatePath: null,
+            tpnTemplatePath: null,
+            generateCodeowners: generateCodeowners,
+            generateCredScanSuppressions: generateCredScanSuppressions,
+            discardPatches: true,
+            reapplyVmrPatches: false,
+            lookUpBuilds: false,
+            cancellationToken: _cancellationToken.Token);
     }
 
     protected async Task<bool> CallDarcBackflow(

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -179,8 +179,6 @@ internal abstract class VmrTestsBase
             mappingName: mapping,
             targetRevision: commit,
             targetVersion: null,
-            officialBuildId: null,
-            barId: null,
             initializeDependencies: true,
             sourceMappingsPath: sourceMappingsPath,
             additionalRemotes: Array.Empty<AdditionalRemote>(),


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/4166

We need to skip the look-up in some scenarios such as public PR builds of dotnet/sdk where we run the sync but don't have access to AzDO.
