### PR TITLE
Ignore mapping disables during non-recursive synchronization

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -198,12 +198,6 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         bool discardPatches,
         CancellationToken cancellationToken)
     {
-        if (update.Mapping.DisableSynchronization)
-        {
-            _logger.LogInformation("Synchronization for {repo} is disabled, skipping...", update.Mapping.Name);
-            return [];
-        }
-
         VmrDependencyVersion currentVersion = _dependencyTracker.GetDependencyVersion(update.Mapping)
             ?? throw new Exception($"Failed to find current version for {update.Mapping.Name}");
 
@@ -340,6 +334,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         {
             if (update.Mapping.DisableSynchronization)
             {
+                _logger.LogInformation("Synchronization for {repo} is disabled, skipping...", update.Mapping.Name);
                 continue;
             }
 


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/4159

This means that we will ignore the flag during forward codeflows which would not otherwise be possible because we want to disable the pipeline sync for a repo always first.
But it's okay to do this because when we want to synchronize a single repository, it doesn't make sense to just refuse to do it because it's toggled off. It does make sense to adhere to this flag during a recursive sync (which happens in the pipeline sync).

Also improves the exception when we can't create a PR.