### PR TITLE
Change PCS staging URL

### DIFF
--- a/eng/templates/jobs/e2e-pcs-tests.yml
+++ b/eng/templates/jobs/e2e-pcs-tests.yml
@@ -22,7 +22,7 @@ jobs:
     - group: Arcade-Services-Scenario-Tests
     - ${{ if not(or(startsWith(variables['Build.SourceBranch'], 'refs/heads/production'), startsWith(variables['Build.SourceBranch'], 'refs/heads/production-'), eq(variables['Build.SourceBranch'], 'refs/heads/production'))) }}:
       - name: PcsTestEndpoint
-        value: https://product-construction-int.delightfuldune-c0f01ab0.westus2.azurecontainerapps.io
+        value: https://product-construction-int.agreeablesky-499be9de.westus2.azurecontainerapps.io
       - name: ScenarioTestSubscription
         value: "Darc: Maestro Staging"
       - name: MaestroAppId

--- a/src/Maestro/Client/src/MaestroApiOptions.cs
+++ b/src/Maestro/Client/src/MaestroApiOptions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Maestro.Client
         public const string StagingMaestroUri = "https://maestro.int-dot.net/";
         public const string OldPcsStagingUri = "https://maestro-int.westus2.cloudapp.azure.com/";
         public const string PcsProdUri = "https://product-construction-prod.wittysky-0c79e3cc.westus2.azurecontainerapps.io/";
-        public const string PcsStagingUri = "https://product-construction-int.delightfuldune-c0f01ab0.westus2.azurecontainerapps.io/";
+        public const string PcsStagingUri = "https://product-construction-int.agreeablesky-499be9de.westus2.azurecontainerapps.io/";
         public const string PcsLocalUri = "https://localhost:53180/";
 
         private const string APP_USER_SCOPE = "Maestro.User";

--- a/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/ProductConstructionServiceApiOptions.cs
+++ b/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/ProductConstructionServiceApiOptions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.ProductConstructionService.Client
         public const string StagingMaestroUri = "https://maestro.int-dot.net/";
         public const string OldStagingMaestroUri = "https://maestro-int.westus2.cloudapp.azure.com/";
         public const string PcsProdUri = "https://product-construction-prod.wittysky-0c79e3cc.westus2.azurecontainerapps.io/";
-        public const string PcsStagingUri = "https://product-construction-int.delightfuldune-c0f01ab0.westus2.azurecontainerapps.io/";
+        public const string PcsStagingUri = "https://product-construction-int.agreeablesky-499be9de.westus2.azurecontainerapps.io/";
         public const string PcsLocalUri = "https://localhost:53180/";
 
         private const string APP_USER_SCOPE = "Maestro.User";

--- a/test/ProductConstructionService.ScenarioTests/TestParameters.cs
+++ b/test/ProductConstructionService.ScenarioTests/TestParameters.cs
@@ -58,7 +58,7 @@ public class TestParameters : IDisposable
 
         PcsBaseUri = Environment.GetEnvironmentVariable("PCS_BASEURI")
             ?? userSecrets["PCS_BASEURI"]
-            ?? "https://product-construction-int.delightfuldune-c0f01ab0.westus2.azurecontainerapps.io/";
+            ?? "https://product-construction-int.agreeablesky-499be9de.westus2.azurecontainerapps.io/";
         pcsToken = Environment.GetEnvironmentVariable("PCS_TOKEN")
             ?? userSecrets["PCS_TOKEN"];
         IsCI = Environment.GetEnvironmentVariable("DARC_IS_CI")?.ToLower() == "true";


### PR DESCRIPTION
The INT app was re-created and got a new URL last week. Fixing so that we go green in tests
https://github.com/dotnet/arcade-services/issues/3797