### PR TITLE
Remove cache entries for already merged PRs

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -117,6 +117,8 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 case PullRequestStatus.Invalid:
                     // If the PR is completed, we will open a new one
                     pr = null;
+                    await _pullRequestState.TryDeleteAsync();
+                    await _pullRequestCheckReminders.UnsetReminderAsync(isCodeFlow);
                     break;
                 case PullRequestStatus.InProgressCanUpdate:
                     // If we can update it, we will do it below


### PR DESCRIPTION
The cache is getting full of entries which are never removed if a PR is closed by someone other than Maestro.
Also improves the table that shows tracked PRs so it's easier to understand.

https://github.com/dotnet/arcade-services/issues/4198