### PR TITLE
Fix clean-up after the ArcadeSDK E2E test

### DIFF
--- a/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
@@ -1021,12 +1021,12 @@ internal abstract partial class ScenarioTestBase
 
     protected static string GetTestChannelName([CallerMemberName] string testName = "")
     {
-        return $"c{testName}_{Guid.NewGuid().ToString().Substring(0, 16)}";
+        return $"Test {testName} {Guid.NewGuid().ToString().Substring(0, 16)}";
     }
 
     protected static string GetTestBranchName([CallerMemberName] string testName = "")
     {
-        return $"b{testName}_{Guid.NewGuid().ToString().Substring(0, 16)}";
+        return $"test/{testName}/{Guid.NewGuid().ToString().Substring(0, 16)}";
     }
 
     protected string GetUniqueAssetName(string packageName)

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_SdkUpdate.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_SdkUpdate.cs
@@ -20,12 +20,12 @@ internal class ScenarioTests_SdkUpdate : ScenarioTestBase
     [TestCase(true)]
     public async Task ArcadeSdkUpdate_E2E(bool targetAzDO)
     {
-        var testChannelName = "Test Channel " + _random.Next(int.MaxValue);
-        const string sourceOrg = "maestro-auth-test";
+        var testChannelName = GetTestChannelName();
+        var targetBranch = GetTestBranchName();
+
         const string sourceRepo = "arcade";
-        const string sourceRepoUri = $"https://github.com/{sourceOrg}/{sourceRepo}";
+        const string sourceRepoUri = $"https://github.com/{TestRepository.TestOrg}/{sourceRepo}";
         const string sourceBranch = "dependencyflow-tests";
-        const string sourceCommit = "f3d51d2c9af2a3eb046fa54c5acdef9fb37db172";
         const string newArcadeSdkVersion = "2.1.0";
         var sourceBuildNumber = _random.Next(int.MaxValue).ToString();
 
@@ -37,21 +37,19 @@ internal class ScenarioTests_SdkUpdate : ScenarioTestBase
                 Version = newArcadeSdkVersion
             }
         ];
-        var targetRepo = "maestro-test2";
-        var targetBranch = "test/" + _random.Next(int.MaxValue).ToString();
 
         await using AsyncDisposableValue<string> channel =
             await CreateTestChannelAsync(testChannelName);
         await using AsyncDisposableValue<string> sub =
-            await CreateSubscriptionAsync(testChannelName, sourceRepo, targetRepo, targetBranch, "none", sourceOrg: sourceOrg, targetIsAzDo: targetAzDO);
+            await CreateSubscriptionAsync(testChannelName, sourceRepo, TestRepository.TestRepo2Name, targetBranch, "none", TestRepository.TestOrg, targetIsAzDo: targetAzDO);
         Build build =
-            await CreateBuildAsync(GetRepoUrl(sourceOrg, sourceRepo), sourceBranch, sourceCommit, sourceBuildNumber, sourceAssets);
+            await CreateBuildAsync(GetRepoUrl(TestRepository.TestOrg, sourceRepo), sourceBranch, TestRepository.ArcadeTestRepoCommit, sourceBuildNumber, sourceAssets);
 
         await using IAsyncDisposable _ = await AddBuildToChannelAsync(build.Id, testChannelName);
 
         using TemporaryDirectory repo = targetAzDO
-            ? await CloneAzDoRepositoryAsync(targetRepo)
-            : await CloneRepositoryAsync(targetRepo);
+            ? await CloneAzDoRepositoryAsync(TestRepository.TestRepo2Name)
+            : await CloneRepositoryAsync(TestRepository.TestRepo2Name);
 
         using (ChangeDirectory(repo.Directory))
         {
@@ -64,13 +62,13 @@ internal class ScenarioTests_SdkUpdate : ScenarioTestBase
             await using IAsyncDisposable ___ = await PushGitBranchAsync("origin", targetBranch);
             await TriggerSubscriptionAsync(sub.Value);
 
-            var expectedTitle = $"[{targetBranch}] Update dependencies from {sourceOrg}/{sourceRepo}";
+            var expectedTitle = $"[{targetBranch}] Update dependencies from {TestRepository.TestOrg}/{sourceRepo}";
             DependencyDetail expectedDependency = new()
             {
                 Name = DependencyFileManager.ArcadeSdkPackageName,
                 Version = newArcadeSdkVersion,
                 RepoUri = sourceRepoUri,
-                Commit = sourceCommit,
+                Commit = TestRepository.ArcadeTestRepoCommit,
                 Type = DependencyType.Toolset,
                 Pinned = false,
             };
@@ -80,7 +78,7 @@ internal class ScenarioTests_SdkUpdate : ScenarioTestBase
             {
                 prHead = await CheckAzDoPullRequest(
                     expectedTitle,
-                    targetRepo,
+                    TestRepository.TestRepo2Name,
                     targetBranch,
                     [expectedDependency],
                     repo.Directory,
@@ -92,7 +90,7 @@ internal class ScenarioTests_SdkUpdate : ScenarioTestBase
             }
             else
             {
-                Octokit.PullRequest pr = await WaitForPullRequestAsync(targetRepo, targetBranch);
+                Octokit.PullRequest pr = await WaitForPullRequestAsync(TestRepository.TestRepo2Name, targetBranch);
                 pr.Title.Should().BeEquivalentTo(expectedTitle);
                 prHead = pr.Head.Ref;
             }
@@ -106,23 +104,23 @@ internal class ScenarioTests_SdkUpdate : ScenarioTestBase
                   $"Name:             {DependencyFileManager.ArcadeSdkPackageName}",
                   $"Version:          {newArcadeSdkVersion}",
                   $"Repo:             {sourceRepoUri}",
-                  $"Commit:           {sourceCommit}",
+                  $"Commit:           {TestRepository.ArcadeTestRepoCommit}",
                    "Type:             Toolset",
                    "Pinned:           False",
                 ]);
 
-            using TemporaryDirectory arcadeRepo = await CloneRepositoryAsync(sourceOrg, sourceRepo);
+            using TemporaryDirectory arcadeRepo = await CloneRepositoryAsync(TestRepository.TestOrg, sourceRepo);
             using (ChangeDirectory(arcadeRepo.Directory))
             {
-                await CheckoutRemoteRefAsync(sourceCommit);
+                await CheckoutRemoteRefAsync(TestRepository.ArcadeTestRepoCommit);
             }
 
             var arcadeFiles = Directory.EnumerateFileSystemEntries(Path.Join(arcadeRepo.Directory, "eng", "common"),
                     "*", SearchOption.AllDirectories)
                 .Select(s => s.Substring(arcadeRepo.Directory.Length))
                 .ToHashSet();
-            var repoFiles = Directory.EnumerateFileSystemEntries(Path.Join(repo.Directory, "eng", "common"), "*",
-                    SearchOption.AllDirectories)
+            var repoFiles = Directory.EnumerateFileSystemEntries(Path.Join(repo.Directory, "eng", "common"),
+                    "*", SearchOption.AllDirectories)
                 .Select(s => s.Substring(repo.Directory.Length))
                 .ToHashSet();
 

--- a/test/ProductConstructionService.ScenarioTests/TestRepository.cs
+++ b/test/ProductConstructionService.ScenarioTests/TestRepository.cs
@@ -5,15 +5,16 @@ namespace ProductConstructionService.ScenarioTests;
 
 internal class TestRepository
 {
-    internal static string TestRepo1Name => "maestro-test1";
-    internal static string TestRepo2Name => "maestro-test2";
-    internal static string TestRepo3Name => "maestro-test3";
-    internal static string VmrTestRepoName => "maestro-test-vmr";
-    internal static string SourceBranch => "master";
+    internal const string TestOrg = "maestro-auth-test";
+    internal const string TestRepo1Name = "maestro-test1";
+    internal const string TestRepo2Name = "maestro-test2";
+    internal const string TestRepo3Name = "maestro-test3";
+    internal const string VmrTestRepoName = "maestro-test-vmr";
+    internal const string SourceBranch = "master";
 
     // This branch and commit data is special for the coherency test
     // It's required to make sure that the dependency tree is set up correctly in the repo without conflicting with other test cases
-    internal static string CoherencySourceBranch => "coherency-tree";
-    internal static string CoherencyTestRepo1Commit => "cc1a27107a1f4c4bc5e2f796c5ef346f60abb404";
-    internal static string CoherencyTestRepo2Commit => "8460158878d4b7568f55d27960d4453877523ea6";
+    internal const string CoherencyTestRepo1Commit = "cc1a27107a1f4c4bc5e2f796c5ef346f60abb404";
+    internal const string CoherencyTestRepo2Commit = "8460158878d4b7568f55d27960d4453877523ea6";
+    internal const string ArcadeTestRepoCommit = "f3d51d2c9af2a3eb046fa54c5acdef9fb37db172";
 }


### PR DESCRIPTION
This is the last test that is not cleaning up its branches properly. Also made it name branches/channels the same way as the other tests.

https://github.com/dotnet/arcade-services/issues/4172
