### PR TITLE
Improve the "Tracked PRs" page

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/PullRequestController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/PullRequestController.cs
@@ -84,8 +84,8 @@ public partial class PullRequestController : ControllerBase
 
             prs.Add(new TrackedPullRequest(
                 TurnApiUrlToWebsite(pr.Url),
-                sampleSub?.Channel?.Name ?? "N/A",
-                sampleSub?.TargetBranch ?? "N/A",
+                sampleSub?.Channel?.Name,
+                sampleSub?.TargetBranch,
                 updates));
         }
 
@@ -114,8 +114,8 @@ public partial class PullRequestController : ControllerBase
 
     private record TrackedPullRequest(
         string Url,
-        string Channel,
-        string TargetBranch,
+        string? Channel,
+        string? TargetBranch,
         List<PullRequestUpdate> Updates);
 
     private record PullRequestUpdate(

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Layout/MainLayout.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Layout/MainLayout.razor
@@ -9,6 +9,10 @@
 
         <FluentSpacer />
 
+        <FluentAnchor Href="/pullrequests" Appearance="Appearance.Outline" Style="margin-right: 40px">
+            Tracked pull requests
+        </FluentAnchor>
+
         <div class="settings">
             <FluentButton BackgroundColor="var(--neutral-layer-4)" OnClick="OpenSiteSettingsAsync" Title="Site settings">
                 <FluentIcon Value="@(new Icons.Regular.Size20.Settings())" Color="Color.Neutral" Title="Site settings" />

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/PullRequests.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/PullRequests.razor
@@ -8,15 +8,37 @@
 
 <GridViewTemplate Title="Pull Requests" ShowSkeleton="TrackedPullRequests == null">
     <Content>
-        <FluentDataGrid Id="pullRequestsGrid" Items="@TrackedPullRequests" GridTemplateColumns="3fr 1fr 1fr" TGridItem=TrackedPullRequest Style="width: 100%">
-            <TemplateColumn Sortable="true" Align="Align.Start" Title="Pull Request">
+        <FluentDataGrid Id="pullRequestsGrid" Items="@TrackedPullRequests" GridTemplateColumns="2fr 1fr 1fr" TGridItem=TrackedPullRequest Style="width: 100%">
+            <TemplateColumn Sortable="true" Align="Align.Start" Title="Pull request">
                 <FluentAnchor Href="@context.Url" Target="_blank" Appearance="Appearance.Hypertext">@context.Url</FluentAnchor>
             </TemplateColumn>
             <TemplateColumn Sortable="true" Align="Align.Center" Title="Channel">
-                <FluentLabel>@context.Channel</FluentLabel>
+                @if (context.Channel != null)
+                {
+                    <FluentLabel>@context.Channel</FluentLabel>
+                }
+                else
+                {
+                    <FluentLabel>
+                        <FluentIcon Value="@(new Icons.Filled.Size20.Warning())"
+                                    Color="Color.Warning"
+                                    Title="Subscription for which this PR was created was not found" />
+                    </FluentLabel>
+                }
             </TemplateColumn>
             <TemplateColumn Sortable="true" Align="Align.Center" Title="Target branch">
-                <FluentLabel>@context.TargetBranch</FluentLabel>
+                @if (context.TargetBranch != null)
+                {
+                    <FluentLabel>@context.TargetBranch</FluentLabel>
+                }
+                else
+                {
+                    <FluentLabel>
+                        <FluentIcon Value="@(new Icons.Filled.Size20.Warning())"
+                                    Color="Color.Warning"
+                                    Title="Subscription for which this PR was created was not found" />
+                    </FluentLabel>
+                }
             </TemplateColumn>
         </FluentDataGrid>
     </Content>

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/PullRequests.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/PullRequests.razor
@@ -45,11 +45,23 @@
 </GridViewTemplate>
 
 @code {
-
     IQueryable<TrackedPullRequest>? TrackedPullRequests = null;
+    Timer? _timer;
 
     protected override async Task OnInitializedAsync()
     {
+        await LoadDataAsync();
+        _timer = new Timer(async _ => await LoadDataAsync(), null, TimeSpan.Zero, TimeSpan.FromSeconds(30));
+    }
+
+    private async Task LoadDataAsync()
+    {
         TrackedPullRequests = (await api.PullRequest.GetTrackedPullRequestsAsync()).AsQueryable();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
     }
 }


### PR DESCRIPTION
- Adds a main menu item for the "Tracked PRs" page
- Decodes GUIDs in org/repo names of AzDO PR URLs
- Makes the page refresh every 30 seconds

https://github.com/dotnet/arcade-services/issues/4198