### PR TITLE
Validate repository URLs in darc subscription commands

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionData.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionData.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.DotNet.Darc.Models.PopUps;
+
+/// <summary>
+/// Helper class for YAML encoding/decoding purposes.
+/// This is used so that we can have friendly alias names for elements.
+/// </summary>
+internal class SubscriptionData
+{
+    public const string SourceRepoElement = "Source Repository URL";
+    public const string TargetRepoElement = "Target Repository URL";
+    public const string SourceEnabledElement = "Source Enabled";
+
+    private const string ChannelElement = "Channel";
+    private const string TargetBranchElement = "Target Branch";
+    private const string UpdateFrequencyElement = "Update Frequency";
+    private const string MergePolicyElement = "Merge Policies";
+    private const string BatchableElement = "Batchable";
+    private const string FailureNotificationTagsElement = "Pull Request Failure Notification Tags";
+    private const string SourceDirectoryElement = "Source Directory";
+    private const string TargetDirectoryElement = "Target Directory";
+    private const string ExcludedAssetsElement = "Excluded Assets";
+
+    [YamlMember(Alias = ChannelElement, ApplyNamingConventions = false)]
+    public string Channel { get; set; }
+
+    [YamlMember(Alias = SourceRepoElement, ApplyNamingConventions = false)]
+    public string SourceRepository { get; set; }
+
+    [YamlMember(Alias = TargetRepoElement, ApplyNamingConventions = false)]
+    public string TargetRepository { get; set; }
+
+    [YamlMember(Alias = TargetBranchElement, ApplyNamingConventions = false)]
+    public string TargetBranch { get; set; }
+
+    [YamlMember(Alias = UpdateFrequencyElement, ApplyNamingConventions = false)]
+    public string UpdateFrequency { get; set; }
+
+    [YamlMember(Alias = BatchableElement, ApplyNamingConventions = false)]
+    public string Batchable { get; set; }
+
+    [YamlMember(Alias = MergePolicyElement, ApplyNamingConventions = false)]
+    public List<MergePolicyData> MergePolicies { get; set; }
+
+    [YamlMember(Alias = FailureNotificationTagsElement, ApplyNamingConventions = false)]
+    public string FailureNotificationTags { get; set; }
+
+    [YamlMember(Alias = SourceEnabledElement, ApplyNamingConventions = false)]
+    public string SourceEnabled { get; set; }
+
+    [YamlMember(Alias = SourceDirectoryElement, ApplyNamingConventions = false)]
+    public string SourceDirectory { get; set; }
+
+    [YamlMember(Alias = TargetDirectoryElement, ApplyNamingConventions = false)]
+    public string TargetDirectory { get; set; }
+
+    [YamlMember(Alias = ExcludedAssetsElement, ApplyNamingConventions = false)]
+    public List<string> ExcludedAssets { get; set; }
+}

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
@@ -17,25 +17,13 @@ namespace Microsoft.DotNet.Darc.Models.PopUps;
 /// <summary>
 /// Common class for subscription management popups.
 /// </summary>
-public abstract class SubscriptionPopUp : EditorPopUp
+internal abstract class SubscriptionPopUp<TData> : EditorPopUp where TData : SubscriptionData
 {
-    private const string ChannelElement = "Channel";
-    private const string SourceRepoElement = "Source Repository URL";
-    private const string TargetRepoElement = "Target Repository URL";
-    private const string TargetBranchElement = "Target Branch";
-    private const string UpdateFrequencyElement = "Update Frequency";
-    private const string MergePolicyElement = "Merge Policies";
-    private const string BatchableElement = "Batchable";
-    private const string FailureNotificationTagsElement = "Pull Request Failure Notification Tags";
-    protected const string SourceEnabledElement = "Source Enabled";
-    private const string SourceDirectoryElement = "Source Directory";
-    private const string TargetDirectoryElement = "Target Directory";
-    private const string ExcludedAssetsElement = "Excluded Assets";
-
-    protected readonly SubscriptionData _data;
+    protected readonly TData _data;
     private readonly bool _forceCreation;
     private readonly IEnumerable<string> _suggestedChannels;
     private readonly IEnumerable<string> _suggestedRepositories;
+    private readonly IEnumerable<string> _availableUpdateFrequencies;
     private readonly IEnumerable<string> _availableMergePolicyHelp;
     private readonly ILogger _logger;
     private readonly IGitRepoFactory _gitRepoFactory;
@@ -58,10 +46,11 @@ public abstract class SubscriptionPopUp : EditorPopUp
         bool forceCreation,
         IEnumerable<string> suggestedChannels,
         IEnumerable<string> suggestedRepositories,
+        IEnumerable<string> availableUpdateFrequencies,
         IEnumerable<string> availableMergePolicyHelp,
         ILogger logger,
         IGitRepoFactory gitRepoFactory,
-        SubscriptionData data,
+        TData data,
         IEnumerable<Line> header)
         : base(path)
     {
@@ -69,6 +58,7 @@ public abstract class SubscriptionPopUp : EditorPopUp
         _forceCreation = forceCreation;
         _suggestedChannels = suggestedChannels;
         _suggestedRepositories = suggestedRepositories;
+        _availableUpdateFrequencies = availableUpdateFrequencies;
         _availableMergePolicyHelp = availableMergePolicyHelp;
         _logger = logger;
         _gitRepoFactory = gitRepoFactory;
@@ -85,7 +75,7 @@ public abstract class SubscriptionPopUp : EditorPopUp
 
         foreach (string line in lines)
         {
-            if (line.StartsWith(SourceEnabledElement))
+            if (line.StartsWith(SubscriptionData.SourceEnabledElement))
             {
                 Contents.AddRange(
                 [
@@ -97,11 +87,19 @@ public abstract class SubscriptionPopUp : EditorPopUp
             Contents.Add(new Line(line));
         }
 
-        Contents.Add(new($"Suggested repository URLs for '{SourceRepoElement}' or '{TargetRepoElement}':", true));
+        Contents.Add(new($"Suggested repository URLs for '{SubscriptionData.SourceRepoElement}' or '{SubscriptionData.TargetRepoElement}':", true));
 
         foreach (string suggestedRepo in _suggestedRepositories)
         {
             Contents.Add(new($"  {suggestedRepo}", true));
+        }
+
+        Contents.Add(Line.Empty);
+        Contents.Add(new("Possible update frequencies", true));
+
+        foreach (string frequency in _availableUpdateFrequencies)
+        {
+            Contents.Add(new($"  {frequency}", true));
         }
 
         Contents.Add(Line.Empty);
@@ -117,7 +115,7 @@ public abstract class SubscriptionPopUp : EditorPopUp
         }
     }
 
-    protected async Task<int> ParseAndValidateData(SubscriptionData outputYamlData)
+    protected virtual async Task<int> ParseAndValidateData(TData outputYamlData)
     {
         if (!MergePoliciesPopUpHelpers.ValidateMergePolicies(MergePoliciesPopUpHelpers.ConvertMergePolicies(outputYamlData.MergePolicies), _logger))
         {
@@ -137,6 +135,32 @@ public abstract class SubscriptionPopUp : EditorPopUp
         if (string.IsNullOrEmpty(_data.SourceRepository))
         {
             _logger.LogError("Source repository URL must be non-empty");
+            return Constants.ErrorCode;
+        }
+
+        if (!Uri.TryCreate(_data.SourceRepository, UriKind.Absolute, out Uri? _))
+        {
+            _logger.LogError("Source repository URL must be a valid URI");
+            return Constants.ErrorCode;
+        }
+
+        _data.TargetRepository = ParseSetting(outputYamlData.TargetRepository, _data.TargetRepository, false);
+        if (string.IsNullOrEmpty(_data.TargetRepository))
+        {
+            _logger.LogError("Target repository URL must be non-empty");
+            return Constants.ErrorCode;
+        }
+
+        if (!Uri.TryCreate(_data.TargetRepository, UriKind.Absolute, out Uri? _))
+        {
+            _logger.LogError("Target repository URL must be a valid URI");
+            return Constants.ErrorCode;
+        }
+
+        _data.TargetBranch = ParseSetting(outputYamlData.TargetBranch, _data.TargetBranch, false);
+        if (string.IsNullOrEmpty(_data.TargetBranch))
+        {
+            _logger.LogError("Target branch must be non-empty");
             return Constants.ErrorCode;
         }
 
@@ -220,6 +244,31 @@ public abstract class SubscriptionPopUp : EditorPopUp
         return Constants.SuccessCode;
     }
 
+    public override async Task<int> ProcessContents(IList<Line> contents)
+    {
+        TData outputYamlData;
+
+        try
+        {
+            outputYamlData = ParseYamlData<TData>(contents);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to parse input yaml. Please see help for correct format.");
+            return Constants.ErrorCode;
+        }
+
+        return await ParseAndValidateData(outputYamlData);
+    }
+
+    protected static T ParseYamlData<T>(IList<Line> contents)
+    {
+        // Join the lines back into a string and deserialize as YAML.
+        string yamlString = contents.Aggregate("", (current, line) => $"{current}{Environment.NewLine}{line.Text}");
+        IDeserializer serializer = new DeserializerBuilder().Build();
+        return serializer.Deserialize<T>(yamlString);
+    }
+
     private async Task CheckIfRepoIsVmr(string repoUri, string branch)
     {
         try
@@ -231,49 +280,5 @@ public abstract class SubscriptionPopUp : EditorPopUp
         {
             throw new DarcException($"Target repository is not a VMR ({e.Message}). Use -f to override this check.");
         }
-    }
-
-    /// <summary>
-    /// Helper class for YAML encoding/decoding purposes.
-    /// This is used so that we can have friendly alias names for elements.
-    /// </summary>
-#nullable disable
-    protected class SubscriptionData
-    {
-        [YamlMember(Alias = ChannelElement, ApplyNamingConventions = false)]
-        public string Channel { get; set; }
-
-        [YamlMember(Alias = SourceRepoElement, ApplyNamingConventions = false)]
-        public string SourceRepository { get; set; }
-
-        [YamlMember(Alias = TargetRepoElement, ApplyNamingConventions = false)]
-        public string TargetRepository { get; set; }
-
-        [YamlMember(Alias = TargetBranchElement, ApplyNamingConventions = false)]
-        public string TargetBranch { get; set; }
-
-        [YamlMember(Alias = UpdateFrequencyElement, ApplyNamingConventions = false)]
-        public string UpdateFrequency { get; set; }
-
-        [YamlMember(Alias = BatchableElement, ApplyNamingConventions = false)]
-        public string Batchable { get; set; }
-
-        [YamlMember(Alias = MergePolicyElement, ApplyNamingConventions = false)]
-        public List<MergePolicyData> MergePolicies { get; set; }
-
-        [YamlMember(Alias = FailureNotificationTagsElement, ApplyNamingConventions = false)]
-        public string FailureNotificationTags { get; set; }
-
-        [YamlMember(Alias = SourceEnabledElement, ApplyNamingConventions = false)]
-        public string SourceEnabled { get; set; }
-
-        [YamlMember(Alias = SourceDirectoryElement, ApplyNamingConventions = false)]
-        public string SourceDirectory { get; set; }
-
-        [YamlMember(Alias = TargetDirectoryElement, ApplyNamingConventions = false)]
-        public string TargetDirectory { get; set; }
-
-        [YamlMember(Alias = ExcludedAssetsElement, ApplyNamingConventions = false)]
-        public List<string> ExcludedAssets { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionUpdateData.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionUpdateData.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using YamlDotNet.Serialization;
+
+#nullable enable
+namespace Microsoft.DotNet.Darc.Models.PopUps;
+
+/// <summary>
+/// Helper class for YAML encoding/decoding purposes.
+/// This is used so that we can have friendly alias names for elements.
+/// </summary>
+#nullable disable
+internal class SubscriptionUpdateData : SubscriptionData
+{
+    public const string EnabledElement = "Enabled";
+
+    [YamlMember(ApplyNamingConventions = false)]
+    public string Id { get; set; }
+
+    [YamlMember(Alias = EnabledElement, ApplyNamingConventions = false)]
+    public string Enabled { get; set; }
+}

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/UpdateSubscriptionPopUp.cs
@@ -1,26 +1,20 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.Extensions.Logging;
-using YamlDotNet.Serialization;
 
 #nullable enable
 namespace Microsoft.DotNet.Darc.Models.PopUps;
 
-public class UpdateSubscriptionPopUp : SubscriptionPopUp
+internal class UpdateSubscriptionPopUp : SubscriptionPopUp<SubscriptionUpdateData>
 {
-    public const string EnabledElement = "Enabled";
-
     private readonly ILogger _logger;
-    private readonly SubscriptionUpdateData _yamlData;
 
-    public bool Enabled => bool.Parse(_yamlData.Enabled);
+    public bool Enabled => bool.Parse(_data.Enabled);
 
     private UpdateSubscriptionPopUp(
         string path,
@@ -30,9 +24,10 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
         Subscription subscription,
         IEnumerable<string> suggestedChannels,
         IEnumerable<string> suggestedRepositories,
+        IEnumerable<string> availableUpdateFrequencies,
         IEnumerable<string> availableMergePolicyHelp,
         SubscriptionUpdateData data)
-        : base(path, forceCreation, suggestedChannels, suggestedRepositories, availableMergePolicyHelp, logger, gitRepoFactory, data,
+        : base(path, forceCreation, suggestedChannels, suggestedRepositories, availableUpdateFrequencies, availableMergePolicyHelp, logger, gitRepoFactory, data,
             header: [
                 new Line($"Use this form to update the values of subscription '{subscription.Id}'.", true),
                 new Line($"Note that if you are setting 'Is batchable' to true you need to remove all Merge Policies.", true),
@@ -47,7 +42,6 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
             ])
     {
         _logger = logger;
-        _yamlData = data;
     }
 
     public UpdateSubscriptionPopUp(
@@ -65,7 +59,7 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
         string sourceDirectory,
         string targetDirectory,
         List<string> excludedAssets)
-        : this(path, forceCreation, gitRepoFactory, logger, subscription, suggestedChannels, suggestedRepositories, availableMergePolicyHelp,
+        : this(path, forceCreation, gitRepoFactory, logger, subscription, suggestedChannels, suggestedRepositories, availableUpdateFrequencies, availableMergePolicyHelp,
               new SubscriptionUpdateData
               {
                   Id = GetCurrentSettingForDisplay(subscription.Id.ToString(), subscription.Id.ToString(), false),
@@ -86,46 +80,22 @@ public class UpdateSubscriptionPopUp : SubscriptionPopUp
     {
     }
 
-    public override async Task<int> ProcessContents(IList<Line> contents)
+    protected override async Task<int> ParseAndValidateData(SubscriptionUpdateData data)
     {
-        SubscriptionUpdateData outputYamlData;
-
-        try
+        int result = await base.ParseAndValidateData(data);
+        if (result != Constants.SuccessCode)
         {
-            string yamlString = contents.Aggregate(string.Empty, (current, line) => $"{current}{Environment.NewLine}{line.Text}");
-            IDeserializer serializer = new DeserializerBuilder().Build();
-            outputYamlData = serializer.Deserialize<SubscriptionUpdateData>(yamlString);
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Failed to parse input yaml.  Please see help for correct format.");
-            return Constants.ErrorCode;
+            return result;
         }
 
-        var result = await ParseAndValidateData(outputYamlData);
-
-        if (!bool.TryParse(outputYamlData.Enabled, out bool enabled))
+        if (!bool.TryParse(data.Enabled, out _))
         {
             _logger.LogError("Enabled is not a valid boolean value.");
             return Constants.ErrorCode;
         }
 
-        _yamlData.Enabled = ParseSetting(outputYamlData.Enabled, _yamlData.Enabled, false)!;
+        _data.Enabled = ParseSetting(data.Enabled, _data.Enabled, false)!;
 
-        return result;
-    }
-
-    /// <summary>
-    /// Helper class for YAML encoding/decoding purposes.
-    /// This is used so that we can have friendly alias names for elements.
-    /// </summary>
-    #nullable disable
-    private class SubscriptionUpdateData : SubscriptionData
-    {
-        [YamlMember(ApplyNamingConventions = false)]
-        public string Id { get; set; }
-
-        [YamlMember(Alias = EnabledElement, ApplyNamingConventions = false)]
-        public string Enabled { get; set; }
+        return Constants.SuccessCode;
     }
 }


### PR DESCRIPTION
Improves the error message that we get when we only provide a repo name for instance.

Raised in [this discussion](https://teams.microsoft.com/l/message/19:afba3d1545dd45d7b79f34c1821f6055@thread.skype/1734091396832?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&parentMessageId=1734091396832&teamName=.NET%20Core%20Eng%20Services%20Partners&channelName=First%20Responders&createdTime=1734091396832)