### PR TITLE
Drop non-External artifacts when publishing to BAR

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
         [XmlAttribute(AttributeName = "PublishingVersion")]
         public int PublishingVersion { get; set; }
-        
+
         [XmlAttribute(AttributeName = "IsReleaseOnlyPackageVersion")]
         public string IsReleaseOnlyPackageVersion { get; set; } = "false";
 
@@ -103,6 +103,9 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
         [XmlAttribute(AttributeName = "DotNetReleaseShipping")]
         public bool DotNetReleaseShipping { get; set; }
+
+        [XmlAttribute(AttributeName = "Visibility")]
+        public string Visibility { get; set; }
     }
 
     [XmlRoot(ElementName = "Blob")]
@@ -119,6 +122,9 @@ namespace Microsoft.DotNet.Maestro.Tasks
 
         [XmlAttribute(AttributeName = "DotNetReleaseShipping")]
         public bool DotNetReleaseShipping { get; set; }
+
+        [XmlAttribute(AttributeName = "Visibility")]
+        public string Visibility { get; set; }
     }
 
     [XmlRoot(ElementName = "SigningInformation")]

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -502,16 +502,12 @@ namespace Microsoft.DotNet.Maestro.Tasks
                     Attributes = new Dictionary<string, string>
                     {
                         { NonShippingAttributeName, package.NonShipping.ToString().ToLower() },
-                        { DotNetReleaseShippingAttributeName, package.DotNetReleaseShipping.ToString().ToLower() }
+                        { DotNetReleaseShippingAttributeName, package.DotNetReleaseShipping.ToString().ToLower() },
+                        { VisibilityAttributeName, !string.IsNullOrEmpty(package.Visibility) ? package.Visibility : "External" }
                     },
                     Id = package.Id,
                     Version = package.Version
                 };
-
-                if (packageArtifact.Attributes.TryGetValue(VisibilityAttributeName, out string visibility))
-                {
-                    packageArtifact.Attributes[VisibilityAttributeName] = visibility;
-                }
 
                 packageArtifacts.Add(packageArtifact);
             }
@@ -527,15 +523,11 @@ namespace Microsoft.DotNet.Maestro.Tasks
                             CategoryAttributeName,
                             !string.IsNullOrEmpty(blob.Category) ? blob.Category.ToString().ToUpper() : NoCategory
                         },
-                        { DotNetReleaseShippingAttributeName, blob.DotNetReleaseShipping.ToString().ToLower() }
+                        { DotNetReleaseShippingAttributeName, blob.DotNetReleaseShipping.ToString().ToLower() },
+                        { VisibilityAttributeName, !string.IsNullOrEmpty(blob.Visibility) ? blob.Visibility : "External" }
                     },
                     Id = blob.Id,
                 };
-
-                if (blobArtifact.Attributes.TryGetValue(VisibilityAttributeName, out string visibility))
-                {
-                    blobArtifact.Attributes[VisibilityAttributeName] = visibility;
-                }
 
                 blobArtifacts.Add(blobArtifact);
             }

--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -367,7 +367,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                     && !string.IsNullOrEmpty(visibility)
                     && visibility != "External")
                 {
-                    Log.LogMessage(MessageImportance.High, $"Skipping non-external visibility package '{package.Id}'");
+                    continue;
                 }
                 AddAsset(
                     assets,
@@ -384,7 +384,7 @@ namespace Microsoft.DotNet.Maestro.Tasks
                     && !string.IsNullOrEmpty(visibility)
                     && visibility != "External")
                 {
-                    Log.LogMessage(MessageImportance.High, $"Skipping non-external visibility blob '{blob.Id}'");
+                    continue;
                 }
 
                 string version = GetVersion(blob.Id);

--- a/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
+++ b/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
@@ -123,7 +123,8 @@ public class ParseBuildManifestMetadataTests
         Attributes = new Dictionary<string, string>()
         {
             { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
-            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "true" }
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "true" },
+            { PushMetadataToBuildAssetRegistry.VisibilityAttributeName, "External" },
         },
         Id = "Microsoft.Cci.Extensions",
         Version = Version
@@ -134,7 +135,8 @@ public class ParseBuildManifestMetadataTests
         Attributes = new Dictionary<string, string>()
         {
             { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
-            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" }
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" },
+            { PushMetadataToBuildAssetRegistry.VisibilityAttributeName, "External" },
         },
         Id = "Microsoft.DotNet.ApiCompat",
         Version = Version
@@ -145,7 +147,8 @@ public class ParseBuildManifestMetadataTests
         Attributes = new Dictionary<string, string>()
         {
             { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
-            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" }
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" },
+            { PushMetadataToBuildAssetRegistry.VisibilityAttributeName, "External" },
         },
         Id = "Microsoft.Cci.Extensions",
         Version = null
@@ -202,7 +205,8 @@ public class ParseBuildManifestMetadataTests
         {
             { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
             { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "NONE" },
-            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" }
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" },
+            { PushMetadataToBuildAssetRegistry.VisibilityAttributeName, "External" },
         },
         Id = "assets/manifests/dotnet-arcade/6.0.0-beta.20516.5/MergedManifest.xml"
     };
@@ -213,7 +217,8 @@ public class ParseBuildManifestMetadataTests
         {
             { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
             { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "OTHER" },
-            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" }
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" },
+            { PushMetadataToBuildAssetRegistry.VisibilityAttributeName, "External" },
         },
         Id = "assets/symbols/Microsoft.Cci.Extensions.6.0.0-beta.20516.5.symbols.nupkg"
     };
@@ -224,7 +229,8 @@ public class ParseBuildManifestMetadataTests
         {
             { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
             { PushMetadataToBuildAssetRegistry.CategoryAttributeName, "NONE" },
-            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" }
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" },
+            { PushMetadataToBuildAssetRegistry.VisibilityAttributeName, "External" },
         },
         Id = "assets/symbols/Microsoft.DotNet.Arcade.Sdk.6.0.0-beta.20516.5.symbols.nupkg"
     };

--- a/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
+++ b/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
@@ -671,7 +671,7 @@ public class ParseBuildManifestMetadataTests
         buildData.Should().BeEquivalentTo(expectedBuildData);
     }
 
-    [Fact]
+    [Test]
     public void ExternalVisibilityPackagesToBuildData()
     {
         _buildModel.Artifacts = new ArtifactSet();
@@ -700,7 +700,7 @@ public class ParseBuildManifestMetadataTests
         buildData.Should().BeEquivalentTo(expectedBuildData);
     }
 
-    [Fact]
+    [Test]
     public void InternalVisibilityPackageNotAddedToBuildData()
     {
         _buildModel.Artifacts = new ArtifactSet();

--- a/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
+++ b/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
@@ -162,7 +162,7 @@ public class ParseBuildManifestMetadataTests
         },
         Id = "Microsoft.Cci.Extensions",
         Version = Version
-    }
+    };
 
     private static readonly PackageArtifactModel internalPackageArtifactModel = new()
     {
@@ -175,7 +175,7 @@ public class ParseBuildManifestMetadataTests
         },
         Id = "Microsoft.Cci.Extensions",
         Version = Version
-    }
+    };
 
     private static readonly Package unversionedPackage = new()
     {

--- a/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
+++ b/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
@@ -151,6 +151,32 @@ public class ParseBuildManifestMetadataTests
         Version = null
     };
 
+    private static readonly PackageArtifactModel externalPackageArtifactModel1 = new()
+    {
+
+        Attributes = new Dictionary<string, string>()
+        {
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" },
+            { PushMetadataToBuildAssetRegistry.VisibilityAttributeName, "Internal" },
+        },
+        Id = "Microsoft.Cci.Extensions",
+        Version = Version
+    }
+
+    private static readonly PackageArtifactModel internalPackageArtifactModel = new()
+    {
+
+        Attributes = new Dictionary<string, string>()
+        {
+            { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
+            { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" },
+            { PushMetadataToBuildAssetRegistry.VisibilityAttributeName, "Internal" },
+        },
+        Id = "Microsoft.Cci.Extensions",
+        Version = Version
+    }
+
     private static readonly Package unversionedPackage = new()
     {
         Id = "Microsoft.Cci.Extensions",
@@ -642,6 +668,63 @@ public class ParseBuildManifestMetadataTests
         var buildData =
             _pushMetadata.GetMaestroBuildDataFromMergedManifest(_buildModel, manifest1, CancellationToken.None);
         buildData.Assets.Should().BeEquivalentTo(expectedBuildData.Assets);
+        buildData.Should().BeEquivalentTo(expectedBuildData);
+    }
+
+    [Fact]
+    public void ExternalVisibilityPackagesToBuildData()
+    {
+        _buildModel.Artifacts = new ArtifactSet();
+        _buildModel.Artifacts.Packages.Add(externalPackageArtifactModel1);
+        var expectedBuildData = new BuildData(
+            commit: Commit,
+            azureDevOpsAccount: AzureDevOpsAccount1,
+            azureDevOpsProject: AzureDevOpsProject1,
+            azureDevOpsBuildNumber: AzureDevOpsBuildNumber1,
+            azureDevOpsRepository: AzureDevOpsRepository1,
+            azureDevOpsBranch: AzureDevOpsBranch1,
+            stable: false,
+            released: false)
+        {
+            Assets = new List<AssetData>().ToImmutableList(),
+            AzureDevOpsBuildId = AzureDevOpsBuildId1,
+            AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1,
+            GitHubRepository = GitHubRepositoryName,
+            GitHubBranch = GitHubBranch,
+        };
+
+        expectedBuildData.Assets = expectedBuildData.Assets.Add(PackageAsset1);
+        var buildData =
+            _pushMetadata.GetMaestroBuildDataFromMergedManifest(_buildModel, manifest1, CancellationToken.None);
+        buildData.Assets.Should().BeEquivalentTo(expectedBuildData.Assets);
+        buildData.Should().BeEquivalentTo(expectedBuildData);
+    }
+
+    [Fact]
+    public void InternalVisibilityPackageNotAddedToBuildData()
+    {
+        _buildModel.Artifacts = new ArtifactSet();
+        _buildModel.Artifacts.Packages.Add(internalPackageArtifactModel);
+        var expectedBuildData = new BuildData(
+            commit: Commit,
+            azureDevOpsAccount: AzureDevOpsAccount1,
+            azureDevOpsProject: AzureDevOpsProject1,
+            azureDevOpsBuildNumber: AzureDevOpsBuildNumber1,
+            azureDevOpsRepository: AzureDevOpsRepository1,
+            azureDevOpsBranch: AzureDevOpsBranch1,
+            stable: false,
+            released: false)
+        {
+            Assets = new List<AssetData>().ToImmutableList(),
+            AzureDevOpsBuildId = AzureDevOpsBuildId1,
+            AzureDevOpsBuildDefinitionId = AzureDevOpsBuildDefinitionId1,
+            GitHubRepository = GitHubRepositoryName,
+            GitHubBranch = GitHubBranch,
+        };
+
+        var buildData =
+            _pushMetadata.GetMaestroBuildDataFromMergedManifest(_buildModel, manifest1, CancellationToken.None);
+        buildData.Assets.Should().BeEmpty();
         buildData.Should().BeEquivalentTo(expectedBuildData);
     }
 }

--- a/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
+++ b/test/Microsoft.DotNet.Maestro.Tasks.Tests/ParseBuildManifestMetadataTests.cs
@@ -158,7 +158,7 @@ public class ParseBuildManifestMetadataTests
         {
             { PushMetadataToBuildAssetRegistry.NonShippingAttributeName, "true" },
             { PushMetadataToBuildAssetRegistry.DotNetReleaseShippingAttributeName, "false" },
-            { PushMetadataToBuildAssetRegistry.VisibilityAttributeName, "Internal" },
+            { PushMetadataToBuildAssetRegistry.VisibilityAttributeName, "External" },
         },
         Id = "Microsoft.Cci.Extensions",
         Version = Version


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Implements the "Publish to BAR" portion of https://github.com/dotnet/arcade/pull/15344


Validation that the jobs are dropped before going to BAR and the dropped artifacts are not uploaded to feeds by darc:

WindowsDesktop job that published to BAR with all rid-agnostic assets and exe installers marked as "Internal": https://dev.azure.com/dnceng/internal/_build/results?buildId=2604238&view=results
BAR record for that job showing that no rid-agnostic packages nor exe installers are present: https://maestro.dot.net/channel/529/azdo:dnceng:internal:dotnet-windowsdesktop/build/250107
Build Promotion job that shows that the internal assets were excluded from upload (the job failure later is due to an unrelated ongoing FR issue): https://dev.azure.com/dnceng/internal/_build/results?buildId=2604256&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=74531eb2-9b39-5603-839e-94e3ba212b65&l=278