### PR TITLE
Stop running old E2E tests

### DIFF
--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -128,31 +128,3 @@ stages:
         env:
           GH_TOKEN: $(dotnet-bot-arcade-services-content-rw)
         continueOnError: true
-
-- stage: validateDeployment
-  displayName: E2E tests
-  dependsOn:
-  - deploy
-
-  jobs:
-  - template: ../jobs/e2e-tests.yml
-    parameters:
-      name: scenarioTests_GitHub
-      displayName: GitHub tests
-      testFilter: 'TestCategory=GitHub'
-      isProd: ${{ parameters.isProd }}
-
-  - template: ../jobs/e2e-tests.yml
-    parameters:
-      name: scenarioTests_AzDO
-      displayName: AzDO tests
-      testFilter: 'TestCategory=AzDO'
-      isProd: ${{ parameters.isProd }}
-
-  - template: ../jobs/e2e-tests.yml
-    parameters:
-      name: scenarioTests_Other
-      displayName: Other tests
-      testFilter: 'TestCategory!=GitHub&TestCategory!=AzDO'
-      isProd: ${{ parameters.isProd }}
-      runAuthTests: true


### PR DESCRIPTION
The tests are flaky and we run them in the PCS pipeline anyway

https://github.com/dotnet/arcade-services/issues/3455