### PR TITLE
Make Age column wider in DependencyGrid.razor

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Components/DependencyGrid.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Components/DependencyGrid.razor
@@ -17,7 +17,7 @@
     <TemplateColumn Title="Commit" Align="Align.Start" Width="6rem">
         <a href="@(context.CommitLink ?? "javascript:void(0)")" target="_blank">@context.CommitShort</a>
     </TemplateColumn>
-    <PropertyColumn Title="Age (days)" Property="@(r => r.AgeDays)" Sortable="true" Align="Align.End" Width="5rem" />
+    <PropertyColumn Title="Age (days)" Property="@(r => r.AgeDays)" Sortable="true" Align="Align.Start" Width="6rem" />
     <PropertyColumn Title="Newer builds?" Property="@(r => r.BuildStaleness)" Align="Align.Start" Width="8rem" />
     <TemplateColumn Sortable="false" Align="Align.Start" Title="Build Number" Width="8rem">
         <a href="@context.BuildUrl" target="_blank">


### PR DESCRIPTION
Also align with start like the other columns.

<img width="186" alt="image" src="https://github.com/user-attachments/assets/14a62eaf-24af-4926-8470-433d34c6e445" />

<!-- https://github.com/dotnet/arcade-services/issues/4262 -->