### PR TITLE
Add --default-channels-required option for 'darc add-build-to-channel'

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
@@ -131,7 +131,9 @@ internal class AddBuildToChannelOperation : Operation
 
                 if (!targetChannels.Any() && _options.DefaultChannelsRequired)
                 {
-                    Console.WriteLine($"Build '{build.Id}' is from branch '{build.GetRepository()}@{build.GetBranch()}' that is not associated to any enabled default channel(s). Either add one with 'darc add-default-channel' or do not enforce existence with the '--default-channels-required' option.");
+                    _logger.LogError(
+                        "Build '{buildId}' is from branch '{repository}@{branch}' that is not associated to any enabled default channel(s). Either add one with 'darc add-default-channel' or do not enforce existence with the '--default-channels-required' option.",
+                        build.Id, build.GetRepository(), build.GetBranch());
                     return Constants.ErrorCode;
                 }
             }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddBuildToChannelOperation.cs
@@ -128,6 +128,12 @@ internal class AddBuildToChannelOperation : Operation
                         Where(dc => dc.Enabled).
                         Select(dc => dc.Channel).
                         DistinctBy(c => c.Id));
+
+                if (!targetChannels.Any() && _options.DefaultChannelsRequired)
+                {
+                    Console.WriteLine($"Build '{build.Id}' is from branch '{build.GetRepository()}@{build.GetBranch()}' that is not associated to any enabled default channel(s). Either add one with 'darc add-default-channel' or do not enforce existence with the '--default-channels-required' option.");
+                    return Constants.ErrorCode;
+                }
             }
 
             IEnumerable<Channel> currentChannels = build.Channels.Where(ch => targetChannels.Any(tc => tc.Id == ch.Id));

--- a/src/Microsoft.DotNet.Darc/Darc/Options/AddBuildToChannelCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/AddBuildToChannelCommandLineOptions.cs
@@ -22,6 +22,9 @@ internal class AddBuildToChannelCommandLineOptions : CommandLineOptions<AddBuild
     [Option("default-channels", HelpText = "Assign build to all default channels. Required if --channel is not specified.")]
     public bool AddToDefaultChannels { get; set; }
 
+    [Option("default-channels-required", HelpText = "Requires existence of enabled default channel association for a build branch. Applies only if --default-channels specified.")]
+    public bool DefaultChannelsRequired { get; set; }
+
     [Option("source-branch", Default = "main", HelpText = "Branch that should be used as base for the promotion build. Required if source-sha is specified.")]
     public string SourceBranch { get; set; }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade-services/issues/4276

### Context

Recently we've hit quite a few times issues with unnoticed missing dependency flow or symbols publishing due to improperly configured default branch->channels association.

In such case the command succeeds with the message:

```
The build '{build.Id}' is already on these target channel(s):
```

This is missleading to untrained eye - especially in a long build output spew.

Instead we'd like to have an option to error out if the essociation is missing

### Changes made

Added optional option `--default-channels-required` that enables enforcing the existence of branch->channel association.