### PR TITLE
Revert "Check if a reminder already exists when trying to set one"

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/ReminderManager.cs
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/ReminderManager.cs
@@ -31,13 +31,9 @@ public class ReminderManager<T> : IReminderManager<T> where T : WorkItem
 
     public async Task SetReminderAsync(T payload, TimeSpan visibilityTimeout, bool isCodeFlow)
     {
-        // Check if the updater already has a reminder. If it doesn't, we don't need to add another one
-        if ((await _receiptCache.TryGetStateAsync()) == null)
-        {
-            var client = _workItemProducerFactory.CreateProducer<T>(isCodeFlow);
-            var sendReceipt = await client.ProduceWorkItemAsync(payload, visibilityTimeout);
-            await _receiptCache.SetAsync(new ReminderArguments(sendReceipt.PopReceipt, sendReceipt.MessageId), visibilityTimeout + TimeSpan.FromHours(4));
-        }
+        var client = _workItemProducerFactory.CreateProducer<T>(isCodeFlow);
+        var sendReceipt = await client.ProduceWorkItemAsync(payload, visibilityTimeout);
+        await _receiptCache.SetAsync(new ReminderArguments(sendReceipt.PopReceipt, sendReceipt.MessageId), visibilityTimeout + TimeSpan.FromHours(4));
     }
 
     public async Task UnsetReminderAsync(bool isCodeFlow)


### PR DESCRIPTION
Reverts https://github.com/dotnet/arcade-services/issues/4278

The receipt stays in the memory longer than the queue message so upon completion, the service didn't set the follow-up reminder.