### PR TITLE
Set reminder receipt TTL same as the queue message's

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/ReminderManager.cs
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/ReminderManager.cs
@@ -36,7 +36,7 @@ public class ReminderManager<T> : IReminderManager<T> where T : WorkItem
         {
             var client = _workItemProducerFactory.CreateProducer<T>(isCodeFlow);
             var sendReceipt = await client.ProduceWorkItemAsync(payload, visibilityTimeout);
-            await _receiptCache.SetAsync(new ReminderArguments(sendReceipt.PopReceipt, sendReceipt.MessageId), visibilityTimeout + TimeSpan.FromHours(4));
+            await _receiptCache.SetAsync(new ReminderArguments(sendReceipt.PopReceipt, sendReceipt.MessageId), visibilityTimeout);
         }
     }
 


### PR DESCRIPTION
Fixes a problem introduced in https://github.com/dotnet/arcade-services/issues/4278.

The receipt stayed in the memory longer than the queue message so upon completion, the service didn't set the follow-up reminder because the receipt was still there.

