### PR TITLE
Log work item start/end/exception using current's scope logger

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItemScopeManager.cs
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItemScopeManager.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.ApplicationInsights;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;


### PR DESCRIPTION
This makes the start/end/exception log item have the same operationId inside so it's easier to look for it in application insights

<!-- https://github.com/dotnet/arcade-services/issues/4299 -->
