### PR TITLE
Simplify PCS initialization for local developer workflows

### DIFF
--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -32,8 +32,6 @@ When running locally:
     - Check your environmental variables, you might have `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` set, and the `DefaultAzureCredential` is attempting to use `EnvironmentalCredentials` for an app that doesn't have access to the dev KV.
  - The service is configured to use the same SQL Express database Maestro uses. To se it up, follow the [instructions](https://github.com/dotnet/arcade-services/blob/main/docs/DevGuide.md)
  - Configure the `ProductConstructionService.AppHost/Properties/launchSettings`.json file:
-   - `VmrUri`: URI of the VMR that will be targeted by the service.
-   - `VmrPath`: path to the cloned [VMR](https://github.com/dotnet/dotnet) on your machine.
    - `TmpPath`: path to the TMP folder that the service will use to clone other repos (like runtime). If you've already worked with the VMR and have the TMP VMR folder on your machine, you can point the service there and it will reuse the cloned repos you already have.
    - AppHost's `launchSettings.json` config should look something like this (fill in the VMR paths):
     ```json
@@ -46,9 +44,7 @@ When running locally:
                 "launchBrowser": true,
                 "applicationUrl": "https://localhost:18848",
                 "environmentVariables": {
-                    "VmrPath": "D:\\tmp\\vmr",
                     "TmpPath": "D:\\tmp\\",
-                    "VmrUri": "https://github.com/maestro-auth-test/dnceng-vmr",
                     "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:19265",
                     "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:20130"
                 }
@@ -67,9 +63,7 @@ When running locally:
                 "applicationUrl": "https://localhost:53180",
                 "environmentVariables": {
                     "ASPNETCORE_ENVIRONMENT": "Development",
-                    "VmrPath": "D:\\tmp\\dnceng-vmr",
-                    "TmpPath": "D:\\tmp\\",
-                    "VmrUri": "https://github.com/maestro-auth-test/dnceng-vmr"
+                    "TmpPath": "D:\\tmp\\"
                 }
             }
         }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCloneManager.cs
@@ -33,7 +33,6 @@ public class VmrCloneManager : CloneManager, IVmrCloneManager
 {
     private readonly IVmrInfo _vmrInfo;
     private readonly IVmrDependencyTracker _dependencyTracker;
-    private readonly ISourceManifest _sourceManifest;
 
     public VmrCloneManager(
         IVmrInfo vmrInfo,
@@ -49,7 +48,6 @@ public class VmrCloneManager : CloneManager, IVmrCloneManager
     {
         _vmrInfo = vmrInfo;
         _dependencyTracker = dependencyTracker;
-        _sourceManifest = sourceManifest;
     }
 
     public async Task<ILocalGitRepo> PrepareVmrAsync(

--- a/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
@@ -143,7 +143,6 @@ internal static class PcsStartup
         bool addSwagger)
     {
         bool isDevelopment = builder.Environment.IsDevelopment();
-        bool initializeService = !isDevelopment;
 
         // Read configuration
         string? managedIdentityId = builder.Configuration[ConfigurationKeys.ManagedIdentityId];
@@ -180,7 +179,7 @@ internal static class PcsStartup
         await builder.AddRedisCache(authRedis);
         builder.AddBuildAssetRegistry();
         builder.AddMetricRecorder();
-        builder.AddWorkItemQueues(azureCredential, waitForInitialization: initializeService);
+        builder.AddWorkItemQueues(azureCredential, waitForInitialization: true);
         builder.AddDependencyFlowProcessors();
         builder.AddVmrRegistrations();
         builder.AddGitHubClientFactory(
@@ -202,15 +201,7 @@ internal static class PcsStartup
         builder.Services.AddMergePolicies();
         builder.Services.Configure<SlaOptions>(builder.Configuration.GetSection(ConfigurationKeys.DependencyFlowSLAs));
 
-        if (initializeService)
-        {
-            builder.InitializeVmrFromRemote();
-        }
-        else
-        {
-            builder.InitializeVmrFromDisk();
-        }
-
+        builder.InitializeVmrFromRemote();
         builder.AddServiceDefaults();
 
         // Configure API

--- a/src/ProductConstructionService/ProductConstructionService.Api/VirtualMonoRepo/VmrConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/VirtualMonoRepo/VmrConfiguration.cs
@@ -8,7 +8,6 @@ namespace ProductConstructionService.Api.VirtualMonoRepo;
 
 internal static class VmrConfiguration
 {
-    private const string VmrPathKey = "VmrPath";
     private const string TmpPathKey = "TmpPath";
     private const string VmrUriKey = "VmrUri";
     private const string VmrReadyHealthCheckName = "VmrReady";
@@ -26,16 +25,5 @@ internal static class VmrConfiguration
         builder.Services.AddSingleton(new InitializationBackgroundServiceOptions(vmrUri));
         builder.Services.AddHostedService<InitializationBackgroundService>();
         builder.Services.AddHealthChecks().AddCheck<InitializationHealthCheck>(VmrReadyHealthCheckName, tags: [VmrReadyHealthCheckTag]);
-    }
-
-    public static void InitializeVmrFromDisk(this WebApplicationBuilder builder)
-    {
-        // This is expected in local flows and it's useful to learn about this early
-        var vmrPath = builder.Configuration.GetRequiredValue(VmrPathKey);
-        if (!Directory.Exists(vmrPath))
-        {
-            throw new InvalidOperationException($"VMR not found at {vmrPath}. " +
-                $"Either run the service in initialization mode or clone a VMR into {vmrPath}.");
-        }
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Production.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Production.json
@@ -5,7 +5,6 @@
         "redis": "product-construction-service-redis-prod.redis.cache.windows.net:6380,ssl=true"
     },
     "ManagedIdentityClientId": "e49bf24a-ec75-490b-803b-6fad99d19159",
-    "VmrUri": "https://github.com/maestro-auth-test/dnceng-vmr",
     "BuildAssetRegistrySqlConnectionString": "Data Source=tcp:maestro-prod.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False; User Id=USER_ID_PLACEHOLDER",
     "Kusto": {
         "Database": "engineeringdata",

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
@@ -5,7 +5,6 @@
         "redis": "product-construction-service-redis-int.redis.cache.windows.net:6380,ssl=true"
     },
     "ManagedIdentityClientId": "1d43ba8a-c2a6-4fad-b064-6d8c16fc0745",
-    "VmrUri": "https://github.com/maestro-auth-test/maestro-test-vmr",
     "BuildAssetRegistrySqlConnectionString": "Data Source=tcp:maestro-int-server.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False; User Id=USER_ID_PLACEHOLDER",
     "Kusto": {
         "Database": "engineeringdata",
@@ -29,8 +28,4 @@
     "SubscriptionId": "e6b5f9f5-0ca4-4351-879b-014d78400ec2",
     "ResourceGroupName": "product-construction-service",
     "ContainerAppName": "product-construction-int"
-    // "ApiRedirect": {
-    //     "Uri": "https://maestro.dot.net/",
-    //     "ManagedIdentityClientId": "1d43ba8a-c2a6-4fad-b064-6d8c16fc0745"
-    // }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.json
@@ -26,5 +26,6 @@
         "UserRole": "User",
         "CallbackPath": "/signin-oidc",
         "SignedOutCallbackPath": "/signout-callback-oidc"
-    }
+    },
+    "VmrUri": "https://github.com/maestro-auth-test/maestro-test-vmr"
 }


### PR DESCRIPTION
With the way the VMR cloning was reworked in https://github.com/dotnet/arcade-services/issues/4175, it's no longer necessary to distinguish the local runs as it will use a local clone the same way as when initializing in cloud.
This means it's no longer necessary to clone the VMR manually and add it to the configuration when running the service locally for the first time.
