### PR TITLE
Make code flow updates a single commit

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
@@ -71,7 +71,7 @@ public interface ILocalGitClient
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///     Commit amends the last commit by clling git commit --amend
+    ///     Commit amends the last staged changes by calling git commit --amend
     /// </summary>
     /// <param name="repoPath">Path of the local repository</param>
     /// <returns></returns>

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
@@ -71,7 +71,7 @@ public interface ILocalGitClient
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///     Commit amends the last staged changes by calling git commit --amend
+    ///     Commit amends the staged changes by calling git commit --amend
     /// </summary>
     /// <param name="repoPath">Path of the local repository</param>
     /// <returns></returns>

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
@@ -37,7 +37,7 @@ public interface ILocalGitClient
         string? blameFromCommit = null);
 
     /// <summary>
-    /// Checks if the repository has any working tree changes.
+    ///     Checks if the repository has any working tree changes.
     /// </summary>
     /// <param name="repoPath">Path to the repository</param>
     Task<bool> HasWorkingTreeChangesAsync(string repoPath);
@@ -50,7 +50,7 @@ public interface ILocalGitClient
     Task CheckoutAsync(string repoPath, string refToCheckout);
 
     /// <summary>
-    /// Resets the working tree (or a given subpath) to match the index.
+    ///     Resets the working tree (or a given subpath) to match the index.
     /// </summary>
     /// <param name="repoPath">Path to the root of the repo</param>
     /// <param name="relativePath">Relative path inside of the repo to reset only (or none if the whole repo)</param>
@@ -69,6 +69,13 @@ public interface ILocalGitClient
         bool allowEmpty,
         (string Name, string Email)? author = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Commit amends the last commit by clling git commit --amend
+    /// </summary>
+    /// <param name="repoPath">Path of the local repository</param>
+    /// <returns></returns>
+    Task CommitAmendAsync(string repoPath, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Creates a local branch.
@@ -149,7 +156,7 @@ public interface ILocalGitClient
     Task<bool> GitRefExists(string repoPath, string gitRef, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Fetches from all remotes.
+    ///     Fetches from all remotes.
     /// </summary>
     /// <param name="repoPath">Path to a git repository</param>
     /// <param name="remoteUris">List of remotes to fetch from</param>
@@ -159,7 +166,7 @@ public interface ILocalGitClient
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Performs `git pull`
+    ///     Performs `git pull`
     /// </summary>
     /// <param name="repoPath">Path to a git repository</param>
     Task PullAsync(
@@ -177,14 +184,14 @@ public interface ILocalGitClient
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Add the authorization header to the git command line arguments and environment variables.
+    ///     Add the authorization header to the git command line arguments and environment variables.
     /// </summary>
     /// <param name="args">Where to add the new argument into</param>
     /// <param name="envVars">Where to add the new variables into</param>
     Task AddGitAuthHeader(IList<string> args, IDictionary<string, string> envVars, string repoUri);
 
     /// <summary>
-    /// Gets a value of a given git configuration setting.
+    ///     Gets a value of a given git configuration setting.
     /// </summary>
     /// <param name="repoPath">Path to a git repository</param>
     /// <param name="setting">Name of the setting</param>
@@ -192,7 +199,7 @@ public interface ILocalGitClient
     Task<string> GetConfigValue(string repoPath, string setting);
 
     /// <summary>
-    /// Sets a value of a given git configuration setting.
+    ///     Sets a value of a given git configuration setting.
     /// </summary>
     /// <param name="repoPath">Path to a git repository</param>
     /// <param name="setting">Name of the setting</param>
@@ -200,7 +207,7 @@ public interface ILocalGitClient
     Task SetConfigValue(string repoPath, string setting, string value);
 
     /// <summary>
-    /// Runs git with the given arguments and returns the result.
+    ///     Runs git with the given arguments and returns the result.
     /// </summary>
     Task<ProcessExecutionResult> RunGitCommandAsync(
         string repoPath,

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
@@ -17,12 +17,12 @@ public interface ILocalGitRepo
     NativePath Path { get; }
 
     /// <summary>
-    /// Executes git over the repo directory with specified arguments.
+    ///     Executes git over the repo directory with specified arguments.
     /// </summary>
     Task<ProcessExecutionResult> ExecuteGitCommand(string[] args, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Executes git over the repo directory with specified arguments.
+    ///     Executes git over the repo directory with specified arguments.
     /// </summary>
     Task<ProcessExecutionResult> ExecuteGitCommand(params string[] args);
 
@@ -48,7 +48,7 @@ public interface ILocalGitRepo
         string? blameFromCommit = null);
 
     /// <summary>
-    /// Checks if the repository has any working tree changes.
+    ///     Checks if the repository has any working tree changes.
     /// </summary>
     Task<bool> HasWorkingTreeChangesAsync();
 
@@ -59,7 +59,7 @@ public interface ILocalGitRepo
     Task CheckoutAsync(string refToCheckout);
 
     /// <summary>
-    /// Resets the working tree (or a given subpath) to match the index.
+    ///     Resets the working tree (or a given subpath) to match the index.
     /// </summary>
     /// <param name="relativePath">Relative path inside of the repo to reset only (or none if the whole repo)</param>
     Task ResetWorkingTree(UnixPath? relativePath = null);
@@ -77,7 +77,7 @@ public interface ILocalGitRepo
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///     Commit amends the last commit by clling git commit --amend
+    ///     Commit amends the staged changes by calling git commit --amend
     /// </summary>
     /// <param name="repoPath">Path of the local repository</param>
     /// <returns></returns>
@@ -143,27 +143,27 @@ public interface ILocalGitRepo
     Task<GitObjectType> GetObjectTypeAsync(string objectSha);
 
     /// <summary>
-    /// Gets a value of a given git configuration setting.
+    ///     Gets a value of a given git configuration setting.
     /// </summary>
     /// <param name="setting">Name of the setting</param>
     /// <returns>Value of the setting</returns>
     Task<string> GetConfigValue(string setting);
 
     /// <summary>
-    /// Sets a value of a given git configuration setting.
+    ///     Sets a value of a given git configuration setting.
     /// </summary>
     /// <param name="setting">Name of the setting</param>
     /// <param name="value">New value</param>
     Task SetConfigValue(string setting, string value);
 
     /// <summary>
-    /// Fetches from all remotes.
+    ///     Fetches from all remotes.
     /// </summary>
     /// <param name="remoteUris">List of remotes to fetch from</param>
     Task FetchAllAsync(IReadOnlyCollection<string> remoteUris, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Performs `git pull`
+    ///     Performs `git pull`
     /// </summary>
     Task PullAsync(CancellationToken cancellationToken = default);
 
@@ -180,7 +180,7 @@ public interface ILocalGitRepo
     Task StageAsync(IEnumerable<string> pathsToStage, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Add the authorization header to the git command line arguments and environment variables.
+    ///     Add the authorization header to the git command line arguments and environment variables.
     /// </summary>
     /// <param name="args">Where to add the new argument into</param>
     /// <param name="envVars">Where to add the new variables into</param>

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
@@ -77,6 +77,13 @@ public interface ILocalGitRepo
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    ///     Commit amends the last commit by clling git commit --amend
+    /// </summary>
+    /// <param name="repoPath">Path of the local repository</param>
+    /// <returns></returns>
+    Task CommitAmendAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     ///     Creates a local branch.
     /// </summary>
     /// <param name="branchName">New branch name</param>

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Maestro.Common;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
+using Microsoft.Identity.Client;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib;
@@ -147,6 +148,14 @@ public class LocalGitClient : ILocalGitClient
 
         var result = await _processManager.ExecuteGit(repoPath, args, cancellationToken: cancellationToken);
         result.ThrowIfFailed($"Failed to commit {repoPath}");
+    }
+
+    public async Task CommitAmendAsync(
+        string repoPath,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _processManager.ExecuteGit(repoPath, ["commit", "--amend", "--no-edit"], cancellationToken: cancellationToken);
+        result.ThrowIfFailed($"Failed to amend commit in {repoPath}");
     }
 
     public async Task StageAsync(string repoPath, IEnumerable<string> pathsToStage, CancellationToken cancellationToken = default)

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using Maestro.Common;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
-using Microsoft.Identity.Client;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib;

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitRepo.cs
@@ -44,6 +44,9 @@ public class LocalGitRepo(NativePath repoPath, ILocalGitClient localGitClient, I
     public async Task CommitAsync(string message, bool allowEmpty, (string Name, string Email)? author = null, CancellationToken cancellationToken = default)
         => await _localGitClient.CommitAsync(Path, message, allowEmpty, author, cancellationToken);
 
+    public async Task CommitAmendAsync(CancellationToken cancellationToken = default)
+        => await _localGitClient.CommitAmendAsync(Path, cancellationToken);
+
     public async Task CreateBranchAsync(string branchName, bool overwriteExistingBranch = false)
         => await _localGitClient.CreateBranchAsync(Path, branchName, overwriteExistingBranch);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
@@ -41,5 +41,6 @@ public interface IVmrUpdater
         bool discardPatches,
         bool reapplyVmrPatches,
         bool lookUpBuilds,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken,
+        bool amendReapplyCommit = false);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -257,7 +257,7 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             build,
             excludedAssets,
             sourceElementSha: build.Commit,
-            amendCommit: hasChanges,
+            hadPreviousChanges: hasChanges,
             cancellationToken);
 
         return hasChanges;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -257,6 +257,7 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             build,
             excludedAssets,
             sourceElementSha: build.Commit,
+            amendCommit: hasChanges,
             cancellationToken);
 
         return hasChanges;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -413,8 +413,8 @@ internal abstract class VmrCodeFlower
 
         await targetRepo.StageAsync(["."], cancellationToken);
 
-        // TODO: Better commit message?
-        await targetRepo.CommitAsync("Updated dependencies", allowEmpty: true, cancellationToken: cancellationToken);
+        await targetRepo.CommitAmendAsync(cancellationToken);
+
         return true;
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -418,7 +418,6 @@ internal abstract class VmrCodeFlower
         if (amendCommit)
         {
             await targetRepo.CommitAmendAsync(cancellationToken);
-
         }
         else
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -317,14 +317,14 @@ internal abstract class VmrCodeFlower
     /// <param name="build">Build with assets (dependencies) that is being flows</param>
     /// <param name="excludedAssets">Assets to exclude from the dependency flow</param>
     /// <param name="sourceElementSha">For backflows, VMR SHA that is being flown so it can be stored in Version.Details.xml</param>
-    /// <param name="amendCommit">Set to true when we already had a code flow commit to amend the dependency update into it</param>
+    /// <param name="hadPreviousChanges">Set to true when we already had a code flow commit to amend the dependency update into it</param>
     protected async Task<bool> UpdateDependenciesAndToolset(
         NativePath sourceRepo,
         ILocalGitRepo targetRepo,
         Build build,
         IReadOnlyCollection<string>? excludedAssets,
         string? sourceElementSha,
-        bool amendCommit,
+        bool hadPreviousChanges,
         CancellationToken cancellationToken)
     {
         string versionDetailsXml = await targetRepo.GetFileFromGitAsync(VersionFiles.VersionDetailsXml)
@@ -415,7 +415,7 @@ internal abstract class VmrCodeFlower
 
         await targetRepo.StageAsync(["."], cancellationToken);
 
-        if (amendCommit)
+        if (hadPreviousChanges)
         {
             await targetRepo.CommitAmendAsync(cancellationToken);
         }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -317,12 +317,14 @@ internal abstract class VmrCodeFlower
     /// <param name="build">Build with assets (dependencies) that is being flows</param>
     /// <param name="excludedAssets">Assets to exclude from the dependency flow</param>
     /// <param name="sourceElementSha">For backflows, VMR SHA that is being flown so it can be stored in Version.Details.xml</param>
+    /// <param name="amendCommit">Set to true when we already had a code flow commit to amend the dependency update into it</param>
     protected async Task<bool> UpdateDependenciesAndToolset(
         NativePath sourceRepo,
         ILocalGitRepo targetRepo,
         Build build,
         IReadOnlyCollection<string>? excludedAssets,
         string? sourceElementSha,
+        bool amendCommit,
         CancellationToken cancellationToken)
     {
         string versionDetailsXml = await targetRepo.GetFileFromGitAsync(VersionFiles.VersionDetailsXml)
@@ -413,7 +415,15 @@ internal abstract class VmrCodeFlower
 
         await targetRepo.StageAsync(["."], cancellationToken);
 
-        await targetRepo.CommitAmendAsync(cancellationToken);
+        if (amendCommit)
+        {
+            await targetRepo.CommitAmendAsync(cancellationToken);
+
+        }
+        else
+        {
+            await targetRepo.CommitAsync("Updated dependencies", allowEmpty: true, cancellationToken: cancellationToken);
+        }
 
         return true;
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -170,6 +170,7 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             build,
             excludedAssets,
             sourceElementSha: null,
+            hasChanges,
             cancellationToken);
 
         return hasChanges;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -254,7 +254,8 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 discardPatches,
                 reapplyVmrPatches: true,
                 lookUpBuilds: true,
-                cancellationToken);
+                amendReapplyCommit: true,
+                cancellationToken: cancellationToken);
         }
         catch (PatchApplicationFailedException e)
         {
@@ -309,7 +310,8 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 discardPatches,
                 reapplyVmrPatches: true,
                 lookUpBuilds: true,
-                cancellationToken);
+                amendReapplyCommit: true,
+                cancellationToken: cancellationToken);
         }
 
         return hadUpdates;
@@ -384,6 +386,7 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             discardPatches,
             reapplyVmrPatches: true,
             lookUpBuilds: true,
-            cancellationToken);
+            amendReapplyCommit: true,
+            cancellationToken: cancellationToken);
     }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -177,7 +177,7 @@ public abstract class VmrManagerBase
             cancellationToken.ThrowIfCancellationRequested();
         }
 
-        await CommitAsync("[VMR patches] Re-apply VMR patches");
+        await CommitAmendAsync();
 
         _logger.LogInformation("VMR patches re-applied back onto the VMR");
     }
@@ -191,6 +191,17 @@ public abstract class VmrManagerBase
         await _localGitClient.CommitAsync(_vmrInfo.VmrPath, commitMessage, allowEmpty: true, author);
 
         _logger.LogInformation("Committed in {duration} seconds", (int)watch.Elapsed.TotalSeconds);
+    }
+
+    protected async Task CommitAmendAsync()
+    {
+        _logger.LogInformation("Amending the commit..");
+
+        var watch = Stopwatch.StartNew();
+
+        await _localGitClient.CommitAmendAsync(_vmrInfo.VmrPath);
+
+        _logger.LogInformation("Amended the commit in {duration} seconds", (int)watch.Elapsed.TotalSeconds);
     }
 
     /// <summary>

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -153,7 +153,8 @@ public abstract class VmrManagerBase
 
     protected async Task ReapplyVmrPatchesAsync(
         IReadOnlyCollection<VmrIngestionPatch> patches,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool amendCommit = false)
     {
         if (patches.Count == 0)
         {
@@ -177,7 +178,14 @@ public abstract class VmrManagerBase
             cancellationToken.ThrowIfCancellationRequested();
         }
 
-        await CommitAmendAsync();
+        if (amendCommit)
+        {
+            await CommitAmendAsync();
+        }
+        else
+        {
+            await CommitAsync("[VMR patches] Re-apply VMR patches");
+        }
 
         _logger.LogInformation("VMR patches re-applied back onto the VMR");
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -107,7 +107,8 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         bool discardPatches,
         bool reapplyVmrPatches,
         bool lookUpBuilds,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool amendReapplyPatchesCommit = false)
     {
         await _dependencyTracker.RefreshMetadata();
 
@@ -168,7 +169,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
 
                 if (reapplyVmrPatches)
                 {
-                    await ReapplyVmrPatchesAsync(patchesToReapply, cancellationToken);
+                    await ReapplyVmrPatchesAsync(patchesToReapply, cancellationToken, amendReapplyPatchesCommit);
                 }
 
                 return true;

--- a/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/ProductConstructionServiceApiOptions.cs
+++ b/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/ProductConstructionServiceApiOptions.cs
@@ -18,9 +18,11 @@ namespace Microsoft.DotNet.ProductConstructionService.Client
         private const string MaestroStagingAppId = "baf98f1b-374e-487d-af42-aa33807f11e4";
 
         public const string ProductionMaestroUri = "https://maestro.dot.net/";
+        // TODO delete this after arcde rollout
         public const string OldProductionMaestroUri = "https://maestro-prod.westus2.cloudapp.azure.com/";
 
         public const string StagingMaestroUri = "https://maestro.int-dot.net/";
+        // TODO delete this after arcde rollout
         public const string OldStagingMaestroUri = "https://maestro-int.westus2.cloudapp.azure.com/";
         public const string PcsLocalUri = "https://localhost:53180/";
 

--- a/src/ProductConstructionService/ProductConstructionService.ReproTool/ReproTool.cs
+++ b/src/ProductConstructionService/ProductConstructionService.ReproTool/ReproTool.cs
@@ -150,7 +150,9 @@ internal class ReproTool(
 
         if (options.SkipCleanup)
         {
-            logger.LogInformation("Skipping cleanup. If you want to re-trigger the reproduced subscription run \"darc trigger-subscriptions --ids {subscriptionId}\"", testSubscription.Value);
+            logger.LogInformation("Skipping cleanup. If you want to re-trigger the reproduced subscription run \"darc trigger-subscriptions --ids {subscriptionId}\" --bar-uri {barUri}",
+                testSubscription.Value,
+                ProductConstructionServiceApiOptions.PcsLocalUri);
         }
         else
         {

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/GitOperationsHelper.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/GitOperationsHelper.cs
@@ -48,6 +48,12 @@ internal class GitOperationsHelper
         return log.StandardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).First();
     }
 
+    public async Task<string> GetRepoLastCommitMessage(NativePath repo)
+    {
+        var log = await _processManager.ExecuteGit(repo, "log", "--format=format:%s");
+        return log.StandardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).First();
+    }
+
     public async Task CheckAllIsCommitted(string repo)
     {
         var gitStatus = await _processManager.ExecuteGit(repo, "status", "--porcelain");

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrBackflowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrBackflowTest.cs
@@ -26,6 +26,11 @@ internal class VmrBackflowTest : VmrCodeFlowTests
 
         var hadUpdates = await ChangeVmrFileAndFlowIt("New content from the VMR", branchName);
         hadUpdates.ShouldHaveUpdates();
+
+        // Verify that the update dependencies commit got amended
+        var commitMessage = await GitOperations.GetRepoLastCommitMessage(ProductRepoPath);
+        commitMessage.Should().StartWith("[VMR] Codeflow");
+
         await GitOperations.MergePrBranch(ProductRepoPath, branchName);
         CheckFileContents(_productRepoFilePath, "New content from the VMR");
         // Backflow again - should be a no-op
@@ -456,6 +461,7 @@ internal class VmrBackflowTest : VmrCodeFlowTests
             ProductRepoPath,
             backflowBranch,
             buildToFlow: build1);
+
         hadUpdates.ShouldHaveUpdates();
 
         // Verify the version files are updated


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4294
I went through all of the places that called the `GitCommitAsync` method, and checked if they need to be amended in some cases

test: PR created in maestro-test-auth with the repro tool: https://github.com/maestro-auth-test/dotnet/pull/11