### PR TITLE
Silence a well-known exception when merging AzDO PRs

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/AzureDevOpsClient.cs
@@ -480,7 +480,8 @@ public class AzureDevOpsClient : RemoteRepoBase, IRemoteGitRepo, IAzureDevOpsCli
         catch (Exception ex) when (
             ex.Message.StartsWith("The pull request needs a minimum number of approvals") ||
             ex.Message == "Proof of presence is required" ||
-            ex.Message == "Failure while attempting to queue Build.")
+            ex.Message == "Failure while attempting to queue Build." ||
+            ex.Message.Contains("Please re-approve the most recent pull request iteration"))
         {
             throw new PullRequestNotMergeableException(ex.Message);
         }


### PR DESCRIPTION
Noticed there's a new message which caused these exceptions to be logged.

<!-- https://github.com/dotnet/arcade-services/issues/4337 -->
