### PR TITLE
Set tracked branch after pushing

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
@@ -359,6 +359,7 @@ public class LocalLibGit2Client : LocalGitClient, ILocalLibGit2Client
         };
 
         repo.Network.Push(remote, branch.CanonicalName, pushOptions);
+        repo.Branches.Update(branch, b => b.TrackedBranch = $"refs/remotes/{remote.Name}/{branch.FriendlyName}");
 
         _logger.LogInformation($"Pushed branch {branch} to remote {remote.Name}");
     }


### PR DESCRIPTION
Fixes a problem introduced in https://github.com/dotnet/arcade-services/issues/4348 where the local branch was not tracking anything and we were not able to reset it when we tried to use it the next time.

This sets the tracking to the just pushed branch.
