### PR TITLE
Disallow batched subscription from the VMR

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/SubscriptionsController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/SubscriptionsController.cs
@@ -226,6 +226,11 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
             return BadRequest(new ApiError("The request is invalid. Only one of source or target directory can be set"));
         }
 
+        if (update.Policy != null && update.Policy.Batchable && update.SourceEnabled == true && update.SourceDirectory != null)
+        {
+            return BadRequest(new ApiError("The request is invalid. Source-enabled subscriptions from a source directory cannot be batched."));
+        }
+
         if (update.SourceDirectory != subscription.SourceDirectory)
         {
             subscription.SourceDirectory = update.SourceDirectory;
@@ -417,6 +422,11 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
             if (!string.IsNullOrEmpty(subscription.SourceDirectory) && !string.IsNullOrEmpty(subscription.TargetDirectory))
             {
                 return BadRequest(new ApiError("The request is invalid. Only one of source or target directory can be set"));
+            }
+
+            if (subscription.Policy.Batchable && subscription.SourceEnabled.Value && subscription.SourceDirectory != null)
+            {
+                return BadRequest(new ApiError("The request is invalid. Source-enabled subscriptions from a source directory cannot be batched."));
             }
         }
 

--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/SubscriptionsController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/SubscriptionsController.cs
@@ -228,7 +228,7 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
 
         if (update.Policy != null && update.Policy.Batchable && update.SourceEnabled == true && update.SourceDirectory != null)
         {
-            return BadRequest(new ApiError("The request is invalid. Source-enabled subscriptions from a source directory cannot be batched."));
+            return BadRequest(new ApiError("The request is invalid. Source-enabled backflow subscriptions cannot be batched."));
         }
 
         if (update.SourceDirectory != subscription.SourceDirectory)
@@ -426,7 +426,7 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
 
             if (subscription.Policy.Batchable && subscription.SourceEnabled.Value && subscription.SourceDirectory != null)
             {
-                return BadRequest(new ApiError("The request is invalid. Source-enabled subscriptions from a source directory cannot be batched."));
+                return BadRequest(new ApiError("The request is invalid. Source-enabled backflow subscriptions cannot be batched."));
             }
         }
 


### PR DESCRIPTION
We consider that batching the backflow subscription from the VMR to other repos is undesirable enough that it's worth disallowing. Modify the PCS API to return a 400 error when requests attempt to create batched subscriptions from the VMR.

https://github.com/dotnet/arcade-services/issues/4359