### PR TITLE
Add RemoveDependency method to DependencyFileManager

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -237,23 +237,25 @@ public class DependencyFileManager : IDependencyFileManager
     private async Task<JObject> RemoveDotnetToolsDependencyAsync(DependencyDetail dependency, string repoUri, string branch, bool repoIsVmr)
     {
         var dotnetTools = await ReadDotNetToolsConfigJsonAsync(repoUri, branch, repoIsVmr);
-        if (dotnetTools != null)
-        {
-            var tools = dotnetTools["tools"] as JObject;
-            if (tools != null)
-            {
-                // we have to do this because JObject is case sensitive
-                var toolProperty = tools.Properties().FirstOrDefault(p => p.Name.Equals(dependency.Name, StringComparison.OrdinalIgnoreCase));
-                if (toolProperty != null)
-                {
-                    tools.Remove(toolProperty.Name);
-                }
 
-                return dotnetTools;
-            }
+        if (dotnetTools == null)
+        {
+            return null;
         }
 
-        return null;
+        if (dotnetTools["tools"] is not JObject tools)
+        {
+            return null;
+        }
+
+        // we have to do this because JObject is case sensitive
+        var toolProperty = tools.Properties().FirstOrDefault(p => p.Name.Equals(dependency.Name, StringComparison.OrdinalIgnoreCase));
+        if (toolProperty != null)
+        {
+            tools.Remove(toolProperty.Name);
+        }
+
+        return dotnetTools;
     }
 
     private async Task<XmlDocument> RemoveDependencyFromVersionPropsAsync(DependencyDetail dependency, string repoUri, string branch)

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -240,7 +240,7 @@ public class DependencyFileManager : IDependencyFileManager
             element = versionProps.SelectSingleNode($"//{alternateNodeName}");
             if (element == null)
             {
-                throw new Exception($"Couldn't find dependency {dependency.Name} in Version.props");
+                throw new DependencyException($"Couldn't find dependency {dependency.Name} in Version.props");
             }
         }
         element.ParentNode.RemoveChild(element);
@@ -255,7 +255,7 @@ public class DependencyFileManager : IDependencyFileManager
 
         if (dependencyNode == null)
         {
-            throw new Exception($"Dependency {dependency.Name} not found in this repository");
+            throw new DependencyException($"Dependency {dependency.Name} not found in Version.Details.xml");
         }
 
         dependencyNode.ParentNode.RemoveChild(dependencyNode);

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IDependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IDependencyFileManager.cs
@@ -20,7 +20,8 @@ namespace Microsoft.DotNet.DarcLib.Helpers;
 public interface IDependencyFileManager
 {
     Task AddDependencyAsync(DependencyDetail dependency, string repoUri, string branch);
-    Task RemoveDependencyAsync(DependencyDetail dependency, string repoUri, string branch);
+
+    Task RemoveDependencyAsync(DependencyDetail dependency, string repoUri, string branch, bool repoIsVmr = false);
 
     Dictionary<string, HashSet<string>> FlattenLocationsAndSplitIntoGroups(Dictionary<string, HashSet<string>> assetLocationMap);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IDependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IDependencyFileManager.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.DarcLib.Helpers;
 public interface IDependencyFileManager
 {
     Task AddDependencyAsync(DependencyDetail dependency, string repoUri, string branch);
+    Task RemoveDependencyAsync(DependencyDetail dependency, string repoUri, string branch);
 
     Dictionary<string, HashSet<string>> FlattenLocationsAndSplitIntoGroups(Dictionary<string, HashSet<string>> assetLocationMap);
 

--- a/test/Microsoft.DotNet.DarcLib.Tests/Helpers/DependencyFileManagerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Helpers/DependencyFileManagerTests.cs
@@ -134,4 +134,29 @@ public class DependencyFileManagerTests
             }
         }
     }
+
+    [Test]
+    public async Task RemoveDependencyShouldThrowWhenDependencyDoesNotExist()
+    {
+        DependencyDetail dependency = new()
+        {
+            Name = "gaa"
+        };
+
+        Mock<IGitRepo> repo = new();
+        Mock<IGitRepoFactory> repoFactory = new();
+
+        repo.Setup(r => r.GetFileContentsAsync(VersionFiles.VersionDetailsXml, It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(VersionDetails);
+        repo.Setup(r => r.GetFileContentsAsync(VersionFiles.VersionProps, It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(VersionProps);
+
+        DependencyFileManager manager = new(
+            repoFactory.Object,
+            new VersionDetailsParser(),
+            NullLogger.Instance);
+
+        Func<Task> act = async () => await manager.RemoveDependencyAsync(dependency, string.Empty, string.Empty);
+        await act.Should().ThrowAsync<DependencyException>();
+    }
 }

--- a/test/Microsoft.DotNet.DarcLib.Tests/Helpers/DependencyFileManagerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Helpers/DependencyFileManagerTests.cs
@@ -1,0 +1,137 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.Models.Darc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+
+namespace Microsoft.DotNet.DarcLib.Tests.Helpers;
+
+[TestFixture]
+public class DependencyFileManagerTests
+{
+    private const string VersionDetails = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <Dependencies>
+          <!-- Elements contains all product dependencies -->
+          <ProductDependencies>
+            <Dependency Name="foo" Version="1.0.0">
+              <Uri>https://github.com/dotnet/foo</Uri>
+              <Sha>sha1</Sha>
+            </Dependency>
+            <Dependency Name="bar" Version="1.0.0">
+              <Uri>https://github.com/dotnet/bar</Uri>
+              <Sha>sha1</Sha>
+            </Dependency>
+          </ProductDependencies>
+          <ToolsetDependencies>
+          </ToolsetDependencies>
+        </Dependencies>
+        """;
+
+    private const string VersionProps = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <Project>
+          <PropertyGroup>
+          </PropertyGroup>
+          <!--Package versions-->
+          <PropertyGroup>
+            <fooPackageVersion>1.0.0</fooPackageVersion>
+            <barPackageVersion>1.0.0</barPackageVersion>
+          </PropertyGroup>
+        </Project>
+        """;
+
+    [Test]
+    public async Task RemoveDependencyShouldRemoveDependency()
+    {
+        var expectedVersionDetails = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <Dependencies>
+          <!-- Elements contains all product dependencies -->
+          <ProductDependencies>
+            <Dependency Name="bar" Version="1.0.0">
+              <Uri>https://github.com/dotnet/bar</Uri>
+              <Sha>sha1</Sha>
+            </Dependency>
+          </ProductDependencies>
+          <ToolsetDependencies>
+          </ToolsetDependencies>
+        </Dependencies>
+        """;
+        var expectedVersionProps = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Project>
+              <PropertyGroup>
+              </PropertyGroup>
+              <!--Package versions-->
+              <PropertyGroup>
+                <barPackageVersion>1.0.0</barPackageVersion>
+              </PropertyGroup>
+            </Project>
+            """;
+
+
+        var tmpVersionDetailsPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tmpVersionPropsPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        DependencyDetail dependency = new()
+        {
+            Name = "foo"
+        };
+
+        Mock<IGitRepo> repo = new();
+        Mock<IGitRepoFactory> repoFactory = new();
+
+        repo.Setup(r => r.GetFileContentsAsync(VersionFiles.VersionDetailsXml, It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(VersionDetails);
+        repo.Setup(r => r.GetFileContentsAsync(VersionFiles.VersionProps, It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(VersionProps);
+        repo.Setup(r => r.CommitFilesAsync(
+            It.Is<List<GitFile>>(files =>
+                files.Count == 2 && files.Any(f => f.FilePath == VersionFiles.VersionDetailsXml) && files.Any(f => f.FilePath == VersionFiles.VersionProps)),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>()))
+            .Callback<List<GitFile>, string, string, string>((files, repoUri, branch, commitMessage) =>
+            {
+                File.WriteAllText(tmpVersionDetailsPath, files[0].Content);
+                File.WriteAllText(tmpVersionPropsPath, files[1].Content);
+            });
+
+        repoFactory.Setup(repoFactory => repoFactory.CreateClient(It.IsAny<string>())).Returns(repo.Object);
+
+        DependencyFileManager manager = new(
+            repoFactory.Object,
+            new VersionDetailsParser(),
+            NullLogger.Instance);
+
+        try
+        {
+            await manager.RemoveDependencyAsync(dependency, string.Empty, string.Empty);
+
+            File.ReadAllText(tmpVersionDetailsPath).Replace("\r\n", "\n").TrimEnd().Should()
+                .Be(expectedVersionDetails.Replace("\r\n", "\n").TrimEnd());
+            File.ReadAllText(tmpVersionPropsPath).Replace("\r\n", "\n").TrimEnd().Should()
+                .Be(expectedVersionProps.Replace("\r\n", "\n").TrimEnd());
+        }
+        finally
+        {
+            if (File.Exists(tmpVersionDetailsPath))
+            {
+                File.Delete(tmpVersionDetailsPath);
+            }
+            if (File.Exists(tmpVersionPropsPath))
+            {
+                File.Delete(tmpVersionPropsPath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4390
Adds a `RemoveDependencyAsync` method with the same API as `AddDependencyAsync`