### PR TITLE
Stop using the BAR token in darc

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AuthenticateEditorPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/AuthenticateEditorPopUp.cs
@@ -13,7 +13,6 @@ internal class AuthenticateEditorPopUp : EditorPopUp
 {
     private readonly ILogger _logger;
 
-    private const string BarPasswordElement = "bar_password";
     private const string GithubTokenElement = "github_token";
     private const string AzureDevOpsTokenElement = "azure_devops_token";
     private const string BarBaseUriElement = "build_asset_registry_base_uri";
@@ -40,12 +39,6 @@ internal class AuthenticateEditorPopUp : EditorPopUp
         // Initialize line contents.
         Contents =
         [
-            new("[DEPRECATED]", isComment: true),
-            new("BAR tokens (formerly created at https://maestro.dot.net/Account/Tokens) are now deprecated.", isComment: true),
-            new("Interactive sign-in through a security group is now enabled.", isComment: true),
-            new("See https://github.com/dotnet/arcade/blob/main/Documentation/Darc.md#setting-up-your-darc-client for more information.", isComment: true),
-            new($"{BarPasswordElement}={GetCurrentSettingForDisplay(settings.BuildAssetRegistryToken, string.Empty, true)}"),
-            new(string.Empty),
             new("Create new GitHub personal access tokens at https://github.com/settings/tokens (no scopes needed but needs SSO enabled on the PAT)", isComment: true),
             new($"{GithubTokenElement}={GetCurrentSettingForDisplay(settings.GitHubToken, string.Empty, true)}"),
             new(string.Empty),
@@ -72,15 +65,6 @@ internal class AuthenticateEditorPopUp : EditorPopUp
 
             switch (keyValue[0])
             {
-                case BarPasswordElement:
-                    settings.BuildAssetRegistryToken = ParseSetting(keyValue[1], settings.BuildAssetRegistryToken, true);
-
-                    if (!string.IsNullOrEmpty(settings.BuildAssetRegistryToken))
-                    {
-                        _logger.LogWarning("BAR password is being deprecated and will stop working soon.");
-                    }
-
-                    break;
                 case GithubTokenElement:
                     settings.GitHubToken = ParseSetting(keyValue[1], settings.GitHubToken, true);
                     break;

--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -28,9 +28,19 @@ public abstract class CommandLineOptions<T> : CommandLineOptions where T : Opera
 public abstract class CommandLineOptions : ICommandLineOptions
 {
     [Option('p', "password",
-        HelpText = "Token used to authenticate to BAR. If it or the federated token are omitted, auth falls back to Azure CLI or an interactive browser login flow.")]
+        HelpText = "[DEPRECATED] Token used to authenticate to BAR. Please use Azure CLI or an interactive browser login flow.")]
     [RedactFromLogging]
-    public string BuildAssetRegistryToken { get; set; }
+    public string BuildAssetRegistryToken
+    {
+        get => null;
+        set
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                Console.WriteLine("The --password option is deprecated. Please use Azure CLI or an interactive browser login flow.");
+            }
+        }
+    }
 
     [Option("github-pat", HelpText = "Token used to authenticate GitHub.")]
     [RedactFromLogging]
@@ -106,7 +116,6 @@ public abstract class CommandLineOptions : ICommandLineOptions
         AzureDevOpsPat ??= localSettings.AzureDevOpsToken;
         GitHubPat ??= localSettings.GitHubToken;
         BuildAssetRegistryBaseUri ??= localSettings.BuildAssetRegistryBaseUri;
-        BuildAssetRegistryToken ??= localSettings.BuildAssetRegistryToken;
     }
 
     /// <summary>


### PR DESCRIPTION
Token is no longer supported (https://github.com/dotnet/arcade-services/issues/4312)

`darc` will
- stop reading/storing the BAR token from the local settings
- stop using it if it's supplied as an argument (but not fail yet)
- warn if it's supplied
- stop giving a warning when the user has not called `darc authenticate` yet

