### PR TITLE
Allow passing in the Entra token

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -28,19 +28,9 @@ public abstract class CommandLineOptions<T> : CommandLineOptions where T : Opera
 public abstract class CommandLineOptions : ICommandLineOptions
 {
     [Option('p', "password",
-        HelpText = "[DEPRECATED] Token used to authenticate to BAR. Please use Azure CLI or an interactive browser login flow.")]
+        HelpText = "Token used to authenticate to BAR. When omitted, Azure CLI or an interactive browser login flow are used.")]
     [RedactFromLogging]
-    public string BuildAssetRegistryToken
-    {
-        get => null;
-        set
-        {
-            if (!string.IsNullOrEmpty(value))
-            {
-                Console.WriteLine("The --password option is deprecated. Please use Azure CLI or an interactive browser login flow.");
-            }
-        }
-    }
+    public string BuildAssetRegistryToken { get; set; } = null;
 
     [Option("github-pat", HelpText = "Token used to authenticate GitHub.")]
     [RedactFromLogging]

--- a/test/ProductConstructionService.ScenarioTests/TestHelpers.cs
+++ b/test/ProductConstructionService.ScenarioTests/TestHelpers.cs
@@ -133,7 +133,7 @@ public static class TestHelpers
     public static string FormatExecutableCall(string executable, params string[] args)
     {
         var output = new StringBuilder();
-        var secretArgNames = new[] { "-p", "--password", "--github-pat", "--azdev-pat" };
+        var secretArgNames = new[] { "--github-pat", "--azdev-pat" };
 
         output.Append(executable);
         for (var i = 0; i < args.Length; i++)

--- a/test/ProductConstructionService.ScenarioTests/TestHelpers.cs
+++ b/test/ProductConstructionService.ScenarioTests/TestHelpers.cs
@@ -133,7 +133,7 @@ public static class TestHelpers
     public static string FormatExecutableCall(string executable, params string[] args)
     {
         var output = new StringBuilder();
-        var secretArgNames = new[] { "--github-pat", "--azdev-pat" };
+        var secretArgNames = new[] { "-p", "--password", "--github-pat", "--azdev-pat" };
 
         output.Append(executable);
         for (var i = 0; i < args.Length; i++)


### PR DESCRIPTION
Partially reverted https://github.com/dotnet/arcade-services/issues/4415 where we still want to be able to pass in the token. This happens in the scenario tests where we get it from Azure CLI manually.