### PR TITLE
Start the service as working always

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItemProcessorState.cs
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItemProcessorState.cs
@@ -82,6 +82,6 @@ public class WorkItemProcessorState
 
     public async Task<string> GetStateAsync()
     {
-        return await _stateCache.GetStateAsync() ?? Stopped;
+        return await _stateCache.GetStateAsync() ?? Working;
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItemProcessorState.cs
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItemProcessorState.cs
@@ -69,14 +69,7 @@ public class WorkItemProcessorState
         }
     }
 
-    public async Task InitializationFinished()
-    {
-        var status = await _stateCache.GetStateAsync();
-        if (!string.IsNullOrEmpty(status) && status == Initializing)
-        {
-            await _stateCache.SetStateAsync(Stopped);
-        }
-    }
+    public async Task InitializationFinished() => await SetStartAsync();
 
     public async Task FinishWorkItemAndStopAsync()
     {

--- a/test/ProductConstructionService.WorkItem.Tests/WorkItemsProcessorScopeManagerTests.cs
+++ b/test/ProductConstructionService.WorkItem.Tests/WorkItemsProcessorScopeManagerTests.cs
@@ -55,7 +55,7 @@ public class WorkItemsProcessorScopeManagerTests
 
         // Initialization is done
         await _state.InitializationFinished();
-        (await _state.GetStateAsync()).Should().Be(WorkItemProcessorState.Stopped);
+        (await _state.GetStateAsync()).Should().Be(WorkItemProcessorState.Working);
 
         TaskCompletionSource workItemCompletion1 = new();
         TaskCompletionSource workItemCompletion2 = new();
@@ -65,12 +65,6 @@ public class WorkItemsProcessorScopeManagerTests
             workItemCompletion1.SetResult();
         });
         t.Start();
-
-        // Wait for the worker to start and get blocked
-        while (t.ThreadState != ThreadState.WaitSleepJoin) ;
-
-        // Start the service again
-        await _state.SetStartAsync();
 
         (await _state.GetStateAsync()).Should().Be(WorkItemProcessorState.Working);
 
@@ -121,12 +115,9 @@ public class WorkItemsProcessorScopeManagerTests
 
         await _state.InitializationFinished();
         // The workItems processor should start in a stopped state
-        (await _state.GetStateAsync()).Should().Be(WorkItemProcessorState.Stopped);
+        (await _state.GetStateAsync()).Should().Be(WorkItemProcessorState.Working);
 
         await _state.FinishWorkItemAndStopAsync();
-
-        // We were already stopped, so we should continue to be so
-        (await _state.GetStateAsync()).Should().Be(WorkItemProcessorState.Stopped);
 
         TaskCompletionSource workItemCompletion = new();
 
@@ -157,7 +148,7 @@ public class WorkItemsProcessorScopeManagerTests
         await _state.SetInitializingAsync();
         await _state.InitializationFinished();
 
-        (await _state.GetStateAsync()).Should().Be(WorkItemProcessorState.Stopped);
+        (await _state.GetStateAsync()).Should().Be(WorkItemProcessorState.Working);
 
         // Start the WorkItemsProcessor multiple times in a row
         await _state.SetStartAsync();

--- a/test/ProductConstructionService.WorkItem.Tests/WorkItemsProcessorScopeManagerTests.cs
+++ b/test/ProductConstructionService.WorkItem.Tests/WorkItemsProcessorScopeManagerTests.cs
@@ -56,6 +56,7 @@ public class WorkItemsProcessorScopeManagerTests
         // Initialization is done
         await _state.InitializationFinished();
         (await _state.GetStateAsync()).Should().Be(WorkItemProcessorState.Working);
+        await _state.FinishWorkItemAndStopAsync();
 
         TaskCompletionSource workItemCompletion1 = new();
         TaskCompletionSource workItemCompletion2 = new();
@@ -65,6 +66,12 @@ public class WorkItemsProcessorScopeManagerTests
             workItemCompletion1.SetResult();
         });
         t.Start();
+
+        // Wait for the worker to start and get blocked
+        while (t.ThreadState != ThreadState.WaitSleepJoin) ;
+
+        // Start the service again
+        await _state.SetStartAsync();
 
         (await _state.GetStateAsync()).Should().Be(WorkItemProcessorState.Working);
 


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/4414
- We want the service to start working right after booting so that random container reboots don't stop the service from processing.
- We also don't want to stop working when the cache gets emptied.

<!-- https://github.com/dotnet/arcade-services/issues/4420 -->
