### PR TITLE
Only use `maestro-auth-test` repos locally

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/MaestroAuthTestRepositoryExtensions.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/MaestroAuthTestRepositoryExtensions.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib;
+
+namespace ProductConstructionService.Api.Configuration;
+
+public static class MaestroAuthTestRepositoryExtensions
+{
+    /// <summary>
+    /// Makes sure we redirect any requests for GitHub dotnet repositories to maestro-auth-test.
+    /// The GitHub application used in local runs does not have access to the real repositories.
+    /// The forks under the maestro-auth-test organization are used instead.
+    /// Used when running the service locally.
+    /// </summary>
+    public static void UseMaestroAuthTestRepositories(this IServiceCollection services)
+    {
+        services.AddScoped<IRepositoryCloneManager, MaestroAuthTestRepositoryCloneManager>();
+        services.AddScoped<RepositoryCloneManager>();
+    }
+
+    private class MaestroAuthTestRepositoryCloneManager : IRepositoryCloneManager
+    {
+        private readonly RepositoryCloneManager _cloneManager;
+
+        public MaestroAuthTestRepositoryCloneManager(RepositoryCloneManager cloneManager)
+        {
+            _cloneManager = cloneManager;
+        }
+
+        public async Task<ILocalGitRepo> PrepareCloneAsync(
+            SourceMapping mapping,
+            IReadOnlyCollection<string> remoteUris,
+            IReadOnlyCollection<string> requestedRefs,
+            string checkoutRef,
+            bool resetToRemote = false,
+            CancellationToken cancellationToken = default)
+        {
+            remoteUris = [.. remoteUris.Select(uri => uri.Replace("github.com/dotnet/", "github.com/maestro-auth-test/"))];
+            return await _cloneManager.PrepareCloneAsync(mapping, remoteUris, requestedRefs, checkoutRef, resetToRemote, cancellationToken);
+        }
+
+        public async Task<ILocalGitRepo> PrepareCloneAsync(
+            string repoUri,
+            string checkoutRef,
+            bool resetToRemote = false,
+            CancellationToken cancellationToken = default)
+        {
+            repoUri = repoUri.Replace("github.com/dotnet/", "github.com/maestro-auth-test/");
+            return await _cloneManager.PrepareCloneAsync(repoUri, checkoutRef, resetToRemote, cancellationToken);
+        }
+
+        public async Task<ILocalGitRepo> PrepareCloneAsync(
+            SourceMapping mapping,
+            IReadOnlyCollection<string> remoteUris,
+            string checkoutRef,
+            bool resetToRemote = false,
+            CancellationToken cancellationToken = default)
+        {
+            remoteUris = [.. remoteUris.Select(uri => uri.Replace("github.com/dotnet/", "github.com/maestro-auth-test/"))];
+            return await _cloneManager.PrepareCloneAsync(mapping, remoteUris, checkoutRef, resetToRemote, cancellationToken);
+        }
+    }
+}

--- a/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
@@ -122,6 +122,11 @@ internal static class PcsStartup
             return new RemoteTokenProvider(azdoTokenProvider, new Microsoft.DotNet.DarcLib.GitHubTokenProvider(gitHubTokenProvider));
         });
 
+        if (isDevelopment)
+        {
+            builder.Services.UseMaestroAuthTestRepositories();
+        }
+
         await builder.AddRedisCache(authRedis);
         builder.AddBuildAssetRegistry();
         builder.AddMetricRecorder();


### PR DESCRIPTION
I discovered that using the repro tool locally does not entirely work because during code flows, we try to use all of the previous remotes (such as the URI stored in the `source-manifest.json`).
We cannot override those in the repositories because some scenarios such as previous flow reconstructions would still break.

So it's easier to override the URI like this and just keep cloning the repos that we have access to.

<!-- https://github.com/dotnet/arcade-services/issues/4438 -->