### PR TITLE
Use Add/RemoveDependency during VMR test setup

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IDependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IDependencyFileManager.cs
@@ -21,7 +21,7 @@ public interface IDependencyFileManager
 {
     Task AddDependencyAsync(DependencyDetail dependency, string repoUri, string branch);
 
-    Task RemoveDependencyAsync(DependencyDetail dependency, string repoUri, string branch, bool repoIsVmr = false);
+    Task RemoveDependencyAsync(string dependencyName, string repoUri, string branch, bool repoIsVmr = false);
 
     Dictionary<string, HashSet<string>> FlattenLocationsAndSplitIntoGroups(Dictionary<string, HashSet<string>> assetLocationMap);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Local.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Local.cs
@@ -54,6 +54,15 @@ public class Local
     }
 
     /// <summary>
+    ///     Adds a dependency to the dependency files
+    /// </summary>
+    /// <returns></returns>
+    public async Task RemoveDependencyAsync(string dependencyName)
+    {
+        await _fileManager.RemoveDependencyAsync(dependencyName, _repoRootDir.Value, null);
+    }
+
+    /// <summary>
     ///     Updates existing dependencies in the dependency files
     /// </summary>
     /// <param name="dependencies">Dependencies that need updates.</param>

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeFlowTests.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeFlowTests.cs
@@ -113,7 +113,7 @@ internal abstract class VmrCodeFlowTests : VmrTestsBase
                 Version = a.Version,
                 RepoUri = build.GitHubRepository,
                 Commit = build.Commit,
-                Type = DependencyType.Product,
+                Type = a.Name == DependencyFileManager.ArcadeSdkPackageName ? DependencyType.Toolset : DependencyType.Product,
                 Pinned = false,
             })
             .ToList();

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTwoWayCodeflowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTwoWayCodeflowTest.cs
@@ -478,72 +478,45 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
 
         await EnsureTestRepoIsInitialized();
 
-        await File.WriteAllTextAsync(ProductRepoPath / VersionFiles.VersionDetailsXml,
-            """
-            <?xml version="1.0" encoding="utf-8"?>
-            <Dependencies>
-              <ProductDependencies>
-                <!-- Dependencies from https://github.com/dotnet/repo1 -->
-                <Dependency Name="Package.A1" Version="1.0.0">
-                  <Uri>https://github.com/dotnet/repo1</Uri>
-                  <Sha>a01</Sha>
-                </Dependency>
-                <Dependency Name="Package.B1" Version="1.0.0">
-                  <Uri>https://github.com/dotnet/repo1</Uri>
-                  <Sha>b02</Sha>
-                </Dependency>
-                <!-- End of dependencies from https://github.com/dotnet/repo1 -->
-                <!-- Dependencies from https://github.com/dotnet/repo2 -->
-                <Dependency Name="Package.C2" Version="1.0.0">
-                  <Uri>https://github.com/dotnet/repo2</Uri>
-                  <Sha>c03</Sha>
-                </Dependency>
-                <!-- End of dependencies from https://github.com/dotnet/repo2 -->
-                <!-- Dependencies from https://github.com/dotnet/repo3 -->
-                <Dependency Name="Package.D3" Version="1.0.0">
-                  <Uri>https://github.com/dotnet/repo3</Uri>
-                  <Sha>d04</Sha>
-                </Dependency>
-                <!-- End of dependencies from https://github.com/dotnet/repo3 -->
-              </ProductDependencies>
-              <ToolsetDependencies />
-            </Dependencies>
-            """);
+        var repo = GetLocal(ProductRepoPath);
 
-        // The Versions.props file intentionally contains padding comment lines like in real repos
-        // These lines make sure that neighboring lines are not getting in conflict when used as context during patch application
-        // Repos like SDK have figured out that this is a good practice to avoid conflicts in the version files
-        await File.WriteAllTextAsync(ProductRepoPath / VersionFiles.VersionProps,
-            """
-            <?xml version="1.0" encoding="utf-8"?>
-            <Project>
-              <PropertyGroup>
-                <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-              </PropertyGroup>
-              <PropertyGroup>
-                <VersionPrefix>9.0.100</VersionPrefix>
-              </PropertyGroup>
-              <!-- Dependencies from https://github.com/dotnet/repo1 -->
-              <PropertyGroup>
-                <!-- Dependencies from https://github.com/dotnet/repo1-->
-                <PackageA1PackageVersion>1.0.0</PackageA1PackageVersion>
-                <PackageB1PackageVersion>1.0.0</PackageB1PackageVersion>
-              </PropertyGroup>
-              <!-- End of dependencies from https://github.com/dotnet/repo1 -->
-              <!-- Dependencies from https://github.com/dotnet/repo2 -->
-              <PropertyGroup>
-                <!-- Dependencies from https://github.com/dotnet/repo2-->
-                <PackageC2PackageVersion>1.0.0</PackageC2PackageVersion>
-              </PropertyGroup>
-              <!-- End of dependencies from https://github.com/dotnet/repo2 -->
-              <!-- Dependencies from https://github.com/dotnet/repo3 -->
-              <PropertyGroup>
-                <!-- Dependencies from https://github.com/dotnet/repo3 -->
-                <PackageD3PackageVersion>1.0.0</PackageD3PackageVersion>
-              </PropertyGroup>
-              <!-- End of dependencies from https://github.com/dotnet/repo3 -->
-            </Project>
-            """);
+        await repo.RemoveDependencyAsync(FakePackageName);
+
+        await repo.AddDependencyAsync(new DependencyDetail
+        {
+            Name = "Package.A1",
+            Version = "1.0.0",
+            RepoUri = "https://github.com/dotnet/repo1",
+            Commit = "a01",
+            Type = DependencyType.Product,
+        });
+
+        await repo.AddDependencyAsync(new DependencyDetail
+        {
+            Name = "Package.B1",
+            Version = "1.0.0",
+            RepoUri = "https://github.com/dotnet/repo1",
+            Commit = "b02",
+            Type = DependencyType.Product,
+        });
+
+        await repo.AddDependencyAsync(new DependencyDetail
+        {
+            Name = "Package.C2",
+            Version = "1.0.0",
+            RepoUri = "https://github.com/dotnet/repo2",
+            Commit = "c03",
+            Type = DependencyType.Product,
+        });
+
+        await repo.AddDependencyAsync(new DependencyDetail
+        {
+            Name = "Package.D3",
+            Version = "1.0.0",
+            RepoUri = "https://github.com/dotnet/repo3",
+            Commit = "d04",
+            Type = DependencyType.Product,
+        });
 
         // Level the repo and the VMR
         await GitOperations.CommitAll(ProductRepoPath, "Changing version files");

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTwoWayCodeflowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTwoWayCodeflowTest.cs
@@ -478,6 +478,11 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
 
         await EnsureTestRepoIsInitialized();
 
+        /*
+        TODO https://github.com/dotnet/arcade-services/issues/4342:
+        When conflict resolution is implemented
+        this test should be updated and padding lines removed
+
         var repo = GetLocal(ProductRepoPath);
 
         await repo.RemoveDependencyAsync(FakePackageName);
@@ -517,6 +522,74 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
             Commit = "d04",
             Type = DependencyType.Product,
         });
+        */
+
+        await File.WriteAllTextAsync(ProductRepoPath / VersionFiles.VersionDetailsXml,
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Dependencies>
+              <ProductDependencies>
+                <!-- Dependencies from https://github.com/dotnet/repo1 -->
+                <Dependency Name="Package.A1" Version="1.0.0">
+                  <Uri>https://github.com/dotnet/repo1</Uri>
+                  <Sha>a01</Sha>
+                </Dependency>
+                <Dependency Name="Package.B1" Version="1.0.0">
+                  <Uri>https://github.com/dotnet/repo1</Uri>
+                  <Sha>b02</Sha>
+                </Dependency>
+                <!-- End of dependencies from https://github.com/dotnet/repo1 -->
+                <!-- Dependencies from https://github.com/dotnet/repo2 -->
+                <Dependency Name="Package.C2" Version="1.0.0">
+                  <Uri>https://github.com/dotnet/repo2</Uri>
+                  <Sha>c03</Sha>
+                </Dependency>
+                <!-- End of dependencies from https://github.com/dotnet/repo2 -->
+                <!-- Dependencies from https://github.com/dotnet/repo3 -->
+                <Dependency Name="Package.D3" Version="1.0.0">
+                  <Uri>https://github.com/dotnet/repo3</Uri>
+                  <Sha>d04</Sha>
+                </Dependency>
+                <!-- End of dependencies from https://github.com/dotnet/repo3 -->
+              </ProductDependencies>
+              <ToolsetDependencies />
+            </Dependencies>
+            """);
+
+        // The Versions.props file intentionally contains padding comment lines like in real repos
+        // These lines make sure that neighboring lines are not getting in conflict when used as context during patch application
+        // Repos like SDK have figured out that this is a good practice to avoid conflicts in the version files
+        await File.WriteAllTextAsync(ProductRepoPath / VersionFiles.VersionProps,
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Project>
+              <PropertyGroup>
+                <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+              </PropertyGroup>
+              <PropertyGroup>
+                <VersionPrefix>9.0.100</VersionPrefix>
+              </PropertyGroup>
+              <!-- Dependencies from https://github.com/dotnet/repo1 -->
+              <PropertyGroup>
+                <!-- Dependencies from https://github.com/dotnet/repo1-->
+                <PackageA1PackageVersion>1.0.0</PackageA1PackageVersion>
+                <PackageB1PackageVersion>1.0.0</PackageB1PackageVersion>
+              </PropertyGroup>
+              <!-- End of dependencies from https://github.com/dotnet/repo1 -->
+              <!-- Dependencies from https://github.com/dotnet/repo2 -->
+              <PropertyGroup>
+                <!-- Dependencies from https://github.com/dotnet/repo2-->
+                <PackageC2PackageVersion>1.0.0</PackageC2PackageVersion>
+              </PropertyGroup>
+              <!-- End of dependencies from https://github.com/dotnet/repo2 -->
+              <!-- Dependencies from https://github.com/dotnet/repo3 -->
+              <PropertyGroup>
+                <!-- Dependencies from https://github.com/dotnet/repo3 -->
+                <PackageD3PackageVersion>1.0.0</PackageD3PackageVersion>
+              </PropertyGroup>
+              <!-- End of dependencies from https://github.com/dotnet/repo3 -->
+            </Project>
+            """);
 
         // Level the repo and the VMR
         await GitOperations.CommitAll(ProductRepoPath, "Changing version files");

--- a/test/Microsoft.DotNet.DarcLib.Tests/Helpers/DependencyFileManagerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Helpers/DependencyFileManagerTests.cs
@@ -181,7 +181,7 @@ public class DependencyFileManagerTests
 
         try
         {
-            await manager.RemoveDependencyAsync(dependency, string.Empty, string.Empty);
+            await manager.RemoveDependencyAsync(dependency.Name, string.Empty, string.Empty);
 
             File.ReadAllText(tmpVersionDetailsPath).Replace("\r\n", "\n").TrimEnd().Should()
                 .Be(expectedVersionDetails.Replace("\r\n", "\n").TrimEnd());
@@ -232,7 +232,7 @@ public class DependencyFileManagerTests
             new VersionDetailsParser(),
             NullLogger.Instance);
 
-        Func<Task> act = async () => await manager.RemoveDependencyAsync(dependency, string.Empty, string.Empty);
+        Func<Task> act = async () => await manager.RemoveDependencyAsync(dependency.Name, string.Empty, string.Empty);
         await act.Should().ThrowAsync<DependencyException>();
     }
 }


### PR DESCRIPTION
With the addition of `RemoveDependencyAsync`, we can stop generating XMLs when we need to omit a package inside a test.

https://github.com/dotnet/arcade-services/issues/4390
