### PR TITLE
Only look at NuGet when cleaning darc feeds

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
@@ -167,9 +167,19 @@ public class FeedCleaner
                     asset.Name,
                     asset.Version);
 
-                asset.Locations.Remove(asset.Locations.First(l => l.Location.Contains(feed.Name, StringComparison.OrdinalIgnoreCase)));
+                try
+                {
+                    asset.Locations.Remove(asset.Locations.First(l => l.Location.Contains(feed.Name, StringComparison.OrdinalIgnoreCase)));
 
-                await _context.SaveChangesAsync();
+                    await _context.SaveChangesAsync();
+                }
+                catch
+                {
+                    _logger.LogWarning("Failed to remove location {feed} from {package}.{version} in BAR",
+                        feed.Name,
+                        asset.Name,
+                        asset.Version);
+                }
             }
             catch (HttpRequestException e)
             {

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
@@ -186,9 +186,9 @@ public class FeedCleaner
         {
             await _context.SaveChangesAsync();
         }
-        catch
+        catch (Exception e)
         {
-            _logger.LogWarning("Failed to remove location {feed} from Assets in BAR", feed.Name);
+            _logger.LogError(e, "Failed to remove location {feed} from Assets in BAR", feed.Name);
         }
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
@@ -167,18 +167,10 @@ public class FeedCleaner
                     asset.Name,
                     asset.Version);
 
-                try
+                var assetLocation = asset.Locations.FirstOrDefault(al => al.Location.Contains(feed.Name, StringComparison.OrdinalIgnoreCase));
+                if (assetLocation != null)
                 {
-                    asset.Locations.Remove(asset.Locations.First(l => l.Location.Contains(feed.Name, StringComparison.OrdinalIgnoreCase)));
-
-                    await _context.SaveChangesAsync();
-                }
-                catch
-                {
-                    _logger.LogWarning("Failed to remove location {feed} from {package}.{version} in BAR",
-                        feed.Name,
-                        asset.Name,
-                        asset.Version);
+                    asset.Locations.Remove(assetLocation);
                 }
             }
             catch (HttpRequestException e)
@@ -188,6 +180,15 @@ public class FeedCleaner
                     asset.Version,
                     feed.Name);
             }
+        }
+
+        try
+        {
+            await _context.SaveChangesAsync();
+        }
+        catch
+        {
+            _logger.LogWarning("Failed to remove location {feed} from Assets in BAR", feed.Name);
         }
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerConfiguration.cs
@@ -34,6 +34,13 @@ public static class FeedCleanerConfiguration
         builder.Services.AddTransient<IAzureDevOpsClient, AzureDevOpsClient>();
         builder.Services.AddTransient<ILogger>(sp => sp.GetRequiredService<ILogger<FeedCleanerJob>>());
         builder.Services.AddTransient<IProcessManager>(sp => ActivatorUtilities.CreateInstance<ProcessManager>(sp, "git"));
+        builder.Services.AddHttpClient().ConfigureHttpClientDefaults(builder =>
+        {
+            builder.ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            {
+                CheckCertificateRevocationList = true,
+            });
+        });
 
         builder.Services.AddTransient<FeedCleanerJob>();
         builder.Services.AddTransient<FeedCleaner>();

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
@@ -10,8 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-using PackagesInReleaseFeeds = System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>>>;
-
 namespace ProductConstructionService.FeedCleaner;
 
 public class FeedCleanerJob
@@ -101,38 +99,5 @@ public class FeedCleanerJob
                 managedFeeds.Count,
                 azdoAccount);
         }
-    }
-
-    /// <summary>
-    /// Construct a nuget feed URL for an Azure DevOps Artifact feed
-    /// </summary>
-    /// <param name="feedName">Name of the feed</param>
-    /// <param name="account">Azure DevOps Account where the feed is hosted</param>
-    /// <param name="project">Optional project for the feed.</param>
-    /// <returns>Url of the form https://pkgs.dev.azure.com/account/project/_packaging/feedName/nuget/v3/index.json </returns>
-    private static string ComputeAzureArtifactsNuGetFeedUrl(string feedName, string account, string project = "")
-    {
-        string projectSection = string.IsNullOrEmpty(project) ? "" : $"{project}/";
-        return $"https://pkgs.dev.azure.com/{account}/{projectSection}_packaging/{feedName}/nuget/v3/index.json";
-    }
-
-    /// <summary>
-    /// Gets a Mapping of package -> versions for an Azure DevOps feed.
-    /// </summary>
-    /// <param name="azdoClient">Azure DevOps client.</param>
-    /// <param name="account">Azure DevOps account.</param>
-    /// <param name="project">Azure DevOps project the feed is hosted in.</param>
-    /// <param name="feedName">Name of the feed</param>
-    /// <returns>Dictionary where the key is the package name, and the value is a HashSet of the versions of the package in the feed</returns>
-    private async Task<Dictionary<string, HashSet<string>>> GetPackageVersionsForFeedAsync(string account, string project, string feedName)
-    {
-        var packagesWithVersions = new Dictionary<string, HashSet<string>>();
-        List<AzureDevOpsPackage> packagesInFeed = await _azureDevOpsClient.GetPackagesForFeedAsync(account, project, feedName);
-        foreach (AzureDevOpsPackage package in packagesInFeed)
-        {
-            packagesWithVersions.Add(package.Name, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
-            packagesWithVersions[package.Name].UnionWith(package.Versions?.Where(v => !v.IsDeleted).Select(v => v.Version) ?? []);
-        }
-        return packagesWithVersions;
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerOptions.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerOptions.cs
@@ -7,9 +7,5 @@ public class FeedCleanerOptions
 {
     public required bool Enabled { get; set; }
 
-    public required List<ReleasePackageFeed> ReleasePackageFeeds { get; set; }
-
     public required List<string> AzdoAccounts { get; set; }
 }
-
-public record ReleasePackageFeed(string Account, string Project, string Name);

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/appsettings.json
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/appsettings.json
@@ -7,28 +7,6 @@
         }
     },
     "FeedCleaner": {
-        "Enabled": false,
-        "ReleasePackageFeeds": [
-            {
-                "Account": "dnceng",
-                "Project": "public",
-                "Name": "dotnet3"
-            },
-            {
-                "Account": "dnceng",
-                "Project": "public",
-                "Name": "dotnet3.1"
-            },
-            {
-                "Account": "dnceng",
-                "Project": "public",
-                "Name": "dotnet5"
-            },
-            {
-                "Account": "dnceng",
-                "Project": "public",
-                "Name": "dotnet-tools"
-            }
-        ]
+        "Enabled": false
     }
 }

--- a/test/ProductConstructionService.FeedCleaner.Tests/FeedCleanerTests.cs
+++ b/test/ProductConstructionService.FeedCleaner.Tests/FeedCleanerTests.cs
@@ -1,16 +1,19 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using FluentAssertions;
 using Maestro.Common.AzureDevOpsTokens;
 using Maestro.Data;
 using Maestro.Data.Models;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models.AzureDevOps;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;
+using Moq.Protected;
 using NUnit.Framework;
 
 namespace ProductConstructionService.FeedCleaner.Tests;
@@ -27,6 +30,7 @@ public class FeedCleanerTests
     private const string ReleaseFeedName = "release-feed";
     private const string FeedWithAllPackagesReleasedName = "darc-pub-some-repo-12345679";
     private const string FeedWithUnreleasedPackagesName = "darc-int-some-repo-12345678";
+    private const string ReleasedPackagePrefix = "packageInNuget";
 
     private FeedCleanerJob InitializeFeedCleaner(string name)
     {
@@ -46,10 +50,6 @@ public class FeedCleanerTests
             (options) =>
             {
                 options.Enabled = true;
-                options.ReleasePackageFeeds =
-                [
-                    new ReleasePackageFeed(SomeAccount, "someProject", ReleaseFeedName),
-                ];
 
                 options.AzdoAccounts =
                 [
@@ -60,6 +60,7 @@ public class FeedCleanerTests
 
         services.AddSingleton<IAzureDevOpsTokenProvider, AzureDevOpsTokenProvider>();
         services.AddSingleton(SetupAzdoMock().Object);
+        services.AddSingleton(SetupHttpClientFactoryMock().Object);
         services.Configure<AzureDevOpsTokenProviderOptions>(
             (options) =>
             {
@@ -91,7 +92,7 @@ public class FeedCleanerTests
         unreleasedFeed.Packages.Should().HaveCount(2);
         var packagesWithDeletedVersions = unreleasedFeed.Packages.Where(p => p.Versions.Any(v => v.IsDeleted)).ToList();
         packagesWithDeletedVersions.Should().ContainSingle();
-        packagesWithDeletedVersions.First().Name.Should().Be("releasedPackage1");
+        packagesWithDeletedVersions.First().Name.Should().Be($"{ReleasedPackagePrefix}1");
         var deletedVersions = packagesWithDeletedVersions.First().Versions.Where(v => v.IsDeleted).ToList();
         deletedVersions.Should().ContainSingle();
         deletedVersions.First().Version.Should().Be("1.0");
@@ -111,16 +112,11 @@ public class FeedCleanerTests
             .Include(a => a.Locations)
             .Where(a => a.Locations.Any(l => l.Location.Contains(FeedWithAllPackagesReleasedName)))
             .ToList();
-        assetsInDeletedFeed.Should().HaveCount(4);
-        assetsInDeletedFeed.Should().Contain(a =>
-            a.Name.Equals("Newtonsoft.Json") &&
-            a.Version == "12.0.2" &&
-            a.Locations.Any(l => l.Location.Equals("https://api.nuget.org/v3/index.json")));
+        assetsInDeletedFeed.Should().HaveCount(3);
 
         // All other assets should also have been updated to be in the release feed
         assetsInDeletedFeed.Should().NotContain(a =>
-            !a.Name.Equals("Newtonsoft.Json") &&
-            !a.Locations.Any(l => l.Location.Contains(ReleaseFeedName)));
+            !a.Locations.Any(l => l.Location.Contains(FeedConstants.NuGetOrgLocation)));
 
         // "releasedPackage1" should've been released and have its location updated to the released feed.
         var assetsInRemainingFeed = context.Assets
@@ -130,10 +126,10 @@ public class FeedCleanerTests
         assetsInRemainingFeed.Should().HaveCount(2);
 
         var releasedAssets = assetsInRemainingFeed
-            .Where(a => a.Locations.Any(l => l.Location.Contains(ReleaseFeedName)))
+            .Where(a => a.Locations.Any(l => l.Location.Contains(FeedConstants.NuGetOrgLocation)))
             .ToList();
         releasedAssets.Should().ContainSingle();
-        releasedAssets.First().Name.Should().Be("releasedPackage1");
+        releasedAssets.First().Name.Should().Be($"{ReleasedPackagePrefix}1");
         releasedAssets.First().Version.Should().Be("1.0");
 
         // "unreleasedPackage1" hasn't been released, should only have the stable feed as its location
@@ -187,10 +183,37 @@ public class FeedCleanerTests
         azdoClientMock.Setup(a => a.DeleteNuGetPackageVersionFromFeedAsync(SomeAccount, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .Callback<string, string, string, string, string>((account, project, feed, package, version) => MarkVersionAsDeleted(_feeds[feed].Packages, package, version))
             .Returns(Task.CompletedTask);
-        azdoClientMock.Setup(a => a.DeleteFeedAsync(SomeAccount, It.IsAny<string>(), It.IsAny<string>()))
-            .Callback<string, string, string>((account, project, feedIdentifier) => _feeds.Remove(feedIdentifier))
-            .Returns(Task.CompletedTask);
         return azdoClientMock;
+    }
+
+    private Mock<IHttpClientFactory> SetupHttpClientFactoryMock()
+    {
+        Mock<HttpMessageHandler> handlerMock = new();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage request, CancellationToken token) =>
+            {
+                var response = new HttpResponseMessage();
+                if (request.RequestUri != null &&
+                    request.RequestUri.AbsolutePath.Contains(ReleasedPackagePrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    response.StatusCode = HttpStatusCode.OK;
+                }
+                else
+                {
+                    response.StatusCode = HttpStatusCode.BadRequest;
+                }
+                return response;
+            });
+
+        Mock<IHttpClientFactory> httpClientFactoryMock = new();
+        httpClientFactoryMock.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(new HttpClient(handlerMock.Object));
+
+        return httpClientFactoryMock;
     }
 
     private static void MarkVersionAsDeleted(List<AzureDevOpsPackage> packages, string packageName, string version)
@@ -209,30 +232,6 @@ public class FeedCleanerTests
         var someProject = new AzureDevOpsProject("0", "someProject");
         var allFeeds = new Dictionary<string, AzureDevOpsFeed>();
 
-        // This is the reference release feed.
-        var releaseFeed = new AzureDevOpsFeed(account, "0", ReleaseFeedName, someProject)
-        {
-            Packages =
-            [
-                new AzureDevOpsPackage("releasedPackage1", "nuget")
-                {
-                    Versions =
-                    [
-                        new AzureDevOpsPackageVersion("1.0", isDeleted: false),
-                        new AzureDevOpsPackageVersion("2.0", isDeleted: true),
-                    ]
-                },
-                new AzureDevOpsPackage("releasedPackage2", "nuget")
-                {
-                    Versions =
-                    [
-                        new AzureDevOpsPackageVersion("1.0", isDeleted: false),
-                        new AzureDevOpsPackageVersion("2.0", isDeleted: false),
-                    ]
-                }
-            ]
-        };
-        allFeeds.Add(releaseFeed.Name, releaseFeed);
 
         var managedFeedWithUnreleasedPackages = new AzureDevOpsFeed(account, "1", FeedWithUnreleasedPackagesName, null)
         {
@@ -245,7 +244,7 @@ public class FeedCleanerTests
                         new AzureDevOpsPackageVersion("1.0", isDeleted: false)
                     ]
                 },
-                new AzureDevOpsPackage("releasedPackage1", "nuget")
+                new AzureDevOpsPackage($"{ReleasedPackagePrefix}1", "nuget")
                 {
                     Versions =
                     [
@@ -260,21 +259,14 @@ public class FeedCleanerTests
         {
             Packages =
             [
-                new AzureDevOpsPackage("Newtonsoft.Json", "nuget")
-                {
-                    Versions =
-                    [
-                        new AzureDevOpsPackageVersion("12.0.2", isDeleted: false)
-                    ]
-                },
-                new AzureDevOpsPackage("releasedPackage1", "nuget")
+                new AzureDevOpsPackage($"{ReleasedPackagePrefix}2", "nuget")
                 {
                     Versions =
                     [
                         new AzureDevOpsPackageVersion("1.0", isDeleted: false)
                     ]
                 },
-                new AzureDevOpsPackage("releasedPackage2", "nuget")
+                new AzureDevOpsPackage($"{ReleasedPackagePrefix}3", "nuget")
                 {
                     Versions =
                     [


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4266
Discussed with Matt, we don't need to look at AzDo feeds anymore, everything that's released should be in NuGet