### PR TITLE
Fixup invalid source comparison for build trigger

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/SubscriptionTriggerConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/SubscriptionTriggerConfiguration.cs
@@ -42,9 +42,15 @@ internal static class SubscriptionTriggerConfiguration
                 .Where(sub =>
                     sub.Enabled &&
                     sub.ChannelId == entity.ChannelId &&
-                    (sub.SourceRepository == entity.Build.GitHubRepository || sub.SourceDirectory == entity.Build.AzureDevOpsRepository) &&
+                    (sub.SourceRepository == entity.Build.GitHubRepository || sub.SourceRepository == entity.Build.AzureDevOpsRepository) &&
                     JsonExtensions.JsonValue(sub.PolicyString, "lax $.UpdateFrequency") == ((int)UpdateFrequency.EveryBuild).ToString())
                 .ToList();
+
+            if (!subscriptionsToUpdate.Any())
+            {
+                logger.LogInformation("No subscriptions to trigger for build {buildId}", entity.BuildId);
+                return;
+            }
 
             foreach (Subscription subscription in subscriptionsToUpdate)
             {


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Suspected fix for https://github.com/dotnet/arcade-services/issues/4454

`EveryBuild` trigger was incorrectly comparing the source repo of the build to the subs source directory, resulting in no subscriptions being triggered
