### PR TITLE
Don't use hardcoded template path, get it from the VMR

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceMappingFile.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceMappingFile.cs
@@ -37,6 +37,11 @@ public class SourceMappingFile
     public string? SourceMappingsPath { get; set; }
 
     /// <summary>
+    /// Location within the VMR where the third-party notices template file is stored
+    /// </summary>
+    public string? ThirdPartyNoticesTemplatePath { get; set; }
+
+    /// <summary>
     /// Each of these mappings has a corresponding folder in the src/ directory
     /// </summary>
     public List<SourceMappingSetting> Mappings { get; set; } = [];

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowVmrUpdater.cs
@@ -149,7 +149,7 @@ public class CodeFlowVmrUpdater : VmrManagerBase, ICodeFlowVmrUpdater
                 currentVersion.Sha,
                 commitMessage,
                 restoreVmrPatches: false,
-                tpnTemplatePath: _vmrInfo.VmrPath / VmrInfo.ThirdPartyNoticesTemplatePath,
+                tpnTemplatePath: _vmrInfo.GetThirdPartyNoticesTemplateFullPath,
                 generateCodeowners: true,
                 generateCredScanSuppressions: true,
                 discardPatches: true,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowVmrUpdater.cs
@@ -149,7 +149,7 @@ public class CodeFlowVmrUpdater : VmrManagerBase, ICodeFlowVmrUpdater
                 currentVersion.Sha,
                 commitMessage,
                 restoreVmrPatches: false,
-                tpnTemplatePath: _vmrInfo.GetThirdPartyNoticesTemplateFullPath,
+                tpnTemplatePath: _vmrInfo.ThirdPartyNoticesTemplateFullPath,
                 generateCodeowners: true,
                 generateCredScanSuppressions: true,
                 discardPatches: true,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
@@ -56,6 +56,7 @@ public class SourceMappingParser : ISourceMappingParser
 
         _vmrInfo.PatchesPath = NormalizePath(settings.PatchesPath);
         _vmrInfo.SourceMappingsPath = settings.SourceMappingsPath;
+        _vmrInfo.ThirdPartyNoticesTemplatePath = settings.ThirdPartyNoticesTemplatePath;
 
         if (settings.AdditionalMappings is not null)
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -39,6 +39,11 @@ public interface IVmrInfo
     string? SourceMappingsPath { get; set; }
 
     /// <summary>
+    /// Path to the third-party notices template file
+    /// </summary>
+    string? ThirdPartyNoticesTemplatePath { get; set; }
+
+    /// <summary>
     /// Gets a full path leading to the source manifest JSON file.
     /// </summary>
     NativePath SourceManifestPath { get; }
@@ -59,6 +64,8 @@ public interface IVmrInfo
     /// Gets a full path leading to sources belonging to a given repo
     /// </summary>
     NativePath GetRepoSourcesPath(string mappingName);
+
+    string? GetThirdPartyNoticesTemplateFullPath { get; }
 }
 
 public class VmrInfo : IVmrInfo
@@ -75,9 +82,6 @@ public class VmrInfo : IVmrInfo
     // These git attributes can override cloaking of files when set it individual repositories
     public const string KeepAttribute = "vmr-preserve";
     public const string IgnoreAttribute = "vmr-ignore";
-
-    // TODO (https://github.com/dotnet/arcade-services/issues/4186): Read these from source-mappings.json
-    public const string ThirdPartyNoticesTemplatePath = "src/sdk/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt";
 
     public const string ThirdPartyNoticesFileName = "THIRD-PARTY-NOTICES.txt";
     public const string CodeownersFileName = "CODEOWNERS";
@@ -111,6 +115,8 @@ public class VmrInfo : IVmrInfo
 
     public string? SourceMappingsPath { get; set; }
 
+    public string? ThirdPartyNoticesTemplatePath { get; set; }
+
     public string VmrUri { get; set; }
 
     public IReadOnlyCollection<(string Source, string? Destination)> AdditionalMappings { get; set; } = Array.Empty<(string, string?)>();
@@ -134,6 +140,10 @@ public class VmrInfo : IVmrInfo
     public static UnixPath GetRelativeRepoSourcesPath(SourceMapping mapping) => GetRelativeRepoSourcesPath(mapping.Name);
 
     public static UnixPath GetRelativeRepoSourcesPath(string mappingName) => SourcesDir / mappingName;
+    public string? GetThirdPartyNoticesTemplateFullPath =>
+        string.IsNullOrEmpty(ThirdPartyNoticesTemplatePath!)
+            ? null
+            : (_vmrPath / ThirdPartyNoticesTemplatePath).ToString();
 
     public NativePath SourceManifestPath { get; private set; }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -141,7 +141,7 @@ public class VmrInfo : IVmrInfo
 
     public static UnixPath GetRelativeRepoSourcesPath(string mappingName) => SourcesDir / mappingName;
     public string? GetThirdPartyNoticesTemplateFullPath =>
-        string.IsNullOrEmpty(ThirdPartyNoticesTemplatePath!)
+        string.IsNullOrEmpty(ThirdPartyNoticesTemplatePath)
             ? null
             : (_vmrPath / ThirdPartyNoticesTemplatePath).ToString();
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInfo.cs
@@ -65,7 +65,7 @@ public interface IVmrInfo
     /// </summary>
     NativePath GetRepoSourcesPath(string mappingName);
 
-    string? GetThirdPartyNoticesTemplateFullPath { get; }
+    string? ThirdPartyNoticesTemplateFullPath { get; }
 }
 
 public class VmrInfo : IVmrInfo
@@ -140,7 +140,7 @@ public class VmrInfo : IVmrInfo
     public static UnixPath GetRelativeRepoSourcesPath(SourceMapping mapping) => GetRelativeRepoSourcesPath(mapping.Name);
 
     public static UnixPath GetRelativeRepoSourcesPath(string mappingName) => SourcesDir / mappingName;
-    public string? GetThirdPartyNoticesTemplateFullPath =>
+    public string? ThirdPartyNoticesTemplateFullPath =>
         string.IsNullOrEmpty(ThirdPartyNoticesTemplatePath)
             ? null
             : (_vmrPath / ThirdPartyNoticesTemplatePath).ToString();


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4186
We'l also have to add this path to the VMR