### PR TITLE
Look up previous builds when reconstructing flows during conflicts

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
@@ -25,6 +25,7 @@ public interface ISourceManifest
     VmrDependencyVersion? GetVersion(string repository);
     bool TryGetRepoVersion(string mappingName, [NotNullWhen(true)] out ISourceComponent? mapping);
     ISourceComponent GetRepoVersion(string mappingName);
+    RepositoryRecord GetRepositoryRecord(string mapppingName);
     void Refresh(string sourceManifestPath);
 }
 
@@ -174,6 +175,12 @@ public class SourceManifest : ISourceManifest
         {
             return null;
         }
+    }
+
+    public RepositoryRecord GetRepositoryRecord(string mapppingName)
+    {
+        return _repositories.FirstOrDefault(r => r.Path == mapppingName)
+            ?? throw new Exception($"No repository record named {mapppingName} found");
     }
 
     /// <summary>

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrBackFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrBackFlower.cs
@@ -60,8 +60,9 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
             ICoherencyUpdateResolver coherencyUpdateResolver,
             IAssetLocationResolver assetLocationResolver,
             IFileSystem fileSystem,
+            IBasicBarClient barClient,
             ILogger<VmrCodeFlower> logger)
-        : base(vmrInfo, sourceManifest, dependencyTracker, dependencyFileManager, vmrCloneManager, repositoryCloneManager, localGitClient, localGitRepoFactory, versionDetailsParser, vmrPatchHandler, workBranchFactory, libGit2Client, coherencyUpdateResolver, assetLocationResolver, fileSystem, logger)
+        : base(vmrInfo, sourceManifest, dependencyTracker, dependencyFileManager, vmrCloneManager, repositoryCloneManager, localGitClient, localGitRepoFactory, versionDetailsParser, vmrPatchHandler, workBranchFactory, libGit2Client, coherencyUpdateResolver, assetLocationResolver, fileSystem, barClient, logger)
     {
         _sourceManifest = sourceManifest;
         _dependencyTracker = dependencyTracker;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrForwardFlower.cs
@@ -51,8 +51,9 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
         IVersionDetailsParser versionDetailsParser,
         IProcessManager processManager,
         IFileSystem fileSystem,
+        IBasicBarClient barClient,
         ILogger<VmrCodeFlower> logger)
-        : base(vmrInfo, sourceManifest, vmrUpdater, dependencyTracker, vmrCloneManager, localGitClient, localGitRepoFactory, versionDetailsParser, processManager, fileSystem, logger)
+        : base(vmrInfo, sourceManifest, vmrUpdater, dependencyTracker, vmrCloneManager, localGitClient, localGitRepoFactory, versionDetailsParser, processManager, fileSystem, barClient, logger)
     {
         _sourceManifest = sourceManifest;
         _dependencyTracker = dependencyTracker;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -14,6 +14,8 @@ using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.Logging;
 using NuGet.Versioning;
+using Microsoft.Extensions.FileSystemGlobbing;
+using static Microsoft.VisualStudio.Services.Graph.GraphResourceIds.Users;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
@@ -258,50 +260,17 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
 
             // Otherwise, we have a conflicting change in the last backflow PR (before merging)
             // The scenario is described here: https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Full-Code-Flow.md#conflicts
-            _logger.LogInformation("Failed to create PR branch because of a conflict. Re-creating the previous flow..");
-
-            // Find the ID of the last VMR build that flowed into the repo
-            VersionDetails versionDetails = _versionDetailsParser.ParseVersionDetailsFile(targetRepo.Path / VersionFiles.VersionDetailsXml);
-            if (versionDetails.Source?.BarId == null)
-            {
-                throw new Exception($"Repository {mapping.Name} does not have a previously flown VMR build");
-            }
-            Build previouslyAppliedVmrBuild = await _barClient.GetBuildAsync(versionDetails.Source.BarId.Value);
-
-            // Find the last target commit in the repo
-            var previousRepoSha = await BlameLineAsync(
-                targetRepo.Path / VersionFiles.VersionDetailsXml,
-                line => line.Contains(VersionDetailsParser.SourceElementName) && line.Contains(lastFlow.SourceSha),
-                lastFlow.RepoSha);
-            await targetRepo.CheckoutAsync(previousRepoSha);
-            await targetRepo.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
-
-            // Reconstruct the previous flow's branch
-            var lastLastFlow = await GetLastFlowAsync(mapping, targetRepo, currentIsBackflow: true);
-
-            await FlowCodeAsync(
-                lastLastFlow,
-                lastFlow,
-                targetRepo,
+            await RecreatePreviousFlowAndApplyBuild(
                 mapping,
-                previouslyAppliedVmrBuild,
+                targetRepo,
+                lastFlow,
+                headBranch,
+                newBranchName,
                 excludedAssets,
-                headBranch,
-                headBranch,
+                patches,
                 discardPatches,
                 headBranchExisted,
                 cancellationToken);
-
-            // The recursive call right above would returned checked out at targetBranch
-            // The original work branch from above is no longer relevant. We need to create it again
-            workBranch = await _workBranchFactory.CreateWorkBranchAsync(targetRepo, newBranchName, headBranch);
-
-            // The current patches should apply now
-            foreach (VmrIngestionPatch patch in patches)
-            {
-                // TODO https://github.com/dotnet/arcade-services/issues/2995: Catch exceptions?
-                await _vmrPatchHandler.ApplyPatch(patch, targetRepo.Path, discardPatches, reverseApply: false, cancellationToken);
-            }
         }
 
         var commitMessage = $"""
@@ -620,6 +589,70 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         }
 
         return true;
+    }
+
+    private async Task RecreatePreviousFlowAndApplyBuild(
+        SourceMapping mapping,
+        ILocalGitRepo targetRepo,
+        Codeflow lastFlow,
+        string headBranch,
+        string newBranchName,
+        IReadOnlyCollection<string>? excludedAssets,
+        List<VmrIngestionPatch> patches,
+        bool discardPatches,
+        bool headBranchExisted,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Failed to create PR branch because of a conflict. Re-creating the previous flow..");
+
+        var lastLastFlow = await GetLastFlowAsync(mapping, targetRepo, currentIsBackflow: true);
+
+        // Find the ID of the last VMR build that flowed into the repo
+        VersionDetails versionDetails = _versionDetailsParser.ParseVersionDetailsFile(targetRepo.Path / VersionFiles.VersionDetailsXml);
+        Build previouslyAppliedVmrBuild;
+        if (versionDetails.Source?.BarId != null)
+        {
+            previouslyAppliedVmrBuild = await _barClient.GetBuildAsync(versionDetails.Source.BarId.Value);
+        }
+        else
+        {
+            // If we don't find the previously applied build, there probably wasn't one.
+            // In this case, we won't update assets, but that's ok becaus they'll get overwritten by the new build anyway
+            previouslyAppliedVmrBuild = new(-1, DateTimeOffset.Now, 0, false, false, lastLastFlow.VmrSha, [], [], [], []);
+        }
+
+        // Find the last target commit in the repo
+        var previousRepoSha = await BlameLineAsync(
+            targetRepo.Path / VersionFiles.VersionDetailsXml,
+            line => line.Contains(VersionDetailsParser.SourceElementName) && line.Contains(lastFlow.SourceSha),
+            lastFlow.RepoSha);
+        await targetRepo.CheckoutAsync(previousRepoSha);
+        await targetRepo.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
+
+        // Reconstruct the previous flow's branch
+        await FlowCodeAsync(
+            lastLastFlow,
+            lastFlow,
+            targetRepo,
+            mapping,
+            previouslyAppliedVmrBuild,
+            excludedAssets,
+            headBranch,
+            headBranch,
+            discardPatches,
+            headBranchExisted,
+            cancellationToken);
+
+        // The recursive call right above would returned checked out at targetBranch
+        // The original work branch from above is no longer relevant. We need to create it again
+        var workBranch = await _workBranchFactory.CreateWorkBranchAsync(targetRepo, newBranchName, headBranch);
+
+        // The current patches should apply now
+        foreach (VmrIngestionPatch patch in patches)
+        {
+            // TODO https://github.com/dotnet/arcade-services/issues/2995: Catch exceptions?
+            await _vmrPatchHandler.ApplyPatch(patch, targetRepo.Path, discardPatches, reverseApply: false, cancellationToken);
+        }
     }
 
     protected override NativePath GetEngCommonPath(NativePath sourceRepo) => sourceRepo / VmrInfo.ArcadeRepoDir / Constants.CommonScriptFilesPath;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -274,7 +274,7 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             {
                 throw new Exception($"Repository {mapping.Name} does not have a previously flown VMR build");
             }
-            Build lastVmrBuild = await _barClient.GetBuildAsync(versionDetails.Source.BarId.Value);
+            Build previouslyAppliedVmrBuild = await _barClient.GetBuildAsync(versionDetails.Source.BarId.Value);
 
             // Find the last target commit in the repo
             var previousRepoSha = await BlameLineAsync(
@@ -292,7 +292,7 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
                 lastFlow,
                 targetRepo,
                 mapping,
-                lastVmrBuild,
+                previouslyAppliedVmrBuild,
                 excludedAssets,
                 headBranch,
                 headBranch,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -14,8 +14,6 @@ using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.Logging;
 using NuGet.Versioning;
-using Microsoft.Extensions.FileSystemGlobbing;
-using static Microsoft.VisualStudio.Services.Graph.GraphResourceIds.Users;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
@@ -617,7 +615,7 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         else
         {
             // If we don't find the previously applied build, there probably wasn't one.
-            // In this case, we won't update assets, but that's ok becaus they'll get overwritten by the new build anyway
+            // In this case, we won't update assets, but that's ok because they'll get overwritten by the new build anyway
             previouslyAppliedVmrBuild = new(-1, DateTimeOffset.Now, 0, false, false, lastLastFlow.VmrSha, [], [], [], []);
         }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -253,20 +253,12 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             if (headBranchExisted)
             {
                 _logger.LogInformation("Failed to update a PR branch because of a conflict. Stopping the flow..");
-                throw new ConflictInPrBranchException(e.Result, targetBranch, isForwardFlow: false);
+                throw new ConflictInPrBranchException(e.Result, targetBranch, mapping.Name,isForwardFlow: false);
             }
 
             // Otherwise, we have a conflicting change in the last backflow PR (before merging)
             // The scenario is described here: https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Full-Code-Flow.md#conflicts
             _logger.LogInformation("Failed to create PR branch because of a conflict. Re-creating the previous flow..");
-
-            // Find the BarID of the last flown repo build
-            RepositoryRecord previouslyAppliedRepositoryRecord = _sourceManifest.GetRepositoryRecord(mapping.Name);
-            if (previouslyAppliedRepositoryRecord.BarId == null)
-            {
-                throw new Exception($"Repository {mapping.Name} does not have a previously flown build");
-            }
-            Build previouslyAppliedBuild = await _barClient.GetBuildAsync(previouslyAppliedRepositoryRecord.BarId.Value);
 
             // Find the ID of the last VMR build that flowed into the repo
             VersionDetails versionDetails = _versionDetailsParser.ParseVersionDetailsFile(targetRepo.Path / VersionFiles.VersionDetailsXml);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -31,6 +31,8 @@ internal abstract class VmrCodeFlower
     private readonly IFileSystem _fileSystem;
     private readonly ILogger<VmrCodeFlower> _logger;
 
+    protected readonly IBasicBarClient _barClient;
+
     protected VmrCodeFlower(
         IVmrInfo vmrInfo,
         ISourceManifest sourceManifest,
@@ -39,6 +41,7 @@ internal abstract class VmrCodeFlower
         ILocalGitRepoFactory localGitRepoFactory,
         IVersionDetailsParser versionDetailsParser,
         IFileSystem fileSystem,
+        IBasicBarClient barClient,
         ILogger<VmrCodeFlower> logger)
     {
         _vmrInfo = vmrInfo;
@@ -48,6 +51,7 @@ internal abstract class VmrCodeFlower
         _localGitRepoFactory = localGitRepoFactory;
         _versionDetailsParser = versionDetailsParser;
         _fileSystem = fileSystem;
+        _barClient = barClient;
         _logger = logger;
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.Logging;
+using static Microsoft.VisualStudio.Services.Graph.GraphResourceIds.Users;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
@@ -224,50 +225,16 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
 
             // This happens when a conflicting change was made in the last backflow PR (before merging)
             // The scenario is described here: https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Full-Code-Flow.md#conflicts
-            _logger.LogInformation("Failed to create PR branch because of a conflict. Re-creating the previous flow..");
-
-            // Find the BarID of the last flown repo build
-            RepositoryRecord previouslyAppliedRepositoryRecord = _sourceManifest.GetRepositoryRecord(mapping.Name);
-            if (previouslyAppliedRepositoryRecord.BarId == null)
-            {
-                throw new Exception($"Repository {mapping.Name} does not have a previously flown build");
-            }
-            Build previouslyAppliedBuild = await _barClient.GetBuildAsync(previouslyAppliedRepositoryRecord.BarId.Value);
-
-            // Find the VMR sha before the last successful flow
-            var previousFlowTargetSha = await BlameLineAsync(
-                _vmrInfo.SourceManifestPath,
-                line => line.Contains(lastFlow.SourceSha),
-                lastFlow.TargetSha);
-            var vmr = await _vmrCloneManager.PrepareVmrAsync(
-                [_vmrInfo.VmrUri],
-                [previousFlowTargetSha],
-                previousFlowTargetSha,
-                resetToRemote: false,
-                cancellationToken);
-            await vmr.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
-
-            // Reconstruct the previous flow's branch
-            var lastLastFlow = await GetLastFlowAsync(mapping, sourceRepo, currentIsBackflow: true);
-            await FlowCodeAsync(
-                lastLastFlow,
-                lastFlow,
-                sourceRepo,
+            hadUpdates = await RecreatePreviousFlowAndApplyBuild(
                 mapping,
-                previouslyAppliedBuild,
+                lastFlow,
+                headBranch,
+                sourceRepo,
                 excludedAssets,
                 targetBranch,
-                headBranch,
+                build,
                 discardPatches,
                 headBranchExisted,
-                cancellationToken);
-
-            // We apply the current changes on top again - they should apply now
-            // TODO https://github.com/dotnet/arcade-services/issues/2995: Handle exceptions
-            hadUpdates = await _vmrUpdater.UpdateRepository(
-                mapping,
-                build,
-                resetToRemoteWhenCloningRepo: ShouldResetClones,
                 cancellationToken);
         }
 
@@ -404,6 +371,72 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
         _fileSystem.WriteToFile(_vmrInfo.SourceManifestPath, theirSourceManifest.ToJson());
         _sourceManifest.Refresh(_vmrInfo.SourceManifestPath);
         await vmr.StageAsync([_vmrInfo.SourceManifestPath], cancellationToken);
+    }
+
+    private async Task<bool> RecreatePreviousFlowAndApplyBuild(
+        SourceMapping mapping,
+        Codeflow lastFlow,
+        string headBranch,
+        ILocalGitRepo sourceRepo,
+        IReadOnlyCollection<string>? excludedAssets,
+        string targetBranch,
+        Build build,
+        bool discardPatches,
+        bool headBranchExisted,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Failed to create PR branch because of a conflict. Re-creating the previous flow..");
+
+        var lastLastFlow = await GetLastFlowAsync(mapping, sourceRepo, currentIsBackflow: true);
+
+        // Find the BarID of the last flown repo build
+        RepositoryRecord previouslyAppliedRepositoryRecord = _sourceManifest.GetRepositoryRecord(mapping.Name);
+        Build previouslyAppliedBuild;
+        if (previouslyAppliedRepositoryRecord.BarId == null)
+        {
+            // If we don't find the previously applied build, we'll just use the previously flown sha to recreate the flow
+            // We'll apply a new build on top of this one, so the source manifest will get updated anyway
+            previouslyAppliedBuild = new(-1, DateTimeOffset.Now, 0, false, false, lastLastFlow.SourceSha, [], [], [], []);
+        }
+        else
+        {
+            previouslyAppliedBuild = await _barClient.GetBuildAsync(previouslyAppliedRepositoryRecord.BarId.Value);
+        }
+
+        // Find the VMR sha before the last successful flow
+        var previousFlowTargetSha = await BlameLineAsync(
+            _vmrInfo.SourceManifestPath,
+            line => line.Contains(lastFlow.SourceSha),
+            lastFlow.TargetSha);
+        var vmr = await _vmrCloneManager.PrepareVmrAsync(
+            [_vmrInfo.VmrUri],
+            [previousFlowTargetSha],
+            previousFlowTargetSha,
+            resetToRemote: false,
+            cancellationToken);
+        await vmr.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
+
+        // Reconstruct the previous flow's branch
+        await FlowCodeAsync(
+            lastLastFlow,
+            lastFlow,
+            sourceRepo,
+            mapping,
+            previouslyAppliedBuild,
+            excludedAssets,
+            targetBranch,
+            headBranch,
+            discardPatches,
+            headBranchExisted,
+            cancellationToken);
+
+        // We apply the current changes on top again - they should apply now
+        // TODO https://github.com/dotnet/arcade-services/issues/2995: Handle exceptions
+        return await _vmrUpdater.UpdateRepository(
+            mapping,
+            build,
+            resetToRemoteWhenCloningRepo: ShouldResetClones,
+            cancellationToken);
     }
 
     protected override NativePath GetEngCommonPath(NativePath sourceRepo) => sourceRepo / Constants.CommonScriptFilesPath;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -151,6 +151,7 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
         string prBranch,
         CancellationToken cancellationToken)
     {
+        _vmrInfo.VmrUri = vmrUri;
         try
         {
             await _vmrCloneManager.PrepareVmrAsync(
@@ -242,7 +243,7 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 [_vmrInfo.VmrUri],
                 [previousFlowTargetSha],
                 previousFlowTargetSha,
-                ShouldResetVmr,
+                resetToRemote: false,
                 cancellationToken);
             await vmr.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -219,7 +219,7 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             if (headBranchExisted)
             {
                 _logger.LogInformation("Failed to update a PR branch because of a conflict. Stopping the flow..");
-                throw new ConflictInPrBranchException(e.Result, targetBranch, isForwardFlow: true);
+                throw new ConflictInPrBranchException(e.Result, targetBranch, mapping.Name, isForwardFlow: true);
             }
 
             // This happens when a conflicting change was made in the last backflow PR (before merging)

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeFlowTests.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrCodeFlowTests.cs
@@ -24,7 +24,6 @@ internal abstract class VmrCodeFlowTests : VmrTestsBase
     protected const string FakePackageVersion = "1.0.0";
 
     protected readonly string _productRepoFileName = Constants.GetRepoFileName(Constants.ProductRepoName);
-    private readonly Mock<IBasicBarClient> _basicBarClient = new();
 
     protected NativePath _productRepoVmrPath = null!;
     protected NativePath _productRepoVmrFilePath = null!;
@@ -42,7 +41,6 @@ internal abstract class VmrCodeFlowTests : VmrTestsBase
         _productRepoVmrFilePath = _productRepoVmrPath / _productRepoFileName;
         _productRepoScriptFilePath = ProductRepoPath / DarcLib.Constants.CommonScriptFilesPath / "build.ps1";
         _productRepoFilePath = ProductRepoPath / _productRepoFileName;
-        _basicBarClient.Reset();
     }
 
     protected async Task EnsureTestRepoIsInitialized()

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -37,9 +37,10 @@ internal abstract class VmrTestsBase
     protected IServiceProvider ServiceProvider { get; private set; } = null!;
 
     private readonly CancellationTokenSource _cancellationToken = new();
-    private readonly Mock<IBasicBarClient> _basicBarClient = new();
+    protected readonly Mock<IBasicBarClient> _basicBarClient = new();
 
     private int _buildId = 100;
+    private Dictionary<int, Build> _builds = new();
 
     [SetUp]
     public async Task Setup()
@@ -64,13 +65,17 @@ internal abstract class VmrTestsBase
 
         ServiceProvider = CreateServiceProvider().BuildServiceProvider();
         ServiceProvider.GetRequiredService<IVmrInfo>().VmrUri = VmrPath;
-
-        _basicBarClient.Reset();
+    
+        _basicBarClient.Setup(x => x.GetBuildAsync(It.IsAny<int>()))
+            .ReturnsAsync((int id) => {
+                return _builds[id];
+                });
     }
 
     [TearDown]
     public void DeleteCurrentTestDirectory()
     {
+        _basicBarClient.Reset();
         try
         {
             if (CurrentTestDirectory is not null)
@@ -399,10 +404,8 @@ internal abstract class VmrTestsBase
             GitHubBranch = "main",
             GitHubRepository = repoPath,
         };
+        _builds[build.Id] = build;
 
-        _basicBarClient
-            .Setup(x => x.GetBuildAsync(build.Id))
-            .ReturnsAsync(build);
         _basicBarClient
             .Setup(x => x.GetBuildsAsync(repoPath.Path, commit))
             .ReturnsAsync([build]);

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -67,9 +67,7 @@ internal abstract class VmrTestsBase
         ServiceProvider.GetRequiredService<IVmrInfo>().VmrUri = VmrPath;
     
         _basicBarClient.Setup(x => x.GetBuildAsync(It.IsAny<int>()))
-            .ReturnsAsync((int id) => {
-                return _builds[id];
-                });
+             .ReturnsAsync((int id) => _builds[id]);
     }
 
     [TearDown]

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTwoWayCodeflowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTwoWayCodeflowTest.cs
@@ -409,11 +409,16 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         const string backBranchName = nameof(OutOfOrderMergesWithConflictsTest);
         const string forwardBranchName = nameof(OutOfOrderMergesWithConflictsTest) + "-ff";
 
+        // Do a forward flow once and merge so we have something to fall back on
+        var hadUpdates = await ChangeRepoFileAndFlowIt("New content in the individual repo", forwardBranchName);
+        hadUpdates.ShouldHaveUpdates();
+        await GitOperations.MergePrBranch(VmrPath, forwardBranchName);
+
         // 1. Change file in VMR
         // 2. Open a backflow PR
         await File.WriteAllTextAsync(_productRepoVmrPath / "b.txt", bFileContent);
         await GitOperations.CommitAll(VmrPath, bFileContent);
-        var hadUpdates = await ChangeVmrFileAndFlowIt("New content from the VMR #1", backBranchName);
+        hadUpdates = await ChangeVmrFileAndFlowIt("New content from the VMR #1", backBranchName);
         hadUpdates.ShouldHaveUpdates();
         // We make another commit in the repo and add it to the PR branch (this is not in the diagram above)
         await GitOperations.Checkout(ProductRepoPath, "main");

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -504,7 +504,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                     It.IsAny<Microsoft.DotNet.ProductConstructionService.Client.Models.Build>(),
                     It.IsAny<string>(),
                     It.IsAny<CancellationToken>()))
-                .Throws(() => new ConflictInPrBranchException(gitMergeResult, "branch", true));
+                .Throws(() => new ConflictInPrBranchException(gitMergeResult, "branch", "repo", true));
                 
         }
 

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
@@ -1104,4 +1104,10 @@ internal abstract partial class ScenarioTestBase
         }
         throw new ScenarioTestException($"The created pull request for repo targeting {pr.Base.Ref} did not have a new commit within {attempts * 20 / 60} minutes");
     }
+
+    protected static void PullRequestShouldHaveConflicts(Octokit.PullRequest pr)
+    {
+        pr.Mergeable.Should().BeFalse();
+        pr.MergeableState.ToString().Should().Be("dirty");
+    }
 }

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
@@ -103,6 +103,16 @@ internal abstract partial class ScenarioTestBase
         throw new ScenarioTestException($"The created pull request for {targetRepo} targeting {targetBranch} was not updated with subsequent subscriptions after creation");
     }
 
+    protected async Task MergePullRequestAsync(string targetRepo, Octokit.PullRequest pr)
+    {
+        Octokit.MergePullRequest mergePullRequest = new()
+        {
+            MergeMethod = Octokit.PullRequestMergeMethod.Squash
+        };
+
+        await GitHubApi.PullRequest.Merge(TestParameters.GitHubTestOrg, targetRepo, pr.Number, mergePullRequest);
+    }
+
     private async Task<bool> WaitForMergedPullRequestAsync(string targetRepo, string targetBranch, int attempts = 30)
     {
         Octokit.Repository repo = await GitHubApi.Repository.Get(TestParameters.GitHubTestOrg, targetRepo);

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlow.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlow.cs
@@ -120,12 +120,12 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
             sourceDirectory: TestRepository.TestRepo1Name);
 
         TemporaryDirectory testRepoFolder = await CloneRepositoryAsync(TestRepository.TestRepo1Name);
-        TemporaryDirectory reposFolder = await CloneRepositoryAsync(TestRepository.VmrTestRepoName);
-        var newFilePath = Path.Combine(reposFolder.Directory, "src", TestRepository.TestRepo1Name, TestFile1Name);
+        TemporaryDirectory vmrFolder = await CloneRepositoryAsync(TestRepository.VmrTestRepoName);
+        var newFilePath = Path.Combine(vmrFolder.Directory, "src", TestRepository.TestRepo1Name, TestFile1Name);
 
         await CreateTargetBranchAndExecuteTest(targetBranchName, testRepoFolder.Directory, async () =>
         {
-            using (ChangeDirectory(reposFolder.Directory))
+            using (ChangeDirectory(vmrFolder.Directory))
             {
                 await using (await CheckoutBranchAsync(branchName))
                 {

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -288,8 +288,7 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
 
                // WaitForPullRequestAsync fetches prs in bulk, which doesn't fetch fields like Mergeable and MergeableState which we need
                pr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, pr.Number);
-               pr.Mergeable.Should().BeFalse();
-               pr.MergeableState.ToString().Should().Be("dirty");
+               PullRequestShouldHaveConflicts(pr);
            });
     }
 
@@ -397,8 +396,7 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
 
                         // WaitForPullRequestAsync fetches prs in bulk, which doesn't fetch fields like Mergeable and MergeableState which we need
                         pr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, pr.Number);
-                        pr.Mergeable.Should().BeFalse();
-                        pr.MergeableState.ToString().Should().Be("dirty");
+                        PullRequestShouldHaveConflicts(pr);
                     }
                 }
             }

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -292,4 +292,116 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
                pr.MergeableState.ToString().Should().Be("dirty");
            });
     }
+
+    [Test]
+    public async Task Vmr_BackwardConflictFlowTest()
+    {
+        var channelName = GetTestChannelName();
+        var branchName = GetTestBranchName();
+        var productRepo = GetGitHubRepoUrl(TestRepository.TestRepo1Name);
+        var targetBranchName = GetTestBranchName();
+
+        await using AsyncDisposableValue<string> testChannel = await CreateTestChannelAsync(channelName);
+
+        await using AsyncDisposableValue<string> subscriptionId = await CreateBackwardFlowSubscriptionAsync(
+            channelName,
+            TestRepository.VmrTestRepoName,
+            TestRepository.TestRepo1Name,
+            targetBranchName,
+            UpdateFrequency.None.ToString(),
+            TestParameters.GitHubTestOrg,
+            sourceDirectory: TestRepository.TestRepo1Name);
+
+        TemporaryDirectory testRepoFolder = await CloneRepositoryAsync(TestRepository.TestRepo1Name);
+        TemporaryDirectory vmrFolder = await CloneRepositoryAsync(TestRepository.VmrTestRepoName);
+        var newFileInVmrPath = Path.Combine(vmrFolder.Directory, "src", TestRepository.TestRepo1Name, TestFile1Name);
+        var newFilePath = Path.Combine(testRepoFolder.Directory, TestFile1Name);
+
+        await CreateTargetBranchAndExecuteTest(targetBranchName, testRepoFolder.Directory, async () =>
+        {
+            using (ChangeDirectory(vmrFolder.Directory))
+            {
+                await using (await CheckoutBranchAsync(branchName))
+                {
+                    // Make a change in the VMR
+                    TestContext.WriteLine("Making code changes in the VMR");
+                    File.WriteAllText(newFileInVmrPath, "not important");
+
+                    await GitAddAllAsync();
+                    await GitCommitAsync("Add new file");
+
+                    // Push it to github
+                    await using (await PushGitBranchAsync("origin", branchName))
+                    {
+                        var repoSha = (await GitGetCurrentSha()).TrimEnd();
+
+                        // Create a new build from the commit and add it to a channel
+                        Build build = await CreateBuildAsync(
+                            GetGitHubRepoUrl(TestRepository.VmrTestRepoName),
+                            branchName,
+                            repoSha,
+                            "1",
+                            // We might want to add some assets here to mimic what happens in the VMR
+                            []);
+
+                        TestContext.WriteLine("Adding build to channel");
+                        await AddBuildToChannelAsync(build.Id, channelName);
+
+                        TestContext.WriteLine("Triggering the subscription");
+                        // Now trigger the subscription
+                        await TriggerSubscriptionAsync(subscriptionId.Value);
+
+                        TestContext.WriteLine("Waiting for the PR to show up");
+                        Octokit.PullRequest pr = await WaitForPullRequestAsync(TestRepository.TestRepo1Name, targetBranchName);
+
+                        // Now make a change directly in the PR
+                        using (ChangeDirectory(testRepoFolder.Directory))
+                        {
+                            await CheckoutRemoteRefAsync(pr.Head.Ref);
+                            File.WriteAllText(newFilePath, "file edited in PR");
+                            await GitAddAllAsync();
+                            await GitCommitAsync("Edit files in PR");
+                            await RunGitAsync("push", "-u", "origin", pr.Head.Ref);
+                        }
+
+                        // Make a change in the VMR again, it should cause a conflict
+                        await File.WriteAllTextAsync(newFileInVmrPath, TestFilesContent[TestFile1Name]);
+
+                        await GitAddAllAsync();
+                        await GitCommitAsync("Add conflicting changes");
+                        await RunGitAsync("push");
+
+                        repoSha = (await GitGetCurrentSha()).TrimEnd();
+                        TestContext.WriteLine("Creating a build from the new commit");
+                        build = await CreateBuildAsync(
+                            GetGitHubRepoUrl(TestRepository.VmrTestRepoName),
+                            branchName,
+                            repoSha,
+                            "2",
+                            []);
+
+                        TestContext.WriteLine("Adding build to channel");
+                        await AddBuildToChannelAsync(build.Id, channelName);
+
+                        TestContext.WriteLine("Triggering the subscription");
+                        await TriggerSubscriptionAsync(subscriptionId.Value);
+
+                        TestContext.WriteLine("Waiting for conflict comment to show up on the PR");
+                        pr = await WaitForPullRequestComment(TestRepository.TestRepo1Name, targetBranchName, "conflict");
+
+                        TestContext.WriteLine("Merging PR causing the conflict");
+                        await MergePullRequestAsync(TestRepository.TestRepo1Name, pr);
+
+                        TestContext.WriteLine("Waiting for the new PR to show up");
+                        pr = await WaitForPullRequestAsync(TestRepository.TestRepo1Name, targetBranchName);
+
+                        // WaitForPullRequestAsync fetches prs in bulk, which doesn't fetch fields like Mergeable and MergeableState which we need
+                        pr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, pr.Number);
+                        pr.Mergeable.Should().BeFalse();
+                        pr.MergeableState.ToString().Should().Be("dirty");
+                    }
+                }
+            }
+        });
+    }
 }


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4352
This PR:
 - Makes us lookup previous builds instead of just using previous commits when reconstructing flows during conflicts
 - Fixes a bug in `ConflictInPrBranchException` that was happening during backflow
 - Fixes the VmrUri not getting updated when preparing the VMR