### PR TITLE
Fix a "no downgrade" merge policy NRE

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.ReproTool/ReproTool.cs
+++ b/src/ProductConstructionService/ProductConstructionService.ReproTool/ReproTool.cs
@@ -147,7 +147,7 @@ internal class ReproTool(
 
         if (options.SkipCleanup)
         {
-            logger.LogInformation("Skipping cleanup. If you want to re-trigger the reproduced subscription run \"darc trigger-subscriptions --ids {subscriptionId}\" --bar-uri {barUri}",
+            logger.LogInformation("Skipping cleanup. If you want to re-trigger the reproduced subscription run \"darc trigger-subscriptions --ids {subscriptionId} --bar-uri {barUri}\"",
                 testSubscription.Value,
                 ProductConstructionServiceApiOptions.PcsLocalUri);
             return;

--- a/test/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsForCodeFlowTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsForCodeFlowTests.cs
@@ -50,7 +50,8 @@ internal class UpdateAssetsForCodeFlowTests : UpdateAssetsPullRequestUpdaterTest
                     SubscriptionId = Subscription.Id,
                     BuildId = build.Id,
                 }
-            ]
+            ],
+            RequiredUpdates = [],
         };
 
         ThenUpdateReminderIsRemoved();
@@ -177,7 +178,8 @@ internal class UpdateAssetsForCodeFlowTests : UpdateAssetsPullRequestUpdaterTest
                         SubscriptionId = Subscription.Id,
                         BuildId = build2.Id,
                     }
-                ]
+                ],
+                RequiredUpdates = [],
             };
 
             AndShouldHavePullRequestCheckReminder();


### PR DESCRIPTION
We have a pending TODO where we don't fill the `RequiredUpdates` yet. However, the merge policy check fails on an NRE if this is null.

Example: https://github.com/dotnet/scenario-tests/pull/213/checks?check_run_id=37710832910


https://github.com/dotnet/arcade-services/issues/3866
https://github.com/dotnet/arcade-services/issues/4159
