### PR TITLE
Make version file operations idempotent and graceful

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/AssetLocationResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/AssetLocationResolver.cs
@@ -16,7 +16,7 @@ public interface IAssetLocationResolver
     /// </summary>
     /// <param name="dependencies">Dependencies to load locations for</param>
     /// <returns>Async task</returns>
-    Task AddAssetLocationToDependenciesAsync(IReadOnlyCollection<DependencyDetail> dependencies);
+    Task AddAssetLocationToDependenciesAsync(IEnumerable<DependencyDetail> dependencies);
 }
 
 public class AssetLocationResolver : IAssetLocationResolver
@@ -28,7 +28,7 @@ public class AssetLocationResolver : IAssetLocationResolver
         _barClient = barClient;
     }
 
-    public async Task AddAssetLocationToDependenciesAsync(IReadOnlyCollection<DependencyDetail> dependencies)
+    public async Task AddAssetLocationToDependenciesAsync(IEnumerable<DependencyDetail> dependencies)
     {
         var buildCache = new Dictionary<int, Build>();
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IDependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IDependencyFileManager.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.DarcLib.Helpers;
 /// </summary>
 public interface IDependencyFileManager
 {
-    Task AddDependencyAsync(DependencyDetail dependency, string repoUri, string branch);
+    Task AddDependencyAsync(DependencyDetail dependency, string repoUri, string? branch);
 
     Task RemoveDependencyAsync(string dependencyName, string repoUri, string branch, bool repoIsVmr = false);
 

--- a/test/Microsoft.DotNet.Darc.Tests/DependencyAddUpdateTests.cs
+++ b/test/Microsoft.DotNet.Darc.Tests/DependencyAddUpdateTests.cs
@@ -83,14 +83,25 @@ public class DependencyAddUpdateTests
     }
 
     /// <summary>
-    /// Add a dependency and then add it again.  Should throw on second add.
+    /// Add a dependency and then add it again.
     /// </summary>
     [Test]
-    public async Task AddingDuplicateDependencyThrows()
+    public async Task AddingDuplicateDependencyDoesNotThrow()
     {
         // Use assets from #2.
         await DependencyTestDriver.TestAndCompareOutput(nameof(AddProductDependency2), async driver =>
         {
+            await driver.AddDependencyAsync(
+                new DependencyDetail
+                {
+                    Commit = "67890",
+                    Name = "Foo.Bar",
+                    RepoUri = "https://foo.com/foo/bar",
+                    Version = "1.2.2",
+                    Pinned = false,
+                    Type = DependencyType.Product
+                });
+
             await driver.AddDependencyAsync(
                 new DependencyDetail
                 {
@@ -100,17 +111,6 @@ public class DependencyAddUpdateTests
                     Version = "1.2.3",
                     Type = DependencyType.Product
                 });
-
-            await ((System.Func<Task>)(async () => await driver.AddDependencyAsync(
-                new DependencyDetail
-                {
-                    Commit = "67890",
-                    Name = "Foo.Bar",
-                    RepoUri = "https://foo.com/foo/bar",
-                    Version = "1.2.4",
-                    Pinned = false,
-                    Type = DependencyType.Product
-                }))).Should().ThrowExactlyAsync<DependencyException>();
 
             await driver.VerifyAsync();
         });

--- a/test/Microsoft.DotNet.DarcLib.Tests/Helpers/DependencyFileManagerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Helpers/DependencyFileManagerTests.cs
@@ -211,7 +211,7 @@ public class DependencyFileManagerTests
     }
 
     [Test]
-    public async Task RemoveDependencyShouldThrowWhenDependencyDoesNotExist()
+    public async Task RemoveDependencyShouldNotThrowWhenDependencyDoesNotExist()
     {
         DependencyDetail dependency = new()
         {
@@ -233,6 +233,6 @@ public class DependencyFileManagerTests
             NullLogger.Instance);
 
         Func<Task> act = async () => await manager.RemoveDependencyAsync(dependency.Name, string.Empty, string.Empty);
-        await act.Should().ThrowAsync<DependencyException>();
+        await act.Should().NotThrowAsync<DependencyException>();
     }
 }


### PR DESCRIPTION
- Calling `AddDependency` won't blow up when a dependency is in the file already (will upsert instead)
- Calling `RemoveDependency` won't blow up when a dependency is not found

This means we can keep calling these safely and they will gracefully handle idempotency.

https://github.com/dotnet/arcade-services/issues/4487 
