### PR TITLE
Fix update-dependencies when updating from the vmr

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Local.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Local.cs
@@ -105,6 +105,13 @@ public class Local
             {
                 IRemote arcadeRemote = await remoteFactory.CreateRemoteAsync(arcadeItem.RepoUri);
                 List<GitFile> engCommonFiles = await arcadeRemote.GetCommonScriptFilesAsync(arcadeItem.RepoUri, arcadeItem.Commit, repoIsVmr);
+                // If we're updating arcade from a VMR build, the eng/common files will be in the src/arcade repo
+                // so we need to strip the src/arcade prefix from the file paths.
+                if (repoIsVmr)
+                {
+                    engCommonFiles = engCommonFiles.Select(f => new GitFile(f.FilePath.Replace("src/arcade/", string.Empty), f.Content)).ToList();
+                }
+
                 filesToUpdate.AddRange(engCommonFiles);
 
                 List<GitFile> localEngCommonFiles = GetFilesAtRelativeRepoPathAsync(Constants.CommonScriptFilesPath);


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4484