### PR TITLE
Increase the `Asset.Name` column size to 250

### DIFF
--- a/src/Maestro/Maestro.Data/Migrations/20250227091038_IncreaseAssetNameSize.Designer.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20250227091038_IncreaseAssetNameSize.Designer.cs
@@ -4,6 +4,7 @@ using Maestro.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Maestro.Data.Migrations
 {
     [DbContext(typeof(BuildAssetRegistryContext))]
-    partial class BuildAssetRegistryContextModelSnapshot : ModelSnapshot
+    [Migration("20250227091038_IncreaseAssetNameSize")]
+    partial class IncreaseAssetNameSize
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Maestro/Maestro.Data/Migrations/20250227091038_IncreaseAssetNameSize.cs
+++ b/src/Maestro/Maestro.Data/Migrations/20250227091038_IncreaseAssetNameSize.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Maestro.Data.Migrations
+{
+    public partial class IncreaseAssetNameSize : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Assets",
+                type: "nvarchar(250)",
+                maxLength: 250,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(150)",
+                oldMaxLength: 150,
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Assets",
+                type: "nvarchar(150)",
+                maxLength: 150,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(250)",
+                oldMaxLength: 250,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Maestro/Maestro.Data/Models/Asset.cs
+++ b/src/Maestro/Maestro.Data/Models/Asset.cs
@@ -13,7 +13,7 @@ public class Asset
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public int Id { get; set; }
 
-    [StringLength(150)]
+    [StringLength(250)]
     public string Name { get; set; }
 
     [StringLength(75)]


### PR DESCRIPTION
A break in the `dotnet/binaryen` repo due to https://github.com/dotnet/arcade/commit/412357836b422acfd19ce283cc601bd71c834e6d when publishing to BAR:

```
RestApiException`1: The response contained an invalid status code 400 Bad Request
 
Body: {"message":"The request is invalid","errors":["The field Name must be a string with a maximum length of 150.","The field Name must be a string with a maximum length of 150."]}
```

It's because the symbol blob ID is now 153 chars with that change in the `MergedManifest.xml`

<!-- https://github.com/dotnet/arcade-services/issues/4504 -->