### PR TITLE
Asset name length updated according to database field

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2018_07_16/Models/AssetData.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2018_07_16/Models/AssetData.cs
@@ -8,7 +8,7 @@ namespace ProductConstructionService.Api.v2018_07_16.Models;
 
 public class AssetData
 {
-    [StringLength(150)]
+    [StringLength(250)]
     public string Name { get; set; }
 
     [StringLength(75)]


### PR DESCRIPTION
Adjusted validation attribute to database field size

This is follow-up to: https://github.com/dotnet/arcade-services/pull/4504
Issue: https://github.com/dotnet/arcade-services/issues/4504