### PR TITLE
Query PR status only once during dependency flow

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
@@ -294,51 +294,6 @@ public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
     }
 
     /// <summary>
-    /// Get the status of a pull request
-    /// </summary>
-    /// <param name="pullRequestUrl">URI of pull request</param>
-    /// <returns>Pull request status</returns>
-    public async Task<PrInfo> GetPullRequestStatusAsync(string pullRequestUrl)
-    {
-        (string owner, string repo, int id) = ParsePullRequestUri(pullRequestUrl);
-
-        JObject responseContent;
-        using (HttpResponseMessage response = await ExecuteRemoteGitCommandAsync(
-            HttpMethod.Get,
-            $"https://github.com/{owner}/{repo}",
-            $"repos/{owner}/{repo}/pulls/{id}",
-            _logger))
-        {
-            responseContent = JObject.Parse(await response.Content.ReadAsStringAsync());
-        }
-
-        DateTime updatedAt = DateTime.Parse(responseContent["updated_at"]!.ToString());
-
-        if (Enum.TryParse(responseContent["state"]!.ToString(), true, out PrStatus status))
-        {
-            if (status == PrStatus.Open)
-            {
-                return new(status, updatedAt);
-            }
-
-            if (status == PrStatus.Closed)
-            {
-                if (bool.TryParse(responseContent["merged"]!.ToString(), out bool merged))
-                {
-                    if (merged)
-                    {
-                        return new(PrStatus.Merged, updatedAt);
-                    }
-                }
-
-                return new(PrStatus.Closed, updatedAt);
-            }
-        }
-
-        return new(PrStatus.None, updatedAt);
-    }
-
-    /// <summary>
     ///     Retrieve information on a specific pull request
     /// </summary>
     /// <param name="pullRequestUrl">Uri of the pull request</param>
@@ -347,12 +302,25 @@ public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
     {
         (string owner, string repo, int id) = ParsePullRequestUri(pullRequestUrl);
         Octokit.PullRequest pr = await GetClient(owner, repo).PullRequest.Get(owner, repo, id);
+
+        PrStatus status;
+        if (pr.State == ItemState.Closed)
+        {
+            status = pr.Merged == true ? PrStatus.Merged : PrStatus.Closed;
+        }
+        else
+        {
+            status = PrStatus.Open;
+        }
+
         return new PullRequest
         {
             Title = pr.Title,
             Description = pr.Body,
             BaseBranch = pr.Base.Ref,
-            HeadBranch = pr.Head.Ref
+            HeadBranch = pr.Head.Ref,
+            Status = status,
+            UpdatedAt = pr.UpdatedAt,
         };
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
@@ -30,13 +30,6 @@ public interface IRemote
     Task CreateOrUpdatePullRequestMergeStatusInfoAsync(string pullRequestUrl, IReadOnlyList<MergePolicyEvaluationResult> evaluations);
 
     /// <summary>
-    ///     Get the status of a pull request.
-    /// </summary>
-    /// <param name="pullRequestUrl">Url of pull request.</param>
-    /// <returns>PR status information.</returns>
-    Task<PrInfo> GetPullRequestStatusAsync(string pullRequestUrl);
-
-    /// <summary>
     ///     Get the checks that are being run on a pull request.
     /// </summary>
     /// <param name="pullRequestUrl">Url of pull request.</param>

--- a/src/Microsoft.DotNet.Darc/DarcLib/IRemoteGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IRemoteGitRepo.cs
@@ -4,6 +4,7 @@
 using Maestro.MergePolicyEvaluation;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -55,13 +56,6 @@ public interface IRemoteGitRepo : IGitRepoCloner, IGitRepo
         PrStatus status,
         string? keyword = null,
         string? author = null);
-
-    /// <summary>
-    /// Get the status of a pull request, and when it was last updated
-    /// </summary>
-    /// <param name="pullRequestUrl">URI of pull request</param>
-    /// <returns>Pull request status, and when it was last updated</returns>
-    Task<PrInfo> GetPullRequestStatusAsync(string pullRequestUrl);
 
     /// <summary>
     ///     Retrieve information on a specific pull request
@@ -184,4 +178,6 @@ public class PullRequest
     public string Description { get; set; }
     public string BaseBranch { get; set; }
     public string HeadBranch { get; set; }
+    public PrStatus Status { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/PrInfo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/PrInfo.cs
@@ -1,8 +1,0 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using System;
-
-namespace Microsoft.DotNet.DarcLib.Models;
-
-public record PrInfo(PrStatus Status, DateTime UpdatedAt);

--- a/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
@@ -90,18 +90,6 @@ public sealed class Remote : IRemote
         return _remoteGitClient.CreateOrUpdatePullRequestMergeStatusInfoAsync(pullRequestUrl, evaluations);
     }
 
-    public async Task<PrInfo> GetPullRequestStatusAsync(string pullRequestUrl)
-    {
-        CheckForValidGitClient();
-        _logger.LogInformation($"Getting the status of pull request '{pullRequestUrl}'...");
-
-        var prInfo = await _remoteGitClient.GetPullRequestStatusAsync(pullRequestUrl);
-
-        _logger.LogInformation($"Status of pull request '{pullRequestUrl}' is '{prInfo.Status}'");
-
-        return prInfo;
-    }
-
     public Task UpdatePullRequestAsync(string pullRequestUri, PullRequest pullRequest)
     {
         return _remoteGitClient.UpdatePullRequestAsync(pullRequestUri, pullRequest);

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -147,10 +147,12 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         _logger.LogInformation("Processing pending updates for subscription {subscriptionId}", update.SubscriptionId);
         bool isCodeFlow = update.SubscriptionType == SubscriptionType.DependenciesAndSources;
         InProgressPullRequest? pr = await _pullRequestState.TryGetStateAsync();
+        PullRequest? prInfo;
 
         if (pr == null)
         {
             _logger.LogInformation("No existing pull request state found");
+            prInfo = null;
         }
         else
         {
@@ -166,8 +168,9 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 return;
             }
 
-            var prStatus = await GetPullRequestStatusAsync(pr, isCodeFlow, tryingToUpdate: true);
-            switch (prStatus)
+            var pullRequest = await GetPullRequestStatusAsync(pr, isCodeFlow, tryingToUpdate: true);
+            prInfo = pullRequest.PrInfo;
+            switch (pullRequest.Status)
             {
                 case PullRequestStatus.Completed:
                 case PullRequestStatus.Invalid:
@@ -181,29 +184,29 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                     await ScheduleUpdateForLater(pr, update, isCodeFlow);
                     return;
                 default:
-                    throw new NotImplementedException($"Unknown PR status {prStatus}");
+                    throw new NotImplementedException($"Unknown PR status {pullRequest.Status}");
             }
         }
 
         if (isCodeFlow)
         {
-            await ProcessCodeFlowUpdateAsync(update, pr);
+            await ProcessCodeFlowUpdateAsync(update, pr, prInfo);
         }
         else 
         {
-            await ProcessDependencyFlowUpdateAsync(update, pr, isCodeFlow);
+            await ProcessDependencyUpdateAsync(update, pr, prInfo);
         }
     }
 
-    private async Task ProcessDependencyFlowUpdateAsync(
+    private async Task ProcessDependencyUpdateAsync(
         SubscriptionUpdateWorkItem update, 
         InProgressPullRequest? pr,
-        bool isCodeFlow)
+        PullRequest? prInfo)
     {
-        if (pr != null)
+        if (pr != null && prInfo != null)
         {
-            await UpdatePullRequestAsync(pr, update);
-            await _pullRequestUpdateReminders.UnsetReminderAsync(isCodeFlow);
+            await UpdatePullRequestAsync(update, pr, prInfo);
+            await _pullRequestUpdateReminders.UnsetReminderAsync(isCodeFlow: false);
             return;
         }
 
@@ -218,7 +221,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
             _logger.LogInformation("Pull request '{url}' for subscription {subscriptionId} created", prUrl, update.SubscriptionId);
         }
 
-        await _pullRequestUpdateReminders.UnsetReminderAsync(isCodeFlow);
+        await _pullRequestUpdateReminders.UnsetReminderAsync(isCodeFlow: false);
     }
 
     public async Task<bool> CheckPullRequestAsync(PullRequestCheck pullRequestCheck)
@@ -239,8 +242,8 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
     protected virtual async Task<bool> CheckInProgressPullRequestAsync(InProgressPullRequest pullRequestCheck, bool isCodeFlow)
     {
         _logger.LogInformation("Checking in-progress pull request {url}", pullRequestCheck.Url);
-        var status = await GetPullRequestStatusAsync(pullRequestCheck, isCodeFlow, tryingToUpdate: false);
-        return status != PullRequestStatus.Invalid;
+        var pr = await GetPullRequestStatusAsync(pullRequestCheck, isCodeFlow, tryingToUpdate: false);
+        return pr.Status != PullRequestStatus.Invalid;
     }
 
     protected virtual Task TagSourceRepositoryGitHubContactsIfPossibleAsync(InProgressPullRequest pr)
@@ -249,23 +252,24 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         return Task.CompletedTask;
     }
 
-    protected async Task<PullRequestStatus?> GetPullRequestStatusAsync(InProgressPullRequest pr, bool isCodeFlow, bool tryingToUpdate)
+    private async Task<(PullRequestStatus Status, PullRequest PrInfo)> GetPullRequestStatusAsync(InProgressPullRequest pr, bool isCodeFlow, bool tryingToUpdate)
     {
         _logger.LogInformation("Querying status for pull request {prUrl}", pr.Url);
 
         (var targetRepository, _) = await GetTargetAsync();
         var remote = await _remoteFactory.CreateRemoteAsync(targetRepository);
 
-        PrInfo prInfo;
+        PullRequest prInfo;
         try
         {
-            prInfo = await remote.GetPullRequestStatusAsync(pr.Url);
+            prInfo = await remote.GetPullRequestAsync(pr.Url);
         }
-        catch (Exception)
+        catch
         {
-            _logger.LogError($"Couldn't get status of PR {pr.Url}");
+            _logger.LogError("Couldn't get status of PR {prUrl}", pr.Url);
             throw;
         }
+
         _logger.LogInformation("Pull request {url} is {status}", pr.Url, prInfo.Status);
 
         switch (prInfo.Status)
@@ -291,7 +295,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
 
                         // If the PR we just merged was in conflict with an update we previously tried to apply, we shouldn't delete the reminder for the update
                         await ClearAllStateAsync(isCodeFlow, clearPendingUpdates: pr.MergeState == InProgressPullRequestState.Mergeable);
-                        return PullRequestStatus.Completed;
+                        return (PullRequestStatus.Completed, prInfo);
 
                     case MergePolicyCheckResult.FailedPolicies:
                         await TagSourceRepositoryGitHubContactsIfPossibleAsync(pr);
@@ -308,7 +312,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                             var latestCommit = await remote.GetLatestCommitAsync(targetRepository, pr.HeadBranch);
                             if (latestCommit == pr.SourceSha)
                             {
-                                return PullRequestStatus.InProgressCannotUpdate;
+                                return (PullRequestStatus.InProgressCannotUpdate, prInfo);
                             }
                         }
                         // If we're about to update the PR, we should set the default reminder delay
@@ -318,7 +322,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                             tryingToUpdate ?
                                 DefaultReminderDelay :
                                 GetReminderDelay(prInfo.UpdatedAt));
-                        return PullRequestStatus.InProgressCanUpdate;
+                        return (PullRequestStatus.InProgressCanUpdate, prInfo);
 
                     case MergePolicyCheckResult.PendingPolicies:
                         _logger.LogInformation("Pull request {url} still active (not updatable at the moment) - keeping tracking it", pr.Url);
@@ -328,7 +332,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                             tryingToUpdate ?
                                 DefaultReminderDelay :
                                 GetReminderDelay(prInfo.UpdatedAt));
-                        return PullRequestStatus.InProgressCannotUpdate;
+                        return (PullRequestStatus.InProgressCannotUpdate, prInfo);
 
                     default:
                         await SetPullRequestCheckReminder(
@@ -374,7 +378,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                     _logger.LogInformation("Failed to delete branch associated with pull request {url}", pr.Url);
                 }
 
-                return PullRequestStatus.Completed;
+                return (PullRequestStatus.Completed, prInfo);
 
             default:
                 throw new NotImplementedException($"Unknown PR status '{prInfo.Status}'");
@@ -594,17 +598,16 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         }
     }
 
-    private async Task UpdatePullRequestAsync(InProgressPullRequest pr, SubscriptionUpdateWorkItem update)
+    private async Task UpdatePullRequestAsync(SubscriptionUpdateWorkItem update, InProgressPullRequest pr, PullRequest prInfo)
     {
         (var targetRepository, var targetBranch) = await GetTargetAsync();
 
         _logger.LogInformation("Updating pull request {url} branch {targetBranch} in {targetRepository}", pr.Url, targetBranch, targetRepository);
 
         IRemote darcRemote = await _remoteFactory.CreateRemoteAsync(targetRepository);
-        PullRequest pullRequest = await darcRemote.GetPullRequestAsync(pr.Url);
 
         TargetRepoDependencyUpdate targetRepositoryUpdates =
-            await GetRequiredUpdates(update, _remoteFactory, targetRepository, pullRequest.HeadBranch, targetBranch);
+            await GetRequiredUpdates(update, _remoteFactory, targetRepository, prInfo.HeadBranch, targetBranch);
 
         if (targetRepositoryUpdates.CoherencyCheckSuccessful && targetRepositoryUpdates.RequiredUpdates.Count < 1)
         {
@@ -666,15 +669,15 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         var requiredDescriptionUpdates =
             await CalculateOriginalDependencies(darcRemote, targetRepository, targetBranch, targetRepositoryUpdates);
 
-        pullRequest.Description = await _pullRequestBuilder.CalculatePRDescriptionAndCommitUpdatesAsync(
+        prInfo.Description = await _pullRequestBuilder.CalculatePRDescriptionAndCommitUpdatesAsync(
             requiredDescriptionUpdates,
-            pullRequest.Description,
+            prInfo.Description,
             targetRepository,
-            pullRequest.HeadBranch);
+            prInfo.HeadBranch);
 
-        pullRequest.Title = await _pullRequestBuilder.GeneratePRTitleAsync(pr.ContainedSubscriptions, targetBranch);
+        prInfo.Title = await _pullRequestBuilder.GeneratePRTitleAsync(pr.ContainedSubscriptions, targetBranch);
 
-        await darcRemote.UpdatePullRequestAsync(pr.Url, pullRequest);
+        await darcRemote.UpdatePullRequestAsync(pr.Url, prInfo);
         pr.LastUpdate = DateTime.UtcNow;
         pr.NextBuildsToProcess.Remove(update.SubscriptionId);
         await SetPullRequestCheckReminder(pr, isCodeFlow: update.SubscriptionType == SubscriptionType.DependenciesAndSources);
@@ -920,9 +923,9 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         await _pullRequestState.SetAsync(pr);
     }
 
-    private static TimeSpan GetReminderDelay(DateTime updatedAt)
+    private static TimeSpan GetReminderDelay(DateTimeOffset updatedAt)
     {
-        TimeSpan difference = DateTime.UtcNow - updatedAt;
+        TimeSpan difference = DateTimeOffset.UtcNow - updatedAt;
         return difference.TotalDays switch
         {
             >= 30 => TimeSpan.FromHours(12),
@@ -940,7 +943,8 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
     /// </summary>
     private async Task ProcessCodeFlowUpdateAsync(
         SubscriptionUpdateWorkItem update,
-        InProgressPullRequest? pr)
+        InProgressPullRequest? pr,
+        PullRequest? prInfo)
     {
         if (update.SourceSha == pr?.SourceSha)
         {
@@ -1026,11 +1030,16 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
 
         if (pr == null && codeFlowRes.hadUpdates)
         {
-            await CreateCodeFlowPullRequestAsync(update, previousSourceSha, subscription.TargetRepository, subscription.TargetBranch, prHeadBranch);
+            await CreateCodeFlowPullRequestAsync(
+                update,
+                previousSourceSha,
+                subscription.TargetRepository,
+                subscription.TargetBranch,
+                prHeadBranch);
         }
         else if (pr != null)
         {
-            await UpdateCodeFlowPullRequestAsync(update, pr, previousSourceSha, isForwardFlow, subscription, localRepoPath);
+            await UpdateCodeFlowPullRequestAsync(update, pr, prInfo, previousSourceSha, subscription);
             _logger.LogInformation("Code flow update processed for pull request {prUrl}", pr.Url);
         }
     }
@@ -1041,16 +1050,12 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
     private async Task UpdateCodeFlowPullRequestAsync(
         SubscriptionUpdateWorkItem update,
         InProgressPullRequest pullRequest,
+        PullRequest? prInfo,
         string previousSourceSha,
-        bool isForwardFlow,
-        SubscriptionDTO subscription,
-        NativePath localRepoPath)
+        SubscriptionDTO subscription)
     {
         IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
         var build = await _barClient.GetBuildAsync(update.BuildId);
-
-        // todo this is a second query during this flow. Can we bring the PR that was already queried down here?
-        PullRequest realPR = await remote.GetPullRequestAsync(pullRequest.Url);
 
         pullRequest.ContainedSubscriptions.RemoveAll(s => s.SubscriptionId.Equals(update.SubscriptionId));
         pullRequest.ContainedSubscriptions.Add(new SubscriptionPullRequestUpdate
@@ -1064,7 +1069,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
             subscription.TargetBranch,
             pullRequest.ContainedSubscriptions.Select(s => s.SourceRepo).ToList());
 
-        var description = _pullRequestBuilder.GenerateCodeFlowPRDescription(update, build, previousSourceSha, realPR.Description);
+        var description = _pullRequestBuilder.GenerateCodeFlowPRDescription(update, build, previousSourceSha, prInfo?.Description);
 
         try
         {

--- a/test/ProductConstructionService.DependencyFlow.Tests/PendingCodeFlowUpdatesTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PendingCodeFlowUpdatesTests.cs
@@ -42,7 +42,7 @@ internal class PendingCodeFlowUpdatesTests : PendingUpdatePullRequestUpdaterTest
             });
         Build build = GivenANewBuild(true);
 
-        using (WithExistingCodeFlowPullRequest(build, canUpdate: true, hasNewUpdates: false))
+        using (WithExistingCodeFlowPullRequest(build, canUpdate: true))
         {
             await WhenProcessPendingUpdatesAsyncIsCalled(build, isCodeFlow: true);
 
@@ -118,7 +118,7 @@ internal class PendingCodeFlowUpdatesTests : PendingUpdatePullRequestUpdaterTest
             });
         Build build = GivenANewBuild(true);
 
-        using (WithExistingCodeFlowPullRequest(build, canUpdate: true, prAlreadyHasConflict: true, hasNewUpdates: false))
+        using (WithExistingCodeFlowPullRequest(build, canUpdate: true, prAlreadyHasConflict: true))
         {
             await WhenProcessPendingUpdatesAsyncIsCalled(build, isCodeFlow: true);
 

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -406,8 +406,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
         int nextBuildToProcess = 0,
         bool newChangeWillConflict = false,
         bool prAlreadyHasConflict = false,
-        string latestCommitToReturn = ConflictPRRemoteSha,
-        bool hasNewUpdates = true)
+        string latestCommitToReturn = ConflictPRRemoteSha)
         => WithExistingCodeFlowPullRequest(
                 forBuild,
                 PrStatus.Open,
@@ -415,8 +414,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                 nextBuildToProcess,
                 newChangeWillConflict,
                 prAlreadyHasConflict,
-                latestCommitToReturn,
-                hasNewUpdates);
+                latestCommitToReturn);
 
     protected IDisposable WithExistingCodeFlowPullRequest(
         Build forBuild,
@@ -425,8 +423,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
         int nextBuildToProcess = 0,
         bool flowerWillHaveConflict = false,
         bool prAlreadyHasConflict = false,
-        string latestCommitToReturn = ConflictPRRemoteSha,
-        bool hasNewUpdates = true)
+        string latestCommitToReturn = ConflictPRRemoteSha)
     {
         var prUrl = Subscription.TargetDirectory != null
             ? VmrPullRequestUrl

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -365,8 +365,12 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
         }
 
         remote
-            .Setup(x => x.GetPullRequestStatusAsync(prUrl))
-            .ReturnsAsync(new PrInfo(PrStatus.Open, DateTime.UtcNow));
+            .Setup(x => x.GetPullRequestAsync(prUrl))
+            .ReturnsAsync(new PullRequest()
+            {
+                Status = PrStatus.Open,
+                UpdatedAt = DateTime.UtcNow,
+            });
 
         var results = policyEvaluationStatus.HasValue
             ? new MergePolicyEvaluationResults(
@@ -479,8 +483,12 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
 
         var remote = DarcRemotes.GetOrAddValue(targetRepo, () => CreateMock<IRemote>());
         remote
-            .Setup(x => x.GetPullRequestStatusAsync(prUrl))
-            .ReturnsAsync(new PrInfo(prStatus, DateTime.UtcNow));
+            .Setup(x => x.GetPullRequestAsync(prUrl))
+            .ReturnsAsync(new PullRequest()
+            {
+                Status = prStatus,
+                UpdatedAt = DateTime.UtcNow,
+            });
 
         if (prStatus == PrStatus.Open && !policyEvaluationStatus.HasValue && hasNewUpdates && !flowerWillHaveConflict)
         {

--- a/test/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsForCodeFlowTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsForCodeFlowTests.cs
@@ -99,7 +99,7 @@ internal class UpdateAssetsForCodeFlowTests : UpdateAssetsPullRequestUpdaterTest
             });
         Build build = GivenANewBuild(true);
 
-        using (WithExistingCodeFlowPullRequest(build, canUpdate: true, hasNewUpdates: false))
+        using (WithExistingCodeFlowPullRequest(build, canUpdate: true))
         {
             await WhenUpdateAssetsAsyncIsCalled(build);
 

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
@@ -386,7 +386,7 @@ internal abstract partial class ScenarioTestBase
         trimmedTitle.Should().Be(expectedPRTitle);
 
         PrStatus expectedPRState = isCompleted ? PrStatus.Closed : PrStatus.Open;
-        var prInfo = await AzDoClient.GetPullRequestStatusAsync(GetAzDoApiRepoUrl(targetRepoName) + $"/pullRequests/{pullRequestId}");
+        var prInfo = await AzDoClient.GetPullRequestAsync(GetAzDoApiRepoUrl(targetRepoName) + $"/pullRequests/{pullRequestId}");
         prInfo.Status.Should().Be(expectedPRState);
 
         using (ChangeDirectory(repoDirectory))


### PR DESCRIPTION
We have 2 different calls to get PR status but both lead to the same API endpoint (both AzDO and GitHub):
- `GetPullRequestAsync`
- `GetPullRequestStatusAsync`

We call both during dependency updates which means extra calls to GitHub.
This PR unifies them into a single call and reuses the data loaded with the first call instead of the second call.

https://github.com/dotnet/arcade-services/issues/4524#issuecomment-2710525969
