### PR TITLE
Add dependency updates to codeflow PR description

### DIFF
--- a/src/Maestro/Maestro.MergePolicies/DependencyUpdateSummary.cs
+++ b/src/Maestro/Maestro.MergePolicies/DependencyUpdateSummary.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.Serialization;
+using Microsoft.DotNet.DarcLib.Models.Darc;
 
 namespace Maestro.MergePolicies;
 
@@ -16,4 +17,21 @@ public class DependencyUpdateSummary
 
     [DataMember]
     public string ToVersion { get; set; }
+
+    [DataMember]
+    public string FromCommitSha { get; set; }
+
+    [DataMember]
+    public string ToCommitSha { get; set; }
+
+    public DependencyUpdateSummary(DependencyUpdate du)
+    {
+        DependencyName = du.To.Name;
+        FromVersion = du.From.Version;
+        ToVersion = du.To.Version;
+        FromCommitSha = du.From.Commit;
+        ToCommitSha = du.To.Commit;
+    }
+
+    public DependencyUpdateSummary() { }
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
@@ -9,6 +9,7 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.Logging;
+using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 
 #nullable enable
 namespace Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
@@ -26,7 +27,7 @@ internal class BackflowOperation(
     private readonly BackflowCommandLineOptions _options = options;
     private readonly IVmrInfo _vmrInfo = vmrInfo;
 
-    protected override async Task<bool> FlowAsync(
+    protected override async Task<CodeFlowResult> FlowAsync(
         string mappingName,
         NativePath targetDirectory,
         CancellationToken cancellationToken)

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/CodeFlowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/CodeFlowOperation.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.Logging;
 
@@ -64,7 +65,7 @@ internal abstract class CodeFlowOperation : VmrOperationBase
             cancellationToken);
     }
 
-    protected abstract Task<bool> FlowAsync(
+    protected abstract Task<CodeFlowResult> FlowAsync(
         string mappingName,
         NativePath targetDirectory,
         CancellationToken cancellationToken);

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/ForwardFlowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/ForwardFlowOperation.cs
@@ -27,7 +27,7 @@ internal class ForwardFlowOperation(
     private readonly ForwardFlowCommandLineOptions _options = options;
     private readonly IVmrInfo _vmrInfo = vmrInfo;
 
-    protected override async Task<bool> FlowAsync(
+    protected override async Task<CodeFlowResult> FlowAsync(
         string mappingName,
         NativePath repoPath,
         CancellationToken cancellationToken)
@@ -35,7 +35,7 @@ internal class ForwardFlowOperation(
         var build = await basicBarClient.GetBuildAsync(_options.Build
             ?? throw new ArgumentException("Please specify a build to flow"));
 
-        CodeFlowResult codeFlowRes = await vmrForwardFlower.FlowForwardAsync(
+        return await vmrForwardFlower.FlowForwardAsync(
             mappingName,
             repoPath,
             build,
@@ -45,6 +45,5 @@ internal class ForwardFlowOperation(
             _vmrInfo.VmrPath,
             _options.DiscardPatches,
             cancellationToken: cancellationToken);
-        return codeFlowRes.hadUpdates;
     }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/CodeFlowResult.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/CodeFlowResult.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.Models.Darc;
 
 namespace Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 
@@ -9,4 +11,5 @@ public record CodeFlowResult(
         bool hadUpdates, 
         NativePath repoPath,
         string previousFlowRepoSha,
-        string previousFlowVmrSha);
+        string previousFlowVmrSha,
+        List<DependencyUpdate> dependencyUpdates);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrBackFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/PcsVmrBackFlower.cs
@@ -81,7 +81,7 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
 
         Codeflow lastFlow = await GetLastFlowAsync(mapping, targetRepo, currentIsBackflow: true);
 
-        var hadUpdates = await FlowBackAsync(
+        return await FlowBackAsync(
             mapping,
             targetRepo,
             lastFlow,
@@ -92,12 +92,6 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
             discardPatches: true,
             headBranchExisted,
             cancellationToken);
-
-        return new CodeFlowResult(
-            hadUpdates, 
-            targetRepo.Path,
-            lastFlow.RepoSha,
-            lastFlow.VmrSha);
     }
 
     private async Task<(bool, SourceMapping, ILocalGitRepo)> PrepareVmrAndRepo(

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -112,7 +112,7 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
 
         Codeflow lastFlow = await GetLastFlowAsync(mapping, targetRepo, currentIsBackflow: true);
 
-        return await FlowBackAsync(
+        return (await FlowBackAsync(
             mapping,
             targetRepo,
             lastFlow,
@@ -122,10 +122,10 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             headBranch,
             discardPatches,
             headBranchExisted,
-            cancellationToken);
+            cancellationToken)).hadUpdates;
     }
 
-    protected async Task<bool> FlowBackAsync(
+    protected async Task<CodeFlowResult> FlowBackAsync(
         SourceMapping mapping,
         ILocalGitRepo targetRepo,
         Codeflow lastFlow,
@@ -164,7 +164,12 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             headBranchExisted,
             cancellationToken);
 
-        return hasChanges || dependencyUpdates.Any();
+        return new CodeFlowResult(
+            hasChanges || dependencyUpdates.Any(),
+            targetRepo.Path,
+            lastFlow.RepoSha,
+            lastFlow.VmrSha,
+            dependencyUpdates);
     }
 
     protected override async Task<bool> SameDirectionFlowAsync(

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -30,7 +30,7 @@ public interface IVmrBackFlower
     /// <param name="targetBranch">Target branch to create the PR against. If target branch does not exist, it is created off of this branch</param>
     /// <param name="headBranch">New/existing branch to make the changes on</param>
     /// <param name="discardPatches">Keep patch files?</param>
-    Task<bool> FlowBackAsync(
+    Task<CodeFlowResult> FlowBackAsync(
         string mapping,
         NativePath targetRepo,
         Build buildToFlow,
@@ -91,7 +91,7 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         _logger = logger;
     }
 
-    public async Task<bool> FlowBackAsync(
+    public async Task<CodeFlowResult> FlowBackAsync(
         string mappingName,
         NativePath targetRepoPath,
         Build build,
@@ -112,7 +112,7 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
 
         Codeflow lastFlow = await GetLastFlowAsync(mapping, targetRepo, currentIsBackflow: true);
 
-        return (await FlowBackAsync(
+        return await FlowBackAsync(
             mapping,
             targetRepo,
             lastFlow,
@@ -122,7 +122,7 @@ internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             headBranch,
             discardPatches,
             headBranchExisted,
-            cancellationToken)).hadUpdates;
+            cancellationToken);
     }
 
     protected async Task<CodeFlowResult> FlowBackAsync(

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -151,7 +151,8 @@ internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             hasChanges,
             sourceRepo.Path,
             lastFlow.RepoSha,
-            lastFlow.VmrSha);
+            lastFlow.VmrSha,
+            []);
     }
 
     protected async Task<bool> PrepareVmr(

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -383,16 +383,22 @@ internal class PullRequestBuilder : IPullRequestBuilder
 
         if (!string.IsNullOrEmpty(dependencyUpdateSummary.ToCommitSha))
         {
-            if (repoUri.Contains("github.com"))
-            {
-                return $"{repoUri}/commit/{dependencyUpdateSummary.ToCommitSha}";
-            }
-            if (repoUri.Contains("dev.azure.com"))
-            {
-                return $"{repoUri}?_a=history&version=GC{dependencyUpdateSummary.ToCommitSha}";
-            }
+            return GetCommitURI(repoUri, dependencyUpdateSummary.ToCommitSha);
         }
 
+        return null;
+    }
+
+    internal static string? GetCommitURI(string repoUri, string commitSha)
+    {
+        if (repoUri.Contains("github.com"))
+        {
+            return $"{repoUri}/commit/{commitSha}";
+        }
+        if (repoUri.Contains("dev.azure.com"))
+        {
+            return $"{repoUri}?_a=history&version=GC{commitSha}";
+        }
         return null;
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -433,6 +433,11 @@ internal class PullRequestBuilder : IPullRequestBuilder
                                 .Select((group, index) => new { Link = group.Key, Index = index + 1 })
                                 .ToDictionary(x => x.Link, x => x.Index);
 
+        if (linkGroups.Count == 0)
+        {
+            return description;
+        }
+
         foreach (var entry in linkGroups)
         {
             description = Regex.Replace(description, $"\\b{Regex.Escape(entry.Key)}\\b", $"[{entry.Value}]");

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -701,15 +701,15 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         List<DependencyUpdateSummary> existingUpdates,
         List<DependencyUpdate> incomingUpdates)
     {
-        var incomingUpdateSummaries = incomingUpdates
-            .Select(du => new DependencyUpdateSummary(du))
-            .ToList();
+        var incomingUpdateNames = incomingUpdates.Select(du => du.To.Name).ToHashSet();
 
-        return incomingUpdateSummaries
-                .Concat(existingUpdates)
-                .ToLookup(u => u.DependencyName)
-                .Select(g => g.First()) // Keep the incoming update, throw away the existing update
-                .ToList();
+        var updatesToAdd = existingUpdates
+            .Where(du => !incomingUpdateNames.Contains(du.DependencyName));
+
+        return incomingUpdates
+            .Select(du => new DependencyUpdateSummary(du))
+            .Concat(updatesToAdd)
+            .ToList();
     }
 
     private class TargetRepoDependencyUpdate

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -701,7 +701,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         List<DependencyUpdateSummary> existingUpdates,
         List<DependencyUpdate> incomingUpdates)
     {
-        var incomingUpdateNames = incomingUpdates.Select(du => du.To.Name).ToHashSet();
+        var incomingUpdateNames = incomingUpdates.Select(du => du.To.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var updatesToAdd = existingUpdates
             .Where(du => !incomingUpdateNames.Contains(du.DependencyName));

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -559,12 +559,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
 
                 RequiredUpdates = repoDependencyUpdate.RequiredUpdates
                         .SelectMany(update => update.deps)
-                        .Select(du => new DependencyUpdateSummary
-                        {
-                            DependencyName = du.To.Name,
-                            FromVersion = du.From.Version,
-                            ToVersion = du.To.Version
-                        })
+                        .Select(du => new DependencyUpdateSummary(du))
                         .ToList(),
 
                 CoherencyCheckSuccessful = repoDependencyUpdate.CoherencyCheckSuccessful,
@@ -625,7 +620,8 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
 
         _logger.LogInformation("Found {count} required updates for pull request {url}", targetRepositoryUpdates.RequiredUpdates.Count, pr.Url);
 
-        pr.RequiredUpdates = MergeExistingWithIncomingUpdates(pr.RequiredUpdates, targetRepositoryUpdates.RequiredUpdates);
+        pr.RequiredUpdates = MergeExistingWithIncomingUpdates(pr.RequiredUpdates,
+            targetRepositoryUpdates.RequiredUpdates.SelectMany(x => x.deps).ToList());
 
         if (pr.RequiredUpdates.Count < 1)
         {
@@ -703,35 +699,17 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
     /// <returns>Merged list of existing updates along with the new</returns>
     private static List<DependencyUpdateSummary> MergeExistingWithIncomingUpdates(
         List<DependencyUpdateSummary> existingUpdates,
-        List<(SubscriptionUpdateWorkItem update, List<DependencyUpdate> deps)> incomingUpdates)
+        List<DependencyUpdate> incomingUpdates)
     {
-        // First project the new updates to the final list
-        var mergedUpdates =
-            incomingUpdates.SelectMany(update => update.deps)
-                .Select(du => new DependencyUpdateSummary
-                {
-                    DependencyName = du.To.Name,
-                    FromVersion = du.From.Version,
-                    ToVersion = du.To.Version
-                }).ToList();
+        var incomingUpdateSummaries = incomingUpdates
+            .Select(du => new DependencyUpdateSummary(du))
+            .ToList();
 
-        // Project to a form that is easy to search
-        var searchableUpdates =
-            mergedUpdates.Select(u => u.DependencyName).ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        // Add any existing assets that weren't modified by the incoming update
-        if (existingUpdates != null)
-        {
-            foreach (DependencyUpdateSummary update in existingUpdates)
-            {
-                if (!searchableUpdates.Contains(update.DependencyName))
-                {
-                    mergedUpdates.Add(update);
-                }
-            }
-        }
-
-        return mergedUpdates;
+        return incomingUpdateSummaries
+                .Concat(existingUpdates)
+                .ToLookup(u => u.DependencyName)
+                .Select(g => g.First()) // Keep the incoming update, throw away the existing update
+                .ToList();
     }
 
     private class TargetRepoDependencyUpdate
@@ -1034,7 +1012,6 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 subscription.Id,
                 prHeadBranch);
 
-            // TODO https://github.com/dotnet/arcade-services/issues/4199: Handle failures (conflict, non-ff etc)
             using (var scope = _telemetryRecorder.RecordGitOperation(TrackedGitOperation.Push, subscription.TargetRepository))
             {
                 await _gitClient.Push(localRepoPath, prHeadBranch, subscription.TargetRepository);
@@ -1054,11 +1031,12 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 previousSourceSha,
                 subscription.TargetRepository,
                 subscription.TargetBranch,
-                prHeadBranch);
+                prHeadBranch,
+                codeFlowRes.dependencyUpdates);
         }
         else if (pr != null)
         {
-            await UpdateCodeFlowPullRequestAsync(update, pr, prInfo, previousSourceSha, subscription);
+            await UpdateCodeFlowPullRequestAsync(update, pr, prInfo, previousSourceSha, subscription, codeFlowRes.dependencyUpdates);
             _logger.LogInformation("Code flow update processed for pull request {prUrl}", pr.Url);
         }
     }
@@ -1071,7 +1049,8 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         InProgressPullRequest pullRequest,
         PullRequest? prInfo,
         string previousSourceSha,
-        SubscriptionDTO subscription)
+        SubscriptionDTO subscription,
+        List<DependencyUpdate> newDependencyUpdates)
     {
         IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
         var build = await _sqlClient.GetBuildAsync(update.BuildId);
@@ -1084,11 +1063,13 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
             SourceRepo = update.SourceRepo
         });
 
+        pullRequest.RequiredUpdates = MergeExistingWithIncomingUpdates(pullRequest.RequiredUpdates, newDependencyUpdates);
+
         var title = _pullRequestBuilder.GenerateCodeFlowPRTitle(
             subscription.TargetBranch,
             pullRequest.ContainedSubscriptions.Select(s => s.SourceRepo).ToList());
 
-        var description = _pullRequestBuilder.GenerateCodeFlowPRDescription(update, build, previousSourceSha, prInfo?.Description);
+        var description = _pullRequestBuilder.GenerateCodeFlowPRDescription(update, build, previousSourceSha, pullRequest.RequiredUpdates, prInfo?.Description);
 
         try
         {
@@ -1129,14 +1110,16 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         string previousSourceSha,
         string targetRepository,
         string targetBranch,
-        string prBranch)
+        string prBranch,
+        List<DependencyUpdate> dependencyUpdates)
     {
         IRemote darcRemote = await _remoteFactory.CreateRemoteAsync(targetRepository);
         var build = await _sqlClient.GetBuildAsync(update.BuildId);
+        List<DependencyUpdateSummary> requiredUpdates = dependencyUpdates.Select(du => new DependencyUpdateSummary(du)).ToList();
         try
         {
             var title = _pullRequestBuilder.GenerateCodeFlowPRTitle(targetBranch, [update.SourceRepo]);
-            var description = _pullRequestBuilder.GenerateCodeFlowPRDescription(update, build, previousSourceSha, currentDescription: null);
+            var description = _pullRequestBuilder.GenerateCodeFlowPRDescription(update, build, previousSourceSha, requiredUpdates, currentDescription: null);
 
             var prUrl = await darcRemote.CreatePullRequestAsync(
                 targetRepository,
@@ -1164,7 +1147,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                     }
                 ],
                 // TODO (https://github.com/dotnet/arcade-services/issues/3866): Populate fully (assets, coherency checks..)
-                RequiredUpdates = [],
+                RequiredUpdates = requiredUpdates,
             };
 
             await AddDependencyFlowEventsAsync(

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -228,7 +228,7 @@ internal abstract class VmrTestsBase
             buildToFlow = await _basicBarClient.Object.GetBuildAsync(_buildId);
         }
 
-        return await codeflower.FlowBackAsync(
+        CodeFlowResult codeFlowResult = await codeflower.FlowBackAsync(
             mappingName,
             repoPath,
             buildToFlow ?? await CreateNewVmrBuild([]),
@@ -236,6 +236,7 @@ internal abstract class VmrTestsBase
             "main",
             branch,
             cancellationToken: _cancellationToken.Token);
+        return codeFlowResult.hadUpdates;
     }
 
     protected async Task<bool> CallDarcForwardflow(

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -123,7 +123,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             async context =>
             {
                 var builder = ActivatorUtilities.CreateInstance<PullRequestBuilder>(context);
-                description = builder.GenerateCodeFlowPRDescription(update, build, mockPreviousCommitSha, null);
+                description = builder.GenerateCodeFlowPRDescription(update, build, mockPreviousCommitSha, dependencyUpdates: [], currentDescription: null);
                 await Task.CompletedTask; // hacky way to make the lambda async
             });
 
@@ -169,7 +169,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             async context =>
             {
                 var builder = ActivatorUtilities.CreateInstance<PullRequestBuilder>(context);
-                description = builder.GenerateCodeFlowPRDescription(update, build1, previousCommitSha, null);
+                description = builder.GenerateCodeFlowPRDescription(update, build1, previousCommitSha, dependencyUpdates: [], currentDescription: null);
                 await Task.CompletedTask; // hacky way to make the lambda async
             });
         string shortCommitSha = commitSha.Substring(0, 7);
@@ -192,7 +192,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             async context =>
             {
                 var builder = ActivatorUtilities.CreateInstance<PullRequestBuilder>(context);
-                description2 = builder.GenerateCodeFlowPRDescription(update2, build2, previousCommitSha2, description);
+                description2 = builder.GenerateCodeFlowPRDescription(update2, build2, previousCommitSha2, dependencyUpdates: [], description);
                 await Task.CompletedTask; // hacky way to make the lambda async
             });
         string shortCommitSha2 = commitSha2.Substring(0, 7);

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -157,11 +157,11 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             **Updated Dependencies**
             - **Foo.Bar**: [from 1.0.0 to 2.0.0][1]
             - **Foo.Biz**: [from 1.0.0 to 2.0.0][1]
-            - **Biz.Boz**: [from 1.0.0 to 2.0.0]({build.GitHubRepository}/compare/uvw789..xyz890)
+            - **Biz.Boz**: [from 1.0.0 to 2.0.0]({build.GitHubRepository}/compare/uvw789...xyz890)
 
             [marker]: <> (End:{subscriptionGuid})
             
-            [1]: {build.GitHubRepository}/compare/abc123..def456
+            [1]: {build.GitHubRepository}/compare/abc123...def456
 
             """);
     }
@@ -253,9 +253,9 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
         DependencyUpdateSummary newDependency = new()
         {
             DependencyName = "Foo.Bar",
-            FromVersion = "",
+            FromVersion = null,
             ToVersion = "2.0.0",
-            FromCommitSha = "",
+            FromCommitSha = null,
             ToCommitSha = "def456"
         };
 
@@ -263,9 +263,9 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
         {
             DependencyName = "Foo.Biz",
             FromVersion = "1.0.0",
-            ToVersion = "",
+            ToVersion = null,
             FromCommitSha = "abc123",
-            ToCommitSha = ""
+            ToCommitSha = null
         };
 
         DependencyUpdateSummary updatedDependency = new()

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using FluentAssertions;
+using Maestro.MergePolicies;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Models.Darc;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
@@ -114,7 +115,16 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
         build.AzureDevOpsProject = "bar";
         build.AzureDevOpsBuildId = 1234;
         string subscriptionGuid = "11111111-1111-1111-1111-111111111111";
-        SubscriptionUpdateWorkItem update = GivenSubscriptionUpdate(false, build.Id, guid: subscriptionGuid, SubscriptionType.DependenciesAndSources);
+        List<DependencyUpdateSummary> dependencyUpdates = GivenDependencyUpdateSummaries();
+        SubscriptionUpdateWorkItem update = new()
+        {
+            UpdaterId = subscriptionGuid,
+            IsCoherencyUpdate = false,
+            SourceRepo = build.GetRepository(),
+            SubscriptionId = new Guid(subscriptionGuid),
+            BuildId = build.Id,
+            SubscriptionType = SubscriptionType.DependenciesAndSources,
+        };
 
         string mockPreviousCommitSha = "SHA1234567890";
 
@@ -123,7 +133,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             async context =>
             {
                 var builder = ActivatorUtilities.CreateInstance<PullRequestBuilder>(context);
-                description = builder.GenerateCodeFlowPRDescription(update, build, mockPreviousCommitSha, dependencyUpdates: [], currentDescription: null);
+                description = builder.GenerateCodeFlowPRDescription(update, build, mockPreviousCommitSha, dependencyUpdates: dependencyUpdates, currentDescription: null);
                 await Task.CompletedTask; // hacky way to make the lambda async
             });
 
@@ -143,8 +153,15 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             - **Source Diff**: [{shortPreviousCommitSha}..{shortCommitSha}]({build.GitHubRepository}/compare/{mockPreviousCommitSha}..{commitSha})
             - **Commit**: [{commitSha}]({build.GitHubRepository}/commit/{commitSha})
             - **Branch**: main
+            
+            **Updated Dependencies**
+            - **Foo.Bar**: [from 1.0.0 to 2.0.0][1]
+            - **Foo.Biz**: [from 1.0.0 to 2.0.0][1]
+            - **Biz.Boz**: [from 1.0.0 to 2.0.0]({build.GitHubRepository}/compare/uvw789..xyz890)
 
             [marker]: <> (End:{subscriptionGuid})
+            
+            [1]: {build.GitHubRepository}/compare/abc123..def456
 
             """);
     }
@@ -226,6 +243,52 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             - **Branch**: main
 
             [marker]: <> (End:{subscriptionGuid2})
+
+            """);
+    }
+
+    [Test]
+    public void ShouldReturnCorrectDependencyUpdateBlock()
+    {
+        DependencyUpdateSummary newDependency = new()
+        {
+            DependencyName = "Foo.Bar",
+            FromVersion = "",
+            ToVersion = "2.0.0",
+            FromCommitSha = "",
+            ToCommitSha = "def456"
+        };
+
+        DependencyUpdateSummary removedDependency = new()
+        {
+            DependencyName = "Foo.Biz",
+            FromVersion = "1.0.0",
+            ToVersion = "",
+            FromCommitSha = "abc123",
+            ToCommitSha = ""
+        };
+
+        DependencyUpdateSummary updatedDependency = new()
+        {
+            DependencyName = "Biz.Boz",
+            FromVersion = "1.0.0",
+            ToVersion = "2.0.0",
+            FromCommitSha = "uvw789",
+            ToCommitSha = "xyz890"
+        };
+
+        string dependencyBlock = PullRequestBuilder.CreateDependencyUpdateBlock([newDependency, removedDependency, updatedDependency], "https://github.com/Foo");
+
+        dependencyBlock.Should().Be("""
+
+            **New Dependencies**
+            - **Foo.Bar**: [2.0.0](https://github.com/Foo/commit/def456)
+
+            **Removed Dependencies**
+            - **Foo.Biz**: 1.0.0
+
+            **Updated Dependencies**
+            - **Biz.Boz**: [from 1.0.0 to 2.0.0](https://github.com/Foo/compare/uvw789...xyz890)
 
             """);
     }
@@ -324,6 +387,36 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
         }
 
         return dependencies;
+    }
+
+    private static List<DependencyUpdateSummary> GivenDependencyUpdateSummaries()
+    {
+        return [
+            new DependencyUpdateSummary
+            {
+                DependencyName = "Foo.Bar",
+                FromVersion = "1.0.0",
+                ToVersion = "2.0.0",
+                FromCommitSha = "abc123",
+                ToCommitSha = "def456"
+            },
+            new DependencyUpdateSummary
+            {
+                DependencyName = "Foo.Biz",
+                FromVersion = "1.0.0",
+                ToVersion = "2.0.0",
+                FromCommitSha = "abc123",
+                ToCommitSha = "def456"
+            },
+            new DependencyUpdateSummary
+            {
+                DependencyName = "Biz.Boz",
+                FromVersion = "1.0.0",
+                ToVersion = "2.0.0",
+                FromCommitSha = "uvw789",
+                ToCommitSha = "xyz890"
+            }
+        ];
     }
 
     private static SubscriptionUpdateWorkItem GivenSubscriptionUpdate(

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -52,7 +52,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
         services.AddSingleton(_forwardFlower.Object);
         services.AddSingleton(_gitClient.Object);
 
-        CodeFlowResult codeFlowRes = new CodeFlowResult(true, null, "xxx1234", "yyy2345");
+        CodeFlowResult codeFlowRes = new CodeFlowResult(true, null, "xxx1234", "yyy2345", []);
         _forwardFlower.SetReturnsDefault(Task.FromResult(codeFlowRes));
         _backFlower.SetReturnsDefault(Task.FromResult(codeFlowRes));
         _gitClient.SetReturnsDefault(Task.CompletedTask);

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -632,7 +632,9 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                 {
                     DependencyName = d.Name,
                     FromVersion = d.Version,
-                    ToVersion = d.Version
+                    ToVersion = d.Version,
+                    FromCommitSha = NewCommit,
+                    ToCommitSha = "sha3333"
                 })
                 .ToList(),
             CoherencyCheckSuccessful = coherencyCheckSuccessful,


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4407#issue-2823541261


- Extend DependencyUpdateSummary to include From/To commit sha's that can be used to build the PR description. Previously, DependencyUpdateSummary objects were saved in InProgressPullRequest for some kind of edge case check, and were not used to build the PR description. Instead, the entire list of dependencies was built from source of truth for every subscription contained in a PR on every PR update, regardless of the existing DependencyUpdateSummary objects persisted in the InProgressPullRequest. Because the code flow brings in partial dependency updates (that come only from the most recent diff), this works a bit differently for codeflow.
- Add a post-processing method on the codeflow PR description that searches all links that appear multiple times, and replaces them with reference-style links
- Separate dependency updates into new dependencies, removed dependencies, and updated dependencies when building the PR description
- Modify the backflow scenario test to include package updates



➡️ Example codeflow PR with dependency updates: https://github.com/maestro-auth-test/maestro-test1/pull/2671
