### PR TITLE
Allow quoting search terms on the Subscription page

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Code/Helpers/StringExtensions.cs
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Code/Helpers/StringExtensions.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace ProductConstructionService.BarViz.Code.Helpers;
+
+internal static class StringExtensions
+{
+    public static string[] ParseSearchTerms(string searchFilter)
+    {
+        var terms = new List<string>();
+        var currentTerm = new StringBuilder();
+        bool inQuotes = false;
+
+        foreach (var c in searchFilter)
+        {
+            if (c == '"')
+            {
+                inQuotes = !inQuotes;
+                if (!inQuotes && currentTerm.Length > 0)
+                {
+                    terms.Add(currentTerm.ToString());
+                    currentTerm.Clear();
+                }
+            }
+            else if (char.IsWhiteSpace(c) && !inQuotes)
+            {
+                if (currentTerm.Length > 0)
+                {
+                    terms.Add(currentTerm.ToString());
+                    currentTerm.Clear();
+                }
+            }
+            else
+            {
+                currentTerm.Append(c);
+            }
+        }
+
+        if (currentTerm.Length > 0)
+        {
+            terms.Add(currentTerm.ToString());
+        }
+
+        return terms.ToArray();
+    }
+}

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/Subscriptions.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/Subscriptions.razor
@@ -1,9 +1,10 @@
 ﻿@page "/subscriptions"
 
+@using System.Linq.Expressions
+@using System.Text
 @using Microsoft.DotNet.ProductConstructionService.Client
 @using Microsoft.DotNet.ProductConstructionService.Client.Models
 @using Microsoft.FluentUI.AspNetCore.Components.Extensions
-@using System.Linq.Expressions
 @using ProductConstructionService.BarViz.Code.Helpers
 @using ProductConstructionService.BarViz.Components
 @inject NavigationManager NavManager
@@ -62,7 +63,7 @@
                         </ul>
                     </li>
                 </ul>
-                Example: <code>target:dotnet/sdk channel:10 :haspr</code><br />
+                Example: <code>target:dotnet/sdk channel:".NET 10" :haspr</code><br />
                 <i>All subscriptions to dotnet/sdk from channel containg 10 that have an ongoing PR.</i>
             </FluentTooltip>
 
@@ -128,8 +129,11 @@
                 </TemplateColumn>
             </ChildContent>
         </FluentDataGrid>
-
-        <div style="width: 100%; display: flex; justify-content: flex-end">
+        <div style="display: flex; width: 100%">
+            <p>
+                <i>* Double-click a subscription row to display subscription details</i>
+            </p>
+            <FluentSpacer />
             <FluentPaginator State="@Pagination" />
         </div>
     </Content>
@@ -171,22 +175,22 @@
 
         AllSubscriptions = await PcsApi.Subscriptions.ListSubscriptionsAsync();
 
-        UpdateDataSource();
+        FilterSubscriptions();
     }
 
     void HandleSearchInput()
     {
-        UpdateDataSource();
+        FilterSubscriptions();
     }
 
-    void UpdateDataSource()
+    void FilterSubscriptions()
     {
         var filteredSubscriptions = AllSubscriptions?
             .Where(s => ShowDisabled || s.Enabled);
 
         if (!string.IsNullOrEmpty(SearchFilter))
         {
-            var searchTerms = SearchFilter.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var searchTerms = StringExtensions.ParseSearchTerms(SearchFilter);
             if (searchTerms.Length > 0)
             {
                 filteredSubscriptions = filteredSubscriptions?
@@ -203,7 +207,7 @@
     void SetDisabled(bool value)
     {
         ShowDisabled = value;
-        UpdateDataSource();
+        FilterSubscriptions();
     }
 
     bool IsMatch(Subscription subscription, string filter)


### PR DESCRIPTION
- Adds a support for "quoting search terms" when filtering in the Subscription page
- Resolves https://github.com/dotnet/arcade-services/issues/4494