### PR TITLE
Clean up branch after backflow scenario test

### DIFF
--- a/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
@@ -43,11 +43,6 @@ internal abstract partial class ScenarioTestBase
         _packageNameSalt = Guid.NewGuid().ToString().Substring(0, 8);
     }
 
-    public static void ConfigureDarcArgs()
-    {
-        
-    }
-
     protected async Task<Octokit.PullRequest> WaitForPullRequestAsync(string targetRepo, string targetBranch)
     {
         Octokit.Repository repo = await GitHubApi.Repository.Get(TestParameters.GitHubTestOrg, targetRepo);
@@ -103,7 +98,7 @@ internal abstract partial class ScenarioTestBase
         throw new ScenarioTestException($"The created pull request for {targetRepo} targeting {targetBranch} was not updated with subsequent subscriptions after creation");
     }
 
-    protected async Task MergePullRequestAsync(string targetRepo, Octokit.PullRequest pr)
+    protected static async Task MergePullRequestAsync(string targetRepo, Octokit.PullRequest pr)
     {
         Octokit.MergePullRequest mergePullRequest = new()
         {
@@ -1107,7 +1102,7 @@ internal abstract partial class ScenarioTestBase
 
     protected static void PullRequestShouldHaveConflicts(Octokit.PullRequest pr)
     {
-        pr.Mergeable.Should().BeFalse();
-        pr.MergeableState.ToString().Should().Be("dirty");
+        pr.Mergeable.Should().BeFalse("PR " + pr.HtmlUrl + " should have conflicts");
+        pr.MergeableState.ToString().Should().Be("dirty", "PR " + pr.HtmlUrl + " should be dirty");
     }
 }

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using FluentAssertions;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using NUnit.Framework;
@@ -396,7 +395,14 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
 
                         // WaitForPullRequestAsync fetches prs in bulk, which doesn't fetch fields like Mergeable and MergeableState which we need
                         pr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, pr.Number);
-                        PullRequestShouldHaveConflicts(pr);
+                        try
+                        {
+                            await GitHubApi.Git.Reference.Delete(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, $"heads/{pr.Head.Ref}");
+                        }
+                        finally
+                        {
+                            PullRequestShouldHaveConflicts(pr);
+                        }
                     }
                 }
             }

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -397,11 +397,11 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
                         pr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, pr.Number);
                         try
                         {
-                            await GitHubApi.Git.Reference.Delete(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, $"heads/{pr.Head.Ref}");
+                            PullRequestShouldHaveConflicts(pr);
                         }
                         finally
                         {
-                            PullRequestShouldHaveConflicts(pr);
+                            await GitHubApi.Git.Reference.Delete(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, $"heads/{pr.Head.Ref}");
                         }
                     }
                 }

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -395,12 +395,20 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
 
                         // WaitForPullRequestAsync fetches prs in bulk, which doesn't fetch fields like Mergeable and MergeableState which we need
                         pr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, pr.Number);
-                        try
+
+                        await using (AsyncDisposable.Create(
+                            async () =>
+                            {
+                                try
+                                {
+                                    await GitHubApi.Git.Reference.Delete(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, $"heads/{pr.Head.Ref}");
+                                }
+                                catch
+                                {
+                                }
+                            }))
                         {
-                            await GitHubApi.Git.Reference.Delete(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, $"heads/{pr.Head.Ref}");
-                        }
-                        finally
-                        {
+
                             PullRequestShouldHaveConflicts(pr);
                         }
                     }

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -397,11 +397,11 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
                         pr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, pr.Number);
                         try
                         {
-                            PullRequestShouldHaveConflicts(pr);
+                            await GitHubApi.Git.Reference.Delete(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, $"heads/{pr.Head.Ref}");
                         }
                         finally
                         {
-                            await GitHubApi.Git.Reference.Delete(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, $"heads/{pr.Head.Ref}");
+                            PullRequestShouldHaveConflicts(pr);
                         }
                     }
                 }


### PR DESCRIPTION
- Makes sure the test deletes the PR branch (which is left behind after each run)
- Improves error messages when assertions fail
<!-- https://github.com/dotnet/arcade-services/issues/4554 -->