### PR TITLE
Include mapping name in the Source tag

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -320,6 +320,7 @@ public class DependencyFileManager : IDependencyFileManager
                 dependenciesNode.PrependChild(sourceNode);
             }
 
+            SetAttribute(versionDetails, sourceNode, VersionDetailsParser.MappingElementName, sourceDependency.Mapping);
             SetAttribute(versionDetails, sourceNode, VersionDetailsParser.UriElementName, sourceDependency.Uri);
             SetAttribute(versionDetails, sourceNode, VersionDetailsParser.ShaElementName, sourceDependency.Sha);
             if (sourceDependency.BarId != null) {

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/VersionDetailsParser.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/VersionDetailsParser.cs
@@ -28,6 +28,7 @@ public class VersionDetailsParser : IVersionDetailsParser
     public const string VersionPropsAlternateVersionElementSuffix = "Version";
     public const string ShaElementName = "Sha";
     public const string UriElementName = "Uri";
+    public const string MappingElementName = "Mapping";
     public const string BarIdElementName = "BarId";
     public const string DependencyElementName = "Dependency";
     public const string DependenciesElementName = "Dependencies";
@@ -154,13 +155,18 @@ public class VersionDetailsParser : IVersionDetailsParser
         }
 
         var uri = sourceNode.Attributes?[UriElementName]?.Value?.Trim()
-            ?? throw new DarcException($"Malformed {SourceElementName} section - expected {UriElementName} attribute");
+            ?? throw new DarcException($"Malformed {SourceElementName} tag - expected {UriElementName} attribute");
 
         var sha = sourceNode.Attributes[ShaElementName]?.Value?.Trim()
-            ?? throw new DarcException($"Malformed {SourceElementName} section - expected {ShaElementName} attribute");
+            ?? throw new DarcException($"Malformed {SourceElementName} tag - expected {ShaElementName} attribute");
 
-        int.TryParse(sourceNode.Attributes[BarIdElementName]?.Value?.Trim(), out int barId);
-        return new SourceDependency(uri, sha, barId);
+        var mapping = sourceNode.Attributes[MappingElementName]?.Value?.Trim()
+            ?? throw new DarcException($"Malformed {SourceElementName} tag - expected {MappingElementName} attribute");
+
+        var barIdAttribute = sourceNode.Attributes[BarIdElementName]?.Value?.Trim();
+        _ = int.TryParse(barIdAttribute, out int barId);
+
+        return new SourceDependency(uri, mapping, sha, barId);
     }
 
     private static bool ParseBooleanAttribute(XmlAttributeCollection attributes, string attributeName)

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VersionDetails.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VersionDetails.cs
@@ -1,21 +1,21 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System.Collections.Generic;
 using Microsoft.DotNet.DarcLib.Models.Darc;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 
+#nullable enable
 namespace Microsoft.DotNet.DarcLib.Models;
 
 public record VersionDetails(
     IReadOnlyCollection<DependencyDetail> Dependencies,
     SourceDependency? Source);
 
-public record SourceDependency(string Uri, string Sha, int? BarId)
+public record SourceDependency(string Uri, string Mapping, string Sha, int? BarId)
 {
-    public SourceDependency(Build build)
-        : this(build.GetRepository(), build.Commit, build.Id)
+    public SourceDependency(Build build, string mapping)
+        : this(build.GetRepository(), mapping, build.Commit, build.Id)
     {
     }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VersionFileCodeFlowUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VersionFileCodeFlowUpdater.cs
@@ -528,7 +528,7 @@ public class VersionFileCodeFlowUpdater : IVersionFileCodeFlowUpdater
 
         GitFileContentContainer updatedFiles = await _dependencyFileManager.UpdateDependencyFiles(
             updates,
-            new SourceDependency(build),
+            new SourceDependency(build, mappingName),
             targetRepo.Path,
             branch: null, // reads the working tree
             currentRepoDependencies.Dependencies,

--- a/test/Microsoft.DotNet.DarcLib.Tests/Helpers/VersionDetailsParserTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Helpers/VersionDetailsParserTests.cs
@@ -143,7 +143,7 @@ public class VersionDetailsParserTests
             """
             <?xml version="1.0" encoding="utf-8"?>
             <Dependencies>
-              <Source Uri="https://github.com/dotnet/dotnet" Sha="86ba5fba7c39323011c2bfc6b713142affc76171" />
+              <Source Uri="https://github.com/dotnet/dotnet" Mapping="SomeRepo" Sha="86ba5fba7c39323011c2bfc6b713142affc76171" BarId="23412" />
               <ProductDependencies>
                 <Dependency Name="NETStandard.Library.Ref" Version="2.1.0" Pinned="true">
                   <Uri>https://github.com/dotnet/core-setup</Uri>
@@ -171,5 +171,7 @@ public class VersionDetailsParserTests
         versionDetails.Source.Should().NotBeNull();
         versionDetails.Source.Uri.Should().Be("https://github.com/dotnet/dotnet");
         versionDetails.Source.Sha.Should().Be("86ba5fba7c39323011c2bfc6b713142affc76171");
+        versionDetails.Source.Mapping.Should().Be("SomeRepo");
+        versionDetails.Source.BarId.Should().Be(23412);
     }
 }

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VersionFileConflictResolverTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VersionFileConflictResolverTests.cs
@@ -168,7 +168,7 @@ public class VersionFileConflictResolverTests
                 CreateDependency("Package.Updated.In.Both", "1.0.0", LastVmrSha),
                 CreateDependency("Package.Removed.In.VMR", "1.0.0", LastVmrSha), // Will be removed in VMR
             ],
-            new SourceDependency(VmrUri, LastVmrSha, 123456));
+            new SourceDependency(VmrUri, MappingName, LastVmrSha, 123456));
 
         // Dependencies in the target branch of the repo (what we are flowing to)
         _versionDetails[$"repo/{TargetBranch}"] = new VersionDetails(
@@ -178,7 +178,7 @@ public class VersionFileConflictResolverTests
                 CreateDependency("Package.Added.In.Repo", "1.0.0", LastVmrSha), // Added
                 CreateDependency("Package.Added.In.Both", "2.2.2", LastVmrSha), // Added in both
             ],
-            new SourceDependency(VmrUri, LastVmrSha, 123456));
+            new SourceDependency(VmrUri, MappingName, LastVmrSha, 123456));
 
         // The PR branch was just created so it has the same dependencies as the target branch
         _versionDetails[$"repo/{PrBranch}"] = _versionDetails["repo/main"];
@@ -197,7 +197,7 @@ public class VersionFileConflictResolverTests
                 CreateDependency("Package.Added.In.Both", "1.1.1", LastVmrSha), // Added in both
                 // Package.Removed.In.VMR removed
             ],
-            new SourceDependency(VmrUri, LastVmrSha, 123456));
+            new SourceDependency(VmrUri, MappingName, LastVmrSha, 123456));
 
         var build = CreateNewBuild(CurrentVmrSha,
         [
@@ -362,7 +362,7 @@ public class VersionFileConflictResolverTests
                     oldDependencies
                         .Select(dep => itemsToUpdate.FirstOrDefault(d => d.Name == dep.Name) ?? dep)
                         .ToArray(),
-                    new SourceDependency(build));
+                    new SourceDependency(build, MappingName));
 
             })
             .ReturnsAsync(gitFileChanges);


### PR DESCRIPTION
This will be needed for our tooling (such as in https://github.com/dotnet/arcade-services/issues/4539) so that users don't need to keep passing in the mapping name and we can tell from/to where is the repo mapped in the VMR

