### PR TITLE
Remove an extra space from PR titles

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -219,7 +219,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
         string targetBranch,
         List<string> repoNames)
     {
-        return GeneratePRTitle($"[{targetBranch}] Source code updates from ", repoNames);
+        return GeneratePRTitle($"[{targetBranch}] Source code updates from", repoNames);
     }
 
     public string GenerateCodeFlowPRDescription(


### PR DESCRIPTION
Example: https://github.com/dotnet/dotnet/issues/163 (click `Edit` on the title)
