### PR TITLE
Move `PcsCodeFlower` classes to the PCS project

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -41,7 +41,7 @@ public interface IVmrBackFlower
         CancellationToken cancellationToken = default);
 }
 
-internal class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
+public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
 {
     private readonly IVmrInfo _vmrInfo;
     private readonly ISourceManifest _sourceManifest;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 /// This class is responsible for taking changes done to a repo in the VMR and backflowing them into the repo.
 /// It only makes patches/changes locally, no other effects are done.
 /// </summary>
-internal abstract class VmrCodeFlower
+public abstract class VmrCodeFlower
 {
     private readonly IVmrInfo _vmrInfo;
     private readonly ISourceManifest _sourceManifest;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -49,7 +49,7 @@ public interface IVmrForwardFlower
         CancellationToken cancellationToken = default);
 }
 
-internal class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
+public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
 {
     private readonly IVmrInfo _vmrInfo;
     private readonly ISourceManifest _sourceManifest;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -91,9 +91,7 @@ public static class VmrRegistrations
         services.TryAddTransient<IVmrUpdater, VmrUpdater>();
         services.TryAddTransient<IVmrInitializer, VmrInitializer>();
         services.TryAddTransient<IVmrBackFlower, VmrBackFlower>();
-        services.TryAddTransient<IPcsVmrBackFlower, PcsVmrBackFlower>();
         services.TryAddTransient<IVmrForwardFlower, VmrForwardFlower>();
-        services.TryAddTransient<IPcsVmrForwardFlower, PcsVmrForwardFlower>();
         services.TryAddTransient<ICodeFlowVmrUpdater, CodeFlowVmrUpdater>();
         services.TryAddTransient<IVersionFileCodeFlowUpdater, VersionFileCodeFlowUpdater>();
         services.TryAddTransient<IWorkBranchFactory, WorkBranchFactory>();

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/DependencyFlowConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/DependencyFlowConfiguration.cs
@@ -25,6 +25,8 @@ public static class DependencyFlowConfiguration
         services.TryAddTransient<IPullRequestPolicyFailureNotifier, PullRequestPolicyFailureNotifier>();
         services.TryAddScoped<ISqlBarClient, SqlBarClient>();
         services.TryAddScoped<IBasicBarClient, SqlBarClient>();
+        services.TryAddTransient<IPcsVmrBackFlower, PcsVmrBackFlower>();
+        services.TryAddTransient<IPcsVmrForwardFlower, PcsVmrForwardFlower>();
 
         services.AddWorkItemProcessor<BuildCoherencyInfoWorkItem, BuildCoherencyInfoProcessor>();
         services.AddWorkItemProcessor<PullRequestCheck, PullRequestCheckProcessor>();

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
@@ -1,23 +1,21 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using LibGit2Sharp;
+using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+namespace ProductConstructionService.DependencyFlow;
 
 /// <summary>
 /// Class for flowing code from the VMR to product repos.
 /// This class is used in the context of darc CLI as some behaviours around repo preparation differ.
 /// </summary>
-public interface IPcsVmrBackFlower : IVmrBackFlower
+internal interface IPcsVmrBackFlower : IVmrBackFlower
 {
     /// <summary>
     /// Flows backward the code from the VMR to the target branch of a product repo.
@@ -73,7 +71,7 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
         string targetBranch,
         CancellationToken cancellationToken = default)
     {
-        (bool headBranchExisted, SourceMapping mapping, ILocalGitRepo targetRepo) = await PrepareVmrAndRepo(
+        (var headBranchExisted, SourceMapping mapping, ILocalGitRepo targetRepo) = await PrepareVmrAndRepo(
             subscription,
             build,
             targetBranch,

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
@@ -1,22 +1,19 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+namespace ProductConstructionService.DependencyFlow;
 
 /// <summary>
 /// Interface for VmrForwardFlower used in the context of the PCS.
 /// </summary>
-public interface IPcsVmrForwardFlower
+internal interface IPcsVmrForwardFlower
 {
     /// <summary>
     /// Flows forward the code from the source repo to the target branch of the VMR.
@@ -68,7 +65,7 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
         bool headBranchExisted = await PrepareVmr(subscription.TargetRepository, subscription.TargetBranch, headBranch, cancellationToken);
         SourceMapping mapping = _dependencyTracker.GetMapping(subscription.TargetDirectory);
         ISourceComponent repoVersion = _sourceManifest.GetRepoVersion(mapping.Name);
-        List<string> remotes = new[] { mapping.DefaultRemote, repoVersion.RemoteUri }
+        var remotes = new[] { mapping.DefaultRemote, repoVersion.RemoteUri }
             .Distinct()
             .OrderRemotesByLocalPublicOther()
             .ToList();


### PR DESCRIPTION
As part of https://github.com/dotnet/arcade-services/issues/4515, we will create `DarcCodeflower` classes specific to calling the code from CLI. It only makes sense if the PCS ones live in the PCS project while the Darc ones live in the Darc project as their custom implementations to that particular entrypoint.
