### PR TITLE
Fix Source tag matching in scenario tests

### DIFF
--- a/test/ProductConstructionService.ScenarioTests/CodeFlowScenarioTestBase.cs
+++ b/test/ProductConstructionService.ScenarioTests/CodeFlowScenarioTestBase.cs
@@ -84,7 +84,7 @@ internal class CodeFlowScenarioTestBase : ScenarioTestBase
 
             var versionDetailsFile = files.FirstOrDefault(file => file.FileName == "eng/Version.Details.xml");
             versionDetailsFile.Should().NotBeNull();
-            versionDetailsFile!.Patch.Should().Contain(GetExpectedCodeFlowDependencyVersionEntry(sourceRepoName, commitSha, buildId));
+            versionDetailsFile!.Patch.Should().Contain(GetExpectedCodeFlowDependencyVersionEntry(sourceRepoName, targetRepoName, commitSha, buildId));
 
             // Verify new files are in the PR
             foreach (var testFile in testFiles)

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
@@ -267,8 +267,8 @@ internal abstract partial class ScenarioTestBase
         await CheckGitHubPullRequest(expectedPRTitle, targetRepoName, targetBranch, expectedDependencies, repoDirectory, isCompleted, isUpdated, cleanUp);
     }
 
-    protected static string GetExpectedCodeFlowDependencyVersionEntry(string repo, string sha, int buildId) =>
-        $"<Source Uri=\"{GetGitHubRepoUrl(repo)}\" Mapping=\"{repo}\" Sha=\"{sha}\" BarId=\"{buildId}\" />";
+    protected static string GetExpectedCodeFlowDependencyVersionEntry(string sourceRepo, string targetRepoName, string sha, int buildId) =>
+        $"<Source Uri=\"{GetGitHubRepoUrl(sourceRepo)}\" Mapping=\"{targetRepoName}\" Sha=\"{sha}\" BarId=\"{buildId}\" />";
 
     protected async Task CheckGitHubPullRequest(
         string expectedPRTitle,


### PR DESCRIPTION
Wrong fix happened in https://github.com/dotnet/arcade-services/issues/4576
