### PR TITLE
Bump agent image to ubuntu 22.04

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -89,7 +89,7 @@ stages:
         displayName: Build Docker Image
         pool:
           name: NetCore-Public
-          demands: ImageOverride -equals 1es-ubuntu-2004-open
+          demands: ImageOverride -equals build.ubuntu.2204.amd64.open
 
         steps:
         - checkout: self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,7 +164,7 @@ extends:
         displayName: Build/publish docker image
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals 1es-ubuntu-2004
+          demands: ImageOverride -equals 1es-ubuntu-2204
           os: linux
 
         steps:


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Resolves https://github.com/dotnet/arcade-services/issues/4596

There are no 24.04 images in the agent pools we use so pivoted to 22.04 instead

Internal build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2671619&view=results