### PR TITLE
Slightly refactor IsDevelopment check for SwaggerUI usage

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/SwaggerConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/SwaggerConfiguration.cs
@@ -184,36 +184,34 @@ public static class SwaggerConfiguration
     public static void UseLocalSwagger(this WebApplication app)
     {
         // Enable Swagger UI only in local dev env
-        if (!app.Environment.IsDevelopment())
+        if (app.Environment.IsDevelopment())
         {
-            return;
+            app.Use((ctx, next) =>
+            {
+                if (ctx.Request.Path == "/swagger.json")
+                {
+                    var vcp = ctx.RequestServices.GetRequiredService<VersionedControllerProvider>();
+                    string highestVersion = vcp.Versions.Keys.OrderByDescending(n => n).First();
+                    ctx.Request.Path = $"/swagger/{highestVersion}/swagger.json";
+                }
+
+                return next();
+            });
+
+            app.UseSwagger();
+            app.UseSwaggerUI(options => // Enable Swagger UI only in local dev env
+            {
+                options.DocumentTitle = "Product Construction Service API";
+
+                var versions = app.Services.GetRequiredService<VersionedControllerProvider>().Versions.Keys
+                    .OrderDescending();
+
+                foreach (var version in versions)
+                {
+                    options.SwaggerEndpoint($"/swagger/{version}/swagger.json", $"Product Construction Service API {version}");
+                }
+            });
         }
-
-        app.Use((ctx, next) =>
-        {
-            if (ctx.Request.Path == "/swagger.json")
-            {
-                var vcp = ctx.RequestServices.GetRequiredService<VersionedControllerProvider>();
-                string highestVersion = vcp.Versions.Keys.OrderByDescending(n => n).First();
-                ctx.Request.Path = $"/swagger/{highestVersion}/swagger.json";
-            }
-
-            return next();
-        });
-
-        app.UseSwagger();
-        app.UseSwaggerUI(options => // Enable Swagger UI only in local dev env
-        {
-            options.DocumentTitle = "Product Construction Service API";
-
-            var versions = app.Services.GetRequiredService<VersionedControllerProvider>().Versions.Keys
-                .OrderDescending();
-
-            foreach (var version in versions)
-            {
-                options.SwaggerEndpoint($"/swagger/{version}/swagger.json", $"Product Construction Service API {version}");
-            }
-        });
     }
 
     private static string ToCamelCase(string value)


### PR DESCRIPTION
The "only use SwaggerUI in dev" static analyzer is a bit simplistic and only understands code of the form:

```cs
if (IsDevelopment()) {
    // enable SwaggerUI
}
```

Updating the rule is a pain, so the path of least resistance is to avoid the early-exit from this method and instead to surround the entire method body in an `if` block.

Note to reviewers: suggest toggling "ignore whitespace" while looking at the diff.