### PR TITLE
Add the `flow-commit` ReproTool command

### DIFF
--- a/arcade-services.sln
+++ b/arcade-services.sln
@@ -96,6 +96,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProductConstructionService.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatFlowMigrationCli", "tools\FlatFlowMigrationCli\FlatFlowMigrationCli.csproj", "{89DF188B-B1FC-D3C4-A76E-019144ABA9CB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tools.Common", "tools\Tools.Common\Tools.Common.csproj", "{977060F4-EEEF-420D-02E8-5E58D3E51942}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -514,6 +516,18 @@ Global
 		{89DF188B-B1FC-D3C4-A76E-019144ABA9CB}.Release|x64.Build.0 = Release|Any CPU
 		{89DF188B-B1FC-D3C4-A76E-019144ABA9CB}.Release|x86.ActiveCfg = Release|Any CPU
 		{89DF188B-B1FC-D3C4-A76E-019144ABA9CB}.Release|x86.Build.0 = Release|Any CPU
+		{977060F4-EEEF-420D-02E8-5E58D3E51942}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{977060F4-EEEF-420D-02E8-5E58D3E51942}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{977060F4-EEEF-420D-02E8-5E58D3E51942}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{977060F4-EEEF-420D-02E8-5E58D3E51942}.Debug|x64.Build.0 = Debug|Any CPU
+		{977060F4-EEEF-420D-02E8-5E58D3E51942}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{977060F4-EEEF-420D-02E8-5E58D3E51942}.Debug|x86.Build.0 = Debug|Any CPU
+		{977060F4-EEEF-420D-02E8-5E58D3E51942}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{977060F4-EEEF-420D-02E8-5E58D3E51942}.Release|Any CPU.Build.0 = Release|Any CPU
+		{977060F4-EEEF-420D-02E8-5E58D3E51942}.Release|x64.ActiveCfg = Release|Any CPU
+		{977060F4-EEEF-420D-02E8-5E58D3E51942}.Release|x64.Build.0 = Release|Any CPU
+		{977060F4-EEEF-420D-02E8-5E58D3E51942}.Release|x86.ActiveCfg = Release|Any CPU
+		{977060F4-EEEF-420D-02E8-5E58D3E51942}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -556,6 +570,7 @@ Global
 		{B95B12A8-FCE1-618A-CA77-134B59A5C050} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{261CB211-6023-8025-48E1-D11953F4C61C} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{89DF188B-B1FC-D3C4-A76E-019144ABA9CB} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{977060F4-EEEF-420D-02E8-5E58D3E51942} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {32B9C883-432E-4FC8-A1BF-090EB033DD5B}

--- a/tools/FlatFlowMigrationCli/FlatFlowMigrationCli.csproj
+++ b/tools/FlatFlowMigrationCli/FlatFlowMigrationCli.csproj
@@ -20,5 +20,6 @@
     <ProjectReference Include="..\..\src\Microsoft.DotNet.Darc\DarcLib\Microsoft.DotNet.DarcLib.csproj" />
     <ProjectReference Include="..\..\src\ProductConstructionService\Microsoft.DotNet.ProductConstructionService.Client\Microsoft.DotNet.ProductConstructionService.Client.csproj" />
     <ProjectReference Include="..\..\src\ProductConstructionService\ProductConstructionService.Common\ProductConstructionService.Common.csproj" />
+    <ProjectReference Include="..\Tools.Common\Tools.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/tools/FlatFlowMigrationCli/MigrationLogger.cs
+++ b/tools/FlatFlowMigrationCli/MigrationLogger.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.Logging;
+using Tools.Common;
 
 namespace FlatFlowMigrationCli;
 

--- a/tools/FlatFlowMigrationCli/Operations/MigrateOperation.cs
+++ b/tools/FlatFlowMigrationCli/Operations/MigrateOperation.cs
@@ -9,6 +9,8 @@ using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.DotNet.ProductConstructionService.Client;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.Logging;
+using Tools.Common;
+using Constants = Tools.Common.Constants;
 
 namespace FlatFlowMigrationCli.Operations;
 

--- a/tools/FlatFlowMigrationCli/Options/Options.cs
+++ b/tools/FlatFlowMigrationCli/Options/Options.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using ProductConstructionService.Common;
+using Tools.Common;
 
 namespace FlatFlowMigrationCli.Options;
 

--- a/tools/FlatFlowMigrationCli/SubscriptionMigrator.cs
+++ b/tools/FlatFlowMigrationCli/SubscriptionMigrator.cs
@@ -5,6 +5,7 @@ using FlatFlowMigrationCli.Operations;
 using Microsoft.DotNet.ProductConstructionService.Client;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.Logging;
+using Tools.Common;
 
 namespace FlatFlowMigrationCli;
 

--- a/tools/ProductConstructionService.ReproTool/Operations/FlowCommitOperation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/FlowCommitOperation.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.ProductConstructionService.Client;
+using Microsoft.DotNet.ProductConstructionService.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ProductConstructionService.ReproTool.Options;
+using GitHubClient = Octokit.GitHubClient;
+
+namespace ProductConstructionService.ReproTool.Operations;
+
+internal class FlowCommitOperation : Operation
+{
+    private readonly FlowCommitOptions _options;
+    private readonly ILogger<FlowCommitOperation> _logger;
+    private readonly GitHubClient _ghClient;
+    private readonly DarcProcessManager _darc;
+    private readonly IProductConstructionServiceApi _localPcsApi;
+
+    public FlowCommitOperation(
+            FlowCommitOptions options,
+            ILogger<FlowCommitOperation> logger,
+            GitHubClient ghClient,
+            DarcProcessManager darc,
+            [FromKeyedServices("local")] IProductConstructionServiceApi localPcsApi)
+        : base(logger, ghClient, localPcsApi)
+    {
+        _options = options;
+        _logger = logger;
+        _ghClient = ghClient;
+        _darc = darc;
+        _localPcsApi = localPcsApi;
+    }
+
+    internal override async Task RunAsync()
+    {
+        await _darc.InitializeAsync();
+
+        _logger.LogInformation("Flowing commit from {sourceRepo}@{sourceBranch} to {targetRepo}@{targetBranch}",
+            _options.SourceRepository,
+            _options.SourceBranch,
+            _options.TargetRepository,
+            _options.TargetBranch);
+
+        List<Channel> channels = await _localPcsApi.Channels.ListChannelsAsync();
+        Channel? channel = channels.FirstOrDefault(c => c.Name == _options.Channel)
+            ?? await _localPcsApi.Channels.CreateChannelAsync("test", _options.Channel);
+
+        var subscriptions = await _localPcsApi.Subscriptions.ListSubscriptionsAsync(
+            channelId: channel.Id,
+            sourceRepository: _options.SourceRepository,
+            targetRepository: _options.TargetRepository,
+            sourceEnabled: true);
+
+        var (repoName, owner) = GitRepoUrlParser.GetRepoNameAndOwner(_options.SourceRepository);
+
+        var isBackflow = false;
+        try
+        {
+            await _ghClient.Repository.Content.GetAllContents(owner, repoName, SourceMappingsPath);
+            isBackflow = true;
+        }
+        catch { }
+
+        var mappingName = (isBackflow ? _options.TargetRepository : _options.SourceRepository).TrimEnd('/').Split('/').Last();
+
+        Subscription subscription = subscriptions.FirstOrDefault(s => s.TargetBranch == _options.TargetBranch)
+            ?? await _localPcsApi.Subscriptions.CreateAsync(
+                new SubscriptionData(
+                    channelName: channel.Name,
+                    sourceRepository: _options.SourceRepository,
+                    targetRepository: _options.TargetRepository,
+                    targetBranch: _options.TargetBranch,
+                    new SubscriptionPolicy(batchable: false, UpdateFrequency.None)
+                    {
+                        MergePolicies = [new MergePolicy() { Name = "Standard" }]
+                    },
+                    null)
+                {
+                    SourceEnabled = true,
+                    SourceDirectory = isBackflow ? mappingName : null,
+                    TargetDirectory = isBackflow ? null : mappingName,
+                });
+
+        var commit = (await _ghClient.Repository.Branch.Get(owner, repoName, _options.SourceBranch)).Commit;
+
+        _logger.LogInformation("Creating build for {repo}@{branch} (commit {commit})",
+            _options.SourceRepository,
+            _options.SourceBranch,
+            Microsoft.DotNet.DarcLib.Commit.GetShortSha(commit.Sha));
+
+        var build = await _localPcsApi.Builds.CreateAsync(new BuildData(
+            commit.Sha,
+            "dnceng",
+            "internal",
+            $"{DateTime.UtcNow:yyyyMMdd}.{new Random().Next(1, 75)}",
+            $"https://dev.azure.com/dnceng/internal/_git/{owner}-{repoName}",
+            _options.SourceBranch,
+            released: false,
+            stable: false)
+        {
+            GitHubRepository = _options.SourceRepository,
+            GitHubBranch = _options.SourceBranch,
+        });
+
+        await using var _ = await _darc.AddBuildToChannelAsync(build.Id, channel.Name, skipCleanup: true);
+
+        _logger.LogInformation("Build created: {buildId}", build.Id);
+
+        await TriggerSubscriptionAsync(subscription.Id.ToString(), build.Id);
+
+        _logger.LogInformation("Subscription triggered. Wait for a PR in {url}", $"{_options.TargetRepository}/pulls");
+    }
+}

--- a/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
@@ -1,0 +1,204 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using Microsoft.DotNet.ProductConstructionService.Client;
+using Microsoft.DotNet.ProductConstructionService.Client.Models;
+using Microsoft.Extensions.Logging;
+using Octokit;
+
+namespace ProductConstructionService.ReproTool.Operations;
+internal abstract class Operation(
+    ILogger<Operation> logger,
+    GitHubClient ghClient,
+    IProductConstructionServiceApi localPcsApi)
+{
+    protected const string MaestroAuthTestOrgName = "maestro-auth-test";
+    protected const string VmrForkRepoName = "dotnet";
+    protected const string VmrForkUri = $"https://github.com/{MaestroAuthTestOrgName}/{VmrForkRepoName}";
+    protected const string ProductRepoFormat = $"https://github.com/{MaestroAuthTestOrgName}/";
+    protected const long InstallationId = 289474;
+    protected const string SourceMappingsPath = $"{VmrInfo.SourceDirName}/{VmrInfo.SourceMappingsFileName}";
+    protected const string SourceManifestPath = $"{VmrInfo.SourceDirName}/{VmrInfo.SourceManifestFileName}";
+    protected const string DarcPRBranchPrefix = "darc";
+
+    internal abstract Task RunAsync();
+
+    protected async Task DeleteDarcPRBranchAsync(string repo, string targetBranch)
+    {
+        var branch = (await ghClient.Repository.Branch.GetAll(MaestroAuthTestOrgName, repo))
+            .FirstOrDefault(branch => branch.Name.StartsWith($"{DarcPRBranchPrefix}-{targetBranch}"));
+
+        if (branch == null)
+        {
+            logger.LogWarning("Couldn't find darc PR branch targeting branch {targetBranch}", targetBranch);
+        }
+        else
+        {
+            await DeleteGitHubBranchAsync(repo, branch.Name);
+        }
+    }
+
+    private async Task DeleteGitHubBranchAsync(string repo, string branch) => await ghClient.Git.Reference.Delete(MaestroAuthTestOrgName, repo, $"heads/{branch}");
+
+    protected async Task<Build> CreateBuildAsync(string repositoryUrl, string branch, string commit, List<AssetData> assets)
+    {
+        logger.LogInformation("Creating a test build");
+
+        Build build = await localPcsApi.Builds.CreateAsync(new BuildData(
+            commit: commit,
+            azureDevOpsAccount: "test",
+            azureDevOpsProject: "test",
+            azureDevOpsBuildNumber: $"{DateTime.UtcNow:yyyyMMdd}.{new Random().Next(1, 75)}",
+            azureDevOpsRepository: repositoryUrl,
+            azureDevOpsBranch: branch,
+            released: false,
+            stable: false)
+        {
+            GitHubRepository = repositoryUrl,
+            GitHubBranch = branch,
+            Assets = assets
+        });
+
+        return build;
+    }
+
+    protected async Task TriggerSubscriptionAsync(string subscriptionId, int buildId = 0)
+    {
+        logger.LogInformation("Triggering subscription {subscriptionId}", subscriptionId);
+        await localPcsApi.Subscriptions.TriggerSubscriptionAsync(buildId, Guid.Parse(subscriptionId));
+    }
+
+    protected async Task<AsyncDisposableValue<string>> PrepareVmrForkAsync(string branch, bool skipCleanup)
+    {
+        logger.LogInformation("Preparing VMR fork");
+        // Sync the VMR fork branch
+        await SyncForkAsync("dotnet", "dotnet", branch);
+
+        return await CreateTmpBranchAsync(VmrForkRepoName, branch, skipCleanup);
+    }
+
+    protected async Task UpdateVmrSourceFiles(string branch, string productRepoUri, string productRepoForkUri)
+    {
+        // Fetch source mappings and source manifest files and replace the mapping for the repo we're testing on
+        logger.LogInformation("Updating source mappings and source manifest files in VMR fork to replace original product repo mapping with fork mapping");
+        await UpdateRemoteVmrForkFileAsync(branch, productRepoUri, productRepoForkUri, SourceMappingsPath);
+        await UpdateRemoteVmrForkFileAsync(branch, productRepoUri, productRepoForkUri, SourceManifestPath);
+    }
+
+    private async Task UpdateRemoteVmrForkFileAsync(string branch, string productRepoUri, string productRepoForkUri, string filePath)
+    {
+        logger.LogInformation("Updating file {file} on branch {branch} in the VMR fork", filePath, branch);
+        // Fetch remote file and replace the product repo URI with the repo we're testing on        
+        var sourceMappingsFile = (await ghClient.Repository.Content.GetAllContentsByRef(
+                MaestroAuthTestOrgName,
+                VmrForkRepoName,
+                filePath,
+                branch))
+            .FirstOrDefault()
+            ?? throw new Exception($"Failed to find file {SourceMappingsPath} in {MaestroAuthTestOrgName}" +
+                                   $"/{VmrForkRepoName} on branch {SourceMappingsPath}");
+
+        // Replace the product repo uri with the forked one
+        var updatedSourceMappings = sourceMappingsFile.Content.Replace(productRepoUri, productRepoForkUri);
+        UpdateFileRequest update = new(
+            $"Update {productRepoUri} source mapping",
+            updatedSourceMappings,
+            sourceMappingsFile.Sha,
+            branch);
+
+        await ghClient.Repository.Content.UpdateFile(
+            MaestroAuthTestOrgName,
+            VmrForkRepoName,
+            filePath,
+            update);
+    }
+
+    protected async Task<AsyncDisposableValue<string>> PrepareProductRepoForkAsync(
+        string productRepoUri,
+        string productRepoForkUri,
+        string productRepoBranch,
+        bool skipCleanup)
+    {
+        logger.LogInformation("Preparing product repo {repo} fork", productRepoUri);
+        (var name, var org) = GitRepoUrlParser.GetRepoNameAndOwner(productRepoUri);
+        // Check if the product repo fork already exists
+        var allRepos = await ghClient.Repository.GetAllForOrg(MaestroAuthTestOrgName);
+
+        // If we already have a fork in maestro-auth-test, sync the branch we need with the source
+        if (allRepos.FirstOrDefault(repo => repo.HtmlUrl == productRepoForkUri) != null)
+        {
+            logger.LogInformation("Product repo fork {fork} already exists, syncing branch {branch} with source", productRepoForkUri, productRepoBranch);
+            await SyncForkAsync(org, name, productRepoBranch);
+        }
+        // If we don't, create a fork
+        else
+        {
+            logger.LogInformation("Forking product repo {source} to fork {fork}", productRepoUri, productRepoForkUri);
+            await ghClient.Repository.Forks.Create(org, name, new NewRepositoryFork { Organization = MaestroAuthTestOrgName });
+
+            // The Octokit client doesn't wait for the fork to actually be created, so we should wait a bit to make sure it's there
+            await Task.Delay(TimeSpan.FromSeconds(15));
+        }
+
+        return await CreateTmpBranchAsync(name, productRepoBranch, skipCleanup);
+    }
+
+    protected async Task SyncForkAsync(string originOrg, string repoName, string branch)
+    {
+        logger.LogInformation("Syncing fork {fork} branch {branch} with upstream repo {upstream}", $"{MaestroAuthTestOrgName}/{repoName}", branch, $"{originOrg}/{repoName}");
+        var reference = $"heads/{branch}";
+        var upstream = await ghClient.Git.Reference.Get(originOrg, repoName, reference);
+        await ghClient.Git.Reference.Update(MaestroAuthTestOrgName, repoName, reference, new ReferenceUpdate(upstream.Object.Sha, true));
+    }
+
+    protected async Task<AsyncDisposableValue<string>> CreateTmpBranchAsync(string repoName, string originalBranch, bool skipCleanup)
+    {
+        var newBranchName = $"repro/{Guid.NewGuid()}";
+        logger.LogInformation("Creating temporary branch {branch} in {repo}", newBranchName, $"{MaestroAuthTestOrgName}/{repoName}");
+
+        var baseBranch = await ghClient.Git.Reference.Get(MaestroAuthTestOrgName, repoName, $"heads/{originalBranch}");
+        var newBranch = new NewReference($"refs/heads/{newBranchName}", baseBranch.Object.Sha);
+        await ghClient.Git.Reference.Create(MaestroAuthTestOrgName, repoName, newBranch);
+
+        return AsyncDisposableValue.Create(newBranchName, async () =>
+        {
+            if (skipCleanup)
+            {
+                return;
+            }
+
+            logger.LogInformation("Cleaning up temporary branch {branchName}", newBranchName);
+            try
+            {
+                await DeleteGitHubBranchAsync(repoName, newBranchName);
+            }
+            catch
+            {
+                // If this throws an exception the most likely cause is that the branch was already deleted
+            }
+        });
+    }
+
+    protected static List<AssetData> CreateAssetDataFromBuild(Build build)
+    {
+        return build.Assets
+            .Select(asset => new AssetData(false)
+            {
+                Name = asset.Name,
+                Version = asset.Version,
+                Locations = asset.Locations?.Select(location => new AssetLocationData(location.Type) { Location = location.Location }).ToList()
+            })
+            .ToList();
+    }
+
+    protected async Task<string> GetLatestCommitInBranch(string owner, string repo, string branch)
+    {
+        var reference = await ghClient.Git.Reference.Get(owner, repo, $"heads/{branch}");
+        return reference.Object.Sha;
+    }
+
+    protected async Task<GitHubCommit> GetCommit(string sourceRepoOwner, string sourceRepoName, string commit)
+        => await ghClient.Repository.Commit.Get(sourceRepoOwner, sourceRepoName, commit);
+}

--- a/tools/ProductConstructionService.ReproTool/Operations/ReproOperation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/ReproOperation.cs
@@ -1,0 +1,157 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Maestro.Data;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.ProductConstructionService.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Octokit;
+using ProductConstructionService.ReproTool.Options;
+using Build = Microsoft.DotNet.ProductConstructionService.Client.Models.Build;
+using GitHubClient = Octokit.GitHubClient;
+
+namespace ProductConstructionService.ReproTool.Operations;
+
+internal class ReproOperation(
+    IBarApiClient prodBarClient,
+    ReproOptions options,
+    DarcProcessManager darcProcessManager,
+    [FromKeyedServices("local")] IProductConstructionServiceApi localPcsApi,
+    GitHubClient ghClient,
+    ILogger<ReproOperation> logger) : Operation(logger, ghClient, localPcsApi)
+{
+    internal override async Task RunAsync()
+    {
+        logger.LogInformation("Fetching {subscriptionId} subscription from BAR",
+            options.Subscription);
+        var subscription = await prodBarClient.GetSubscriptionAsync(options.Subscription);
+
+        if (subscription == null)
+        {
+            throw new ArgumentException($"Couldn't find subscription with subscription id {options.Subscription}");
+        }
+
+        if (!subscription.SourceEnabled)
+        {
+            throw new ArgumentException($"Subscription {options.Subscription} is not a code flow subscription");
+        }
+
+        if (!string.IsNullOrEmpty(subscription.SourceDirectory) && !string.IsNullOrEmpty(subscription.TargetDirectory))
+        {
+            throw new ArgumentException("Code flow subscription incorrectly configured: is missing SourceDirectory or TargetDirectory");
+        }
+
+        if (!string.IsNullOrEmpty(options.Commit) && options.BuildId != null)
+        {
+            throw new ArgumentException($"Only one of {nameof(ReproOptions.Commit)} and {nameof(ReproOptions.BuildId)} can be provided");
+        }
+
+        Build? build = null;
+        if (options.BuildId != null)
+        {
+            build = await prodBarClient.GetBuildAsync(options.BuildId.Value);
+            if (build.GitHubRepository != subscription.SourceRepository)
+            {
+                throw new ArgumentException($"Build {build.Id} repository {build.GitHubRepository} doesn't match the subscription source repository {subscription.SourceRepository}");
+            }
+        }
+        await darcProcessManager.InitializeAsync();
+
+        var defaultChannel = (await prodBarClient.GetDefaultChannelsAsync(repository: subscription.SourceRepository, channel: subscription.Channel.Name)).First();
+
+        string vmrBranch, productRepoUri, productRepoBranch;
+        var isForwardFlow = !string.IsNullOrEmpty(subscription.TargetDirectory);
+        if (isForwardFlow)
+        {
+            vmrBranch = subscription.TargetBranch;
+            productRepoUri = subscription.SourceRepository;
+            productRepoBranch = defaultChannel.Branch;
+        }
+        else
+        {
+            vmrBranch = defaultChannel.Branch;
+            productRepoUri = subscription.TargetRepository;
+            productRepoBranch = subscription.TargetBranch;
+        }
+        var productRepoForkUri = ProductRepoFormat + productRepoUri.Split('/', StringSplitOptions.RemoveEmptyEntries).Last();
+        logger.LogInformation("Reproducing subscription from {sourceRepo} to {targetRepo}",
+            isForwardFlow ? productRepoForkUri : VmrForkUri,
+            isForwardFlow ? VmrForkUri : productRepoForkUri);
+
+        await using var vmrTmpBranch = await PrepareVmrForkAsync(vmrBranch, options.SkipCleanup);
+        await UpdateVmrSourceFiles(vmrTmpBranch.Value, productRepoUri, productRepoForkUri);
+
+        logger.LogInformation("Preparing product repo fork {productRepoFork}, branch {branch}", productRepoForkUri, productRepoBranch);
+        await using var productRepoTmpBranch = await PrepareProductRepoForkAsync(productRepoUri, productRepoForkUri, productRepoBranch, options.SkipCleanup);
+
+        // Find the latest commit in the source repo to create a build from
+        string sourceRepoSha;
+        (var sourceRepoName, var sourceRepoOwner) = GitRepoUrlParser.GetRepoNameAndOwner(subscription.SourceRepository);
+        if (build != null)
+        {
+            sourceRepoSha = build.Commit;
+        }
+        else if (string.IsNullOrEmpty(options.Commit))
+        {
+            sourceRepoSha = await GetLatestCommitInBranch(sourceRepoOwner, sourceRepoName, defaultChannel.Branch);
+        }
+        else
+        {
+            // Validate that the commit actually exists
+            try
+            {
+                await GetCommit(sourceRepoOwner, sourceRepoName, options.Commit);
+            }
+            catch (NotFoundException)
+            {
+                throw new ArgumentException($"Commit {options.Commit} doesn't exist in repo {subscription.SourceRepository}");
+            }
+            sourceRepoSha = options.Commit;
+        }
+
+        var channelName = $"repro-{Guid.NewGuid()}";
+        await using var channel = await darcProcessManager.CreateTestChannelAsync(channelName, options.SkipCleanup);
+
+        var testBuild = await CreateBuildAsync(
+            isForwardFlow ? productRepoForkUri : VmrForkUri,
+            isForwardFlow ? productRepoTmpBranch.Value : vmrTmpBranch.Value,
+            sourceRepoSha,
+            build != null ? CreateAssetDataFromBuild(build) : []);
+
+        await using var testSubscription = await darcProcessManager.CreateSubscriptionAsync(
+            channel: channelName,
+            sourceRepo: isForwardFlow ? productRepoForkUri : VmrForkUri,
+            targetRepo: isForwardFlow ? VmrForkUri : productRepoForkUri,
+            targetBranch: isForwardFlow ? vmrTmpBranch.Value : productRepoTmpBranch.Value,
+            sourceDirectory: subscription.SourceDirectory,
+            targetDirectory: subscription.TargetDirectory,
+            skipCleanup: options.SkipCleanup);
+
+        await darcProcessManager.AddBuildToChannelAsync(testBuild.Id, channelName, options.SkipCleanup);
+
+        await TriggerSubscriptionAsync(testSubscription.Value);
+
+        if (options.SkipCleanup)
+        {
+            logger.LogInformation("Skipping cleanup. If you want to re-trigger the reproduced subscription run \"darc trigger-subscriptions --ids {subscriptionId} --bar-uri {barUri}\"",
+                testSubscription.Value,
+                ProductConstructionServiceApiOptions.PcsLocalUri);
+            return;
+        }
+
+        logger.LogInformation("Code flow successfully recreated. Press enter to finish and cleanup");
+        Console.ReadLine();
+
+        // Cleanup
+        if (isForwardFlow)
+        {
+            await DeleteDarcPRBranchAsync(VmrForkRepoName, vmrTmpBranch.Value);
+        }
+        else
+        {
+            await DeleteDarcPRBranchAsync(productRepoUri.Split('/').Last(), productRepoTmpBranch.Value);
+        }
+    }
+}

--- a/tools/ProductConstructionService.ReproTool/Options/FlowCommitOptions.cs
+++ b/tools/ProductConstructionService.ReproTool/Options/FlowCommitOptions.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using ProductConstructionService.ReproTool.Operations;
+
+namespace ProductConstructionService.ReproTool.Options;
+
+[Verb("flow-commit", HelpText = "Flows the given branch between a repo and a VMR (both in maestro-auth-test) using local PCS")]
+internal class FlowCommitOptions : Options
+{
+    [Option("channel", HelpText = "Channel to use / create", Required = true)]
+    public required string Channel { get; init; }
+
+    [Option("source-repo", HelpText = "Repo (full URI) to flow the commit from (must be under maestro-auth-test/)", Required = true)]
+    public required string SourceRepository { get; init; }
+
+    [Option("source-branch", HelpText = "Branch whose commit will be flown", Required = true)]
+    public required string SourceBranch { get; init; }
+
+    [Option("target-repo", HelpText = "Repo (full URI) to flow the commit to (must be under maestro-auth-test/)", Required = true)]
+    public required string TargetRepository { get; init; }
+
+    [Option("target-branch", HelpText = "Branch to flow the commit into", Required = true)]
+    public required string TargetBranch { get; init; }
+
+    internal override Operation GetOperation(IServiceProvider sp)
+        => ActivatorUtilities.CreateInstance<FlowCommitOperation>(sp, this);
+}

--- a/tools/ProductConstructionService.ReproTool/Options/Options.cs
+++ b/tools/ProductConstructionService.ReproTool/Options/Options.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using CommandLine;
+using Maestro.Data;
+using Maestro.DataProviders;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.GitHub.Authentication;
+using Microsoft.DotNet.Kusto;
+using Microsoft.DotNet.ProductConstructionService.Client;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+using Octokit;
+using ProductConstructionService.Common;
+using ProductConstructionService.ReproTool.Operations;
+using GitHubClient = Octokit.GitHubClient;
+
+namespace ProductConstructionService.ReproTool.Options;
+internal abstract class Options
+{
+    private const string LocalDbConnectionString = "Data Source=localhost\\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true";
+    private const string MaestroProdUri = "https://maestro.dot.net";
+    internal const string PcsLocalUri = "https://localhost:53180";
+
+    public string? GitHubToken { get; set; }
+
+    internal abstract Operation GetOperation(IServiceProvider sp);
+
+    public virtual IServiceCollection RegisterServices(IServiceCollection services)
+    {
+        services.AddLogging(b => b
+            .AddConsole(o => o.FormatterName = CompactConsoleLoggerFormatter.FormatterName)
+            .AddConsoleFormatter<CompactConsoleLoggerFormatter, SimpleConsoleFormatterOptions>()
+            .SetMinimumLevel(LogLevel.Information));
+        services.AddSingleton<ILogger>(sp => sp.GetRequiredService<ILogger<IProcessManager>>());
+
+        services.AddSingleton<IBarApiClient>(sp => new BarApiClient(
+            null,
+            managedIdentityId: null,
+            disableInteractiveAuth: false,
+            MaestroProdUri));
+        services.AddSingleton<IProcessManager>(sp => ActivatorUtilities.CreateInstance<ProcessManager>(sp, "git"));
+        services.AddSingleton<DarcProcessManager>();
+        services.AddKeyedSingleton("local", PcsApiFactory.GetAnonymous(PcsLocalUri));
+        services.AddSingleton(PcsApiFactory.GetAuthenticated(MaestroProdUri, null, null, false));
+        services.AddSingleton(_ => new GitHubClient(new ProductHeaderValue("repro-tool"))
+        {
+            Credentials = new Credentials(GitHubToken)
+        });
+
+        services.TryAddTransient<IBasicBarClient, SqlBarClient>();
+
+        services.AddDbContext<BuildAssetRegistryContext>(options =>
+        {
+            // Do not log DB context initialization and command executed events
+            options.ConfigureWarnings(w =>
+            {
+                w.Ignore(CoreEventId.ContextInitialized);
+                w.Ignore(RelationalEventId.CommandExecuted);
+            });
+
+            options.UseSqlServer(LocalDbConnectionString, sqlOptions =>
+            {
+                sqlOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SingleQuery);
+            });
+        });
+
+        services.AddKustoClientProvider("Kusto");
+        services.AddSingleton<IInstallationLookup, BuildAssetRegistryInstallationLookup>();
+
+        return services;
+    }
+}

--- a/tools/ProductConstructionService.ReproTool/Options/ReproOptions.cs
+++ b/tools/ProductConstructionService.ReproTool/Options/ReproOptions.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using ProductConstructionService.ReproTool.Operations;
+
+namespace ProductConstructionService.ReproTool.Options;
+
+[Verb("repro", HelpText = "Locally reproduce a codeflow subscription in the maestro-auth-test org")]
+internal class ReproOptions : Options
+{
+    [Option('s', "subscription", HelpText = "Subscription that's getting reproduced", Required = true)]
+    public required string Subscription { get; init; }
+
+    [Option("commit", HelpText = "Commit to flow. Use when not flowing a build. If neither commit or build is specified, the latest commit in the subscription's source repository is flown", Required = false)]
+    public string? Commit { get; init; }
+
+    [Option("buildId", HelpText = "BAR build ID to flow", Required = false)]
+    public int? BuildId { get; init; }
+
+    [Option("skip-cleanup", HelpText = "Don't delete the created resources if they're needed for further testing. This includes the channel, subscription and PR branches. False by default", Required = false)]
+    public bool SkipCleanup { get; init; } = false;
+
+    internal override Operation GetOperation(IServiceProvider sp)
+        => ActivatorUtilities.CreateInstance<ReproOperation>(sp, this);
+}

--- a/tools/ProductConstructionService.ReproTool/ProductConstructionService.ReproTool.csproj
+++ b/tools/ProductConstructionService.ReproTool/ProductConstructionService.ReproTool.csproj
@@ -21,5 +21,6 @@
     <ProjectReference Include="..\..\src\Microsoft.DotNet.Darc\DarcLib\Microsoft.DotNet.DarcLib.csproj" />
     <ProjectReference Include="..\..\src\ProductConstructionService\Microsoft.DotNet.ProductConstructionService.Client\Microsoft.DotNet.ProductConstructionService.Client.csproj" />
     <ProjectReference Include="..\..\src\ProductConstructionService\ProductConstructionService.Common\ProductConstructionService.Common.csproj" />
+    <ProjectReference Include="..\Tools.Common\Tools.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/tools/ProductConstructionService.ReproTool/Program.cs
+++ b/tools/ProductConstructionService.ReproTool/Program.cs
@@ -2,15 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using CommandLine;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using ProductConstructionService.ReproTool;
+using ProductConstructionService.ReproTool.Operations;
+using ProductConstructionService.ReproTool.Options;
+using Tools.Common;
 
-Parser.Default.ParseArguments<ReproToolOptions>(args)
-    .WithParsed<ReproToolOptions>(o =>
+Type[] options =
+[
+    typeof(ReproOptions),
+    typeof(FlowCommitOptions),
+];
+
+Parser.Default.ParseArguments(args, options)
+    .MapResult((Options o) =>
     {
         IConfiguration userSecrets = new ConfigurationBuilder()
-            .AddUserSecrets<ReproTool>()
+            .AddUserSecrets<ReproOperation>()
             .Build();
         o.GitHubToken ??= userSecrets["GITHUB_TOKEN"];
         o.GitHubToken ??= Environment.GetEnvironmentVariable("GITHUB_TOKEN");
@@ -18,9 +27,15 @@ Parser.Default.ParseArguments<ReproToolOptions>(args)
 
         var services = new ServiceCollection();
 
-        services.RegisterServices(o);
+        o.RegisterServices(services);
+        services.AddSingleton<VmrDependencyResolver>();
+
+        services.AddMultiVmrSupport(Path.GetTempPath());
 
         var provider = services.BuildServiceProvider();
 
-        ActivatorUtilities.CreateInstance<ReproTool>(provider).ReproduceCodeFlow().GetAwaiter().GetResult();
-    });
+        o.GetOperation(provider).RunAsync().GetAwaiter().GetResult();
+
+        return 0;
+    },
+    (_) => -1);

--- a/tools/Tools.Common/Constants.cs
+++ b/tools/Tools.Common/Constants.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Tools.Common;
+
+public static class Constants
+{
+    public const string VmrUri = "https://github.com/dotnet/dotnet";
+    public const string ArcadeRepoUri = "https://github.com/dotnet/arcade";
+    public const string SdkRepoUri = "https://github.com/dotnet/sdk";
+    public const string LatestArcadeChannel = ".NET Eng - Latest";
+    public const string VmrChannelName = ".NET 10 UB";
+    public const string SdkPatchLocation = "src/SourceBuild/patches";
+}

--- a/tools/Tools.Common/Tools.Common.csproj
+++ b/tools/Tools.Common/Tools.Common.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Darc\DarcLib\Microsoft.DotNet.DarcLib.csproj" />
+    <ProjectReference Include="..\..\src\ProductConstructionService\Microsoft.DotNet.ProductConstructionService.Client\Microsoft.DotNet.ProductConstructionService.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Tools.Common/VmrDependencyResolver.cs
+++ b/tools/Tools.Common/VmrDependencyResolver.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using FlatFlowMigrationCli.Operations;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
@@ -9,22 +8,22 @@ using Microsoft.DotNet.ProductConstructionService.Client;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.Logging;
 
-namespace FlatFlowMigrationCli;
+namespace Tools.Common;
 
-internal record VmrRepository(SourceMapping Mapping, DefaultChannel Channel);
+public record VmrRepository(SourceMapping Mapping, DefaultChannel Channel);
 
-internal class VmrDependencyResolver
+public class VmrDependencyResolver
 {
     private readonly IProductConstructionServiceApi _pcsClient;
     private readonly IGitRepoFactory _gitRepoFactory;
     private readonly ISourceMappingParser _sourceMappingParser;
-    private readonly ILogger<MigrateOperation> _logger;
+    private readonly ILogger<VmrDependencyResolver> _logger;
 
     public VmrDependencyResolver(
         IProductConstructionServiceApi pcsClient,
         IGitRepoFactory gitRepoFactory,
         ISourceMappingParser sourceMappingParser,
-        ILogger<MigrateOperation> logger)
+        ILogger<VmrDependencyResolver> logger)
     {
         _pcsClient = pcsClient;
         _logger = logger;


### PR DESCRIPTION
Adds a new command that takes a given commit in `maestro-auth-test/` repo/VMR and flows it to a given target repo/VMR.
(it creates a fake build that will flow)

Useful for testing various changes, conflicts etc.

https://github.com/dotnet/arcade-services/issues/4535
