### PR TITLE
Fix an NRE in BuildsController

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/BuildsController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/BuildsController.cs
@@ -179,6 +179,11 @@ public class BuildsController : v2019_01_16.Controllers.BuildsController
 
         IRemote remote = await _factory.CreateRemoteAsync(build.AzureDevOpsRepository ?? build.GitHubRepository);
         Microsoft.DotNet.DarcLib.Commit commit = await remote.GetCommitAsync(build.AzureDevOpsRepository ?? build.GitHubRepository, build.Commit);
+        if (commit == null)
+        {
+            return NotFound();
+        }
+
         return Ok(new ProductConstructionService.Api.v2020_02_20.Models.Commit(commit.Author, commit.Sha, commit.Message));
     }
 


### PR DESCRIPTION
Fixes a common NRE that happens when we query builds for commits that don't exist (e.g. during scenario tests):
https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Ffbd6122a-9ad3-42e4-976e-bccb82486856%2FresourceGroups%2Fproduct-construction-service%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fproduct-construction-service-ai-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA0utSE4tKMnMzysGAGAbcigKAAAA/timespan/PT12H/limit/1000

<!-- https://github.com/dotnet/arcade-services/issues/4622 -->