### PR TITLE
Add both source and target repo in Conflict messages

### DIFF
--- a/src/Maestro/Maestro.DataProviders/RemoteFactory.cs
+++ b/src/Maestro/Maestro.DataProviders/RemoteFactory.cs
@@ -74,7 +74,7 @@ public class RemoteFactory : IRemoteFactory
         string normalizedUrl = AzureDevOpsClient.NormalizeUrl(repoUrl);
 
         long installationId = await _context.GetInstallationId(normalizedUrl);
-        var repoType = GitRepoUrlParser.ParseTypeFromUri(normalizedUrl);
+        var repoType = GitRepoUrlUtils.ParseTypeFromUri(normalizedUrl);
 
         if (repoType == GitRepoType.GitHub && installationId == default)
         {

--- a/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Helpers/RemoteFactory.cs
@@ -44,7 +44,7 @@ internal class RemoteFactory : IRemoteFactory
     {
         string temporaryRepositoryRoot = Path.GetTempPath();
 
-        var repoType = GitRepoUrlParser.ParseTypeFromUri(repoUrl);
+        var repoType = GitRepoUrlUtils.ParseTypeFromUri(repoUrl);
 
         return repoType switch
         {

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/SetRepositoryMergePoliciesOperation.cs
@@ -45,7 +45,7 @@ internal class SetRepositoryMergePoliciesOperation : Operation
             return Constants.ErrorCode;
         }
 
-        var repoType = GitRepoUrlParser.ParseTypeFromUri(_options.Repository);
+        var repoType = GitRepoUrlUtils.ParseTypeFromUri(_options.Repository);
         if (repoType == GitRepoType.Local || repoType == GitRepoType.None)
         {
             Console.WriteLine("Please specify full repository URL (GitHub or AzDO)");

--- a/src/Microsoft.DotNet.Darc/DarcLib/GitRepoFactory.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitRepoFactory.cs
@@ -43,7 +43,7 @@ public class GitRepoFactory : IGitRepoFactory
         _temporaryPath = temporaryPath;
     }
 
-    public IGitRepo CreateClient(string repoUri) => GitRepoUrlParser.ParseTypeFromUri(repoUri) switch
+    public IGitRepo CreateClient(string repoUri) => GitRepoUrlUtils.ParseTypeFromUri(repoUri) switch
     {
         GitRepoType.AzureDevOps => new AzureDevOpsClient(
             _azdoTokenProvider,

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -514,7 +514,7 @@ public class LocalGitClient : ILocalGitClient
             return;
         }
 
-        var repoType = GitRepoUrlParser.ParseTypeFromUri(repoUri);
+        var repoType = GitRepoUrlUtils.ParseTypeFromUri(repoUri);
         if (repoType == GitRepoType.None)
         {
             return;

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/ManifestRecord.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/ManifestRecord.cs
@@ -29,7 +29,7 @@ public interface ISourceComponent
         var url = RemoteUri;
         const string GitSuffix = ".git";
 
-        switch (GitRepoUrlParser.ParseTypeFromUri(url))
+        switch (GitRepoUrlUtils.ParseTypeFromUri(url))
         {
             case GitRepoType.GitHub:
                 if (url.EndsWith(GitSuffix))

--- a/src/Microsoft.DotNet.Darc/DarcLib/RemoteTokenProvider.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/RemoteTokenProvider.cs
@@ -49,7 +49,7 @@ public class RemoteTokenProvider : IRemoteTokenProvider
 
     public async Task<string?> GetTokenForRepositoryAsync(string repoUri)
     {
-        var repoType = GitRepoUrlParser.ParseTypeFromUri(repoUri);
+        var repoType = GitRepoUrlUtils.ParseTypeFromUri(repoUri);
 
         return repoType switch
         {
@@ -62,7 +62,7 @@ public class RemoteTokenProvider : IRemoteTokenProvider
 
     public string? GetTokenForRepository(string repoUri)
     {
-        var repoType = GitRepoUrlParser.ParseTypeFromUri(repoUri);
+        var repoType = GitRepoUrlUtils.ParseTypeFromUri(repoUri);
 
         return repoType switch
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPusher.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPusher.cs
@@ -78,7 +78,7 @@ public class VmrPusher : IVmrPusher
     {
         var commitsSearchArguments = _sourceManifest
             .Repositories
-            .Select(r => (GitRepoUrlParser.GetRepoNameAndOwner(r.RemoteUri), r.CommitSha))
+            .Select(r => (GitRepoUrlUtils.GetRepoNameAndOwner(r.RemoteUri), r.CommitSha))
             .Select(r => new CommitSearchArguments(r.Item1.RepoName, r.Item1.Org, r.CommitSha));
 
         var commits = await GetGitHubCommits(commitsSearchArguments, gitHubApiPat, cancellationToken);

--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/PullRequestController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/PullRequestController.cs
@@ -87,11 +87,11 @@ public partial class PullRequestController : ControllerBase
             string? repoName = null;
             if (sampleSub != null)
             {
-                if (GitRepoUrlParser.ParseTypeFromUri(sampleSub.TargetRepository) == GitRepoType.AzureDevOps)
+                if (GitRepoUrlUtils.ParseTypeFromUri(sampleSub.TargetRepository) == GitRepoType.AzureDevOps)
                 {
                     try
                     {
-                        (repoName, org) = GitRepoUrlParser.GetRepoNameAndOwner(sampleSub.TargetRepository);
+                        (repoName, org) = GitRepoUrlUtils.GetRepoNameAndOwner(sampleSub.TargetRepository);
                     }
                     catch
                     {

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestConflictNotifier.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestConflictNotifier.cs
@@ -65,11 +65,11 @@ internal class PullRequestConflictNotifier : IPullRequestConflictNotifier
         foreach (var file in conflictException.FilesInConflict)
         {
             var sourceString = subscription.IsBackflow()
-                ? $"[VMR]({GitRepoUrlUtils.GetRepoFileAtCommitUri(update.SourceRepo, update.SourceSha, file)})"
-                : $"[{GitRepoUrlUtils.GetRepoNameWithOrg(update.SourceRepo)}]({GitRepoUrlUtils.GetRepoFileAtCommitUri(update.SourceRepo, update.SourceSha, file)})";
+                ? $"[🔍 view in VMR]({GitRepoUrlUtils.GetRepoFileAtCommitUri(update.SourceRepo, update.SourceSha, file)})"
+                : $"[🔍 view in {GitRepoUrlUtils.GetRepoNameWithOrg(update.SourceRepo)}]({GitRepoUrlUtils.GetRepoFileAtCommitUri(update.SourceRepo, update.SourceSha, file)})";
             var targetString = subscription.IsBackflow()
-                ? $"[{GitRepoUrlUtils.GetRepoNameWithOrg(subscription.TargetRepository)}]({GitRepoUrlUtils.GetRepoFileAtBranchUri(subscription.TargetRepository, subscription.TargetBranch, file)})"
-                : $"[VMR]({GitRepoUrlUtils.GetRepoFileAtBranchUri(subscription.TargetRepository, subscription.TargetBranch, file)})";
+                ? $"[🔍 view in {GitRepoUrlUtils.GetRepoNameWithOrg(subscription.TargetRepository)}]({GitRepoUrlUtils.GetRepoFileAtBranchUri(subscription.TargetRepository, subscription.TargetBranch, file)})"
+                : $"[🔍 view in VMR]({GitRepoUrlUtils.GetRepoFileAtBranchUri(subscription.TargetRepository, subscription.TargetBranch, file)})";
             sb.AppendLine($" - `{file}` - {sourceString} / {targetString}");
         }
         sb.AppendLine();

--- a/test/Microsoft.DotNet.DarcLib.Tests/Helpers/GitRepoUrlParserTest.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Helpers/GitRepoUrlParserTest.cs
@@ -17,7 +17,7 @@ public class GitRepoUrlParserTest
     public void ParseGitHubUrlTest()
     {
         var gitHubUrl = "https://github.com/org/repo.name";
-        var (name, org) = GitRepoUrlParser.GetRepoNameAndOwner(gitHubUrl);
+        var (name, org) = GitRepoUrlUtils.GetRepoNameAndOwner(gitHubUrl);
         name.Should().Be("repo.name");
         org.Should().Be("org");
     }
@@ -26,7 +26,7 @@ public class GitRepoUrlParserTest
     public void ParseAzureDevOpsUrlTest()
     {
         var url = "https://dev.azure.com/dnceng/internal/_git/org-repo-name";
-        var (name, org) = GitRepoUrlParser.GetRepoNameAndOwner(url);
+        var (name, org) = GitRepoUrlUtils.GetRepoNameAndOwner(url);
         name.Should().Be("repo-name");
         org.Should().Be("org");
     }
@@ -35,7 +35,7 @@ public class GitRepoUrlParserTest
     public void ParseAzureDevOpsOtherFormUrlTest()
     {
         var url = "https://dnceng@dev.azure.com/dnceng/someproject/_git/org-repo-name";
-        var (name, org) = GitRepoUrlParser.GetRepoNameAndOwner(url);
+        var (name, org) = GitRepoUrlUtils.GetRepoNameAndOwner(url);
         name.Should().Be("repo-name");
         org.Should().Be("org");
     }
@@ -44,7 +44,7 @@ public class GitRepoUrlParserTest
     public void ParseVisualStudioUrlTest()
     {
         var url = "https://dnceng.visualstudio.com/internal/_git/org-repo-name";
-        var (name, org) = GitRepoUrlParser.GetRepoNameAndOwner(url);
+        var (name, org) = GitRepoUrlUtils.GetRepoNameAndOwner(url);
         name.Should().Be("repo-name");
         org.Should().Be("org");
     }
@@ -61,7 +61,7 @@ public class GitRepoUrlParserTest
         };
 
         var sorted = repos
-            .OrderBy(r => GitRepoUrlParser.ParseTypeFromUri(r.Uri), Comparer<GitRepoType>.Create(GitRepoUrlParser.OrderByLocalPublicOther))
+            .OrderBy(r => GitRepoUrlUtils.ParseTypeFromUri(r.Uri), Comparer<GitRepoType>.Create(GitRepoUrlUtils.OrderByLocalPublicOther))
             .Select(r => r.Name)
             .ToArray();
 
@@ -74,6 +74,6 @@ public class GitRepoUrlParserTest
     [TestCase("https://dev.azure.com/devdiv/DevDiv/_git/NuGet-NuGet.Client-Trusted", "https://github.com/NuGet/NuGet.Client")]
     public void ConvertInternalUriToPublicTest(string internalUri, string publicUri)
     {
-        GitRepoUrlParser.ConvertInternalUriToPublic(internalUri).Should().Be(publicUri);
+        GitRepoUrlUtils.ConvertInternalUriToPublic(internalUri).Should().Be(publicUri);
     }
 }

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -227,8 +227,8 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
                             TestRepository.VmrTestRepoName,
                             pr,
                             [
-                                $"[{TestFile1Name}](https://github.com/{TestRepository.TestOrg}/{TestRepository.TestRepo1Name}/blob/{repoSha}/{TestFile1Name})",
-                                $"[{TestFile2Name}](https://github.com/{TestRepository.TestOrg}/{TestRepository.TestRepo1Name}/blob/{repoSha}/{TestFile2Name})"
+                                $"`{TestFile1Name}` - [{TestRepository.TestOrg}/{TestRepository.TestRepo1Name}](https://github.com/{TestRepository.TestOrg}/{TestRepository.TestRepo1Name}/blob/{repoSha}/{TestFile1Name}) / [VMR](https://github.com/{TestRepository.TestOrg}/{TestRepository.VmrTestRepoName}/blob/{targetBranchName}/{TestFile1Name}",
+                                $"`{TestFile2Name}` - [{TestRepository.TestOrg}/{TestRepository.TestRepo1Name}](https://github.com/{TestRepository.TestOrg}/{TestRepository.TestRepo1Name}/blob/{repoSha}/{TestFile2Name}) / [VMR](https://github.com/{TestRepository.TestOrg}/{TestRepository.VmrTestRepoName}/blob/{targetBranchName}/{TestFile2Name}",
                             ]);
 
                         await test();

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -227,8 +227,8 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
                             TestRepository.VmrTestRepoName,
                             pr,
                             [
-                                $"`{TestFile1Name}` - [{TestRepository.TestOrg}/{TestRepository.TestRepo1Name}](https://github.com/{TestRepository.TestOrg}/{TestRepository.TestRepo1Name}/blob/{repoSha}/{TestFile1Name}) / [VMR](https://github.com/{TestRepository.TestOrg}/{TestRepository.VmrTestRepoName}/blob/{targetBranchName}/{TestFile1Name}",
-                                $"`{TestFile2Name}` - [{TestRepository.TestOrg}/{TestRepository.TestRepo1Name}](https://github.com/{TestRepository.TestOrg}/{TestRepository.TestRepo1Name}/blob/{repoSha}/{TestFile2Name}) / [VMR](https://github.com/{TestRepository.TestOrg}/{TestRepository.VmrTestRepoName}/blob/{targetBranchName}/{TestFile2Name}",
+                                $"`{TestFile1Name}` - [🔍 view in {TestRepository.TestOrg}/{TestRepository.TestRepo1Name}](https://github.com/{TestRepository.TestOrg}/{TestRepository.TestRepo1Name}/blob/{repoSha}/{TestFile1Name}) / [🔍 view in VMR](https://github.com/{TestRepository.TestOrg}/{TestRepository.VmrTestRepoName}/blob/{targetBranchName}/{TestFile1Name}",
+                                $"`{TestFile2Name}` - [🔍 view in {TestRepository.TestOrg}/{TestRepository.TestRepo1Name}](https://github.com/{TestRepository.TestOrg}/{TestRepository.TestRepo1Name}/blob/{repoSha}/{TestFile2Name}) / [🔍 view in VMR](https://github.com/{TestRepository.TestOrg}/{TestRepository.VmrTestRepoName}/blob/{targetBranchName}/{TestFile2Name}",
                             ]);
 
                         await test();

--- a/tools/ProductConstructionService.ReproTool/Operations/FlowCommitOperation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/FlowCommitOperation.cs
@@ -54,7 +54,7 @@ internal class FlowCommitOperation : Operation
             targetRepository: _options.TargetRepository,
             sourceEnabled: true);
 
-        var (repoName, owner) = GitRepoUrlParser.GetRepoNameAndOwner(_options.SourceRepository);
+        var (repoName, owner) = GitRepoUrlUtils.GetRepoNameAndOwner(_options.SourceRepository);
 
         var isBackflow = false;
         try

--- a/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
@@ -122,7 +122,7 @@ internal abstract class Operation(
         bool skipCleanup)
     {
         logger.LogInformation("Preparing product repo {repo} fork", productRepoUri);
-        (var name, var org) = GitRepoUrlParser.GetRepoNameAndOwner(productRepoUri);
+        (var name, var org) = GitRepoUrlUtils.GetRepoNameAndOwner(productRepoUri);
         // Check if the product repo fork already exists
         var allRepos = await ghClient.Repository.GetAllForOrg(MaestroAuthTestOrgName);
 

--- a/tools/ProductConstructionService.ReproTool/Operations/ReproOperation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/ReproOperation.cs
@@ -88,7 +88,7 @@ internal class ReproOperation(
 
         // Find the latest commit in the source repo to create a build from
         string sourceRepoSha;
-        (var sourceRepoName, var sourceRepoOwner) = GitRepoUrlParser.GetRepoNameAndOwner(subscription.SourceRepository);
+        (var sourceRepoName, var sourceRepoOwner) = GitRepoUrlUtils.GetRepoNameAndOwner(subscription.SourceRepository);
         if (build != null)
         {
             sourceRepoSha = build.Commit;


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4604
Makes it so the conflict messages have the follow format:
 - `file name` - `source repo` / `target repo`
