### PR TITLE
Ignore additional mappings during codeflow

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/CodeFlowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/CodeFlowOperation.cs
@@ -229,7 +229,7 @@ internal abstract class CodeFlowOperation(
             relativePaths: false,
             workingDir: targetRepo.Path,
             applicationPath: null,
-            applyAdditionalMappings: false,
+            includeAdditionalMappings: false,
             cancellationToken);
 
         foreach (VmrIngestionPatch patch in patches)

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/CodeFlowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/CodeFlowOperation.cs
@@ -229,6 +229,7 @@ internal abstract class CodeFlowOperation(
             relativePaths: false,
             workingDir: targetRepo.Path,
             applicationPath: null,
+            applyAdditionalMappings: false,
             cancellationToken);
 
         foreach (VmrIngestionPatch patch in patches)

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/InitializeOperation.cs
@@ -45,7 +45,8 @@ internal class InitializeOperation : VmrOperationBase
                 _options.TpnTemplate,
                 _options.GenerateCodeowners,
                 _options.GenerateCredScanSuppressions,
-                _options.DiscardPatches),
+                _options.DiscardPatches,
+                ApplyAdditionalMappings: true),
             _options.EnableBuildLookUp,
             cancellationToken);
     }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/UpdateOperation.cs
@@ -42,7 +42,8 @@ internal class UpdateOperation : VmrOperationBase
                 _options.TpnTemplate,
                 _options.GenerateCodeowners,
                 _options.GenerateCredScanSuppressions,
-                _options.DiscardPatches),
+                _options.DiscardPatches,
+                ApplyAdditionalMappings: true),
             _options.EnableBuildLookUp,
             cancellationToken: cancellationToken);
     }

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/VmrDiffOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/VmrDiffOperation.cs
@@ -276,6 +276,7 @@ internal class VmrDiffOperation(
             relativePaths: false,
             workingDir: new NativePath(repo1),
             applicationPath: null,
+            applyAdditionalMappings: false,
             CancellationToken.None);
 
         // If tmpDirectory is not null, it means the output path was not provided, so we just want to

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/VmrDiffOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/VmrDiffOperation.cs
@@ -276,7 +276,7 @@ internal class VmrDiffOperation(
             relativePaths: false,
             workingDir: new NativePath(repo1),
             applicationPath: null,
-            applyAdditionalMappings: false,
+            includeAdditionalMappings: false,
             CancellationToken.None);
 
         // If tmpDirectory is not null, it means the output path was not provided, so we just want to

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/CodeFlowParameters.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/CodeFlowParameters.cs
@@ -12,4 +12,5 @@ public record CodeFlowParameters(
     string? TpnTemplatePath,
     bool GenerateCodeOwners,
     bool GenerateCredScanSuppressions,
-    bool DiscardPatches);
+    bool DiscardPatches,
+    bool ApplyAdditionalMappings);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowVmrUpdater.cs
@@ -153,7 +153,8 @@ public class CodeFlowVmrUpdater : VmrManagerBase, ICodeFlowVmrUpdater
                     TpnTemplatePath: _vmrInfo.ThirdPartyNoticesTemplateFullPath,
                     GenerateCodeOwners: false,
                     GenerateCredScanSuppressions: true,
-                    DiscardPatches: true),
+                    DiscardPatches: true,
+                    ApplyAdditionalMappings: false),
                 cancellationToken);
 
             return true;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -26,6 +26,7 @@ public interface IVmrPatchHandler
         string sha2,
         NativePath destDir,
         NativePath tmpPath,
+        bool applyAdditionalMappings,
         CancellationToken cancellationToken);
 
     Task<List<VmrIngestionPatch>> CreatePatches(
@@ -37,6 +38,7 @@ public interface IVmrPatchHandler
         bool relativePaths,
         NativePath workingDir,
         UnixPath? applicationPath,
+        bool applyAdditionalMappings,
         CancellationToken cancellationToken);
 
     IReadOnlyCollection<VmrIngestionPatch> GetVmrPatches();

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -26,7 +26,7 @@ public interface IVmrPatchHandler
         string sha2,
         NativePath destDir,
         NativePath tmpPath,
-        bool applyAdditionalMappings,
+        bool includeAdditionalMappings,
         CancellationToken cancellationToken);
 
     Task<List<VmrIngestionPatch>> CreatePatches(
@@ -38,7 +38,7 @@ public interface IVmrPatchHandler
         bool relativePaths,
         NativePath workingDir,
         UnixPath? applicationPath,
-        bool applyAdditionalMappings,
+        bool includeAdditionalMappings,
         CancellationToken cancellationToken);
 
     IReadOnlyCollection<VmrIngestionPatch> GetVmrPatches();

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -198,7 +198,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             relativePaths: true,
             workingDir: _vmrInfo.GetRepoSourcesPath(mapping),
             applicationPath: null,
-            applyAdditionalMappings: false,
+            includeAdditionalMappings: false,
             cancellationToken);
 
         if (patches.Count == 0 || patches.All(p => _fileSystem.GetFileInfo(p.Path).Length == 0))
@@ -308,7 +308,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             relativePaths: true,
             workingDir: _vmrInfo.GetRepoSourcesPath(mapping),
             applicationPath: null,
-            applyAdditionalMappings: false,
+            includeAdditionalMappings: false,
             cancellationToken);
 
         _logger.LogInformation("Created {count} patch(es)", patches.Count);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -198,6 +198,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             relativePaths: true,
             workingDir: _vmrInfo.GetRepoSourcesPath(mapping),
             applicationPath: null,
+            applyAdditionalMappings: false,
             cancellationToken);
 
         if (patches.Count == 0 || patches.All(p => _fileSystem.GetFileInfo(p.Path).Length == 0))
@@ -307,6 +308,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             relativePaths: true,
             workingDir: _vmrInfo.GetRepoSourcesPath(mapping),
             applicationPath: null,
+            applyAdditionalMappings: false,
             cancellationToken);
 
         _logger.LogInformation("Created {count} patch(es)", patches.Count);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -88,6 +88,7 @@ public abstract class VmrManagerBase
             update.TargetRevision,
             _vmrInfo.TmpPath,
             _vmrInfo.TmpPath,
+            codeFlowParameters.ApplyAdditionalMappings,
             cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -116,8 +116,6 @@ public class VmrPatchHandler : IVmrPatchHandler
             repoPath = new NativePath(_fileSystem.GetDirectoryName(repoPath)!);
         }
 
-        var patchName = destDir / $"{mapping.Name}-{Commit.GetShortSha(sha1)}-{Commit.GetShortSha(sha2)}.patch";
-
         List<SubmoduleChange> submoduleChanges = await GetSubmoduleChanges(clone, sha1, sha2);
 
         var changedRecords = submoduleChanges
@@ -146,6 +144,8 @@ public class VmrPatchHandler : IVmrPatchHandler
             filters.AddRange(submoduleChanges.Select(c => $":(exclude){c.Path}").Distinct());
         }
 
+        var patchName = destDir / $"{mapping.Name}-{Commit.GetShortSha(sha1)}-{Commit.GetShortSha(sha2)}.patch";
+
         var patches = new List<VmrIngestionPatch>();
         patches.AddRange(await CreatePatches(
             patchName,
@@ -161,7 +161,7 @@ public class VmrPatchHandler : IVmrPatchHandler
 
         if (applyAdditionalMappings)
         {
-            patches.AddRange(await CreatePatchesForAdditionalMappings(mapping, sha1, sha2, destDir, repoPath, patchName, cancellationToken));
+            patches.AddRange(await CreatePatchesForAdditionalMappings(mapping, sha1, sha2, destDir, repoPath, cancellationToken));
         }
 
         if (!submoduleChanges.Any())
@@ -521,7 +521,6 @@ public class VmrPatchHandler : IVmrPatchHandler
         string sha2,
         NativePath destDir,
         NativePath repoPath,
-        NativePath patchName,
         CancellationToken cancellationToken)
     {
         var patches = new List<VmrIngestionPatch>();
@@ -537,7 +536,7 @@ public class VmrPatchHandler : IVmrPatchHandler
             _logger.LogInformation("Detected 'non-src/' mapped content in {source}. Creating patch..", source);
 
             var prefix = destination != null ? destination.Replace('/', '_') : "root";
-            patchName = destDir / $"{prefix}-{Commit.GetShortSha(sha1)}-{Commit.GetShortSha(sha2)}-{i++}.patch";
+            var patchName = destDir / $"{prefix}-{Commit.GetShortSha(sha1)}-{Commit.GetShortSha(sha2)}-{i++}.patch";
 
             var path = UnixPath.CurrentDir;
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -78,7 +78,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         string sha2,
         NativePath destDir,
         NativePath tmpPath,
-        bool applyAdditionalMappings,
+        bool includeAdditionalMappings,
         CancellationToken cancellationToken)
     {
         _logger.LogInformation("Creating patches for {mapping} in {path}..", mapping.Name, destDir);
@@ -91,7 +91,7 @@ public class VmrPatchHandler : IVmrPatchHandler
             destDir,
             tmpPath,
             new UnixPath(mapping.Name),
-            applyAdditionalMappings,
+            includeAdditionalMappings,
             cancellationToken);
 
         _logger.LogInformation("{count} patch{s} created", patches.Count, patches.Count == 1 ? string.Empty : "es");
@@ -107,7 +107,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         NativePath destDir,
         NativePath tmpPath,
         UnixPath relativePath,
-        bool applyAdditionalMappings,
+        bool includeAdditionalMappings,
         CancellationToken cancellationToken)
     {
         var repoPath = clone.Path;
@@ -156,10 +156,10 @@ public class VmrPatchHandler : IVmrPatchHandler
             relativePaths: false,
             repoPath,
             VmrInfo.SourcesDir / relativePath,
-            applyAdditionalMappings,
+            includeAdditionalMappings,
             cancellationToken));
 
-        if (applyAdditionalMappings)
+        if (includeAdditionalMappings)
         {
             patches.AddRange(await CreatePatchesForAdditionalMappings(mapping, sha1, sha2, destDir, repoPath, cancellationToken));
         }
@@ -201,7 +201,7 @@ public class VmrPatchHandler : IVmrPatchHandler
                 tmpPath,
                 relativePath,
                 change,
-                applyAdditionalMappings,
+                includeAdditionalMappings,
                 cancellationToken));
 
             _logger.LogInformation("Patches created for submodule {submodule} of {repo}", change.Name, mapping.Name);
@@ -332,7 +332,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         bool relativePaths,
         NativePath workingDir,
         UnixPath? applicationPath,
-        bool applyAdditionalMappings,
+        bool includeAdditionalMappings,
         CancellationToken cancellationToken)
     {
         var patch = await CreatePatch(patchName, sha1, sha2, path, filters, relativePaths, workingDir, applicationPath, cancellationToken);
@@ -374,7 +374,7 @@ public class VmrPatchHandler : IVmrPatchHandler
                 true,
                 workingDir / dirName,
                 applicationPath == null ? new UnixPath(dirName) : applicationPath / dirName,
-                applyAdditionalMappings,
+                includeAdditionalMappings,
                 cancellationToken));
         }
 
@@ -570,7 +570,7 @@ public class VmrPatchHandler : IVmrPatchHandler
                 relativePaths: true, // Relative paths so that we can apply the patch on VMR's root dir
                 contentDir,
                 destination != null ? new UnixPath(destination) : null,
-                applyAdditionalMappings: true,
+                includeAdditionalMappings: true,
                 cancellationToken));
         }
 
@@ -593,7 +593,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         NativePath tmpPath,
         UnixPath relativePath,
         SubmoduleChange change,
-        bool applyAdditionalMappings,
+        bool includeAdditionalMappings,
         CancellationToken cancellationToken)
     {
         var checkoutCommit = change.Before == Constants.EmptyGitObject ? change.After : change.Before;
@@ -642,7 +642,7 @@ public class VmrPatchHandler : IVmrPatchHandler
             destDir,
             tmpPath,
             new UnixPath(submodulePath),
-            applyAdditionalMappings,
+            includeAdditionalMappings,
             cancellationToken);
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -65,7 +65,6 @@ public class VmrPatchHandler : IVmrPatchHandler
     /// Submodules are recursively inlined into the VMR (patch is created for each submodule separately).
     /// </summary>
     /// <param name="mapping">Individual repository mapping</param>
-    /// <param name="repoPath">Path to the clone of the repo</param>
     /// <param name="sha1">Diff from this commit</param>
     /// <param name="sha2">Diff to this commit</param>
     /// <param name="destDir">Directory where patches should be placed</param>
@@ -79,11 +78,21 @@ public class VmrPatchHandler : IVmrPatchHandler
         string sha2,
         NativePath destDir,
         NativePath tmpPath,
+        bool applyAdditionalMappings,
         CancellationToken cancellationToken)
     {
         _logger.LogInformation("Creating patches for {mapping} in {path}..", mapping.Name, destDir);
 
-        var patches = await CreatePatchesRecursive(mapping, clone, sha1, sha2, destDir, tmpPath, new UnixPath(mapping.Name), cancellationToken);
+        var patches = await CreatePatchesRecursive(
+            mapping,
+            clone,
+            sha1,
+            sha2,
+            destDir,
+            tmpPath,
+            new UnixPath(mapping.Name),
+            applyAdditionalMappings,
+            cancellationToken);
 
         _logger.LogInformation("{count} patch{s} created", patches.Count, patches.Count == 1 ? string.Empty : "es");
 
@@ -98,6 +107,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         NativePath destDir,
         NativePath tmpPath,
         UnixPath relativePath,
+        bool applyAdditionalMappings,
         CancellationToken cancellationToken)
     {
         var repoPath = clone.Path;
@@ -146,60 +156,19 @@ public class VmrPatchHandler : IVmrPatchHandler
             relativePaths: false,
             repoPath,
             VmrInfo.SourcesDir / relativePath,
+            applyAdditionalMappings,
             cancellationToken));
 
-        // If current mapping hosts VMR's non-src/ content, synchronize it too
-        // We only do it when processing the root mapping, not its submodules
-        var relativeRepoPath = VmrInfo.GetRelativeRepoSourcesPath(mapping);
-        var i = 1;
-        foreach (var (source, destination) in _vmrInfo.AdditionalMappings.Where(m => m.Source.StartsWith(relativeRepoPath)))
+        if (applyAdditionalMappings)
         {
-            var relativeClonePath = source.Substring(relativeRepoPath.Length + 1);
-
-            _logger.LogInformation("Detected 'non-src/' mapped content in {source}. Creating patch..", source);
-
-            patchName = destDir / $"{(destination != null ? destination.Replace('/', '_') : "root")}-{Commit.GetShortSha(sha1)}-{Commit.GetShortSha(sha2)}-{i++}.patch";
-
-            var path = UnixPath.CurrentDir;
-
-            // We take the content path from the VMR config and map it onto the cloned repo
-            var contentDir = repoPath / relativeClonePath;
-
-            var fileName = _fileSystem.GetFileName(source) ?? throw new ArgumentNullException(nameof(source));
-
-            if (_fileSystem.FileExists(contentDir)
-                || (destination != null && _fileSystem.FileExists(_vmrInfo.VmrPath / destination / fileName)))
-            {
-                path = new UnixPath(fileName);
-                
-                var relativeCloneDir = _fileSystem.GetDirectoryName(relativeClonePath)
-                    ?? throw new Exception($"Invalid source path {source} in mapping.");
-           
-                contentDir = repoPath / relativeCloneDir;
-            }
-            else if(!_fileSystem.DirectoryExists(contentDir))
-            {
-                // the source can be a file that doesn't exist, then we skip it
-                continue;
-            }
-
-            patches.AddRange(await CreatePatches(
-                patchName,
-                sha1,
-                sha2,
-                path, // Apply for a given file or directory (we will call this from the content dir)
-                filters: null,
-                relativePaths: true, // Relative paths so that we can apply the patch on VMR's root dir
-                contentDir,
-                destination != null ? new UnixPath(destination) : null,
-                cancellationToken));
+            patches.AddRange(await CreatePatchesForAdditionalMappings(mapping, sha1, sha2, destDir, repoPath, patchName, cancellationToken));
         }
 
         if (!submoduleChanges.Any())
         {
             return patches;
         }
-        
+
         _logger.LogInformation("Creating diffs for submodules of {repo}..", mapping.Name);
 
         foreach (var change in submoduleChanges)
@@ -232,6 +201,7 @@ public class VmrPatchHandler : IVmrPatchHandler
                 tmpPath,
                 relativePath,
                 change,
+                applyAdditionalMappings,
                 cancellationToken));
 
             _logger.LogInformation("Patches created for submodule {submodule} of {repo}", change.Name, mapping.Name);
@@ -362,6 +332,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         bool relativePaths,
         NativePath workingDir,
         UnixPath? applicationPath,
+        bool applyAdditionalMappings,
         CancellationToken cancellationToken)
     {
         var patch = await CreatePatch(patchName, sha1, sha2, path, filters, relativePaths, workingDir, applicationPath, cancellationToken);
@@ -403,6 +374,7 @@ public class VmrPatchHandler : IVmrPatchHandler
                 true,
                 workingDir / dirName,
                 applicationPath == null ? new UnixPath(dirName) : applicationPath / dirName,
+                applyAdditionalMappings,
                 cancellationToken));
         }
 
@@ -540,6 +512,73 @@ public class VmrPatchHandler : IVmrPatchHandler
     }
 
     /// <summary>
+    /// Create patches for additionally mapped content from a repository folder onto a different VMR path.
+    /// </summary>
+    /// <returns>A list of generated patches based on the additional mappings.</returns>
+    private async Task<List<VmrIngestionPatch>> CreatePatchesForAdditionalMappings(
+        SourceMapping mapping,
+        string sha1,
+        string sha2,
+        NativePath destDir,
+        NativePath repoPath,
+        NativePath patchName,
+        CancellationToken cancellationToken)
+    {
+        var patches = new List<VmrIngestionPatch>();
+
+        // If current mapping hosts VMR's non-src/ content, synchronize it too
+        // We only do it when processing the root mapping, not its submodules
+        var relativeRepoPath = VmrInfo.GetRelativeRepoSourcesPath(mapping);
+        var i = 1;
+        foreach (var (source, destination) in _vmrInfo.AdditionalMappings.Where(m => m.Source.StartsWith(relativeRepoPath)))
+        {
+            var relativeClonePath = source.Substring(relativeRepoPath.Length + 1);
+
+            _logger.LogInformation("Detected 'non-src/' mapped content in {source}. Creating patch..", source);
+
+            var prefix = destination != null ? destination.Replace('/', '_') : "root";
+            patchName = destDir / $"{prefix}-{Commit.GetShortSha(sha1)}-{Commit.GetShortSha(sha2)}-{i++}.patch";
+
+            var path = UnixPath.CurrentDir;
+
+            // We take the content path from the VMR config and map it onto the cloned repo
+            var contentDir = repoPath / relativeClonePath;
+
+            var fileName = _fileSystem.GetFileName(source) ?? throw new ArgumentNullException(nameof(source));
+
+            if (_fileSystem.FileExists(contentDir)
+                || (destination != null && _fileSystem.FileExists(_vmrInfo.VmrPath / destination / fileName)))
+            {
+                path = new UnixPath(fileName);
+
+                var relativeCloneDir = _fileSystem.GetDirectoryName(relativeClonePath)
+                    ?? throw new Exception($"Invalid source path {source} in mapping.");
+
+                contentDir = repoPath / relativeCloneDir;
+            }
+            else if (!_fileSystem.DirectoryExists(contentDir))
+            {
+                // the source can be a file that doesn't exist, then we skip it
+                continue;
+            }
+
+            patches.AddRange(await CreatePatches(
+                patchName,
+                sha1,
+                sha2,
+                path, // Apply for a given file or directory (we will call this from the content dir)
+                filters: null,
+                relativePaths: true, // Relative paths so that we can apply the patch on VMR's root dir
+                contentDir,
+                destination != null ? new UnixPath(destination) : null,
+                applyAdditionalMappings: true,
+                cancellationToken));
+        }
+
+        return patches;
+    }
+
+    /// <summary>
     /// Creates and returns path to patch files that inline all submodules recursively.
     /// </summary>
     /// <param name="mapping">Mapping for the current repo/submodule</param>
@@ -555,6 +594,7 @@ public class VmrPatchHandler : IVmrPatchHandler
         NativePath tmpPath,
         UnixPath relativePath,
         SubmoduleChange change,
+        bool applyAdditionalMappings,
         CancellationToken cancellationToken)
     {
         var checkoutCommit = change.Before == Constants.EmptyGitObject ? change.After : change.Before;
@@ -603,6 +643,7 @@ public class VmrPatchHandler : IVmrPatchHandler
             destDir,
             tmpPath,
             new UnixPath(submodulePath),
+            applyAdditionalMappings,
             cancellationToken);
     }
 

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -184,7 +184,8 @@ internal abstract class VmrTestsBase
                 TpnTemplatePath: null,
                 GenerateCodeOwners: false,
                 GenerateCredScanSuppressions: false,
-                DiscardPatches: true),
+                DiscardPatches: true,
+                ApplyAdditionalMappings: true),
             lookUpBuilds: false,
             cancellationToken: _cancellationToken.Token);
     }
@@ -207,7 +208,8 @@ internal abstract class VmrTestsBase
                 TpnTemplatePath: null,
                 GenerateCodeOwners: generateCodeowners,
                 GenerateCredScanSuppressions: generateCredScanSuppressions,
-                DiscardPatches: true),
+                DiscardPatches: true,
+                ApplyAdditionalMappings: true),
             lookUpBuilds: false,
             cancellationToken: _cancellationToken.Token);
     }

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -180,6 +180,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
+            applyAdditionalMappings: true,
             CancellationToken.None);
 
         var expectedArgs = GetExpectedGitDiffArguments(expectedPatchName, Sha1, Sha2, null);
@@ -244,6 +245,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
+            applyAdditionalMappings: true,
             CancellationToken.None);
 
         var expectedArgs = GetExpectedGitDiffArguments(expectedPatchName1, Sha1, Sha2, null);
@@ -333,6 +335,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
+            applyAdditionalMappings: true,
             CancellationToken.None);
 
         var expectedArgs = GetExpectedGitDiffArguments(expectedPatchName, Sha1, Sha2, new[] { _submoduleInfo.Path });
@@ -387,6 +390,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
+            applyAdditionalMappings: true,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -478,6 +482,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
+            applyAdditionalMappings: true,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -585,6 +590,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
+            applyAdditionalMappings: true,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -662,6 +668,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
+            applyAdditionalMappings: true,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -740,6 +747,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
+            applyAdditionalMappings: true,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -923,6 +931,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
+            applyAdditionalMappings: true,
             CancellationToken.None);
 
         var expectedArgs = GetExpectedGitDiffArguments(expectedPatchName, Sha1, Sha2, null);
@@ -982,6 +991,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
+            applyAdditionalMappings: true,
             CancellationToken.None);
 
         // Verify

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -180,7 +180,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
-            applyAdditionalMappings: true,
+            includeAdditionalMappings: true,
             CancellationToken.None);
 
         var expectedArgs = GetExpectedGitDiffArguments(expectedPatchName, Sha1, Sha2, null);
@@ -245,7 +245,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
-            applyAdditionalMappings: true,
+            includeAdditionalMappings: true,
             CancellationToken.None);
 
         var expectedArgs = GetExpectedGitDiffArguments(expectedPatchName1, Sha1, Sha2, null);
@@ -335,7 +335,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
-            applyAdditionalMappings: true,
+            includeAdditionalMappings: true,
             CancellationToken.None);
 
         var expectedArgs = GetExpectedGitDiffArguments(expectedPatchName, Sha1, Sha2, new[] { _submoduleInfo.Path });
@@ -390,7 +390,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
-            applyAdditionalMappings: true,
+            includeAdditionalMappings: true,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -482,7 +482,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
-            applyAdditionalMappings: true,
+            includeAdditionalMappings: true,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -590,7 +590,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
-            applyAdditionalMappings: true,
+            includeAdditionalMappings: true,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -668,7 +668,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
-            applyAdditionalMappings: true,
+            includeAdditionalMappings: true,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -747,7 +747,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
-            applyAdditionalMappings: true,
+            includeAdditionalMappings: true,
             CancellationToken.None);
 
         // Verify diff for the individual repo
@@ -931,7 +931,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
-            applyAdditionalMappings: true,
+            includeAdditionalMappings: true,
             CancellationToken.None);
 
         var expectedArgs = GetExpectedGitDiffArguments(expectedPatchName, Sha1, Sha2, null);
@@ -991,7 +991,7 @@ public class VmrPatchHandlerTests
             Sha2,
             _patchDir,
             TmpDir,
-            applyAdditionalMappings: true,
+            includeAdditionalMappings: true,
             CancellationToken.None);
 
         // Verify


### PR DESCRIPTION
I originally thought that we would just remove the additional mappings from VMR's `source-mappings.json` but that does not work because the flow will be based on the last flown commit where it's likely the additional mappings will still be present.

So we need to explicitly disable this feature for code flows.

https://github.com/dotnet/arcade-services/issues/4618