### PR TITLE
Remove no longer relevant TODOs

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
@@ -164,8 +164,6 @@ internal class AddSubscriptionOperation : Operation
             }
 
             // Grab existing subscriptions to get suggested values.
-            // TODO: When this becomes paged, set a max number of results to avoid
-            // pulling too much.
             var suggestedRepos = _barClient.GetSubscriptionsAsync();
             var suggestedChannels = _barClient.GetChannelsAsync();
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Local.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Local.cs
@@ -21,10 +21,7 @@ public class Local
     private readonly DependencyFileManager _fileManager;
     private readonly ILocalLibGit2Client _gitClient;
     private readonly IVersionDetailsParser _versionDetailsParser;
-
     private readonly ILogger _logger;
-
-    // TODO: Make these not constants and instead attempt to give more accurate information commit, branch, repo name, etc.)
     private readonly Lazy<string> _repoRootDir;
 
     /// <summary>
@@ -45,18 +42,14 @@ public class Local
     /// <summary>
     ///     Adds a dependency to the dependency files
     /// </summary>
-    /// <returns></returns>
     public async Task AddDependencyAsync(DependencyDetail dependency)
     {
-        // TODO: https://github.com/dotnet/arcade/issues/1095
-        // This should be getting back a container and writing the files from here.
         await _fileManager.AddDependencyAsync(dependency, _repoRootDir.Value, null);
     }
 
     /// <summary>
     ///     Adds a dependency to the dependency files
     /// </summary>
-    /// <returns></returns>
     public async Task RemoveDependencyAsync(string dependencyName)
     {
         await _fileManager.RemoveDependencyAsync(dependencyName, _repoRootDir.Value, null);
@@ -150,7 +143,6 @@ public class Local
     /// <summary>
     ///     Gets the local dependencies
     /// </summary>
-    /// <returns></returns>
     public async Task<List<DependencyDetail>> GetDependenciesAsync(string name = null, bool includePinned = true)
     {
         VersionDetails versionDetails = await _fileManager.ParseVersionDetailsXmlAsync(_repoRootDir.Value, null, includePinned);
@@ -171,7 +163,6 @@ public class Local
     /// <summary>
     /// Gets local dependencies from a local repository
     /// </summary>
-    /// <returns></returns>
     public IEnumerable<DependencyDetail> GetDependenciesFromFileContents(string fileContents, bool includePinned = true)
     {
         return _versionDetailsParser.ParseVersionDetailsXml(fileContents, includePinned).Dependencies;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -336,16 +336,14 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         // Now we insert the VMR files
         foreach (var patch in patches)
         {
-            // TODO https://github.com/dotnet/arcade-services/issues/2995: Handle exceptions
             await _vmrPatchHandler.ApplyPatch(patch, targetRepo.Path, discardPatches, reverseApply: false, cancellationToken);
         }
 
-        // TODO https://github.com/dotnet/arcade-services/issues/2995: Check if there are any changes and only commit if there are
+        // Check if there are any changes and only commit if there are
         result = await targetRepo.ExecuteGitCommand(["diff-index", "--quiet", "--cached", "HEAD", "--"], cancellationToken);
 
         if (result.ExitCode == 0)
         {
-            // TODO https://github.com/dotnet/arcade-services/issues/2995: Handle + clean up the work branch
             // When no changes happened, we disregard the work branch and return back to the target branch
             await targetRepo.CheckoutAsync(headBranch);
             return false;
@@ -480,8 +478,15 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         // The current patches should apply now
         foreach (VmrIngestionPatch patch in patches)
         {
-            // TODO https://github.com/dotnet/arcade-services/issues/2995: Catch exceptions?
-            await _vmrPatchHandler.ApplyPatch(patch, targetRepo.Path, discardPatches, reverseApply: false, cancellationToken);
+            try
+            {
+                await _vmrPatchHandler.ApplyPatch(patch, targetRepo.Path, discardPatches, reverseApply: false, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                _logger.LogCritical(e, "Failed to apply changes on top of previously recreated code flow. This is unexpected");
+                throw;
+            }
         }
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -484,7 +484,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             }
             catch (Exception e)
             {
-                _logger.LogCritical(e, "Failed to apply changes on top of previously recreated code flow. This is unexpected");
+                _logger.LogCritical("Failed to apply changes on top of previously recreated code flow: {message}", e.Message);
                 throw;
             }
         }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -131,7 +131,6 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
 
         if (!hasChanges)
         {
-            // TODO: Clean up repos?
             _logger.LogInformation("Nothing to flow from {sourceRepo}", currentFlow is Backflow ? "VMR" : mapping.Name);
         }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -293,8 +293,8 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             build.AzureDevOpsBuildNumber,
             build.Id));
 
-        // TODO: Detect if no changes
-        // TODO: Technically, if we only changed metadata files, there are no updates still
+        // TODO https://github.com/dotnet/arcade-services/issues/4178: Detect if no changes.
+        // Technically, if we only changed metadata files, there are no updates still
         return await _vmrUpdater.UpdateRepository(
             mapping,
             build,
@@ -588,12 +588,19 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             cancellationToken);
 
         // We apply the current changes on top again - they should apply now
-        // TODO https://github.com/dotnet/arcade-services/issues/2995: Handle exceptions
-        return await _vmrUpdater.UpdateRepository(
-            mapping,
-            build,
-            resetToRemoteWhenCloningRepo: ShouldResetClones,
-            cancellationToken);
+        try
+        {
+            return await _vmrUpdater.UpdateRepository(
+                mapping,
+                build,
+                resetToRemoteWhenCloningRepo: ShouldResetClones,
+                cancellationToken);
+        }
+        catch (Exception e)
+        {
+            _logger.LogCritical(e, "Failed to apply changes on top of previously recreated code flow. This is unexpected");
+            throw;
+        }
     }
 
     protected override NativePath GetEngCommonPath(NativePath sourceRepo) => sourceRepo / Constants.CommonScriptFilesPath;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -598,7 +598,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
         }
         catch (Exception e)
         {
-            _logger.LogCritical(e, "Failed to apply changes on top of previously recreated code flow. This is unexpected");
+            _logger.LogCritical("Failed to apply changes on top of previously recreated code flow: {message}", e.Message);
             throw;
         }
     }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -1207,7 +1207,6 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                         CommitSha = update.SourceSha
                     }
                 ],
-                // TODO (https://github.com/dotnet/arcade-services/issues/3866): Populate fully (assets, coherency checks..)
                 RequiredUpdates = requiredUpdates,
                 CodeFlowDirection = subscription.TargetDirectory != null
                     ? CodeFlowDirection.ForwardFlow

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTwoWayCodeflowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTwoWayCodeflowTest.cs
@@ -473,11 +473,6 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
 
         await EnsureTestRepoIsInitialized();
 
-        /*
-        TODO https://github.com/dotnet/arcade-services/issues/4342:
-        When conflict resolution is implemented
-        this test should be updated and padding lines removed
-
         var repo = GetLocal(ProductRepoPath);
 
         await repo.RemoveDependencyAsync(FakePackageName);
@@ -517,7 +512,6 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
             Commit = "d04",
             Type = DependencyType.Product,
         });
-        */
 
         await File.WriteAllTextAsync(ProductRepoPath / VersionFiles.VersionDetailsXml,
             """

--- a/test/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsForCodeFlowTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsForCodeFlowTests.cs
@@ -165,10 +165,6 @@ internal class UpdateAssetsForCodeFlowTests : UpdateAssetsPullRequestUpdaterTest
 
             await WhenUpdateAssetsAsyncIsCalled(build2);
 
-            // TODO (https://github.com/dotnet/arcade-services/issues/3866): We need to populate InProgressPullRequest fully
-            // with assets and other info just like we do in UpdatePullRequestAsync.
-            // Right now, we are not flowing packages in codeflow subscriptions yet, so this functionality is no there
-            // For now, we manually update the info the unit tests expect.
             var expectedState = new InProgressPullRequest()
             {
                 UpdaterId = GetPullRequestUpdaterId(Subscription).Id,


### PR DESCRIPTION
Removed several no longer relevant TODOs, mostly around exception handling which now seems to be handled usually on the appropriate level.
Some TODOs were resolved with additional handling/logging but since we now see how the code behaves in runtime, I believe we will be able to add more error handling as we see fit and these TODOs are just artifacts of some premature ideas of how things will work.

- https://github.com/dotnet/arcade-services/issues/4178
- https://github.com/dotnet/arcade-services/issues/3866
- https://github.com/dotnet/arcade-services/issues/4342
- https://github.com/dotnet/arcade-services/issues/2995
- https://github.com/dotnet/arcade/issues/1095