### PR TITLE
Bump packages to resolve CG alerts (+Aspire update)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);NU5125;CA1416</NoWarn>
     <!--
       We sort of half sort of support macOS in this repo, this warning is telling us that we are on the precipice of

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <AspNetAzureVersion>3.1.24</AspNetAzureVersion>
     <AspNetCoreVersion>6.0.36</AspNetCoreVersion>
     <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>
-    <AspireVersion>9.0.0</AspireVersion>
+    <AspireVersion>9.2.0</AspireVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
@@ -28,7 +28,7 @@
     <PackageVersion Include="Azure.ResourceManager.AppContainers" Version="1.3.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.20.1" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.22.0" />
     <PackageVersion Include="Blazored.SessionStorage" Version="2.4.0" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="DistributedLock.Redis" Version="1.0.3" />
@@ -129,7 +129,7 @@
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
-    <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="9.0.3" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -103,8 +103,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspireVersion)" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.11.4" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.11.4" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.11.7" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.11.7" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="3.8.3" />
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="19.232.0-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
@@ -123,8 +123,8 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.7.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.7.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.7.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -105,15 +105,15 @@
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.11.4" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.11.4" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="3.8.0" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="3.8.3" />
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="19.232.0-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NRedisStack" Version="0.12.0" />
-    <PackageVersion Include="NuGet.Packaging" Version="6.9.1" />
-    <PackageVersion Include="NUnit" Version="4.0.1" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.13.2" />
+    <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="Octokit" Version="13.0.1" />
     <PackageVersion Include="Octokit.Webhooks.AspNetCore" Version="2.4.1" />
@@ -141,6 +141,6 @@
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="TextCopy" Version="6.2.1" />
     <PackageVersion Include="Verify.NUnit" Version="19.6" />
-    <PackageVersion Include="YamlDotNet" Version="16.0.0" />
+    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -114,7 +114,7 @@
     <PackageVersion Include="NRedisStack" Version="0.12.0" />
     <PackageVersion Include="NuGet.Packaging" Version="6.13.2" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="Octokit" Version="13.0.1" />
     <PackageVersion Include="Octokit.Webhooks.AspNetCore" Version="2.4.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -120,6 +120,7 @@
       <package pattern="Microsoft.Rest.ClientRuntime" />
       <package pattern="Microsoft.TeamFoundationServer.Client" />
       <package pattern="Microsoft.TeamFoundation.DistributedTask.Common.Contracts" />
+      <package pattern="Microsoft.Testing.*" />
       <package pattern="Microsoft.TestPlatform.*" />
       <package pattern="Microsoft.VisualStudio.*" />
       <package pattern="Microsoft.Win32.*" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -133,6 +133,7 @@
       <package pattern="Namotion.Reflection" />
       <package pattern="ncrontab.signed" />
       <package pattern="NETStandard.Library" />
+      <package pattern="Nerdbank.Streams" />
       <package pattern="NetTopologySuite" />
       <package pattern="NetTopologySuite.*" />
       <package pattern="Newtonsoft.Json" />
@@ -163,6 +164,7 @@
       <package pattern="SQLitePCLRaw.*" />
       <package pattern="StackExchange.Redis" />
       <package pattern="StyleCop.Analyzers" />
+      <package pattern="StreamJsonRpc" />
       <package pattern="Swashbuckle.AspNetCore" />
       <package pattern="Swashbuckle.AspNetCore.Annotations" />
       <package pattern="Swashbuckle.AspNetCore.Newtonsoft" />

--- a/src/Maestro/Maestro.Data/Maestro.Data.csproj
+++ b/src/Maestro/Maestro.Data/Maestro.Data.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
     <SignAssembly>false</SignAssembly>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>

--- a/src/Maestro/Maestro.Data/Maestro.Data.csproj
+++ b/src/Maestro/Maestro.Data/Maestro.Data.csproj
@@ -15,8 +15,10 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.DotNet.GitHub.Authentication" />
     <PackageReference Include="Microsoft.DotNet.Services.Utility" />
-    <!-- Thiss is needed to bump the package version past what Microsoft.EntityFrameworkCore.SqlServer requires. Can be removed once we update to .NET 8 -->
+    <!-- This is needed to bump the package version past what Microsoft.EntityFrameworkCore.SqlServer requires. Can be removed once we update to .NET 8 -->
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <!-- Remove this pin once updated to net8.0 -->
+    <PackageReference Include="System.IO.Hashing" VersionOverride="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Maestro/Maestro.DataProviders/Maestro.DataProviders.csproj
+++ b/src/Maestro/Maestro.DataProviders/Maestro.DataProviders.csproj
@@ -16,5 +16,7 @@
     <ProjectReference Include="..\..\Microsoft.DotNet.Darc\DarcLib\Microsoft.DotNet.DarcLib.csproj" />
     <ProjectReference Include="..\Maestro.Common\Maestro.Common.csproj" />
     <ProjectReference Include="..\Maestro.Data\Maestro.Data.csproj" />
+    <!-- Remove this pin once updated to net8.0 -->
+    <PackageReference Include="System.IO.Hashing" VersionOverride="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Maestro/Maestro.DataProviders/Maestro.DataProviders.csproj
+++ b/src/Maestro/Maestro.DataProviders/Maestro.DataProviders.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
-    <TargetLatestRuntimePatch>False</TargetLatestRuntimePatch>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework></TargetFramework>
     <SignAssembly>false</SignAssembly>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Maestro/Maestro.MergePolicies/Maestro.MergePolicies.csproj
+++ b/src/Maestro/Maestro.MergePolicies/Maestro.MergePolicies.csproj
@@ -9,6 +9,8 @@
     <PackageReference Include="LibGit2Sharp" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Newtonsoft.Json" />
+    <!-- Remove this pin once updated to net8.0 -->
+    <PackageReference Include="System.IO.Hashing" VersionOverride="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Maestro/Maestro.MergePolicies/Maestro.MergePolicies.csproj
+++ b/src/Maestro/Maestro.MergePolicies/Maestro.MergePolicies.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>latest</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 

--- a/src/Maestro/Maestro.MergePolicyEvaluation/Maestro.MergePolicyEvaluation.csproj
+++ b/src/Maestro/Maestro.MergePolicyEvaluation/Maestro.MergePolicyEvaluation.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Microsoft.DotNet.Darc/Darc/Microsoft.DotNet.Darc.csproj
+++ b/src/Microsoft.DotNet.Darc/Darc/Microsoft.DotNet.Darc.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
     <SignAssembly>false</SignAssembly>
     <IsPackable>true</IsPackable>
     <Description>Darc CLI</Description>

--- a/src/Microsoft.DotNet.Darc/DarcLib/Microsoft.DotNet.DarcLib.csproj
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Microsoft.DotNet.DarcLib.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
     <SignAssembly>false</SignAssembly>
     <IsPackable>true</IsPackable>

--- a/src/Microsoft.DotNet.Darc/DarcLib/Microsoft.DotNet.DarcLib.csproj
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Microsoft.DotNet.DarcLib.csproj
@@ -26,7 +26,8 @@
     <PackageReference Include="Octokit" />
     <!-- This is needed to bump the package version past what Microsoft.TeamFoundationServer.Client requires. Can probably be removed once a new version of that package is released -->
     <PackageReference Include="System.Data.SqlClient" />
-    <PackageReference Include="System.IO.Hashing" />
+    <!-- Remove this pin once updated to net8.0 -->
+    <PackageReference Include="System.IO.Hashing" VersionOverride="8.0.0" />
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="System.Net.Http" />
   </ItemGroup>

--- a/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/Microsoft.DotNet.ProductConstructionService.Client.csproj
+++ b/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/Microsoft.DotNet.ProductConstructionService.Client.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <Description>This package provides access to the PCS API</Description>
     <LangVersion>8.0</LangVersion>
@@ -8,8 +9,6 @@
     <SwaggerOutputDirectory>$(MSBuildProjectDirectory)\Generated</SwaggerOutputDirectory>
     <SwaggerClientName>ProductConstructionServiceApi</SwaggerClientName>
     <SwaggerDocumentUri>https://localhost:53180/swagger.json</SwaggerDocumentUri>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <TargetFramework></TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProductConstructionService/ProductConstructionService.Api/ProductConstructionService.Api.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.Api/ProductConstructionService.Api.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>ae822e9d-17dd-440e-b241-ffd12f1f666d</UserSecretsId>

--- a/src/ProductConstructionService/ProductConstructionService.AppHost/ProductConstructionService.AppHost.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.AppHost/ProductConstructionService.AppHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/ProductConstructionService/ProductConstructionService.AppHost/ProductConstructionService.AppHost.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.AppHost/ProductConstructionService.AppHost.csproj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/ProductConstructionService.BarViz.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/ProductConstructionService.BarViz.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- We're referencing Maestro.Data, which isn't signed and doesn't have a strong name, so we can't be signed neither -->

--- a/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionService.Common.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionService.Common.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework></TargetFramework>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <!-- Remove this pin once updated to net8.0 only -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>False</SignAssembly>

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/ProductConstructionService.DependencyFlow.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/ProductConstructionService.DependencyFlow.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- We're referencing Maestro.Data, which isn't signed and doesn't have a strong name, so we can't be signed neither -->

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/ProductConstructionService.FeedCleaner.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/ProductConstructionService.FeedCleaner.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>False</SignAssembly>

--- a/src/ProductConstructionService/ProductConstructionService.LongestBuildPathUpdater/ProductConstructionService.LongestBuildPathUpdater.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.LongestBuildPathUpdater/ProductConstructionService.LongestBuildPathUpdater.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>False</SignAssembly>

--- a/src/ProductConstructionService/ProductConstructionService.ServiceDefaults/ProductConstructionService.ServiceDefaults.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.ServiceDefaults/ProductConstructionService.ServiceDefaults.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>

--- a/src/ProductConstructionService/ProductConstructionService.SubscriptionTriggerer/ProductConstructionService.SubscriptionTriggerer.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.SubscriptionTriggerer/ProductConstructionService.SubscriptionTriggerer.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>False</SignAssembly>

--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/ProductConstructionService.WorkItems.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/ProductConstructionService.WorkItems.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- We're referencing Maestro.Data, which isn't signed and doesn't have a strong name, so we can't be signed neither -->

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,10 +2,8 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>false</SignAssembly>
-    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/Maestro.Data.Tests/Maestro.Data.Tests.csproj
+++ b/test/Maestro.Data.Tests/Maestro.Data.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/test/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
+++ b/test/Microsoft.DotNet.Darc.Tests/Microsoft.DotNet.Darc.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests.csproj
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 

--- a/test/Microsoft.DotNet.DarcLib.Tests/Microsoft.DotNet.DarcLib.Tests.csproj
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Microsoft.DotNet.DarcLib.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/test/Microsoft.DotNet.Maestro.Tasks.Tests/Microsoft.DotNet.Maestro.Tasks.Tests.csproj
+++ b/test/Microsoft.DotNet.Maestro.Tasks.Tests/Microsoft.DotNet.Maestro.Tasks.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <DebugType>Full</DebugType>
     <Nullable>disable</Nullable>

--- a/test/ProductConstructionService.ScenarioTests/ProductConstructionService.ScenarioTests.csproj
+++ b/test/ProductConstructionService.ScenarioTests/ProductConstructionService.ScenarioTests.csproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/test/VersionPropsFormatter.Tests/VersionPropsFormatter.Tests.csproj
+++ b/test/VersionPropsFormatter.Tests/VersionPropsFormatter.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tools/FlatFlowMigrationCli/FlatFlowMigrationCli.csproj
+++ b/tools/FlatFlowMigrationCli/FlatFlowMigrationCli.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>False</SignAssembly>

--- a/tools/ProductConstructionService.Cli/ProductConstructionService.Cli.csproj
+++ b/tools/ProductConstructionService.Cli/ProductConstructionService.Cli.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>False</SignAssembly>

--- a/tools/ProductConstructionService.ReproTool/ProductConstructionService.ReproTool.csproj
+++ b/tools/ProductConstructionService.ReproTool/ProductConstructionService.ReproTool.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>False</SignAssembly>

--- a/tools/Tools.Common/Tools.Common.csproj
+++ b/tools/Tools.Common/Tools.Common.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>false</SignAssembly>

--- a/tools/VersionPropsFormatter/VersionPropsFormatter.csproj
+++ b/tools/VersionPropsFormatter/VersionPropsFormatter.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>false</SignAssembly>


### PR DESCRIPTION
- Updates packages to handle CG alerts
- Updates Aspire for new features
- Sets `net8.0` TFM globally as the repository default and only downgrades projects which are not migrated yet
- Makes all test projects .NET 8.0

https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-arcade-services?_a=alerts&typeId=6582243&alerts-view-option=active

<!-- https://github.com/dotnet/arcade-services/issues/4650 -->