### PR TITLE
Revert "Improve `darc update-subscription` by allowing to specify policy checks"

### DIFF
--- a/src/Maestro/Maestro.MergePolicies/BackFlowMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/BackFlowMergePolicy.cs
@@ -120,7 +120,7 @@ internal class BackFlowMergePolicy : CodeFlowMergePolicy
 
 public class BackFlowMergePolicyBuilder : IMergePolicyBuilder
 {
-    public string Name => MergePolicyConstants.CodeflowMergePolicyName;
+    public string Name => MergePolicyConstants.BackFlowMergePolicyName;
 
     public Task<IReadOnlyList<IMergePolicy>> BuildMergePoliciesAsync(MergePolicyProperties properties, PullRequestUpdateSummary pr)
     {

--- a/src/Maestro/Maestro.MergePolicies/ForwardFlowMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/ForwardFlowMergePolicy.cs
@@ -128,7 +128,7 @@ internal class ForwardFlowMergePolicy : CodeFlowMergePolicy
 
 public class ForwardFlowMergePolicyBuilder : IMergePolicyBuilder
 {
-    public string Name => MergePolicyConstants.CodeflowMergePolicyName;
+    public string Name => MergePolicyConstants.ForwardFlowMergePolicyName;
 
     public Task<IReadOnlyList<IMergePolicy>> BuildMergePoliciesAsync(MergePolicyProperties properties, PullRequestUpdateSummary pr)
     {

--- a/src/Maestro/Maestro.MergePolicies/MergePolicyServiceCollectionExtensions.cs
+++ b/src/Maestro/Maestro.MergePolicies/MergePolicyServiceCollectionExtensions.cs
@@ -14,8 +14,6 @@ public static class MergePolicyServiceCollectionExtensions
         services.AddTransient<IMergePolicyBuilder, DontAutomergeDowngradesMergePolicyBuilder>();
         services.AddTransient<IMergePolicyBuilder, StandardMergePolicyBuilder>();
         services.AddTransient<IMergePolicyBuilder, ValidateCoherencyMergePolicyBuilder>();
-        services.AddTransient<IMergePolicyBuilder, BackFlowMergePolicyBuilder>();
-        services.AddTransient<IMergePolicyBuilder, ForwardFlowMergePolicyBuilder>();
         return services;
     }
 }

--- a/src/Maestro/Maestro.MergePolicies/StandardMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/StandardMergePolicy.cs
@@ -1,57 +1,66 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Maestro.MergePolicyEvaluation;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Maestro.MergePolicies;
 
 public class StandardMergePolicyBuilder : IMergePolicyBuilder
 {
-    private static readonly IReadOnlyList<string> s_standardGitHubIgnoreChecks = [
-            "WIP",
-            "license/cla",
-            "auto-merge.config.enforce",
-            "Build Analysis"
-        ];
-    private static readonly IReadOnlyList<string> s_standardAzureDevOpsIgnoreChecks = [
-            "Comment requirements",
-            "Minimum number of reviewers",
-            "auto-merge.config.enforce",
-            "Work item linking"
-        ];
+    private static readonly MergePolicyProperties s_standardGitHubProperties;
+    private static readonly MergePolicyProperties s_standardAzureDevOpsProperties;
 
     public string Name => MergePolicyConstants.StandardMergePolicyName;
 
-    private static IEnumerable<string> GetStandardIgnoreChecks(string prUrl)
+    static StandardMergePolicyBuilder()
     {
-        if (prUrl.Contains("github.com"))
+        s_standardGitHubProperties = new MergePolicyProperties(new Dictionary<string, JToken>
         {
-            return s_standardGitHubIgnoreChecks;
-        }
-        else if (prUrl.Contains("dev.azure.com"))
+            { 
+                MergePolicyConstants.IgnoreChecksMergePolicyPropertyName, 
+                new JArray(
+                    "WIP",
+                    "license/cla",
+                    "auto-merge.config.enforce",
+                    "Build Analysis"
+                )
+            },
+        });
+
+        s_standardAzureDevOpsProperties = new MergePolicyProperties(new Dictionary<string, JToken>
         {
-            return s_standardAzureDevOpsIgnoreChecks;
-        }
-        throw new NotImplementedException($"Unknown PR repo URL: {prUrl}");
+            {
+                MergePolicyConstants.IgnoreChecksMergePolicyPropertyName,
+                new JArray(
+                    "Comment requirements",
+                    "Minimum number of reviewers",
+                    "auto-merge.config.enforce",
+                    "Work item linking"
+                )
+            },
+        });
     }
 
     public async Task<IReadOnlyList<IMergePolicy>> BuildMergePoliciesAsync(MergePolicyProperties properties, PullRequestUpdateSummary pr)
     {
         string prUrl = pr.Url;
-        MergePolicyProperties standardProperties = new(new Dictionary<string, JToken>
+        MergePolicyProperties standardProperties;
+        if (prUrl.Contains("github.com"))
         {
-            {
-                MergePolicyConstants.IgnoreChecksMergePolicyPropertyName,
-                new JArray(GetStandardIgnoreChecks(prUrl)
-                    .Concat(properties.Get<IEnumerable<string>>(MergePolicyConstants.IgnoreChecksMergePolicyPropertyName) ?? [])
-                    .Distinct())
-            }
-        });
+            standardProperties = s_standardGitHubProperties;
+        }
+        else if (prUrl.Contains("dev.azure.com"))
+        {
+            standardProperties = s_standardAzureDevOpsProperties;
+        }
+        else
+        {
+            throw new NotImplementedException("Unknown pr repo url");
+        }
 
         var policies = new List<IMergePolicy>();
         policies.AddRange(await new AllChecksSuccessfulMergePolicyBuilder().BuildMergePoliciesAsync(standardProperties, pr));

--- a/src/Maestro/Maestro.MergePolicyEvaluation/MergePolicyConstants.cs
+++ b/src/Maestro/Maestro.MergePolicyEvaluation/MergePolicyConstants.cs
@@ -17,6 +17,7 @@ public class MergePolicyConstants
 
     public const string MaestroMergePolicyDisplayName = "Maestro auto-merge";
 
-    public const string CodeflowMergePolicyName = "Codeflow consistency check";
+    public const string ForwardFlowMergePolicyName = "Codeflow consistency check";
+    public const string BackFlowMergePolicyName = "Codeflow consistency check";
 }
 

--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/MergePoliciesPopUpHelpers.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/MergePoliciesPopUpHelpers.cs
@@ -23,8 +23,7 @@ public static class MergePoliciesPopUpHelpers
         {
             foreach (MergePolicy policy in mergePolicies)
             {
-                if (policy.Name.Equals(MergePolicyConstants.AllCheckSuccessfulMergePolicyName, StringComparison.OrdinalIgnoreCase) ||
-                    policy.Name.Equals(MergePolicyConstants.StandardMergePolicyName, StringComparison.OrdinalIgnoreCase))
+                if (policy.Name.Equals(MergePolicyConstants.AllCheckSuccessfulMergePolicyName, StringComparison.OrdinalIgnoreCase))
                 {
                     // Should either have no properties, or one called "ignoreChecks"
                     if (policy.Properties != null &&
@@ -36,7 +35,7 @@ public static class MergePoliciesPopUpHelpers
                         return false;
                     }
                 }
-                else if (policy.Name.Equals(MergePolicyConstants.CodeflowMergePolicyName, StringComparison.OrdinalIgnoreCase) ||
+                else if (policy.Name.Equals(MergePolicyConstants.StandardMergePolicyName, StringComparison.OrdinalIgnoreCase) ||
                          policy.Name.Equals(MergePolicyConstants.NoRequestedChangesMergePolicyName, StringComparison.OrdinalIgnoreCase) ||
                          policy.Name.Equals(MergePolicyConstants.DontAutomergeDowngradesPolicyName, StringComparison.OrdinalIgnoreCase) ||
                          policy.Name.Equals(MergePolicyConstants.ValidateCoherencyMergePolicyName, StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/AddSubscriptionOperation.cs
@@ -46,14 +46,9 @@ internal class AddSubscriptionOperation : Operation
     /// </summary>
     public override async Task<int> ExecuteAsync()
     {
-        if (_options.IgnoreChecks.Any() && !_options.AllChecksSuccessfulMergePolicy && !_options.StandardAutoMergePolicies)
+        if (_options.IgnoreChecks.Any() && !_options.AllChecksSuccessfulMergePolicy)
         {
-            _logger.LogError("--ignore-checks must be combined with --all-checks-passed or --standard-automerge");
-            return Constants.ErrorCode;
-        }
-        if (_options.CodeFlowCheckMergePolicy && !_options.SourceEnabled)
-        {
-            _logger.LogError("--code-flow-check can only be used with --source-enabled subscriptions");
+            Console.WriteLine($"--ignore-checks must be combined with --all-checks-passed");
             return Constants.ErrorCode;
         }
 
@@ -96,7 +91,7 @@ internal class AddSubscriptionOperation : Operation
                 new MergePolicy
                 {
                     Name = MergePolicyConstants.StandardMergePolicyName,
-                    Properties = new() { [MergePolicyConstants.IgnoreChecksMergePolicyPropertyName] = JToken.FromObject(_options.IgnoreChecks) }
+                    Properties = []
                 });
         }
 
@@ -107,23 +102,6 @@ internal class AddSubscriptionOperation : Operation
                     Name = MergePolicyConstants.ValidateCoherencyMergePolicyName,
                     Properties = []
                 });
-        }
-
-        if (_options.CodeFlowCheckMergePolicy)
-        {
-            if (_options.StandardAutoMergePolicies)
-            {
-                _logger.LogInformation("Code flow check merge policy is already included in standard auto-merge policies. Skipping");
-            }
-            else
-            {
-                mergePolicies.Add(
-                    new MergePolicy
-                    {
-                        Name = MergePolicyConstants.CodeflowMergePolicyName,
-                        Properties = []
-                    });
-            }
         }
 
         if (_options.Batchable && mergePolicies.Count > 0)

--- a/src/Microsoft.DotNet.Darc/Darc/Options/AddSubscriptionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/AddSubscriptionCommandLineOptions.cs
@@ -25,6 +25,23 @@ internal class AddSubscriptionCommandLineOptions : SubscriptionCommandLineOption
     [Option("batchable", HelpText = "Whether this subscription's content can be updated in batches. Not supported when the subscription specifies merge policies and in backflow subscriptions.")]
     public bool Batchable { get; set; }
 
+    [Option("standard-automerge", HelpText = "Use standard auto-merge policies. GitHub ignores WIP, license/cla and auto-merge.config.enforce checks, " +
+                                             "Azure DevOps ignores comment, reviewer and work item linking. Both will not auto-merge if changes are requested.")]
+    public bool StandardAutoMergePolicies { get; set; }
+
+    [Option("all-checks-passed", HelpText = "PR is automatically merged if there is at least one check, and all checks have passed. " +
+                                            "Optionally provide a comma-separated list of ignored check with --ignore-checks.")]
+    public bool AllChecksSuccessfulMergePolicy { get; set; }
+
+    [Option("ignore-checks", Separator = ',', HelpText = "For use with --all-checks-passed. A set of checks that are ignored.")]
+    public IEnumerable<string> IgnoreChecks { get; set; }
+
+    [Option("no-requested-changes", HelpText = "PR is not merged if there are changes requested or the PR has been rejected.")]
+    public bool NoRequestedChangesMergePolicy { get; set; }
+
+    [Option("no-downgrades", HelpText = "PR is not merged if there are version downgrades.")]
+    public bool DontAutomergeDowngradesMergePolicy { get; set; }
+
     [Option('q', "quiet", HelpText = "Non-interactive mode (requires all elements to be passed on the command line).")]
     public bool Quiet { get; set; }
 
@@ -36,6 +53,9 @@ internal class AddSubscriptionCommandLineOptions : SubscriptionCommandLineOption
 
     [Option("no-trigger", SetName = "notrigger", HelpText = "Do not trigger the subscription on creation.")]
     public bool NoTriggerOnCreate { get; set; }
+
+    [Option("validate-coherency", HelpText = "PR is not merged if the coherency algorithm failed.")]
+    public bool ValidateCoherencyCheckMergePolicy { get; set; }
 
     [Option("source-enabled", HelpText = "Get only source-enabled (VMR code flow) subscriptions.", Default = false)]
     public bool SourceEnabled { get; set; }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/SubscriptionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/SubscriptionCommandLineOptions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using CommandLine;
 using Microsoft.DotNet.Darc.Operations;
 
@@ -26,29 +25,4 @@ internal abstract class SubscriptionCommandLineOptions<T> : CommandLineOptions<T
 
     [Option('f', "force", HelpText = "Force subscription creation even when some checks fail.")]
     public bool ForceCreation { get; set; }
-
-    [Option("standard-automerge", HelpText = "Use standard auto-merge policies. GitHub ignores WIP, license/cla and auto-merge.config.enforce checks, " +
-                                             "Azure DevOps ignores comment, reviewer and work item linking. Both will not auto-merge if changes are requested. " +
-                                             "Also adds the Source Flow Check policy for source enabled subscriptions")]
-    public bool StandardAutoMergePolicies { get; set; }
-
-    [Option("all-checks-passed", HelpText = "PR is automatically merged if there is at least one check, and all checks have passed. " +
-                                            "Optionally provide a comma-separated list of ignored check with --ignore-checks.")]
-    public bool AllChecksSuccessfulMergePolicy { get; set; }
-
-    [Option("ignore-checks", Separator = ',', HelpText = "For use with --all-checks-passed or --standard-automerge. A set of checks that are ignored. " +
-                                                         "If used with standard-automerge, ignored checks will be added to the list of default ones")]
-    public IEnumerable<string> IgnoreChecks { get; set; }
-
-    [Option("no-requested-changes", HelpText = "PR is not merged if there are changes requested or the PR has been rejected.")]
-    public bool NoRequestedChangesMergePolicy { get; set; }
-
-    [Option("no-downgrades", HelpText = "PR is not merged if there are version downgrades.")]
-    public bool DontAutomergeDowngradesMergePolicy { get; set; }
-
-    [Option("code-flow-check", HelpText = "PR is not merged if the ForwardFlow/BackFlow check fails for ForwardFlow/BackwardFlow subscription")]
-    public bool CodeFlowCheckMergePolicy { get; set; }
-
-    [Option("validate-coherency", HelpText = "PR is not merged if the coherency algorithm failed.")]
-    public bool ValidateCoherencyCheckMergePolicy { get; set; }
 }

--- a/src/Microsoft.DotNet.Darc/Darc/Options/UpdateSubscriptionCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/UpdateSubscriptionCommandLineOptions.cs
@@ -32,8 +32,4 @@ internal class UpdateSubscriptionCommandLineOptions : SubscriptionCommandLineOpt
 
     [Option("source-enabled", HelpText = "Get only source-enabled (VMR code flow) subscriptions.")]
     public bool? SourceEnabled { get; set; }
-
-    [Option("update-merge-policies", Default = false, HelpText = "By default, if any merge policies are specific in the command, we'll overwrite the old ones. " +
-                                                "This flag makes it so we add onto the previous ones, instead of overwriting")]
-    public bool UpdateMergePolicies { get; set; }
 }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -1,6 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+using System.Xml.Serialization;
+using LibGit2Sharp;
 using Maestro.Data.Models;
 using Maestro.DataProviders;
 using Maestro.MergePolicies;


### PR DESCRIPTION
Reverts https://github.com/dotnet/arcade-services/issues/4680

This reverts commit 15c4f8e39a963a4598f0bbf2e6d70aad13766629.

<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
