### PR TITLE
Add attempt number into ACA revision

### DIFF
--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -149,6 +149,7 @@ stages:
           --containerJobNames $(containerjobNames)
           --newImageTag $(newDockerImageTag)
           --imageName $(containerName)
+          --attempt $(System.JobAttempt)
           --azCliPath "$(azCliPath)"
           --redisConnectionString $(redisConnectionString)
       displayName: Deploy container app

--- a/tools/ProductConstructionService.Cli/Operations/DeploymentOperation.cs
+++ b/tools/ProductConstructionService.Cli/Operations/DeploymentOperation.cs
@@ -93,6 +93,11 @@ internal class DeploymentOperation : IOperation
     private async Task<bool> DeployNewRevision(string inactiveRevisionLabel)
     {
         var newRevisionName = $"{_options.ContainerAppName}--{_options.NewImageTag}";
+        if (!string.IsNullOrEmpty(_options.Attempt))
+        {
+            newRevisionName += $"-{_options.Attempt}";
+        }
+
         var newImageFullUrl = $"{_options.ContainerRegistryName}.azurecr.io/{_options.ImageName}:{_options.NewImageTag}";
         try
         {

--- a/tools/ProductConstructionService.Cli/Options/DeploymentOptions.cs
+++ b/tools/ProductConstructionService.Cli/Options/DeploymentOptions.cs
@@ -22,22 +22,34 @@ internal class DeploymentOptions : Options
 {
     [Option("subscriptionId", Required = true, HelpText = "Azure subscription ID")]
     public required string SubscriptionId { get; init; }
+
     [Option("resourceGroupName", Required = true, HelpText = "Resource group name")]
     public required string ResourceGroupName { get; init; }
+
     [Option("containerAppName", Required = true, HelpText = "Container app name")]
     public required string ContainerAppName { get; init; }
+
     [Option("newImageTag", Required = true, HelpText = "New image tag")]
     public required string NewImageTag { get; init; }
+
+    [Option("attempt", Required = false, HelpText = "Attempt number for the deployment")]
+    public string? Attempt { get; init; }
+
     [Option("containerRegistryName", Required = true, HelpText = "Container registry name")]
     public required string ContainerRegistryName { get; init; }
+
     [Option("workspaceName", Required = true, HelpText = "Workspace name")]
     public required string WorkspaceName { get; init; }
+
     [Option("imageName", Required = true, HelpText = "Image name")]
     public required string ImageName { get; init; }
+
     [Option("containerJobNames", Required = true, HelpText = "Container job names")]
     public required string ContainerJobNames { get; init; }
+
     [Option("azCliPath", Required = true, HelpText = "Path to az.cmd")]
     public required string AzCliPath { get; init; }
+
     [Option("redisConnectionString", Required = true, HelpText = "Redis Cache connection string")]
     public required string RedisConnectionString { get; init; }
 


### PR DESCRIPTION
This should enable rerunning deployment stages of older production pipeline runs to quickly roll back PCS

<!-- https://github.com/dotnet/arcade-services/issues/4690 -->