### PR TITLE
Keep darc on .NET 6.0

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Microsoft.DotNet.Darc.csproj
+++ b/src/Microsoft.DotNet.Darc/Darc/Microsoft.DotNet.Darc.csproj
@@ -23,6 +23,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Newtonsoft.Json" />
+    <!-- Pin because of net6.0 tfm -->
+    <PackageReference Include="System.IO.Hashing" VersionOverride="8.0.0" />
     <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Darc/Darc/Microsoft.DotNet.Darc.csproj
+++ b/src/Microsoft.DotNet.Darc/Darc/Microsoft.DotNet.Darc.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <SignAssembly>false</SignAssembly>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
Darc was mistakenly updated to .NET 8 in https://github.com/dotnet/arcade-services/issues/4650
