### PR TITLE
Also make sure source repo installation id is there for source code subs

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/SubscriptionsController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/SubscriptionsController.cs
@@ -396,6 +396,15 @@ public class SubscriptionsController : v2019_01_16.Controllers.SubscriptionsCont
                 "The Maestro github application must be installed by the repository's owner and given access to the repository."
             ]));
         }
+        // We also need to make sure the source repository is registered if the subscription is source-enabled
+        if (subscription.SourceEnabled ?? false && !(await EnsureRepositoryRegistration(subscription.SourceRepository)))
+        {
+            return BadRequest(new ApiError("The request is invalid",
+            [
+                $"No Maestro GitHub application installation found for repository '{subscription.SourceRepository}'. " +
+                "The Maestro github application must be installed by the repository's owner and given access to the repository."
+            ]));
+        }
 
         if (subscription.SourceEnabled.HasValue)
         {


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4426
I excluded non codeflow subscriptions from this PR because in theory they don't need the installation id, and we might be using Maestro somewhere that has this