### PR TITLE
Fix handling submodules during forward flow

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/GitHubTokenProvider.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitHubTokenProvider.cs
@@ -11,11 +11,25 @@ public class GitHubTokenProvider(GitHub.Authentication.IGitHubTokenProvider toke
 {
     public string? GetTokenForRepository(string repoUri)
     {
-        return tokenProvider.GetTokenForRepository(repoUri).GetAwaiter().GetResult();
+        try
+        {
+            return tokenProvider.GetTokenForRepository(repoUri).GetAwaiter().GetResult();
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     public async Task<string?> GetTokenForRepositoryAsync(string repoUri)
     {
-        return await tokenProvider.GetTokenForRepository(repoUri);
+        try
+        {
+            return await tokenProvider.GetTokenForRepository(repoUri);
+        }
+        catch
+        {
+            return null;
+        }
     }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -260,19 +260,12 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
         var patchName = _vmrInfo.TmpPath / $"{headBranch.Replace('/', '-')}.patch";
         var branchName = currentFlow.GetBranchName();
 
-        List<GitSubmoduleInfo> submodules =
-        [
-            .. await sourceRepo.GetGitSubmodulesAsync(lastFlow.RepoSha),
-            .. await sourceRepo.GetGitSubmodulesAsync(currentFlow.RepoSha),
-        ];
-
         // We will remove everything not-cloaked and replace it with current contents of the source repo
-        // When flowing to the VMR, we remove all files but submodules and cloaked files
+        // When flowing to the VMR, we remove all files but the cloaked files
         List<string> removalFilters =
         [
             .. mapping.Include.Select(VmrPatchHandler.GetInclusionRule),
-            .. mapping.Exclude.Select(VmrPatchHandler.GetExclusionRule),
-            .. submodules.Select(s => s.Path).Distinct().Select(VmrPatchHandler.GetExclusionRule),
+            .. mapping.Exclude.Select(VmrPatchHandler.GetExclusionRule)
         ];
 
         var result = await _processManager.Execute(


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4644
There was a bug in forwardflow when the previous flow was backwards
Basically, we were leaving the submodules as is in our repo, but creating the patches for them from 0 commit. When these patches we're applied, we were getting exceptions that the files already exist in the index.
This PR fixes the issue by making sure we remove the submodules at the beginning of the forward flow, so we restore them like the normal repo, from the 0 commit