### PR TITLE
Use DefaultAzureCredential instead of AzureCliCredential for unattended (pipeline) authentication to Darc/PCS API

### DIFF
--- a/src/Maestro/Maestro.Common/AppCredentials/AppCredential.cs
+++ b/src/Maestro/Maestro.Common/AppCredentials/AppCredential.cs
@@ -101,7 +101,7 @@ public class AppCredential : TokenCredential
     public static AppCredential CreateNonUserCredential(string appId)
     {
         var requestContext = new TokenRequestContext([$"{appId}/.default"]);
-        var credential = new AzureCliCredential();
+        var credential = new DefaultAzureCredential();
         return new AppCredential(credential, requestContext);
     }
 }


### PR DESCRIPTION
Azure CLI is not strictly necessary for authentication with Managed Identity.

You can instead use [WorkloadIdentityCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.workloadidentitycredential.-ctor?view=azure-dotnet#azure-identity-workloadidentitycredential-ctor) and specify AZURE_TENANT_ID, AZURE_CLIENT_ID and AZURE_FEDERATED_TOKEN_FILE. This is preferable for scenarios where you want to access PCS/Darc from a container, since you can get the AZURE_FEDERATED_TOKEN_FILE from the host machine, and you don't need to install Azure CLI in the container image (it brings along with it ~500MB of dependencies).

[DefaultAzureCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet) actually tries several types of credentials in order, including both WorkloadIdentityCredential and AzureCliCredential, so by using DefaultAzureCredential, existing workflows _shouldn't_ break (but I'm not sure how to verify that).

We already do this today in the .NET Docker tooling: https://github.com/dotnet/docker-tools/blob/b6f70ca4d333ea28dcff877fce01a1d1430813ff/src/Microsoft.DotNet.ImageBuilder/src/AzureTokenCredentialProvider.cs#L27

Fixes https://github.com/dotnet/arcade-services/issues/4702