### PR TITLE
Fix the 401 HTTP status code check from string

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/HttpRequestManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/HttpRequestManager.cs
@@ -118,7 +118,7 @@ public class HttpRequestManager
                 response?.Dispose();
 
                 // For CLI users this will look normal, but translating to a DarcAuthenticationFailureException means it opts in to automated failure logging.
-                if (ex is HttpRequestException && ex.Message.Contains(((int)HttpStatusCode.Unauthorized).ToString()))
+                if (ex is HttpRequestException httpEx && httpEx.StatusCode == HttpStatusCode.Unauthorized)
                 {
                     var queryParamIndex = _requestUri.IndexOf('?');
                     var sanitizedRequestUri = queryParamIndex < 0 ? _requestUri : $"{_requestUri.Substring(0, queryParamIndex)}?***";


### PR DESCRIPTION
Fix the issue with contains certain HTTP status code in error message. Problem was that 401 appeared in the name of non-existent feed and it was interpreted as unauthorized access.

Issue: https://github.com/dotnet/arcade-services/issues/4703
https://github.com/dotnet/arcade-services/issues/2479
