### PR TITLE
Add `global.json` mapping for `CMake.Sdk`

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -40,6 +40,7 @@ public class DependencyFileManager : IDependencyFileManager
         { "Microsoft.DotNet.Helix.Sdk", "msbuild-sdks" },
         { "Microsoft.DotNet.SharedFramework.Sdk", "msbuild-sdks" },
         { "Microsoft.NET.SharedFramework.Sdk", "msbuild-sdks" },
+        { "Microsoft.DotNet.CMake.Sdk", "msbuild-sdks" },
         { "dotnet", "tools" },
     }.ToImmutableDictionary();
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -41,6 +41,7 @@ public class DependencyFileManager : IDependencyFileManager
         { "Microsoft.DotNet.SharedFramework.Sdk", "msbuild-sdks" },
         { "Microsoft.NET.SharedFramework.Sdk", "msbuild-sdks" },
         { "Microsoft.DotNet.CMake.Sdk", "msbuild-sdks" },
+        { "Microsoft.NET.Sdk.IL", "msbuild-sdks" },
         { "dotnet", "tools" },
     }.ToImmutableDictionary();
 


### PR DESCRIPTION
One of the issues seen in https://github.com/dotnet/arcade-services/issues/4721
