### PR TITLE
Fix upserting of `Versions.props` properties

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -1666,5 +1666,5 @@ public class DependencyFileManager : IDependencyFileManager
     }
 
     public static XmlNode GetVersionPropsNode(XmlDocument versionProps, string nodeName) =>
-        versionProps.DocumentElement?.SelectSingleNode($"//*[local-name()='{nodeName}' and parent::PropertyGroup]");
+        versionProps.DocumentElement?.SelectSingleNode($"//*[local-name()='{nodeName}' and parent::*[local-name()='PropertyGroup']]");
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VersionFileCodeFlowUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VersionFileCodeFlowUpdater.cs
@@ -518,7 +518,7 @@ public class VersionFileCodeFlowUpdater : IVersionFileCodeFlowUpdater
         // Later we update them
         foreach (var update in updates)
         {
-            await _dependencyFileManager.AddDependencyAsync(new DependencyDetail(update) { Version = "0.0.0" }, targetRepo.Path, branch: null!);
+            await _dependencyFileManager.AddDependencyAsync(new DependencyDetail(update), targetRepo.Path, branch: null!);
         }
 
         // If we are updating the arcade sdk we need to update the eng/common files as well


### PR DESCRIPTION
Fixes a problem of a code path that was not really exercised but has been present in the codebase for years where `AddDependency` would fail to update an existing item and instead would create a new one.

https://github.com/dotnet/arcade-services/issues/4720