### PR TITLE
Prefer the `az cli` credential in CI deployments

### DIFF
--- a/tools/ProductConstructionService.Cli/Options/DeploymentOptions.cs
+++ b/tools/ProductConstructionService.Cli/Options/DeploymentOptions.cs
@@ -59,9 +59,9 @@ internal class DeploymentOptions : Options
     {
         services.AddTransient<IProcessManager>(sp => new ProcessManager(sp.GetRequiredService<ILogger<ProcessManager>>(), "git"));
 
-        DefaultAzureCredential credential = new();
+        AzureCliCredential credential = new();
         services.AddSingleton(credential);
-        services.AddTransient<ArmClient>(sp => new(sp.GetRequiredService<DefaultAzureCredential>()));
+        services.AddTransient<ArmClient>(_ => new(credential));
         services.AddTransient<ResourceGroupResource>(sp =>
         {
             return new ArmClient(credential)

--- a/tools/ProductConstructionService.Cli/Options/DeploymentOptions.cs
+++ b/tools/ProductConstructionService.Cli/Options/DeploymentOptions.cs
@@ -59,7 +59,9 @@ internal class DeploymentOptions : Options
     {
         services.AddTransient<IProcessManager>(sp => new ProcessManager(sp.GetRequiredService<ILogger<ProcessManager>>(), "git"));
 
-        AzureCliCredential credential = new();
+        var credential = new ChainedTokenCredential(
+            new AzureCliCredential(),
+            new DefaultAzureCredential());
         services.AddSingleton(credential);
         services.AddTransient<ArmClient>(_ => new(credential));
         services.AddTransient<ResourceGroupResource>(sp =>


### PR DESCRIPTION
We started seeing failures in the deployments because some other identity is being picked up suddenly.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2694710&view=results

<!-- https://github.com/dotnet/arcade-services/issues/4734 -->