### PR TITLE
Don't use DefaultAzureCredential when not running locally

### DIFF
--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -3,20 +3,20 @@
 1. Install the latest Preview VS.
   - Be sure to install the `Azure Development => .NET Aspire SDK (Preview)` optional workload in the VS installer
   - Be sure to install the `ASP.NET and web development` => `.NET 8.0/9.0 WebAssembly Build Tools`
-1. Install Docker Desktop: https://www.docker.com/products/docker-desktop
-1. Configure git to support long paths:
+2. Install Docker Desktop: https://www.docker.com/products/docker-desktop
+3. Configure git to support long paths:
     ```ps1
     git config --system core.longpaths true # you will need elevated shell for this one
     git config --global core.longpaths true
     ```
-1. Install SQL Server Express: https://www.microsoft.com/en-us/sql-server/sql-server-downloads
-1. Install Entity Framework Core CLI by running `dotnet tool install --global dotnet-ef`
-1. Build the `src\Maestro\Maestro.Data\Maestro.Data.csproj` project (either from console or from IDE)
-1. From the `src\Maestro\Maestro.Data` project directory, run `dotnet ef --msbuildprojectextensionspath <full path to obj dir for Maestro repo (e.g. "C:\arcade-services\artifacts\obj\Maestro.Data\")> database update`
+4. Install SQL Server Express: https://www.microsoft.com/en-us/sql-server/sql-server-downloads
+5. Install Entity Framework Core CLI by running `dotnet tool install --global dotnet-ef`
+6. Build the `src\Maestro\Maestro.Data\Maestro.Data.csproj` project (either from console or from IDE)
+7. From the `src\Maestro\Maestro.Data` project directory, run `dotnet ef --msbuildprojectextensionspath <full path to obj dir for Maestro repo (e.g. "C:\arcade-services\artifacts\obj\Maestro.Data\")> database update`
     - Note that the generated files are in the root artifacts folder, not the artifacts folder within the `Maestro.Data` project folder
-1. Join the `maestro-auth-test` org in GitHub (you will need to ask someone to manually add you to the org)
-1. Make sure you can read the `ProductConstructionDev` keyvault. If you can't, ask someone to add you to the keyvault
-1. In SQL Server Object Explorer in Visual Studio, find the local SQLExpress database for the build asset registry and populate the Repositories table with the following rows:
+8. Join the `maestro-auth-test` org in GitHub (you will need to ask someone to manually add you to the org)
+9. Make sure you can read the `ProductConstructionDev` keyvault. If you can't, ask someone to add you to the keyvault
+10. In SQL Server Object Explorer in Visual Studio, find the local SQLExpress database for the build asset registry and populate the Repositories table with the following rows:
 
   ```sql
   INSERT INTO [Repositories] (RepositoryName, InstallationId) VALUES

--- a/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
+++ b/src/Maestro/Maestro.Common/AzureDevOpsTokens/AzureDevOpsTokenProvider.cs
@@ -6,7 +6,6 @@ using Azure.Core;
 using Azure.Identity;
 using Maestro.Common.AppCredentials;
 using Microsoft.Extensions.Options;
-using Microsoft.DncEng.Configuration.Extensions;
 
 namespace Maestro.Common.AzureDevOpsTokens;
 

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/GatherDropOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/GatherDropOperation.cs
@@ -47,9 +47,7 @@ internal class GatherDropOperation : Operation
         IRemoteFactory remoteFactory)
     {
         _options = options;
-        _azureTokenCredential = new Lazy<TokenCredential>(() =>
-            AzureAuthentication.GetCliCredential()
-        );
+        _azureTokenCredential = new Lazy<TokenCredential>(AzureAuthentication.GetCliCredential);
         _logger = logger;
         _barClient = barClient;
         _remoteFactory = remoteFactory;

--- a/src/Microsoft.DotNet.Darc/Darc/Options/GatherDropCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/GatherDropCommandLineOptions.cs
@@ -78,7 +78,7 @@ internal class GatherDropCommandLineOptions : CommandLineOptions<GatherDropOpera
     [RedactFromLogging]
     public IEnumerable<string> SASSuffixes { get; set; }
 
-    [Option("use-azure-credential-for-blobs", HelpText = "Use DefaultAzureCredential to acquire token for downloading assets from Blob storages")]
+    [Option("use-azure-credential-for-blobs", HelpText = "Use AzCliCredential to acquire token for downloading assets from Blob storages")]
     public bool UseAzureCredentialForBlobs { get; set; }
 
     [Option("always-download-asset-filters", HelpText = "Comma-separated list of exact names or regexes which will always be downloaded. If not part of the usual payload, they will be downloaded to an 'extra-assets' folder.")]

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/AzureAuthentication.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/AzureAuthentication.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Azure.Core;
+using Azure.Identity;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.Helpers;
+public static class AzureAuthentication
+{
+    public static TokenCredential GetCliCredential() => new ChainedTokenCredential(
+            new AzureCliCredential(),
+            new DefaultAzureCredential());
+
+    public static TokenCredential GetServiceCredential(bool isDevelopment, string? managedIdentityClientId)
+    {
+        if (isDevelopment)
+        {
+            return new DefaultAzureCredential();
+        }
+        else
+        {
+            return new ManagedIdentityCredential(ManagedIdentityId.FromUserAssignedClientId(managedIdentityClientId ??
+                throw new ArgumentException($"{nameof(managedIdentityClientId)} can't be null when creating service identity")));
+        }
+    }
+}

--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/DataProtection.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/DataProtection.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Azure.Core;
 using Azure.Identity;
 using Microsoft.AspNetCore.DataProtection;
 
@@ -13,7 +14,7 @@ internal static class DataProtection
 
     private static readonly TimeSpan DataProtectionKeyLifetime = new(days: 240, hours: 0, minutes: 0, seconds: 0);
 
-    public static void AddDataProtection(this WebApplicationBuilder builder, DefaultAzureCredential credential)
+    public static void AddDataProtection(this WebApplicationBuilder builder, TokenCredential credential)
     {
         var keyBlobUri = builder.Configuration[DataProtectionKeyBlobUri];
         var dataProtectionKeyUri = builder.Configuration[DataProtectionKeyUri];

--- a/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/PcsStartup.cs
@@ -37,6 +37,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Octokit.Webhooks.AspNetCore;
 using Octokit.Webhooks;
 using ProductConstructionService.Api.Controllers;
+using Azure.Core;
+using Microsoft.DotNet.DarcLib.Helpers;
 
 namespace ProductConstructionService.Api;
 
@@ -90,10 +92,7 @@ internal static class PcsStartup
             .Replace(SqlConnectionStringUserIdPlaceholder, managedIdentityId);
         builder.Services.Configure<AzureDevOpsTokenProviderOptions>(ConfigurationKeys.AzureDevOpsConfiguration, (o, s) => s.Bind(o));
 
-        DefaultAzureCredential azureCredential = new(new DefaultAzureCredentialOptions
-        {
-            ManagedIdentityClientId = managedIdentityId,
-        });
+        TokenCredential azureCredential = AzureAuthentication.GetServiceCredential(isDevelopment, managedIdentityId);
 
         builder.AddDataProtection(azureCredential);
         builder.AddTelemetry();

--- a/src/ProductConstructionService/ProductConstructionService.SubscriptionTriggerer/SubscriptionTriggererConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.SubscriptionTriggerer/SubscriptionTriggererConfiguration.cs
@@ -10,6 +10,7 @@ using ProductConstructionService.Common;
 using Azure.Identity;
 using ProductConstructionService.WorkItems;
 using Maestro.Data;
+using Azure.Core;
 
 namespace ProductConstructionService.SubscriptionTriggerer;
 
@@ -19,11 +20,9 @@ public static class SubscriptionTriggererConfiguration
         this HostApplicationBuilder builder,
         ITelemetryChannel telemetryChannel)
     {
-        DefaultAzureCredential credential = new(
-            new DefaultAzureCredentialOptions
-            {
-                ManagedIdentityClientId = builder.Configuration[ProductConstructionServiceExtension.ManagedIdentityClientId]
-            });
+        TokenCredential credential = AzureAuthentication.GetServiceCredential(
+            builder.Environment.IsDevelopment(),
+            builder.Configuration[ProductConstructionServiceExtension.ManagedIdentityClientId]);
 
         builder.RegisterLogging(telemetryChannel);
 

--- a/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItemConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.WorkItems/WorkItemConfiguration.cs
@@ -36,7 +36,7 @@ public static class WorkItemConfiguration
         WriteIndented = false,
     };
 
-    public static void AddWorkItemQueues(this IHostApplicationBuilder builder, DefaultAzureCredential credential, bool waitForInitialization)
+    public static void AddWorkItemQueues(this IHostApplicationBuilder builder, TokenCredential credential, bool waitForInitialization)
     {
         builder.AddWorkItemProducerFactory(credential);
 
@@ -79,7 +79,7 @@ public static class WorkItemConfiguration
         }
     }
 
-    public static void AddWorkItemProducerFactory(this IHostApplicationBuilder builder, DefaultAzureCredential credential)
+    public static void AddWorkItemProducerFactory(this IHostApplicationBuilder builder, TokenCredential credential)
     {
         builder.AddAzureQueueClient("queues", settings => settings.Credential = credential);
 

--- a/tools/ProductConstructionService.Cli/Options/DeploymentOptions.cs
+++ b/tools/ProductConstructionService.Cli/Options/DeploymentOptions.cs
@@ -59,9 +59,7 @@ internal class DeploymentOptions : Options
     {
         services.AddTransient<IProcessManager>(sp => new ProcessManager(sp.GetRequiredService<ILogger<ProcessManager>>(), "git"));
 
-        var credential = new ChainedTokenCredential(
-            new AzureCliCredential(),
-            new DefaultAzureCredential());
+        var credential = AzureAuthentication.GetCliCredential();
         services.AddSingleton(credential);
         services.AddTransient<ArmClient>(_ => new(credential));
         services.AddTransient<ResourceGroupResource>(sp =>


### PR DESCRIPTION
We shouldn't be using `DefaultAzureCredential` when running in a pipeline or a service. We should be using either ManagedIdentityCredential, or AzureCliCredential.
https://learn.microsoft.com/en-us/dotnet/azure/sdk/authentication/best-practices?tabs=aspdotnet#:~:text=and%20mitigation%20techniques.-,Use%20deterministic%20credentials%20in%20production%20environments,-DefaultAzureCredential%20is%20the

https://github.com/dotnet/arcade-services/issues/4738