### PR TITLE
Allow ReproTool's `flow-commit` to work for non-VMR subscriptions

### DIFF
--- a/tools/ProductConstructionService.ReproTool/DarcProcessManager.cs
+++ b/tools/ProductConstructionService.ReproTool/DarcProcessManager.cs
@@ -141,9 +141,12 @@ internal class DarcProcessManager(
     {
         logger.LogInformation("Creating a test subscription");
 
-        string[] directoryArg = !string.IsNullOrEmpty(sourceDirectory) ?
-            ["--source-directory", sourceDirectory] :
-            ["--target-directory", targetDirectory!];
+        string[] directoryArg = (sourceDirectory?.Length, targetDirectory?.Length) switch
+        {
+            (> 0, _) => ["--source-directory", sourceDirectory],
+            (_, > 0) => ["--target-directory", targetDirectory],
+            _ => []
+        };
 
         string[] excludedAssetsParameter = excludedAssets != null ?
             [ "--excluded-assets", string.Join(';', excludedAssets) ] :
@@ -157,7 +160,7 @@ internal class DarcProcessManager(
                 "--target-branch", targetBranch,
                 "-q",
                 "--no-trigger",
-                "--source-enabled", "true",
+                "--source-enabled", directoryArg.Length > 0 ? "true" : "false",
                 "--update-frequency", "none",
                 .. directoryArg,
                 .. excludedAssetsParameter

--- a/tools/ProductConstructionService.ReproTool/Options/FlowCommitOptions.cs
+++ b/tools/ProductConstructionService.ReproTool/Options/FlowCommitOptions.cs
@@ -25,6 +25,9 @@ internal class FlowCommitOptions : Options
     [Option("target-branch", HelpText = "Branch to flow the commit into", Required = true)]
     public required string TargetBranch { get; init; }
 
+    [Option("package", HelpText = "Name(s) of package(s) to include in the flown build", Required = false)]
+    public IEnumerable<string> Packages { get; init; } = [];
+
     internal override Operation GetOperation(IServiceProvider sp)
         => ActivatorUtilities.CreateInstance<FlowCommitOperation>(sp, this);
 }


### PR DESCRIPTION
- Allows to use the `flow-commit` command for any repos (VMR and non-VMR).
- Allows to add a list of packages to be flown too

https://github.com/dotnet/arcade-services/issues/4751