### PR TITLE
Inject services instead of passing them as method parameters

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -150,6 +150,7 @@ public abstract class CommandLineOptions : ICommandLineOptions
             disableInteractiveAuth: IsCi,
             BuildAssetRegistryBaseUri));
         services.TryAddSingleton<IBasicBarClient>(sp => sp.GetRequiredService<IBarApiClient>());
+        services.TryAddTransient<ICoherencyUpdateResolver, CoherencyUpdateResolver>();
         services.TryAddTransient<ILogger>(sp => sp.GetRequiredService<ILogger<Operation>>());
         services.TryAddTransient<ITelemetryRecorder, NoTelemetryRecorder>();
         services.TryAddTransient<IGitRepoFactory>(sp => ActivatorUtilities.CreateInstance<GitRepoFactory>(sp, Path.GetTempPath()));

--- a/src/Microsoft.DotNet.Darc/DarcLib/ICoherencyUpdateResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ICoherencyUpdateResolver.cs
@@ -14,11 +14,8 @@ public interface ICoherencyUpdateResolver
     ///     Get updates required by coherency constraints.
     /// </summary>
     /// <param name="dependencies">Current set of dependencies.</param>
-    /// <param name="remoteFactory">Remote factory for remote queries.</param>
     /// <returns>List of dependency updates.</returns>
-    Task<List<DependencyUpdate>> GetRequiredCoherencyUpdatesAsync(
-        IEnumerable<DependencyDetail> dependencies,
-        IRemoteFactory remoteFactory);
+    Task<List<DependencyUpdate>> GetRequiredCoherencyUpdatesAsync(IEnumerable<DependencyDetail> dependencies);
 
     /// <summary>
     ///     Given a current set of dependencies, determine what non-coherency updates

--- a/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
@@ -127,16 +127,14 @@ public interface IRemote
     /// </summary>
     /// <param name="repoUri">Repository to update</param>
     /// <param name="branch">Branch of <paramref name="repoUri"/> to update.</param>
-    /// <param name="remoteFactory">Remote factory for obtaining common script files from arcade</param>
-    /// <param name="barClientFactory">Factory for getting clients that can query build and asset information</param>
     /// <param name="itemsToUpdate">Dependencies that need updating.</param>
+    /// <param name="sourceRepoIsVmr">Are we flowing from a VMR?</param>
     /// <param name="message">Commit message.</param>
     Task<List<GitFile>> CommitUpdatesAsync(
         string repoUri,
         string branch,
-        IRemoteFactory remoteFactory,
-        IBasicBarClient barClient,
         List<DependencyDetail> itemsToUpdate,
+        bool sourceRepoIsVmr,
         string message);
 
     /// <summary>

--- a/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
@@ -128,13 +128,11 @@ public interface IRemote
     /// <param name="repoUri">Repository to update</param>
     /// <param name="branch">Branch of <paramref name="repoUri"/> to update.</param>
     /// <param name="itemsToUpdate">Dependencies that need updating.</param>
-    /// <param name="sourceRepoIsVmr">Are we flowing from a VMR?</param>
     /// <param name="message">Commit message.</param>
     Task<List<GitFile>> CommitUpdatesAsync(
         string repoUri,
         string branch,
         List<DependencyDetail> itemsToUpdate,
-        bool sourceRepoIsVmr,
         string message);
 
     /// <summary>

--- a/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
@@ -24,6 +24,9 @@ public sealed class Remote : IRemote
     private readonly DependencyFileManager _fileManager;
     private readonly IRemoteGitRepo _remoteGitClient;
     private readonly ISourceMappingParser _sourceMappingParser;
+    private readonly IRemoteFactory _remoteFactory;
+    private readonly IAssetLocationResolver _locationResolver;
+    private readonly IBasicBarClient _barClient;
     private readonly ILogger _logger;
 
     //[DependencyUpdate]: <> (Begin)
@@ -38,12 +41,18 @@ public sealed class Remote : IRemote
         IRemoteGitRepo remoteGitClient,
         IVersionDetailsParser versionDetailsParser,
         ISourceMappingParser sourceMappingParser,
+        IRemoteFactory remoteFactory,
+        IAssetLocationResolver locationResolver,
+        IBasicBarClient barClient,
         ILogger logger)
     {
         _logger = logger;
         _remoteGitClient = remoteGitClient;
         _versionDetailsParser = versionDetailsParser;
         _sourceMappingParser = sourceMappingParser;
+        _remoteFactory = remoteFactory;
+        _locationResolver = locationResolver;
+        _barClient = barClient;
         _fileManager = new DependencyFileManager(remoteGitClient, _versionDetailsParser, _logger);
     }
 
@@ -157,23 +166,21 @@ public sealed class Remote : IRemote
     /// </summary>
     /// <param name="repoUri">Repository to update</param>
     /// <param name="branch">Branch of <paramref name="repoUri"/> to update.</param>
-    /// <param name="remoteFactory">Remote factory for obtaining common script files from arcade</param>
     /// <param name="itemsToUpdate">Dependencies that need updating.</param>
+    /// <param name="sourceRepoIsVmr">Are we flowing from a VMR?</param>
     /// <param name="message">Commit message.</param>
     /// <returns>Async task.</returns>
     public async Task<List<GitFile>> CommitUpdatesAsync(
         string repoUri,
         string branch,
-        IRemoteFactory remoteFactory,
-        IBasicBarClient barClient,
         List<DependencyDetail> itemsToUpdate,
+        bool sourceRepoIsVmr,
         string message)
     {
         CheckForValidGitClient();
 
         List<DependencyDetail> oldDependencies = [.. await GetDependenciesAsync(repoUri, branch)];
-        var locationResolver = new AssetLocationResolver(barClient);
-        await locationResolver.AddAssetLocationToDependenciesAsync(oldDependencies);
+        await _locationResolver.AddAssetLocationToDependenciesAsync(oldDependencies);
 
         // If we are updating the arcade sdk we need to update the eng/common files
         // and the sdk versions in global.json
@@ -181,22 +188,13 @@ public sealed class Remote : IRemote
 
         SemanticVersion targetDotNetVersion = null;
         var mayNeedArcadeUpdate = arcadeItem != null && repoUri != arcadeItem.RepoUri;
-        // If we find version files in src/arcade, we know we're working with a VMR
-        bool sourceRepoIsVmr = true;
-
         if (mayNeedArcadeUpdate)
         {
-            IDependencyFileManager arcadeFileManager = await remoteFactory.CreateDependencyFileManagerAsync(arcadeItem.RepoUri);
-            try
-            {
-                targetDotNetVersion = await arcadeFileManager.ReadToolsDotnetVersionAsync(arcadeItem.RepoUri, arcadeItem.Commit, sourceRepoIsVmr);
-            }
-            catch (DependencyFileNotFoundException)
-            {
-                // global.json not found in src/arcade meaning that repo is not the VMR
-                sourceRepoIsVmr = false;
-                targetDotNetVersion = await arcadeFileManager.ReadToolsDotnetVersionAsync(arcadeItem.RepoUri, arcadeItem.Commit, sourceRepoIsVmr);
-            }
+            IDependencyFileManager arcadeFileManager = await _remoteFactory.CreateDependencyFileManagerAsync(arcadeItem.RepoUri);
+            targetDotNetVersion = await arcadeFileManager.ReadToolsDotnetVersionAsync(
+                arcadeItem.RepoUri,
+                arcadeItem.Commit,
+                sourceRepoIsVmr);
         }
 
         GitFileContentContainer fileContainer = await _fileManager.UpdateDependencyFiles(
@@ -213,7 +211,7 @@ public sealed class Remote : IRemote
         {
             // Files in the source arcade repo. We use the remote factory because the
             // arcade repo may be in github while this remote is targeted at AzDO.
-            IRemote arcadeRemote = await remoteFactory.CreateRemoteAsync(arcadeItem.RepoUri);
+            IRemote arcadeRemote = await _remoteFactory.CreateRemoteAsync(arcadeItem.RepoUri);
             List<GitFile> engCommonFiles = await arcadeRemote.GetCommonScriptFilesAsync(arcadeItem.RepoUri, arcadeItem.Commit, repoIsVmr: sourceRepoIsVmr);
             // If the engCommon files are coming from the VMR, we have to remove 'src/arcade/' from the file paths
             if (sourceRepoIsVmr)

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -28,13 +28,11 @@ internal interface IPullRequestBuilder
     /// </param>
     /// <param name="targetRepository">Target repository that the updates should be applied to</param>
     /// <param name="newBranchName">Target branch the updates should be to</param>
-    /// <param name="sourceRepoIsVmr">Source repository of the update is a VMR</param>
     Task<string> CalculatePRDescriptionAndCommitUpdatesAsync(
         List<(SubscriptionUpdateWorkItem update, List<DependencyUpdate> deps)> requiredUpdates,
         string? currentDescription,
         string targetRepository,
-        string newBranchName,
-        bool sourceRepoIsVmr);
+        string newBranchName);
 
     /// <summary>
     ///     Compute the title for a pull request.
@@ -126,8 +124,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
         List<(SubscriptionUpdateWorkItem update, List<DependencyUpdate> deps)> requiredUpdates,
         string? currentDescription,
         string targetRepository,
-        string newBranchName,
-        bool sourceRepoIsVmr)
+        string newBranchName)
     {
         StringBuilder description = new StringBuilder(currentDescription ?? "This pull request updates the following dependencies")
             .AppendLine()
@@ -175,7 +172,6 @@ internal class PullRequestBuilder : IPullRequestBuilder
                 targetRepository,
                 newBranchName,
                 itemsToUpdate,
-                sourceRepoIsVmr,
                 message.ToString());
 
             AppendBuildDescription(description, ref startingReferenceId, update, deps, committedFiles, build);
@@ -199,7 +195,6 @@ internal class PullRequestBuilder : IPullRequestBuilder
                 targetRepository,
                 newBranchName,
                 itemsToUpdate,
-                sourceRepoIsVmr,
                 message.ToString());
         }
 
@@ -208,7 +203,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
         if (requiredUpdates.Count == 0)
         {
             var message = "Failed to perform coherency update for one or more dependencies.";
-            await remote.CommitUpdatesAsync(targetRepository, newBranchName, [], sourceRepoIsVmr, message);
+            await remote.CommitUpdatesAsync(targetRepository, newBranchName, [], message);
             return $"Coherency update: {message} Please review the GitHub checks or run `darc update-dependencies --coherency-only` locally against {newBranchName} for more information.";
         }
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestPolicyFailureNotifier.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestPolicyFailureNotifier.cs
@@ -24,14 +24,14 @@ internal class PullRequestPolicyFailureNotifier : IPullRequestPolicyFailureNotif
     public PullRequestPolicyFailureNotifier(
         IGitHubTokenProvider gitHubTokenProvider,
         IGitHubClientFactory gitHubClientFactory,
-        IRemoteFactory darcFactory,
+        IRemoteFactory remoteFactory,
         IBasicBarClient barClient,
         ILogger<PullRequestPolicyFailureNotifier> logger)
     {
         _logger = logger;
         _gitHubTokenProvider = gitHubTokenProvider;
         _gitHubClientFactory = gitHubClientFactory;
-        _remoteFactory = darcFactory;
+        _remoteFactory = remoteFactory;
         _barClient = barClient;
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -816,7 +816,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
             _logger.LogInformation("Running a coherency check on the existing dependencies for branch {branch} of repo {repository}",
                 targetBranch,
                 targetRepository);
-            coherencyUpdates = await _coherencyUpdateResolver.GetRequiredCoherencyUpdatesAsync(existingDependencies, _remoteFactory);
+            coherencyUpdates = await _coherencyUpdateResolver.GetRequiredCoherencyUpdatesAsync(existingDependencies);
         }
         catch (DarcCoherencyException e)
         {

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using Maestro.Data;
 using Maestro.Data.Models;
 using Maestro.DataProviders;
 using Maestro.MergePolicies;
@@ -539,8 +540,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 repoDependencyUpdate.RequiredUpdates,
                 currentDescription: null,
                 targetRepository,
-                newBranchName,
-                );
+                newBranchName);
 
             var containedSubscriptions = repoDependencyUpdate.RequiredUpdates
                 // Coherency updates do not have subscription info.
@@ -698,8 +698,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
             requiredDescriptionUpdates,
             prInfo.Description,
             targetRepository,
-            prInfo.HeadBranch,
-            );
+            prInfo.HeadBranch);
 
         prInfo.Title = await _pullRequestBuilder.GeneratePRTitleAsync(pr.ContainedSubscriptions, targetBranch);
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -521,7 +521,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         IRemote darcRemote = await _remoteFactory.CreateRemoteAsync(targetRepository);
 
         TargetRepoDependencyUpdate repoDependencyUpdate =
-            await GetRequiredUpdates(update, _remoteFactory, targetRepository, prBranch: null, targetBranch);
+            await GetRequiredUpdates(update, targetRepository, prBranch: null, targetBranch: targetBranch);
 
         if (repoDependencyUpdate.CoherencyCheckSuccessful && repoDependencyUpdate.RequiredUpdates.Count < 1)
         {
@@ -539,7 +539,8 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 repoDependencyUpdate.RequiredUpdates,
                 currentDescription: null,
                 targetRepository,
-                newBranchName);
+                newBranchName,
+                );
 
             var containedSubscriptions = repoDependencyUpdate.RequiredUpdates
                 // Coherency updates do not have subscription info.
@@ -627,7 +628,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         IRemote darcRemote = await _remoteFactory.CreateRemoteAsync(targetRepository);
 
         TargetRepoDependencyUpdate targetRepositoryUpdates =
-            await GetRequiredUpdates(update, _remoteFactory, targetRepository, prInfo.HeadBranch, targetBranch);
+            await GetRequiredUpdates(update, targetRepository, prInfo.HeadBranch, targetBranch);
 
         if (targetRepositoryUpdates.CoherencyCheckSuccessful && targetRepositoryUpdates.RequiredUpdates.Count < 1)
         {
@@ -697,7 +698,8 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
             requiredDescriptionUpdates,
             prInfo.Description,
             targetRepository,
-            prInfo.HeadBranch);
+            prInfo.HeadBranch,
+            );
 
         prInfo.Title = await _pullRequestBuilder.GeneratePRTitleAsync(pr.ContainedSubscriptions, targetBranch);
 
@@ -754,14 +756,13 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
     /// </remarks>
     private async Task<TargetRepoDependencyUpdate> GetRequiredUpdates(
         SubscriptionUpdateWorkItem update,
-        IRemoteFactory remoteFactory,
         string targetRepository,
         string? prBranch,
         string targetBranch)
     {
         _logger.LogInformation("Getting Required Updates for {branch} of {targetRepository}", targetBranch, targetRepository);
         // Get a remote factory for the target repo
-        IRemote darc = await remoteFactory.CreateRemoteAsync(targetRepository);
+        IRemote darc = await _remoteFactory.CreateRemoteAsync(targetRepository);
 
         TargetRepoDependencyUpdate repoDependencyUpdate = new();
 
@@ -816,7 +817,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
             _logger.LogInformation("Running a coherency check on the existing dependencies for branch {branch} of repo {repository}",
                 targetBranch,
                 targetRepository);
-            coherencyUpdates = await _coherencyUpdateResolver.GetRequiredCoherencyUpdatesAsync(existingDependencies, remoteFactory);
+            coherencyUpdates = await _coherencyUpdateResolver.GetRequiredCoherencyUpdatesAsync(existingDependencies, _remoteFactory);
         }
         catch (DarcCoherencyException e)
         {

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -11,6 +11,8 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Kusto.Cloud.Platform.Modularization;
+using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
@@ -41,7 +43,7 @@ internal abstract class VmrTestsBase
     protected readonly Mock<IBasicBarClient> _basicBarClient = new();
 
     private int _buildId = 100;
-    private Dictionary<int, Build> _builds = new();
+    private readonly Dictionary<int, Build> _builds = [];
 
     [SetUp]
     public async Task Setup()
@@ -95,7 +97,8 @@ internal abstract class VmrTestsBase
     protected virtual IServiceCollection CreateServiceProvider() => new ServiceCollection()
         .AddLogging(b => b.AddConsole().AddFilter(l => l >= LogLevel.Debug))
         .AddSingleVmrSupport("git", VmrPath, TmpPath, null, null)
-        .AddSingleton(_basicBarClient.Object);
+        .AddSingleton(_basicBarClient.Object)
+        .AddTransient<IRemoteFactory, RemoteFactory>();
 
     protected static List<NativePath> GetExpectedFilesInVmr(
         NativePath vmrPath,
@@ -293,7 +296,7 @@ internal abstract class VmrTestsBase
         }
     }
 
-    private static ICollection<LocalPath> GetAllFilesInDirectory(DirectoryInfo directory)
+    private static List<LocalPath> GetAllFilesInDirectory(DirectoryInfo directory)
     {
         var files = new List<LocalPath>();
 
@@ -320,9 +323,8 @@ internal abstract class VmrTestsBase
 
         var dependenciesString = new StringBuilder();
         var propsString = new StringBuilder();
-        if (dependencies != null && dependencies.ContainsKey(repoName))
+        if (dependencies != null && dependencies.TryGetValue(repoName, out List<string>? repoDependencies))
         {
-            var repoDependencies = dependencies[repoName];
             foreach (var dependencyName in repoDependencies)
             {
                 var sha = await CopyRepoAndCreateVersionFiles(dependencyName, dependencies);

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -11,8 +11,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Kusto.Cloud.Platform.Modularization;
-using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;

--- a/test/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
@@ -101,7 +101,6 @@ public class RemoteTests
             sourceMappingParser.Object,
             Mock.Of<IRemoteFactory>(),
             new AssetLocationResolver(barClient.Object),
-            barClient.Object,
             logger);
 
         await remote.MergeDependencyPullRequestAsync("https://github.com/test/test2", mergePullRequest);

--- a/test/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
@@ -95,7 +95,14 @@ public class RemoteTests
 
         var logger = new NUnitLogger();
 
-        var remote = new Remote(client.Object, new VersionDetailsParser(), sourceMappingParser.Object, logger);
+        var remote = new Remote(
+            client.Object,
+            new VersionDetailsParser(),
+            sourceMappingParser.Object,
+            Mock.Of<IRemoteFactory>(),
+            new AssetLocationResolver(barClient.Object),
+            barClient.Object,
+            logger);
 
         await remote.MergeDependencyPullRequestAsync("https://github.com/test/test2", mergePullRequest);
         var expectedCommitMessage =

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VersionFileCodeFlowUpdaterTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VersionFileCodeFlowUpdaterTests.cs
@@ -146,7 +146,7 @@ public class VersionFileCodeFlowUpdaterTests
             _localGitRepoFactory.Object,
             _versionDetailsParser.Object,
             _assetLocationResolver.Object,
-            new CoherencyUpdateResolver(Mock.Of<IBasicBarClient>(), new NullLogger<CoherencyUpdateResolver>()),
+            new CoherencyUpdateResolver(Mock.Of<IBasicBarClient>(), Mock.Of<IRemoteFactory>(), new NullLogger<CoherencyUpdateResolver>()),
             _dependencyFileManager.Object,
             _fileSystem.Object,
             new NullLogger<VersionFileCodeFlowUpdater>());

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -6,7 +6,6 @@ using FluentAssertions;
 using Maestro.MergePolicies;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Models.Darc;
-using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.Services.Common;
@@ -482,7 +481,8 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
                     updates,
                     originalDescription,
                     TargetRepo,
-                    "new-branch"); ;
+                    "new-branch",
+                    sourceRepoIsVmr: false); ;
             });
 
         return description;
@@ -500,9 +500,11 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             channels: [],
             assets: [],
             dependencies: [],
-            incoherencies: []);
+            incoherencies: [])
+        {
+            GitHubRepository = "https://github.com/foo/bar/"
+        };
 
-        build.GitHubRepository = "https://github.com/foo/bar/";
         _barClient
             .Setup(x => x.GetBuildAsync(id))
             .ReturnsAsync(build);

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -481,8 +481,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
                     updates,
                     originalDescription,
                     TargetRepo,
-                    "new-branch",
-                    sourceRepoIsVmr: false); ;
+                    "new-branch");
             });
 
         return description;

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -101,7 +101,6 @@ internal class PullRequestPolicyFailureNotifierTests
             SourceMappingParser.Object,
             Mock.Of<IRemoteFactory>(),
             new AssetLocationResolver(BarClient.Object),
-            BarClient.Object,
             NullLogger.Instance);
 
         RemoteFactory = new Mock<IRemoteFactory>(MockBehavior.Strict);

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Azure.ResourceManager;
 using FluentAssertions;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
@@ -13,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using ClientModels = Microsoft.DotNet.ProductConstructionService.Client.Models;
 
 namespace ProductConstructionService.DependencyFlow.Tests;
@@ -93,7 +95,14 @@ internal class PullRequestPolicyFailureNotifierTests
                 return Task.FromResult((IList<Check>)checksToReturn);
             });
 
-        MockRemote = new Remote(GitRepo.Object, new VersionDetailsParser(), SourceMappingParser.Object, NullLogger.Instance);
+        var remote = new Remote(
+            GitRepo.Object,
+            new VersionDetailsParser(),
+            SourceMappingParser.Object,
+            Mock.Of<IRemoteFactory>(),
+            new AssetLocationResolver(BarClient.Object),
+            BarClient.Object,
+            NullLogger.Instance);
 
         RemoteFactory = new Mock<IRemoteFactory>(MockBehavior.Strict);
         RemoteFactory.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(MockRemote);

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Azure.ResourceManager;
 using FluentAssertions;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
@@ -95,15 +94,14 @@ internal class PullRequestPolicyFailureNotifierTests
                 return Task.FromResult((IList<Check>)checksToReturn);
             });
 
-        var remote = new Remote(
+        RemoteFactory = new Mock<IRemoteFactory>(MockBehavior.Strict);
+        MockRemote = new Remote(
             GitRepo.Object,
             new VersionDetailsParser(),
             SourceMappingParser.Object,
-            Mock.Of<IRemoteFactory>(),
+            RemoteFactory.Object,
             new AssetLocationResolver(BarClient.Object),
             NullLogger.Instance);
-
-        RemoteFactory = new Mock<IRemoteFactory>(MockBehavior.Strict);
         RemoteFactory.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(MockRemote);
 
         Provider = services.BuildServiceProvider();

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -132,7 +132,6 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                     TargetRepo,
                     InProgressPrHeadBranch,
                     Capture.In(updatedDependencies),
-                    It.IsAny<bool>(),
                     It.IsAny<string>()));
 
         updatedDependencies.Should()

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -100,7 +100,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
             .Verify(r => r.GetDependenciesAsync(TargetRepo, prExists ? InProgressPrHeadBranch : TargetBranch, null));
 
         UpdateResolver
-            .Verify(r => r.GetRequiredCoherencyUpdatesAsync(Capture.In(dependencies), RemoteFactory.Object));
+            .Verify(r => r.GetRequiredCoherencyUpdatesAsync(Capture.In(dependencies)));
 
         assets.Should()
             .BeEquivalentTo(
@@ -307,20 +307,16 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
     protected void WithNoRequiredCoherencyUpdates()
     {
         UpdateResolver
-            .Setup(r => r.GetRequiredCoherencyUpdatesAsync(
-                It.IsAny<IEnumerable<DependencyDetail>>(),
-                It.IsAny<IRemoteFactory>()))
+            .Setup(r => r.GetRequiredCoherencyUpdatesAsync(It.IsAny<IEnumerable<DependencyDetail>>()))
             .ReturnsAsync([]);
     }
 
     protected void WithFailsStrictCheckForCoherencyUpdates()
     {
         UpdateResolver
-            .Setup(r => r.GetRequiredCoherencyUpdatesAsync(
-                It.IsAny<IEnumerable<DependencyDetail>>(),
-                It.IsAny<IRemoteFactory>()))
+            .Setup(r => r.GetRequiredCoherencyUpdatesAsync(It.IsAny<IEnumerable<DependencyDetail>>()))
             .ReturnsAsync(
-                (IEnumerable<DependencyDetail> dependencies, IRemoteFactory factory) =>
+                (IEnumerable<DependencyDetail> dependencies) =>
                 {
                     var fakeCoherencyError = new CoherencyError()
                     {

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -131,9 +131,8 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                 r => r.CommitUpdatesAsync(
                     TargetRepo,
                     InProgressPrHeadBranch,
-                    RemoteFactory.Object,
-                    It.IsAny<IBasicBarClient>(),
                     Capture.In(updatedDependencies),
+                    It.IsAny<bool>(),
                     It.IsAny<string>()));
 
         updatedDependencies.Should()


### PR DESCRIPTION
This repository was ridden with places where we were passing dependencies as arguments. We have mostly removed that but yesterday during the bug squashing I found few more places where it's then harder to use the classes so improving that.

<!-- https://github.com/dotnet/arcade-services/issues/4756 -->