### PR TITLE
DI registration for GitNativeRepoCloner

### DIFF
--- a/test/Maestro.Data.Tests/DependencyRegistrationTests.cs
+++ b/test/Maestro.Data.Tests/DependencyRegistrationTests.cs
@@ -28,5 +28,4 @@ public class DependencyRegistrationTests
             },
             out var message).Should().BeTrue(message);
     }
-
 }

--- a/test/Microsoft.DotNet.DarcLib.Tests/Microsoft.DotNet.DarcLib.Tests.csproj
+++ b/test/Microsoft.DotNet.DarcLib.Tests/Microsoft.DotNet.DarcLib.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Internal.DependencyInjection.Testing" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.DotNet.Internal.Testing.Utility" />

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrRegistrationsTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrRegistrationsTests.cs
@@ -16,7 +16,7 @@ public class VmrRegistrationsTests
     [Test]
     public void AddGitNativeRepoClonerSupportRegistrationIsCoherent()
     {
-        DependencyInjectionValidation.IsDependencyResolutionCoherent(sc => VmrRegistrations.AddGitNativeRepoClonerSupport(sc),
+        DependencyInjectionValidation.IsDependencyResolutionCoherent(sc => sc.AddGitNativeRepoClonerSupport(),
         out var message).Should().BeTrue(message);
     }
 }

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrRegistrationsTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrRegistrationsTests.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using Microsoft.DotNet.Internal.DependencyInjection.Testing;
+using NUnit.Framework;
+
+namespace Microsoft.DotNet.DarcLib.Tests.VirtualMonoRepo;
+
+public class VmrRegistrationsTests
+{
+    /// <summary>
+    /// Tests registering of dependencies for GitNativeRepoCloner
+    /// </summary>
+    [Test]
+    public void AddGitNativeRepoClonerSupportRegistrationIsCoherent()
+    {
+        DependencyInjectionValidation.IsDependencyResolutionCoherent(sc => VmrRegistrations.AddGitNativeRepoClonerSupport(sc),
+        out var message).Should().BeTrue(message);
+    }
+}


### PR DESCRIPTION
Infra pipeline will use the new DI registration method to be able to use GitNativeRepoCloner.

Consumer is a code which is implemented for: https://github.com/dotnet/release/issues/1264