### PR TITLE
Fix source SHA in commit diff links

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/CodeFlowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/CodeFlowOperation.cs
@@ -80,7 +80,7 @@ internal abstract class CodeFlowOperation(
         Codeflow lastFlow;
         try
         {
-            lastFlow = await _codeFlower.GetLastFlowAsync(mapping, productRepo, currentFlow is Backflow);
+            (lastFlow, _, _) = await _codeFlower.GetLastFlowsAsync(mapping, productRepo, currentFlow is Backflow);
         }
         catch (InvalidSynchronizationException)
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/CodeFlowResult.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/CodeFlowResult.cs
@@ -5,11 +5,12 @@ using System.Collections.Generic;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models.Darc;
 
+#nullable enable
 namespace Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 
 public record CodeFlowResult(
     bool HadUpdates,
     IReadOnlyCollection<UnixPath> ConflictedFiles,
     NativePath RepoPath,
-    Codeflow PreviousFlow,
+    string? PreviouslyFlownSha,
     List<DependencyUpdate> DependencyUpdates);

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -283,9 +283,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
         string repoUri,
         List<DependencyUpdateSummary> dependencyUpdates)
     {
-        string sourceDiffText = previousSourceCommit != null
-            ? CreateSourceDiffLink(build, previousSourceCommit)
-            : "No previous flow detected";
+        string sourceDiffText = CreateSourceDiffLink(build, previousSourceCommit);
 
         string dependencyUpdateBlock = CreateDependencyUpdateBlock(dependencyUpdates, repoUri);
         return
@@ -407,7 +405,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
         return null;
     }
 
-    private static string CreateSourceDiffLink(BuildDTO build, string previousSourceCommit)
+    private static string CreateSourceDiffLink(BuildDTO build, string? previousSourceCommit)
     {
         // previous source commit may be null in the case of the first code flow between a repo and the VMR ?
         if (string.IsNullOrEmpty(previousSourceCommit))

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -57,7 +57,7 @@ internal interface IPullRequestBuilder
     string GenerateCodeFlowPRDescription(
         SubscriptionUpdateWorkItem update,
         BuildDTO build,
-        string previousSourceCommit,
+        string? previousSourceCommit,
         List<DependencyUpdateSummary> dependencyUpdates,
         string? currentDescription,
         bool isForwardFlow);
@@ -220,7 +220,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
     public string GenerateCodeFlowPRDescription(
         SubscriptionUpdateWorkItem update,
         BuildDTO build,
-        string previousSourceCommit,
+        string? previousSourceCommit,
         List<DependencyUpdateSummary> dependencyUpdates,
         string? currentDescription,
         bool isForwardFlow)
@@ -239,7 +239,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
     private static string GenerateCodeFlowPRDescriptionInternal(
         SubscriptionUpdateWorkItem update,
         BuildDTO build,
-        string previousSourceCommit,
+        string? previousSourceCommit,
         List<DependencyUpdateSummary> dependencyUpdates,
         string? currentDescription,
         bool isForwardFlow)
@@ -278,12 +278,14 @@ internal class PullRequestBuilder : IPullRequestBuilder
 
     private static string GenerateCodeFlowDescriptionForSubscription(
         Guid subscriptionId,
-        string previousSourceCommit,
+        string? previousSourceCommit,
         BuildDTO build,
         string repoUri,
         List<DependencyUpdateSummary> dependencyUpdates)
     {
-        string sourceDiffText = CreateSourceDiffLink(build, previousSourceCommit);
+        string sourceDiffText = previousSourceCommit != null
+            ? CreateSourceDiffLink(build, previousSourceCommit)
+            : "No previous flow detected";
 
         string dependencyUpdateBlock = CreateDependencyUpdateBlock(dependencyUpdates, repoUri);
         return

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -1008,7 +1008,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
 
         NativePath localRepoPath;
         CodeFlowResult codeFlowRes;
-        string previousSourceSha;
+        string? previousSourceSha;
 
         try
         {
@@ -1016,13 +1016,13 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
             {
                 codeFlowRes = await _vmrForwardFlower.FlowForwardAsync(subscription, build, prHeadBranch, cancellationToken: default);
                 localRepoPath = _vmrInfo.VmrPath;
-                previousSourceSha = codeFlowRes.PreviousFlow.RepoSha;
+                previousSourceSha = codeFlowRes.PreviouslyFlownSha;
             }
             else
             {
                 codeFlowRes = await _vmrBackFlower.FlowBackAsync(subscription, build, prHeadBranch, cancellationToken: default);
                 localRepoPath = codeFlowRes.RepoPath;
-                previousSourceSha = codeFlowRes.PreviousFlow.VmrSha;
+                previousSourceSha = codeFlowRes.PreviouslyFlownSha;
             }
         }
         catch (ConflictInPrBranchException conflictException)
@@ -1100,7 +1100,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         SubscriptionUpdateWorkItem update,
         InProgressPullRequest pullRequest,
         PullRequest? prInfo,
-        string previousSourceSha,
+        string? previousSourceSha,
         SubscriptionDTO subscription,
         List<DependencyUpdate> newDependencyUpdates,
         bool isForwardFlow)
@@ -1167,7 +1167,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
 
     private async Task<InProgressPullRequest> CreateCodeFlowPullRequestAsync(
         SubscriptionUpdateWorkItem update,
-        string previousSourceSha,
+        string? previousSourceSha,
         SubscriptionDTO subscription,
         string prBranch,
         List<DependencyUpdate> dependencyUpdates,

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -53,7 +53,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
         services.AddSingleton(_forwardFlower.Object);
         services.AddSingleton(_gitClient.Object);
 
-        CodeFlowResult codeFlowRes = new CodeFlowResult(true, [], null, new Backflow("aaa1234", "bbb2345"), []);
+        CodeFlowResult codeFlowRes = new CodeFlowResult(true, [], new NativePath(VmrPath), "aaa1234", []);
         _forwardFlower.SetReturnsDefault(Task.FromResult(codeFlowRes));
         _backFlower.SetReturnsDefault(Task.FromResult(codeFlowRes));
         _gitClient.SetReturnsDefault(Task.CompletedTask);


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/4777

Fixes a problem where we were just using the last flown SHA regardless of flow direction. So that can also be the SHA of the last incoming flow while we care about the last ongoing flow.

