### PR TITLE
Add missing service registration for remote

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -143,6 +143,8 @@ public abstract class CommandLineOptions : ICommandLineOptions
 
         services.TryAddSingleton<IFileSystem, FileSystem>();
         services.TryAddSingleton<IRemoteFactory, RemoteFactory>();
+        services.TryAddSingleton<IVersionDetailsParser, VersionDetailsParser>();
+        services.TryAddSingleton<IAssetLocationResolver, AssetLocationResolver>();
         services.TryAddTransient<IProcessManager>(sp => new ProcessManager(sp.GetRequiredService<ILogger<ProcessManager>>(), GitLocation));
         services.TryAddSingleton<IBarApiClient>(sp => new BarApiClient(
             BuildAssetRegistryToken,


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->

Fixes an issue with missing services for `IRemote` resolution in Darc introduced in https://github.com/dotnet/arcade-services/pull/4756

<!-- https://github.com/dotnet/arcade-services/issues/4756 -->
