### PR TITLE
Do not store assets work items

### DIFF
--- a/src/Maestro/Maestro.DataProviders/SqlBarClient.cs
+++ b/src/Maestro/Maestro.DataProviders/SqlBarClient.cs
@@ -374,6 +374,7 @@ public class SqlBarClient : ISqlBarClient
             .Include(b => b.BuildChannels)
             .ThenInclude(b => b.Channel)
             .Include(b => b.Assets)
+            .ThenInclude(b => b.Locations)
             .FirstOrDefaultAsync();
 
         if (build != null)

--- a/src/Maestro/Maestro.DataProviders/SqlBarClient.cs
+++ b/src/Maestro/Maestro.DataProviders/SqlBarClient.cs
@@ -294,7 +294,7 @@ public class SqlBarClient : ISqlBarClient
         };
     }
 
-    private Build ToClientModelBuild(Data.Models.Build other)
+    public static Build ToClientModelBuild(Data.Models.Build other)
     {
         var channels = other.BuildChannels?
             .Select(bc => ToClientModelChannel(bc.Channel))
@@ -336,7 +336,7 @@ public class SqlBarClient : ISqlBarClient
         };
     }
 
-    private BuildRef ToClientModelBuildDependency(Data.Models.BuildDependency other)
+    private static BuildRef ToClientModelBuildDependency(Data.Models.BuildDependency other)
         => new(other.BuildId, other.IsProduct, other.TimeToInclusionInMinutes);
 
     private static SubscriptionPolicy ToClientModelSubscriptionPolicy(Data.Models.SubscriptionPolicy other)

--- a/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
@@ -592,7 +592,7 @@ public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
         {
             newUpdateCheckRun.Status = CheckStatus.InProgress;
         }
-        else if (result.Status == MergePolicyEvaluationStatus.DecisiveSuccess)
+        else if (result.Status == MergePolicyEvaluationStatus.DecisiveSuccess || result.Status == MergePolicyEvaluationStatus.TransientSuccess)
         {
             newUpdateCheckRun.Conclusion = "success";
             newUpdateCheckRun.CompletedAt = DateTime.Now;

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/IPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/IPullRequestUpdater.cs
@@ -3,6 +3,7 @@
 
 using ProductConstructionService.DependencyFlow.Model;
 using ProductConstructionService.DependencyFlow.WorkItems;
+using Microsoft.DotNet.ProductConstructionService.Client.Models;
 
 namespace ProductConstructionService.DependencyFlow;
 
@@ -13,15 +14,13 @@ public interface IPullRequestUpdater
 
     Task ProcessPendingUpdatesAsync(
         SubscriptionUpdateWorkItem update,
-        bool forceApply);
+        bool forceApply,
+        Build? build);
 
     Task UpdateAssetsAsync(
         Guid subscriptionId,
         SubscriptionType type,
         int buildId,
-        string sourceRepo,
-        string sourceSha,
-        List<Asset> assets,
         bool forceApply);
 
     PullRequestUpdaterId Id { get; }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/IPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/IPullRequestUpdater.cs
@@ -15,7 +15,7 @@ public interface IPullRequestUpdater
     Task ProcessPendingUpdatesAsync(
         SubscriptionUpdateWorkItem update,
         bool forceApply,
-        Build? build);
+        Build build);
 
     Task UpdateAssetsAsync(
         Guid subscriptionId,

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestConflictNotifier.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestConflictNotifier.cs
@@ -35,7 +35,8 @@ internal interface IPullRequestConflictNotifier
         InProgressPullRequest pr,
         SubscriptionUpdateWorkItem update,
         Subscription subscription,
-        IReadOnlyCollection<UnixPath> conflictedFiles);
+        IReadOnlyCollection<UnixPath> conflictedFiles,
+        Build build);
 }
 
 internal class PullRequestConflictNotifier : IPullRequestConflictNotifier
@@ -91,7 +92,8 @@ internal class PullRequestConflictNotifier : IPullRequestConflictNotifier
         InProgressPullRequest pr,
         SubscriptionUpdateWorkItem update,
         Subscription subscription,
-        IReadOnlyCollection<UnixPath> conflictedFiles)
+        IReadOnlyCollection<UnixPath> conflictedFiles,
+        Build build)
     {
         string metadataFile, contentType, correctContent;
 
@@ -128,7 +130,7 @@ internal class PullRequestConflictNotifier : IPullRequestConflictNotifier
                     subscription.TargetDirectory,
                     update.SourceRepo,
                     update.SourceSha,
-                    update.Assets.FirstOrDefault()?.Version,
+                    build.Assets.FirstOrDefault()?.Version,
                     update.BuildId),
                 new JsonSerializerOptions()
                 {

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/SubscriptionUpdateProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/SubscriptionUpdateProcessor.cs
@@ -1,21 +1,25 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Maestro.DataProviders;
 using ProductConstructionService.DependencyFlow.WorkItems;
 
 namespace ProductConstructionService.DependencyFlow.WorkItemProcessors;
 
-public class SubscriptionUpdateProcessor(IPullRequestUpdaterFactory updaterFactory)
+public class SubscriptionUpdateProcessor(IPullRequestUpdaterFactory updaterFactory, ISqlBarClient sqlClient)
     : DependencyFlowUpdateProcessor<SubscriptionUpdateWorkItem>
 {
     private readonly IPullRequestUpdaterFactory _updaterFactory = updaterFactory;
+    private readonly ISqlBarClient _sqlClient = sqlClient;
 
     public override async Task<bool> ProcessWorkItemAsync(
         SubscriptionUpdateWorkItem workItem,
         CancellationToken cancellationToken)
     {
+        var build = await _sqlClient.GetBuildAsync(workItem.BuildId)
+            ?? throw new InvalidOperationException($"Build with buildId {workItem.BuildId} not found in the DB.");
         var updater = _updaterFactory.CreatePullRequestUpdater(PullRequestUpdaterId.Parse(workItem.UpdaterId));
-        await updater.ProcessPendingUpdatesAsync(workItem, forceApply: false, build: null);
+        await updater.ProcessPendingUpdatesAsync(workItem, forceApply: false, build);
         return true;
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/SubscriptionUpdateProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/SubscriptionUpdateProcessor.cs
@@ -3,21 +3,30 @@
 
 using Maestro.DataProviders;
 using ProductConstructionService.DependencyFlow.WorkItems;
+using Microsoft.Extensions.Logging;
 
 namespace ProductConstructionService.DependencyFlow.WorkItemProcessors;
 
-public class SubscriptionUpdateProcessor(IPullRequestUpdaterFactory updaterFactory, ISqlBarClient sqlClient)
-    : DependencyFlowUpdateProcessor<SubscriptionUpdateWorkItem>
+public class SubscriptionUpdateProcessor(
+    IPullRequestUpdaterFactory updaterFactory,
+    ISqlBarClient sqlClient,
+    ILogger logger)
+: DependencyFlowUpdateProcessor<SubscriptionUpdateWorkItem>
 {
     private readonly IPullRequestUpdaterFactory _updaterFactory = updaterFactory;
     private readonly ISqlBarClient _sqlClient = sqlClient;
+    private readonly ILogger _logger = logger;
 
     public override async Task<bool> ProcessWorkItemAsync(
         SubscriptionUpdateWorkItem workItem,
         CancellationToken cancellationToken)
     {
-        var build = await _sqlClient.GetBuildAsync(workItem.BuildId)
-            ?? throw new InvalidOperationException($"Build with buildId {workItem.BuildId} not found in the DB.");
+        var build = await _sqlClient.GetBuildAsync(workItem.BuildId);
+        if (build == null)
+        {
+            _logger.LogError("Build with buildId {BuildId} not found in the DB.", workItem.BuildId);
+            return false;
+        }
         var updater = _updaterFactory.CreatePullRequestUpdater(PullRequestUpdaterId.Parse(workItem.UpdaterId));
         await updater.ProcessPendingUpdatesAsync(workItem, forceApply: false, build);
         return true;

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/SubscriptionUpdateProcessor.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItemProcessors/SubscriptionUpdateProcessor.cs
@@ -15,7 +15,7 @@ public class SubscriptionUpdateProcessor(IPullRequestUpdaterFactory updaterFacto
         CancellationToken cancellationToken)
     {
         var updater = _updaterFactory.CreatePullRequestUpdater(PullRequestUpdaterId.Parse(workItem.UpdaterId));
-        await updater.ProcessPendingUpdatesAsync(workItem, forceApply: false);
+        await updater.ProcessPendingUpdatesAsync(workItem, forceApply: false, build: null);
         return true;
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItems/SubscriptionUpdateWorkItem.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/WorkItems/SubscriptionUpdateWorkItem.cs
@@ -25,9 +25,6 @@ public class SubscriptionUpdateWorkItem : DependencyFlowWorkItem
     [DataMember]
     public string SourceRepo { get; init; }
 
-    [DataMember]
-    public List<Asset> Assets { get; init; }
-
     /// <summary>
     ///     If true, this is a coherency update and not driven by specific
     ///     subscription ids (e.g. could be multiple if driven by a batched subscription)

--- a/test/ProductConstructionService.DependencyFlow.Tests/PendingUpdatePullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PendingUpdatePullRequestUpdaterTests.cs
@@ -15,11 +15,10 @@ internal abstract class PendingUpdatePullRequestUpdaterTests : PullRequestUpdate
         bool isCodeFlow = false,
         bool forceApply = true)
     {
-
-        BuildDTO buildDTO = SqlBarClient.ToClientModelBuild(forBuild);
         await Execute(
             async context =>
             {
+                BuildDTO buildDTO = SqlBarClient.ToClientModelBuild(forBuild);
                 IPullRequestUpdater updater = CreatePullRequestActor(context);
                 await updater.ProcessPendingUpdatesAsync(CreateSubscriptionUpdate(forBuild, isCodeFlow), forceApply, buildDTO);
             });

--- a/test/ProductConstructionService.DependencyFlow.Tests/PendingUpdatePullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PendingUpdatePullRequestUpdaterTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Maestro.Data.Models;
+using Maestro.DataProviders;
 using ProductConstructionService.DependencyFlow.WorkItems;
+using BuildDTO = Microsoft.DotNet.ProductConstructionService.Client.Models.Build;
 
 namespace ProductConstructionService.DependencyFlow.Tests;
 
@@ -13,11 +15,13 @@ internal abstract class PendingUpdatePullRequestUpdaterTests : PullRequestUpdate
         bool isCodeFlow = false,
         bool forceApply = true)
     {
+
+        BuildDTO buildDTO = SqlBarClient.ToClientModelBuild(forBuild);
         await Execute(
             async context =>
             {
                 IPullRequestUpdater updater = CreatePullRequestActor(context);
-                await updater.ProcessPendingUpdatesAsync(CreateSubscriptionUpdate(forBuild, isCodeFlow), forceApply, null);
+                await updater.ProcessPendingUpdatesAsync(CreateSubscriptionUpdate(forBuild, isCodeFlow), forceApply, buildDTO);
             });
     }
 

--- a/test/ProductConstructionService.DependencyFlow.Tests/PendingUpdatePullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PendingUpdatePullRequestUpdaterTests.cs
@@ -17,7 +17,7 @@ internal abstract class PendingUpdatePullRequestUpdaterTests : PullRequestUpdate
             async context =>
             {
                 IPullRequestUpdater updater = CreatePullRequestActor(context);
-                await updater.ProcessPendingUpdatesAsync(CreateSubscriptionUpdate(forBuild, isCodeFlow), forceApply);
+                await updater.ProcessPendingUpdatesAsync(CreateSubscriptionUpdate(forBuild, isCodeFlow), forceApply, null);
             });
     }
 

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -602,13 +602,6 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
             BuildId = forBuild.Id,
             SourceSha = forBuild.Commit,
             SourceRepo = forBuild.GitHubRepository ?? forBuild.AzureDevOpsRepository,
-            Assets = forBuild.Assets
-                .Select(a => new Asset
-                {
-                    Name = a.Name,
-                    Version = a.Version
-                })
-                .ToList(),
             IsCoherencyUpdate = false,
         };
 

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using FluentAssertions;
-using Kusto.Cloud.Platform.Utils;
 using Maestro.Data;
 using Maestro.Data.Models;
 using Maestro.DataProviders;
@@ -19,7 +18,6 @@ using Microsoft.VisualStudio.Services.Common;
 using Moq;
 using NUnit.Framework;
 using ProductConstructionService.DependencyFlow.WorkItems;
-using Asset = ProductConstructionService.DependencyFlow.Model.Asset;
 using AssetData = Microsoft.DotNet.ProductConstructionService.Client.Models.AssetData;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using System.Collections.Immutable;

--- a/test/ProductConstructionService.DependencyFlow.Tests/SubscriptionUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/SubscriptionUpdaterTests.cs
@@ -61,22 +61,7 @@ internal class SubscriptionUpdaterTests : SubscriptionOrPullRequestUpdaterTests
                     Subscription.Id,
                     SubscriptionType.Dependencies,
                     withBuild.Id,
-                    SourceRepo,
-                    NewCommit,
-                    Capture.In(updatedAssets),
                     true));
-
-        updatedAssets.Should().BeEquivalentTo(
-            new List<List<Asset>>
-            {
-                withBuild.Assets
-                    .Select(a => new Asset
-                    {
-                        Name = a.Name,
-                        Version = a.Version
-                    })
-                    .ToList()
-            });
     }
 
     [Test]

--- a/test/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsPullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsPullRequestUpdaterTests.cs
@@ -18,15 +18,6 @@ internal abstract class UpdateAssetsPullRequestUpdaterTests : PullRequestUpdater
                     Subscription.Id,
                     Subscription.SourceEnabled ? SubscriptionType.DependenciesAndSources : SubscriptionType.Dependencies,
                     forBuild.Id,
-                    SourceRepo,
-                    forBuild.Commit,
-                    forBuild.Assets
-                        .Select(a => new Asset
-                        {
-                            Name = a.Name,
-                            Version = a.Version
-                        })
-                        .ToList(),
                     forceApply: true);
             });
     }


### PR DESCRIPTION
List of assets can be too large to store in the Message Queue, therefore they should not be defined inside work items. To fix this, builds are queried at the beginning of the PullRequestUpdater flow, and the assets are taken from there.

https://github.com/dotnet/arcade-services/issues/4745#issue-3019865179