### PR TITLE
Base codeflow branches on top of last synchronization point

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -59,29 +59,29 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.25225.5">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.25230.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>d3c4c4644a5af855cd30944d9221886369ab375d</Sha>
+      <Sha>4246a31e5de9de87f760218c4f588cebf4661f45</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SignTool" Version="8.0.0-beta.25225.5">
+    <Dependency Name="Microsoft.DotNet.SignTool" Version="8.0.0-beta.25230.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>d3c4c4644a5af855cd30944d9221886369ab375d</Sha>
+      <Sha>4246a31e5de9de87f760218c4f588cebf4661f45</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="8.0.0-beta.25225.5">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="8.0.0-beta.25230.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>d3c4c4644a5af855cd30944d9221886369ab375d</Sha>
+      <Sha>4246a31e5de9de87f760218c4f588cebf4661f45</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="8.0.0-beta.25225.5">
+    <Dependency Name="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="8.0.0-beta.25230.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>d3c4c4644a5af855cd30944d9221886369ab375d</Sha>
+      <Sha>4246a31e5de9de87f760218c4f588cebf4661f45</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Git.IssueManager" Version="8.0.0-beta.25225.5">
+    <Dependency Name="Microsoft.DotNet.Git.IssueManager" Version="8.0.0-beta.25230.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>d3c4c4644a5af855cd30944d9221886369ab375d</Sha>
+      <Sha>4246a31e5de9de87f760218c4f588cebf4661f45</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.VersionTools" Version="8.0.0-beta.25225.5">
+    <Dependency Name="Microsoft.DotNet.VersionTools" Version="8.0.0-beta.25230.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>d3c4c4644a5af855cd30944d9221886369ab375d</Sha>
+      <Sha>4246a31e5de9de87f760218c4f588cebf4661f45</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DncEng.SecretManager" Version="1.1.0-beta.25210.1">
       <Uri>https://github.com/dotnet/dnceng</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,11 +9,11 @@
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <MicrosoftNetFrameworkReferenceAssembliesVersion>1.0.0-preview.1</MicrosoftNetFrameworkReferenceAssembliesVersion>
     <!-- Libs -->
-    <MicrosoftDotNetSignToolVersion>8.0.0-beta.25225.5</MicrosoftDotNetSignToolVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>8.0.0-beta.25225.5</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>8.0.0-beta.25225.5</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
-    <MicrosoftDotNetGitIssueManagerVersion>8.0.0-beta.25225.5</MicrosoftDotNetGitIssueManagerVersion>
-    <MicrosoftDotNetVersionToolsVersion>8.0.0-beta.25225.5</MicrosoftDotNetVersionToolsVersion>
+    <MicrosoftDotNetSignToolVersion>8.0.0-beta.25230.1</MicrosoftDotNetSignToolVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>8.0.0-beta.25230.1</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>8.0.0-beta.25230.1</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
+    <MicrosoftDotNetGitIssueManagerVersion>8.0.0-beta.25230.1</MicrosoftDotNetGitIssueManagerVersion>
+    <MicrosoftDotNetVersionToolsVersion>8.0.0-beta.25230.1</MicrosoftDotNetVersionToolsVersion>
     <MicrosoftNetTestSdkVersion>17.4.1</MicrosoftNetTestSdkVersion>
     <MicrosoftDotNetInternalLoggingVersion>1.1.0-beta.25215.1</MicrosoftDotNetInternalLoggingVersion>
     <MicrosoftAspNetCoreApiPaginationVersion>1.1.0-beta.25215.1</MicrosoftAspNetCoreApiPaginationVersion>

--- a/eng/common/templates-official/jobs/source-build.yml
+++ b/eng/common/templates-official/jobs/source-build.yml
@@ -14,7 +14,7 @@ parameters:
   # This is the default platform provided by Arcade, intended for use by a managed-only repo.
   defaultManagedPlatform:
     name: 'Managed'
-    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
+    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-9-amd64'
 
   # Defines the platforms on which to run build jobs. One job is created for each platform, and the
   # object in this array is sent to the job template as 'platform'. If no platforms are specified,

--- a/eng/common/templates/jobs/source-build.yml
+++ b/eng/common/templates/jobs/source-build.yml
@@ -14,7 +14,7 @@ parameters:
   # This is the default platform provided by Arcade, intended for use by a managed-only repo.
   defaultManagedPlatform:
     name: 'Managed'
-    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
+    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-9-amd64'
 
   # Defines the platforms on which to run build jobs. One job is created for each platform, and the
   # object in this array is sent to the job template as 'platform'. If no platforms are specified,

--- a/global.json
+++ b/global.json
@@ -15,6 +15,6 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.25225.5"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.25230.1"
   }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -403,7 +403,8 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         catch (NotFoundException)
         {
             // If target branch does not exist, we create it off of the base branch
-            await targetRepo.CheckoutAsync(targetBranch);
+            (Codeflow last, _, _) = await GetLastFlowsAsync(mapping, targetRepo, currentIsBackflow: false);
+            await targetRepo.CheckoutAsync(last.RepoSha);
             await targetRepo.CreateBranchAsync(headBranch);
             return (false, mapping);
         }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -384,8 +384,12 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 // source-manifest.json
                 VmrInfo.DefaultRelativeSourceManifestPath,
 
-            // git-info for the repo
-            new UnixPath($"{VmrInfo.GitInfoSourcesDir}/{mappingName}.props")
+                // git-info for the repo
+                new UnixPath($"{VmrInfo.GitInfoSourcesDir}/{mappingName}.props"),
+
+                // TODO https://github.com/dotnet/arcade-services/issues/4792: Do not ignore conflicts in version files
+                ..DependencyFileManager.DependencyFiles.Select(
+                    f => new UnixPath(VmrInfo.GetRelativeRepoSourcesPath(mappingName) / f)),
             ];
 
             var unresolvableConflicts = conflictedFiles

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTwoWayCodeflowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTwoWayCodeflowTest.cs
@@ -29,6 +29,10 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
 
         await EnsureTestRepoIsInitialized();
 
+        await GitOperations.Checkout(VmrPath, "main");
+        await File.WriteAllTextAsync(_productRepoVmrPath / "we-will-delete-this-later.txt", "And it will stay deleted");
+        await GitOperations.CommitAll(VmrPath, "Added a file that will be deleted later");
+
         var hadUpdates = await ChangeRepoFileAndFlowIt("New content in the individual repo", branchName);
         await GitOperations.MergePrBranch(VmrPath, branchName);
 
@@ -60,6 +64,11 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         await GitOperations.CommitAll(ProductRepoPath, "Extra commit in the PR");
         await GitOperations.MergePrBranch(ProductRepoPath, branchName);
 
+        // Delete a file in the VMR to make sure it's not brought back by the forward flow
+        await GitOperations.Checkout(VmrPath, "main");
+        File.Delete(_productRepoVmrPath / "we-will-delete-this-later.txt");
+        await GitOperations.CommitAll(VmrPath, "Deleting a file in the VMR");
+
         // Forward flow
         await File.WriteAllTextAsync(ProductRepoPath / "b.txt", bFileContent2);
         await GitOperations.CommitAll(ProductRepoPath, bFileContent2);
@@ -70,6 +79,7 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         CheckFileContents(_productRepoVmrPath / "b.txt", bFileContent2);
         CheckFileContents(_productRepoVmrFilePath, "Change that happened in the PR");
         File.Exists(_productRepoVmrPath / "cloaked.dll").Should().BeFalse();
+        File.Exists(_productRepoVmrPath / "we-will-delete-this-later.txt").Should().BeFalse();
         await GitOperations.CheckAllIsCommitted(VmrPath);
         await GitOperations.CheckAllIsCommitted(ProductRepoPath);
 


### PR DESCRIPTION
Addressed problems seen in https://github.com/dotnet/arcade-services/issues/4786 where we were overwriting files during opposite direction flows.
This was caused by the fact that we didn't base the PR branch on top of the last synchronized commit but rather on tip of the target branch which was wrong. When we then removed all the files and inserted them again, we brought back deleted files.