### PR TITLE
Improve GitHub exception handling

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
@@ -130,9 +130,9 @@ public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
 
             return this.GetDecodedContent(content);
         }
-        catch (HttpRequestException reqEx) when (reqEx.Message.Contains(((int)HttpStatusCode.NotFound).ToString()))
+        catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.NotFound)
         {
-            throw new DependencyFileNotFoundException(filePath, $"{owner}/{repo}", branch, reqEx);
+            throw new DependencyFileNotFoundException(filePath, $"{owner}/{repo}", branch, e);
         }
     }
 
@@ -176,7 +176,7 @@ public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
 
             _logger.LogInformation("Branch '{branch}' exists, updated", newBranch);
         }
-        catch (HttpRequestException exc) when (exc.Message.Contains(((int)HttpStatusCode.NotFound).ToString()))
+        catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.NotFound)
         {
             _logger.LogInformation("'{branch}' branch doesn't exist. Creating it...", newBranch);
 
@@ -903,8 +903,8 @@ public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
 
             return content["sha"]!.ToString();
         }
-        catch (HttpRequestException exc) when (exc.Message.Contains(((int)HttpStatusCode.NotFound).ToString())
-                                               || exc.Message.Contains(((int)HttpStatusCode.UnprocessableEntity).ToString()))
+        catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.NotFound
+                                          || e.StatusCode == HttpStatusCode.UnprocessableEntity)
         {
             return null;
         }
@@ -1239,7 +1239,7 @@ public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
                 Valid = true
             };
         }
-        catch (HttpRequestException reqEx) when (reqEx.Message.Contains(((int)HttpStatusCode.NotFound).ToString()))
+        catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.NotFound)
         {
             return GitDiff.UnknownDiff();
         }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
@@ -222,10 +222,11 @@ public sealed class Remote : IRemote
             {
                 engCommonFiles = engCommonFiles
                     .Select(f => new GitFile(
-                        f.FilePath.Replace(VmrInfo.ArcadeRepoDir, null).TrimStart('/'),
+                        f.FilePath.Replace(VmrInfo.ArcadeRepoDir, null, StringComparison.InvariantCultureIgnoreCase).TrimStart('/'),
                         f.Content,
                         f.ContentEncoding,
-                        f.Mode))
+                        f.Mode,
+                        f.Operation))
                     .ToList();
             }
 
@@ -239,7 +240,7 @@ public sealed class Remote : IRemote
 
             foreach (GitFile file in targetEngCommonFiles)
             {
-                if (!engCommonFiles.Where(f => f.FilePath == file.FilePath).Any())
+                if (!engCommonFiles.Any(f => f.FilePath.Equals(file.FilePath, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     deletedFiles.Add(file.FilePath);
                     // This is a file in the repo's eng/common folder that isn't present in Arcade at the
@@ -258,10 +259,16 @@ public sealed class Remote : IRemote
 
             if (deletedFiles.Count > 0)
             {
-                _logger.LogInformation($"Dependency update from Arcade commit {arcadeItem.Commit} to {repoUri} " +
-                                       $"on branch {branch}@{latestCommit} will delete files in eng/common." +
-                                       $" Source file count: {engCommonFiles.Count}, Target file count: {targetEngCommonFiles.Count}." +
-                                       $" Deleted files: {string.Join(Environment.NewLine, deletedFiles)}");
+                _logger.LogInformation(
+                    "Dependency update from Arcade commit {commit} to {repoUri} on branch {branch}@{latestCommit} will delete files in eng/common. " +
+                    "Source file count: {sourceFileCount}, Target file count: {targetFileCount}. Deleted files: {deletedFiles}",
+                    arcadeItem.Commit,
+                    repoUri,
+                    branch,
+                    latestCommit,
+                    engCommonFiles.Count,
+                    targetEngCommonFiles.Count,
+                    string.Join(Environment.NewLine, deletedFiles));
             }
         }
 


### PR DESCRIPTION
A possible fix for https://github.com/dotnet/arcade-services/issues/4751 where we use `NotFound` as a signal whether a source repo is or is not a VMR