### PR TITLE
Do not ignore `eng/common` during arcade backflows

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -420,7 +420,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         exclusions = exclusions
             .Concat(DependencyFileManager.DependencyFiles);
 
-        // Exclude eng/common as that will be copied based on the arcade version
+        // Exclude eng/common for non-arcade mappings (it will be copied separately based on the Arcade.Sdk package version)
         if (mapping.Name != "arcade")
         {
             exclusions = exclusions

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using LibGit2Sharp;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models;
-using Microsoft.DotNet.DarcLib.Models.Darc;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.Logging;
@@ -410,18 +409,26 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         }
     }
 
-    private IReadOnlyCollection<string> GetPatchExclusions(SourceMapping mapping) =>
+    private IReadOnlyCollection<string> GetPatchExclusions(SourceMapping mapping)
+    {
         // Exclude all submodules that belong to the mapping
-        [.._sourceManifest.Submodules
+        var exclusions = _sourceManifest.Submodules
             .Where(s => s.Path.StartsWith(mapping.Name + '/'))
-            .Select(s => s.Path.Substring(mapping.Name.Length + 1))
+            .Select(s => s.Path.Substring(mapping.Name.Length + 1));
 
         // Exclude version files as those will be handled manually
-        .Concat(DependencyFileManager.DependencyFiles)
+        exclusions = exclusions
+            .Concat(DependencyFileManager.DependencyFiles);
 
         // Exclude eng/common as that will be copied based on the arcade version
-        .Append(Constants.CommonScriptFilesPath)
-        .Select(VmrPatchHandler.GetExclusionRule)];
+        if (mapping.Name != "arcade")
+        {
+            exclusions = exclusions
+                .Append(Constants.CommonScriptFilesPath);
+        }
+
+        return [.. exclusions.Select(VmrPatchHandler.GetExclusionRule)];
+    }
 
     private async Task RecreatePreviousFlowAndApplyBuild(
         SourceMapping mapping,


### PR DESCRIPTION
Resolves https://github.com/dotnet/arcade-services/issues/4807

1. There was a change in the VMR: https://github.com/dotnet/dotnet/commit/2774010bee5a0e2a8a554bf87490d9eacebc39ab
2. It was not backflown correctly: https://github.com/dotnet/arcade/pull/15814
3. It works with the fix: https://github.com/maestro-auth-test/arcade/pull/1

