### PR TITLE
Stop cleaning symbol feeds

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
@@ -31,42 +31,6 @@ public class FeedCleaner
         _httpClient = httpClientFactory.CreateClient();
     }
 
-    /// <summary>
-    /// Symbol feeds are not cleaned package by package bu rather removed once the matching non-symbol feed is deleted.
-    /// </summary>
-    public async Task CleanSymbolFeedAsync(List<AzureDevOpsFeed> packageFeeds, AzureDevOpsFeed symbolFeed)
-    {
-        _logger.LogInformation("Cleaning symbol feed {feed}...", symbolFeed.Name);
-
-        var matchingFeedName = symbolFeed.Name.Replace("-sym-", "-");
-        var matchingFeed = packageFeeds.FirstOrDefault(f => f.Name == matchingFeedName);
-
-        if (matchingFeed?.Packages.Count(p => p.Versions.Any(v => !v.IsDeleted)) > 0)
-        {
-            _logger.LogInformation("Matching feed {feed} for symbol feed {symbolFeed} still has packages, skipping...", matchingFeedName, symbolFeed.Name);
-            return;
-        }
-
-        if (matchingFeed == null)
-        {
-            _logger.LogInformation("Matching feed {feed} not found for symbol feed {symbolFeed}. Deleting symbol feed...", matchingFeedName, symbolFeed.Name);
-        }
-        else if (matchingFeed.Packages.Count == 0)
-        {
-            _logger.LogInformation("Matching feed {feed} has no packages left, deleting the symbol feed {symbolFeed}", matchingFeedName, symbolFeed.Name);
-        }
-
-        try
-        {
-            await _azureDevOpsClient.DeleteFeedAsync(symbolFeed.Account, symbolFeed.Project?.Name, symbolFeed.Name);
-            _logger.LogInformation("Symbol feed {feed} deleted", symbolFeed.Name);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to delete symbol feed {feed}", symbolFeed.Name);
-        }
-    }
-
     public async Task CleanFeedAsync(AzureDevOpsFeed feed)
     {
         try

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleaner.cs
@@ -31,6 +31,42 @@ public class FeedCleaner
         _httpClient = httpClientFactory.CreateClient();
     }
 
+    /// <summary>
+    /// Symbol feeds are not cleaned package by package bu rather removed once the matching non-symbol feed is deleted.
+    /// </summary>
+    public async Task CleanSymbolFeedAsync(List<AzureDevOpsFeed> packageFeeds, AzureDevOpsFeed symbolFeed)
+    {
+        _logger.LogInformation("Cleaning symbol feed {feed}...", symbolFeed.Name);
+
+        var matchingFeedName = symbolFeed.Name.Replace("-sym-", "-");
+        var matchingFeed = packageFeeds.FirstOrDefault(f => f.Name == matchingFeedName);
+
+        if (matchingFeed?.Packages.Count(p => p.Versions.Any(v => !v.IsDeleted)) > 0)
+        {
+            _logger.LogInformation("Matching feed {feed} for symbol feed {symbolFeed} still has packages, skipping...", matchingFeedName, symbolFeed.Name);
+            return;
+        }
+
+        if (matchingFeed == null)
+        {
+            _logger.LogInformation("Matching feed {feed} not found for symbol feed {symbolFeed}. Deleting symbol feed...", matchingFeedName, symbolFeed.Name);
+        }
+        else if (matchingFeed.Packages.Count == 0)
+        {
+            _logger.LogInformation("Matching feed {feed} has no packages left, deleting the symbol feed {symbolFeed}", matchingFeedName, symbolFeed.Name);
+        }
+
+        try
+        {
+            await _azureDevOpsClient.DeleteFeedAsync(symbolFeed.Account, symbolFeed.Project?.Name, symbolFeed.Name);
+            _logger.LogInformation("Symbol feed {feed} deleted", symbolFeed.Name);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete symbol feed {feed}", symbolFeed.Name);
+        }
+    }
+
     public async Task CleanFeedAsync(AzureDevOpsFeed feed)
     {
         try

--- a/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
+++ b/src/ProductConstructionService/ProductConstructionService.FeedCleaner/FeedCleanerJob.cs
@@ -87,7 +87,7 @@ public class FeedCleanerJob
             feeds,
             new ParallelOptions
             {
-                MaxDegreeOfParallelism = 1
+                MaxDegreeOfParallelism = 5
             },
             async (AzureDevOpsFeed feed, CancellationToken cancellationToken) =>
             {

--- a/test/ProductConstructionService.FeedCleaner.Tests/FeedCleanerTests.cs
+++ b/test/ProductConstructionService.FeedCleaner.Tests/FeedCleanerTests.cs
@@ -132,13 +132,10 @@ public class FeedCleanerTests
     [Test]
     public async Task SymbolFeedsAreCleaned()
     {
-        string feedWithPackages = "darc-int-some-repo-12345678";
-        string feedWithoutPackages = "darc-pub-some-repo-aabbccdd";
-        string feedWithDeletedPackages = "darc-int-some-repo-aaeeffbb-4";
-        string symbolFeedThatShouldStay = feedWithPackages.Replace("-int-", "-int-sym-");
-        string symbolFeedThatShouldGo1 = feedWithoutPackages.Replace("-pub-", "-pub-sym-"); // Matches a feed without packages
-        string symbolFeedThatShouldGo2 = feedWithPackages.Replace("-int-", "-int-sym-") + "-1"; // Matches no feed
-        string symbolFeedThatShouldGo3 = feedWithDeletedPackages.Replace("-int-", "-int-sym-"); // Matches a feed with deleted packages
+        string feedWithReleasedPackages = "darc-int-some-repo-12345678";
+        string feedWithoutReleasedPackages = "darc-pub-some-repo-aabbccdd";
+        string symbolFeedWithReleasedPackages = feedWithReleasedPackages.Replace("-int-", "-int-sym-");
+        string symbolFeedWithoutReleasedPackages = feedWithoutReleasedPackages.Replace("-pub-", "-pub-sym-");
 
         int i = 1;
         AzureDevOpsFeed CreateFeed(string name, params string[] packageNames)
@@ -152,34 +149,21 @@ public class FeedCleanerTests
             };
         }
 
+        string releasedPackage = ReleasedPackagePrefix;
+        string unreleasedPackage = $"nonReleasedPackage";
         var feeds = new Dictionary<string, AzureDevOpsFeed>()
         {
-            { feedWithPackages, CreateFeed(feedWithPackages, "Package1") },
-            { feedWithoutPackages, CreateFeed(feedWithoutPackages) },
-            { feedWithDeletedPackages, CreateFeed(feedWithDeletedPackages, "Package2") },
-            { symbolFeedThatShouldStay, CreateFeed(symbolFeedThatShouldStay, "Symbols") },
-            { symbolFeedThatShouldGo1, CreateFeed(symbolFeedThatShouldGo1, "Symbols1") },
-            { symbolFeedThatShouldGo2, CreateFeed(symbolFeedThatShouldGo2, "Symbols2") },
-            { symbolFeedThatShouldGo3, CreateFeed(symbolFeedThatShouldGo3, "Symbols3") },
+            { feedWithReleasedPackages, CreateFeed(feedWithReleasedPackages, releasedPackage) },
+            { feedWithoutReleasedPackages, CreateFeed(feedWithoutReleasedPackages, unreleasedPackage) },
+            { symbolFeedWithReleasedPackages, CreateFeed(symbolFeedWithReleasedPackages, releasedPackage) },
+            { symbolFeedWithoutReleasedPackages, CreateFeed(symbolFeedWithoutReleasedPackages, unreleasedPackage) },
         };
-
-        feeds[feedWithDeletedPackages].Packages[0].Versions[0].IsDeleted = true;
 
         var feedCleaner = InitializeFeedCleaner(nameof(SymbolFeedsAreCleaned), feeds);
         await feedCleaner.CleanManagedFeedsAsync();
 
-        var deletedFeeds = _feeds
-            .Select(f => f.Value.Name)
-            .Where(name => name.EndsWith("-deleted"))
-            .Select(name => name.Replace("-deleted", null))
-            .ToArray();
-
-        deletedFeeds.Should().BeEquivalentTo(
-        [
-            symbolFeedThatShouldGo1,
-            symbolFeedThatShouldGo2,
-            symbolFeedThatShouldGo3,
-        ]);
+        feeds[symbolFeedWithReleasedPackages].Packages.All(p => p.Versions.All(v => v.IsDeleted));
+        feeds[symbolFeedWithoutReleasedPackages].Packages.All(p => p.Versions.All(v => !v.IsDeleted));
     }
 
     private void SetupAssetsFromFeeds(BuildAssetRegistryContext context)

--- a/test/ProductConstructionService.FeedCleaner.Tests/FeedCleanerTests.cs
+++ b/test/ProductConstructionService.FeedCleaner.Tests/FeedCleanerTests.cs
@@ -129,59 +129,6 @@ public class FeedCleanerTests
         assetsInRemainingFeed.First().Name.Should().Be("unreleasedPackage1");
     }
 
-    [Test]
-    public async Task SymbolFeedsAreCleaned()
-    {
-        string feedWithPackages = "darc-int-some-repo-12345678";
-        string feedWithoutPackages = "darc-pub-some-repo-aabbccdd";
-        string feedWithDeletedPackages = "darc-int-some-repo-aaeeffbb-4";
-        string symbolFeedThatShouldStay = feedWithPackages.Replace("-int-", "-int-sym-");
-        string symbolFeedThatShouldGo1 = feedWithoutPackages.Replace("-pub-", "-pub-sym-"); // Matches a feed without packages
-        string symbolFeedThatShouldGo2 = feedWithPackages.Replace("-int-", "-int-sym-") + "-1"; // Matches no feed
-        string symbolFeedThatShouldGo3 = feedWithDeletedPackages.Replace("-int-", "-int-sym-"); // Matches a feed with deleted packages
-
-        int i = 1;
-        AzureDevOpsFeed CreateFeed(string name, params string[] packageNames)
-        {
-            return new AzureDevOpsFeed(SomeAccount, $"{i++}", name)
-            {
-                Packages = [..packageNames.Select(p => new AzureDevOpsPackage(p, "nuget")
-                {
-                    Versions = [new AzureDevOpsPackageVersion("1.0", isDeleted: false)]
-                })]
-            };
-        }
-
-        var feeds = new Dictionary<string, AzureDevOpsFeed>()
-        {
-            { feedWithPackages, CreateFeed(feedWithPackages, "Package1") },
-            { feedWithoutPackages, CreateFeed(feedWithoutPackages) },
-            { feedWithDeletedPackages, CreateFeed(feedWithDeletedPackages, "Package2") },
-            { symbolFeedThatShouldStay, CreateFeed(symbolFeedThatShouldStay, "Symbols") },
-            { symbolFeedThatShouldGo1, CreateFeed(symbolFeedThatShouldGo1, "Symbols1") },
-            { symbolFeedThatShouldGo2, CreateFeed(symbolFeedThatShouldGo2, "Symbols2") },
-            { symbolFeedThatShouldGo3, CreateFeed(symbolFeedThatShouldGo3, "Symbols3") },
-        };
-
-        feeds[feedWithDeletedPackages].Packages[0].Versions[0].IsDeleted = true;
-
-        var feedCleaner = InitializeFeedCleaner(nameof(SymbolFeedsAreCleaned), feeds);
-        await feedCleaner.CleanManagedFeedsAsync();
-
-        var deletedFeeds = _feeds
-            .Select(f => f.Value.Name)
-            .Where(name => name.EndsWith("-deleted"))
-            .Select(name => name.Replace("-deleted", null))
-            .ToArray();
-
-        deletedFeeds.Should().BeEquivalentTo(
-        [
-            symbolFeedThatShouldGo1,
-            symbolFeedThatShouldGo2,
-            symbolFeedThatShouldGo3,
-        ]);
-    }
-
     private void SetupAssetsFromFeeds(BuildAssetRegistryContext context)
     {
         List<Asset> assets = [];

--- a/test/ProductConstructionService.FeedCleaner.Tests/FeedCleanerTests.cs
+++ b/test/ProductConstructionService.FeedCleaner.Tests/FeedCleanerTests.cs
@@ -162,8 +162,8 @@ public class FeedCleanerTests
         var feedCleaner = InitializeFeedCleaner(nameof(SymbolFeedsAreCleaned), feeds);
         await feedCleaner.CleanManagedFeedsAsync();
 
-        feeds[symbolFeedWithReleasedPackages].Packages.All(p => p.Versions.All(v => v.IsDeleted));
-        feeds[symbolFeedWithoutReleasedPackages].Packages.All(p => p.Versions.All(v => !v.IsDeleted));
+        feeds[symbolFeedWithReleasedPackages].Packages.All(p => p.Versions.All(v => v.IsDeleted)).Should().BeTrue();
+        feeds[symbolFeedWithoutReleasedPackages].Packages.All(p => p.Versions.All(v => !v.IsDeleted)).Should().BeTrue();
     }
 
     private void SetupAssetsFromFeeds(BuildAssetRegistryContext context)


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4767#issue-3028200957
After talking with Matt, we agreed that we'll delete symbols that are already published to NuGet and exist in BAR. We won't delete the symbol feeds tho, this is what caused the crashes we saw