### PR TITLE
Make repro tool work with `NuGet.Client`

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
@@ -115,7 +115,12 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
 
         // Prepare repo
         SourceMapping mapping = _dependencyTracker.GetMapping(subscription.SourceDirectory);
-        var remotes = new[] { mapping.DefaultRemote, _sourceManifest.GetRepoVersion(mapping.Name).RemoteUri }
+        var remotes = new[]
+            {
+                mapping.DefaultRemote,
+                _sourceManifest.GetRepoVersion(mapping.Name).RemoteUri,
+                subscription.TargetRepository
+            }
             .Distinct()
             .OrderRemotesByLocalPublicOther()
             .ToList();

--- a/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
@@ -101,13 +101,8 @@ internal abstract class Operation(
             var settings = JsonSerializer.Deserialize<SourceMappingFile>(content, JsonSerializerOptions)
                 ?? throw new Exception($"Failed to deserialize {VmrInfo.SourceMappingsFileName}");
 
-            foreach (var mapping in settings.Mappings)
-            {
-                if (mapping.DefaultRemote?.Equals(productRepoUri, StringComparison.OrdinalIgnoreCase) ?? false)
-                {
-                    mapping.DefaultRemote = productRepoForkUri;
-                }
-            }
+            var affectedMapping = settings.Mappings.First(m => m.DefaultRemote?.Equals(productRepoUri, StringComparison.OrdinalIgnoreCase) ?? false);
+            affectedMapping.DefaultRemote = productRepoForkUri;
 
             return JsonSerializer.Serialize(settings, JsonSerializerOptions);
         });
@@ -117,13 +112,8 @@ internal abstract class Operation(
             var sourceManifest = SourceManifest.FromJson(content)
                 ?? throw new Exception($"Failed to deserialize {VmrInfo.SourceManifestFileName}");
 
-            foreach (var mapping in sourceManifest.Repositories)
-            {
-                if (mapping.RemoteUri.Equals(productRepoUri, StringComparison.OrdinalIgnoreCase) && mapping is ManifestRecord record)
-                {
-                    record.RemoteUri = productRepoForkUri;
-                }
-            }
+            var affectedRecord = sourceManifest.Repositories.First(m => m.RemoteUri.Equals(productRepoUri, StringComparison.OrdinalIgnoreCase));
+            ((ManifestRecord)affectedRecord).RemoteUri = productRepoForkUri;
 
             return JsonSerializer.Serialize(sourceManifest, JsonSerializerOptions);
         });

--- a/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
@@ -142,8 +142,7 @@ internal abstract class Operation(
                 filePath,
                 branch))
             .FirstOrDefault()
-            ?? throw new Exception($"Failed to find file {SourceMappingsPath} in {MaestroAuthTestOrgName}" +
-                                   $"/{VmrForkRepoName} on branch {SourceMappingsPath}");
+            ?? throw new Exception($"Failed to find file {filePath} in {MaestroAuthTestOrgName}/{VmrForkRepoName} on branch {branch}");
 
         UpdateFileRequest update = new(
             $"Updated {filePath}",

--- a/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
@@ -1,7 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.DotNet.ProductConstructionService.Client;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
@@ -22,6 +25,15 @@ internal abstract class Operation(
     protected const string SourceMappingsPath = $"{VmrInfo.SourceDirName}/{VmrInfo.SourceMappingsFileName}";
     protected const string SourceManifestPath = $"{VmrInfo.SourceDirName}/{VmrInfo.SourceManifestFileName}";
     protected const string DarcPRBranchPrefix = "darc";
+
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
+    {
+        AllowTrailingCommas = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+        WriteIndented = true,
+    };
 
     internal abstract Task RunAsync();
 
@@ -83,11 +95,44 @@ internal abstract class Operation(
     {
         // Fetch source mappings and source manifest files and replace the mapping for the repo we're testing on
         logger.LogInformation("Updating source mappings and source manifest files in VMR fork to replace original product repo mapping with fork mapping");
-        await UpdateRemoteVmrForkFileAsync(branch, productRepoUri, productRepoForkUri, SourceMappingsPath);
-        await UpdateRemoteVmrForkFileAsync(branch, productRepoUri, productRepoForkUri, SourceManifestPath);
+
+        await UpdateRemoteVmrForkFileAsync(branch, SourceMappingsPath, content =>
+        {
+            var settings = JsonSerializer.Deserialize<SourceMappingFile>(content, JsonSerializerOptions)
+                ?? throw new Exception($"Failed to deserialize {VmrInfo.SourceMappingsFileName}");
+
+            foreach (var mapping in settings.Mappings)
+            {
+                if (mapping.DefaultRemote?.Equals(productRepoUri, StringComparison.OrdinalIgnoreCase) ?? false)
+                {
+                    mapping.DefaultRemote = productRepoForkUri;
+                }
+            }
+
+            return JsonSerializer.Serialize(settings, JsonSerializerOptions);
+        });
+
+        await UpdateRemoteVmrForkFileAsync(branch, SourceManifestPath, content =>
+        {
+            var sourceManifest = SourceManifest.FromJson(content)
+                ?? throw new Exception($"Failed to deserialize {VmrInfo.SourceManifestFileName}");
+
+            foreach (var mapping in sourceManifest.Repositories)
+            {
+                if (mapping.RemoteUri.Equals(productRepoUri, StringComparison.OrdinalIgnoreCase) && mapping is ManifestRecord record)
+                {
+                    record.RemoteUri = productRepoForkUri;
+                }
+            }
+
+            return JsonSerializer.Serialize(sourceManifest, JsonSerializerOptions);
+        });
     }
 
-    private async Task UpdateRemoteVmrForkFileAsync(string branch, string productRepoUri, string productRepoForkUri, string filePath)
+    private async Task UpdateRemoteVmrForkFileAsync(
+        string branch,
+        string filePath,
+        Func<string, string> contentUpdater)
     {
         logger.LogInformation("Updating file {file} on branch {branch} in the VMR fork", filePath, branch);
         // Fetch remote file and replace the product repo URI with the repo we're testing on        
@@ -100,11 +145,9 @@ internal abstract class Operation(
             ?? throw new Exception($"Failed to find file {SourceMappingsPath} in {MaestroAuthTestOrgName}" +
                                    $"/{VmrForkRepoName} on branch {SourceMappingsPath}");
 
-        // Replace the product repo uri with the forked one
-        var updatedSourceMappings = sourceMappingsFile.Content.Replace(productRepoUri, productRepoForkUri);
         UpdateFileRequest update = new(
-            $"Update {productRepoUri} source mapping",
-            updatedSourceMappings,
+            $"Updated {filePath}",
+            contentUpdater(sourceMappingsFile.Content),
             sourceMappingsFile.Sha,
             branch);
 

--- a/tools/ProductConstructionService.ReproTool/Operations/ReproOperation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/ReproOperation.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Maestro.Data;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.ProductConstructionService.Client;


### PR DESCRIPTION
The repro tool was not ignoring case when replacing the source mapping/manifest records.
We could do a case-insensitive replace but it just felt better to work with the JSON.

Found during https://github.com/dotnet/arcade-services/issues/4665
