### PR TITLE
Use `maestro-test-arcade` instead of `arcade` for Scenario tests

### DIFF
--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_SdkUpdate.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_SdkUpdate.cs
@@ -24,8 +24,7 @@ internal class ScenarioTests_SdkUpdate : ScenarioTestBase
         var testChannelName = GetTestChannelName();
         var targetBranch = GetTestBranchName();
 
-        const string sourceRepo = "arcade";
-        const string sourceRepoUri = $"https://github.com/{TestRepository.TestOrg}/{sourceRepo}";
+        const string sourceRepoUri = $"https://github.com/{TestRepository.TestOrg}/{TestRepository.TestArcadeName}";
         const string sourceBranch = "dependencyflow-tests";
         const string newArcadeSdkVersion = "2.1.0";
         var sourceBuildNumber = _random.Next(int.MaxValue).ToString();
@@ -42,9 +41,9 @@ internal class ScenarioTests_SdkUpdate : ScenarioTestBase
         await using AsyncDisposableValue<string> channel =
             await CreateTestChannelAsync(testChannelName);
         await using AsyncDisposableValue<string> sub =
-            await CreateSubscriptionAsync(testChannelName, sourceRepo, TestRepository.TestRepo2Name, targetBranch, "none", TestRepository.TestOrg, targetIsAzDo: targetAzDO);
+            await CreateSubscriptionAsync(testChannelName, TestRepository.TestArcadeName, TestRepository.TestRepo2Name, targetBranch, "none", TestRepository.TestOrg, targetIsAzDo: targetAzDO);
         Build build =
-            await CreateBuildAsync(GetRepoUrl(TestRepository.TestOrg, sourceRepo), sourceBranch, TestRepository.ArcadeTestRepoCommit, sourceBuildNumber, sourceAssets);
+            await CreateBuildAsync(GetRepoUrl(TestRepository.TestOrg, TestRepository.TestArcadeName), sourceBranch, TestRepository.ArcadeTestRepoCommit, sourceBuildNumber, sourceAssets);
 
         await using IAsyncDisposable _ = await AddBuildToChannelAsync(build.Id, testChannelName);
 
@@ -63,7 +62,7 @@ internal class ScenarioTests_SdkUpdate : ScenarioTestBase
             await using IAsyncDisposable __ = await PushGitBranchAsync("origin", targetBranch);
             await TriggerSubscriptionAsync(sub.Value);
 
-            var expectedTitle = $"[{targetBranch}] Update dependencies from {TestRepository.TestOrg}/{sourceRepo}";
+            var expectedTitle = $"[{targetBranch}] Update dependencies from {TestRepository.TestOrg}/{TestRepository.TestArcadeName}";
             DependencyDetail expectedDependency = new()
             {
                 Name = DependencyFileManager.ArcadeSdkPackageName,
@@ -120,7 +119,7 @@ internal class ScenarioTests_SdkUpdate : ScenarioTestBase
                        "Pinned:           False",
                     ]);
 
-                using TemporaryDirectory arcadeRepo = await CloneRepositoryAsync(TestRepository.TestOrg, sourceRepo);
+                using TemporaryDirectory arcadeRepo = await CloneRepositoryAsync(TestRepository.TestOrg, TestRepository.TestArcadeName);
                 using (ChangeDirectory(arcadeRepo.Directory))
                 {
                     await CheckoutRemoteRefAsync(TestRepository.ArcadeTestRepoCommit);

--- a/test/ProductConstructionService.ScenarioTests/TestRepository.cs
+++ b/test/ProductConstructionService.ScenarioTests/TestRepository.cs
@@ -11,10 +11,11 @@ internal class TestRepository
     internal const string TestRepo3Name = "maestro-test3";
     internal const string VmrTestRepoName = "maestro-test-vmr";
     internal const string SourceBranch = "master";
+    internal const string TestArcadeName = "maestro-test-arcade";
 
     // This branch and commit data is special for the coherency test
     // It's required to make sure that the dependency tree is set up correctly in the repo without conflicting with other test cases
     internal const string CoherencyTestRepo1Commit = "cc1a27107a1f4c4bc5e2f796c5ef346f60abb404";
     internal const string CoherencyTestRepo2Commit = "8460158878d4b7568f55d27960d4453877523ea6";
-    internal const string ArcadeTestRepoCommit = "f3d51d2c9af2a3eb046fa54c5acdef9fb37db172";
+    internal const string ArcadeTestRepoCommit = "a702b2239b4dd238dd52c26a02d055cf4baff3a1";
 }


### PR DESCRIPTION
Fixes problems where we cannot use `maestro-auth-test/arcade` with `ReproTool`
