### PR TITLE
Remove mapping/repo name check from Backflow merge policy

### DIFF
--- a/src/Maestro/Maestro.MergePolicies/BackFlowMergePolicy.cs
+++ b/src/Maestro/Maestro.MergePolicies/BackFlowMergePolicy.cs
@@ -77,7 +77,7 @@ internal class BackFlowMergePolicy : CodeFlowMergePolicy
         PullRequestUpdateSummary pr,
         SubscriptionUpdateSummary update)
     {
-        List<string> configurationErrors = new();
+        List<string> configurationErrors = [];
         if (sourceDependency.BarId != update.BuildId)
         {
             configurationErrors.Add($"""
@@ -93,16 +93,6 @@ internal class BackFlowMergePolicy : CodeFlowMergePolicy
                 #### {configurationErrors.Count + 1}. Commit SHA Mismatch in `{VersionFiles.VersionDetailsXml}`
                 - **Source Repository**: {update.SourceRepo}
                 - **Error**: Commit SHA `{sourceDependency.Sha}` found in `{VersionFiles.VersionDetailsXml}` does not match the commit SHA of the current update (`{update.CommitSha}`).
-                """);
-        }
-
-        (string targetRepoName, _) = GitRepoUrlUtils.GetRepoNameAndOwner(pr.TargetRepoUrl);
-        if (!targetRepoName.Equals(sourceDependency.Mapping, StringComparison.OrdinalIgnoreCase))
-        {
-            configurationErrors.Add($"""
-                #### {configurationErrors.Count + 1}. Mapping Mismatch in `{VersionFiles.VersionDetailsXml}`
-                - **Source Repository**: {update.SourceRepo}
-                - **Error**: Mapping value `{sourceDependency.Mapping}` found in `{VersionFiles.VersionDetailsXml}` does not match the source repository name of the current update (`{targetRepoName}`).
                 """);
         }
 


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4525
We don't really need this policy, and it's making PRs in nuget.client fail (because the mapping says nuget-client)