### PR TITLE
Fix synchronization of nuget.client forks

### DIFF
--- a/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
@@ -159,7 +159,7 @@ internal abstract class Operation(
         var allRepos = await ghClient.Repository.GetAllForOrg(MaestroAuthTestOrgName);
 
         // If we already have a fork in maestro-auth-test, sync the branch we need with the source
-        if (allRepos.FirstOrDefault(repo => repo.HtmlUrl.Equals(productRepoForkUri, StringComparison.OrdinalIgnoreCase)) != null)
+        if (allRepos.Any(repo => repo.HtmlUrl.Equals(productRepoForkUri, StringComparison.OrdinalIgnoreCase)))
         {
             logger.LogInformation("Product repo fork {fork} already exists, syncing branch {branch} with source", productRepoForkUri, productRepoBranch);
             await SyncForkAsync(org, name, productRepoBranch);

--- a/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/Operation.cs
@@ -159,7 +159,7 @@ internal abstract class Operation(
         var allRepos = await ghClient.Repository.GetAllForOrg(MaestroAuthTestOrgName);
 
         // If we already have a fork in maestro-auth-test, sync the branch we need with the source
-        if (allRepos.FirstOrDefault(repo => repo.HtmlUrl == productRepoForkUri) != null)
+        if (allRepos.FirstOrDefault(repo => repo.HtmlUrl.Equals(productRepoForkUri, StringComparison.OrdinalIgnoreCase)) != null)
         {
             logger.LogInformation("Product repo fork {fork} already exists, syncing branch {branch} with source", productRepoForkUri, productRepoBranch);
             await SyncForkAsync(org, name, productRepoBranch);


### PR DESCRIPTION
The repro tool didn't match the URI because of casing and started creating new forks every time:
![image](https://github.com/user-attachments/assets/378afac0-f62a-46fa-945a-2b3fb19cf967)

<!-- https://github.com/dotnet/arcade-services/issues/4861 -->