### PR TITLE
Fix a new NRE in our service

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -996,6 +996,13 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         }
 
         var subscription = await _sqlClient.GetSubscriptionAsync(update.SubscriptionId);
+        if (subscription == null)
+        {
+            _logger.LogWarning("Subscription {subscriptionId} was not found. Stopping updates", update.SubscriptionId);
+            await ClearAllStateAsync(isCodeFlow: true, clearPendingUpdates: true);
+            return;
+        }
+
         var isForwardFlow = !string.IsNullOrEmpty(subscription.TargetDirectory);
         string prHeadBranch = pr?.HeadBranch ?? GetNewBranchName(subscription.TargetBranch);
 


### PR DESCRIPTION
Possibly introduced in https://github.com/dotnet/arcade-services/issues/4542 where the newly used SQL client does not throw when a subscription does not exist

