### PR TITLE
Persist the base commit of subscription update for diff links

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/SubscriptionPullRequestUpdate.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/SubscriptionPullRequestUpdate.cs
@@ -20,4 +20,7 @@ public class SubscriptionPullRequestUpdate
 
     [DataMember]
     public string CommitSha { get; set; }
+
+    [DataMember]
+    public string BaseSourceSha { get; set; }
 }


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/4777#issue-3030803244

Persist the original base commit throughout subsequent subscription updates on the same open PR in order to generate the right commit diff url. 