### PR TITLE
Fix broken file links again

### DIFF
--- a/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/Subscription.cs
+++ b/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/Subscription.cs
@@ -6,5 +6,6 @@ namespace Microsoft.DotNet.ProductConstructionService.Client.Models
     public partial class Subscription
     {
         public bool IsBackflow() => SourceEnabled && !string.IsNullOrEmpty(SourceDirectory);
+        public bool IsForwardFlow() => SourceEnabled && !string.IsNullOrEmpty(TargetDirectory);
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestConflictNotifier.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestConflictNotifier.cs
@@ -24,7 +24,8 @@ internal interface IPullRequestConflictNotifier
         ConflictInPrBranchException conflictException,
         SubscriptionUpdateWorkItem update,
         Subscription subscription,
-        InProgressPullRequest pr);
+        InProgressPullRequest pr,
+        string prHeadBranch);
 
     /// <summary>
     /// Posts a comment in the PR when the PR has a conflict with the target branch.
@@ -56,22 +57,20 @@ internal class PullRequestConflictNotifier : IPullRequestConflictNotifier
         ConflictInPrBranchException conflictException,
         SubscriptionUpdateWorkItem update,
         Subscription subscription,
-        InProgressPullRequest pr)
+        InProgressPullRequest pr,
+        string prHeadBranch)
     {
         // The PR we're trying to update has a conflict with the source repo. We will mark it as blocked, not allowing any updates from this
         // subscription till it's merged, or the conflict resolved. We'll set a reminder to check on it.
         StringBuilder sb = new();
         sb.AppendLine($"There was a conflict in the PR branch when flowing source from {GitRepoUrlUtils.GetRepoAtCommitUri(update.SourceRepo, update.SourceSha)}");
         sb.AppendLine("Files conflicting with the head branch:");
-        foreach (var file in conflictException.FilesInConflict)
+        foreach (var filePath in conflictException.FilesInConflict)
         {
-            var sourceString = subscription.IsBackflow()
-                ? $"[🔍 View in VMR]({GitRepoUrlUtils.GetVmrFileAtCommitUri(update.SourceRepo, subscription.TargetDirectory, update.SourceSha, file)})"
-                : $"[🔍 View in {GitRepoUrlUtils.GetRepoNameWithOrg(update.SourceRepo)}]({GitRepoUrlUtils.GetRepoFileAtCommitUri(update.SourceRepo, update.SourceSha, file)})";
-            var targetString = subscription.IsBackflow()
-                ? $"[🔍 View in {GitRepoUrlUtils.GetRepoNameWithOrg(subscription.TargetRepository)}]({GitRepoUrlUtils.GetRepoFileAtBranchUri(subscription.TargetRepository, subscription.TargetBranch, file)})"
-                : $"[🔍 View in VMR]({GitRepoUrlUtils.GetVmrFileAtBranchUri(subscription.TargetRepository, subscription.SourceDirectory, subscription.TargetBranch, file)})";
-            sb.AppendLine($" - `{file}` - {sourceString} / {targetString}");
+            var (fileUrlInVmr, fileUrlInRepo) = GetFileUrls(update, subscription, filePath, prHeadBranch);
+            string vmrString = $"[🔍 View in VMR]({fileUrlInVmr})";
+            string repoString = $"[🔍 View in {GitRepoUrlUtils.GetRepoNameWithOrg(subscription.TargetRepository)}]({fileUrlInRepo})";
+            sb.AppendLine($" - `{filePath}` - {repoString} / {vmrString}");
         }
         sb.AppendLine();
         sb.AppendLine("Updates from this subscription will be blocked until the conflict is resolved, or the PR is merged");
@@ -86,6 +85,30 @@ internal class PullRequestConflictNotifier : IPullRequestConflictNotifier
         {
             _logger.LogWarning("Posting comment to {prUrl} failed with exception {message}", pr.Url, e.Message);
         }
+    }
+
+    private (string, string) GetFileUrls(SubscriptionUpdateWorkItem update,
+        Subscription subscription,
+        string filePath,
+        string prHeadBranch)
+    {
+        string vmrFileUrl;
+        string repoFileUrl;
+        if (subscription.IsBackflow())
+        {
+            vmrFileUrl = GitRepoUrlUtils.GetVmrFileAtCommitUri(update.SourceRepo, subscription.SourceDirectory, update.SourceSha, filePath);
+            repoFileUrl = GitRepoUrlUtils.GetRepoFileAtBranchUri(subscription.TargetRepository, prHeadBranch, filePath);
+        }
+        else if (subscription.IsForwardFlow())
+        {
+            vmrFileUrl = GitRepoUrlUtils.GetVmrFileAtBranchUri(subscription.TargetRepository, subscription.TargetDirectory, prHeadBranch, filePath);
+            repoFileUrl = GitRepoUrlUtils.GetRepoFileAtCommitUri(update.SourceRepo, update.SourceSha, filePath);
+        }
+        else
+        {
+            throw new InvalidOperationException($"Failed to generate codeflow conflict message because subscription {subscription.Id} is not source-enabled.");
+        }
+        return (vmrFileUrl, repoFileUrl);
     }
 
     public async Task NotifyAboutMergeConflictAsync(

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestConflictNotifier.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestConflictNotifier.cs
@@ -21,7 +21,7 @@ internal interface IPullRequestConflictNotifier
     /// because there are conflicts between the sources in the PR and in the update.
     /// </summary>
     Task NotifyAboutConflictingUpdateAsync(
-        ConflictInPrBranchException conflictException,
+        List<string> filesInConflict,
         SubscriptionUpdateWorkItem update,
         Subscription subscription,
         InProgressPullRequest pr,
@@ -54,7 +54,7 @@ internal class PullRequestConflictNotifier : IPullRequestConflictNotifier
     }
 
     public async Task NotifyAboutConflictingUpdateAsync(
-        ConflictInPrBranchException conflictException,
+        List<string> filesInConflict,
         SubscriptionUpdateWorkItem update,
         Subscription subscription,
         InProgressPullRequest pr,
@@ -65,7 +65,7 @@ internal class PullRequestConflictNotifier : IPullRequestConflictNotifier
         StringBuilder sb = new();
         sb.AppendLine($"There was a conflict in the PR branch when flowing source from {GitRepoUrlUtils.GetRepoAtCommitUri(update.SourceRepo, update.SourceSha)}");
         sb.AppendLine("Files conflicting with the head branch:");
-        foreach (var filePath in conflictException.FilesInConflict)
+        foreach (var filePath in filesInConflict)
         {
             var (fileUrlInVmr, fileUrlInRepo) = GetFileUrls(update, subscription, filePath, prHeadBranch);
             string vmrString = $"[🔍 View in VMR]({fileUrlInVmr})";

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -1038,7 +1038,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         {
             if (pr != null)
             {
-                await HandlePrUpdateConflictAsync(conflictException, update, subscription, pr, prHeadBranch);
+                await HandlePrUpdateConflictAsync(conflictException.FilesInConflict, update, subscription, pr, prHeadBranch);
             }
             return;
         }
@@ -1259,13 +1259,13 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
     /// In this case, we post a comment on the PR with the list of files that are in conflict,
     /// </summary>
     private async Task HandlePrUpdateConflictAsync(
-        ConflictInPrBranchException conflictException,
+        List<string> filesInConflict,
         SubscriptionUpdateWorkItem update,
         SubscriptionDTO subscription,
         InProgressPullRequest pr,
         string prHeadBranch)
     {
-        await _pullRequestConflictNotifier.NotifyAboutConflictingUpdateAsync(conflictException, update, subscription, pr, prHeadBranch);
+        await _pullRequestConflictNotifier.NotifyAboutConflictingUpdateAsync(filesInConflict, update, subscription, pr, prHeadBranch);
 
         // If the headBranch gets updated, we will retry to update it with previously conflicting changes. If these changes still cause a conflict, we should update the
         // InProgressPullRequest with the latest commit from the remote branch

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -1038,7 +1038,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         {
             if (pr != null)
             {
-                await HandlePrUpdateConflictAsync(conflictException, update, subscription, pr);
+                await HandlePrUpdateConflictAsync(conflictException, update, subscription, pr, prHeadBranch);
             }
             return;
         }
@@ -1262,9 +1262,10 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         ConflictInPrBranchException conflictException,
         SubscriptionUpdateWorkItem update,
         SubscriptionDTO subscription,
-        InProgressPullRequest pr)
+        InProgressPullRequest pr,
+        string prHeadBranch)
     {
-        await _pullRequestConflictNotifier.NotifyAboutConflictingUpdateAsync(conflictException, update, subscription, pr);
+        await _pullRequestConflictNotifier.NotifyAboutConflictingUpdateAsync(conflictException, update, subscription, pr, prHeadBranch);
 
         // If the headBranch gets updated, we will retry to update it with previously conflicting changes. If these changes still cause a conflict, we should update the
         // InProgressPullRequest with the latest commit from the remote branch


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/4841#issue-3068326194

At first I thought this issue was happening only because we were using URL-generating methods intended for normal repos in the VMR - but the VMR needs an additional "src/repoName" in the file paths.

But there was another issue as well, which this PR fixes. The conflict comment was linking to files in the target branches - but the target branch is the one that doesn't have the file until the PR is merged. Therefore, the generated link has to point at the head branch instead.

On top of fixing the issue, I also rewrote the code to make it a bit easier to understand - it was like a mini IQ test to decipher the ternary conditionals for backflow, forward flow, source repo, and target repo.

Tested by modifying scenario tests to include the 'file conflict comment' on the new files even though there was no conflict
Batched PR: https://github.com/maestro-auth-test/maestro-test-vmr/pull/1887
Forward flow PR: https://github.com/maestro-auth-test/maestro-test-vmr/pull/1881
Backflow PR: https://github.com/maestro-auth-test/maestro-test2/pull/28228

All links are working now