### PR TITLE
Add the `darc vmr diff --name-only` option

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrDiffOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrDiffOptions.cs
@@ -5,6 +5,7 @@ using CommandLine;
 using Microsoft.DotNet.Darc.Operations.VirtualMonoRepo;
 
 namespace Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
+
 [Verb("diff", HelpText = "Diffs the VMR and the product repositories. Outputs the diff to stdout, "
     + "or saves it to a patch file (or multiple if patch > 1 GB), if --output-path is provided")]
 internal class VmrDiffOptions : VmrCommandLineOptions<VmrDiffOperation>
@@ -17,4 +18,7 @@ internal class VmrDiffOptions : VmrCommandLineOptions<VmrDiffOperation>
         "where remote can be a local path or remote URI. Alternatively, only one target can be provided in " +
         "which case current directory will be used as the source for the diff")]
     public string Repositories { get; set; }
+
+    [Option("name-only", Required = false, HelpText = "Only list differing files without the diffs")]
+    public bool NameOnly { get; set; }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -293,7 +293,6 @@ public class VmrPatchHandler : IVmrPatchHandler
     /// <summary>
     /// Resolves a list of all files that are part of a given patch diff.
     /// </summary>
-    /// <param name="repoPath">Path (to the repo) the patch applies onto</param>
     /// <param name="patchPath">Path to the patch file</param>
     /// <returns>List of all files (paths relative to repo's root) that are part of a given patch diff</returns>
     public async Task<IReadOnlyCollection<UnixPath>> GetPatchedFiles(string patchPath, CancellationToken cancellationToken)
@@ -305,7 +304,7 @@ public class VmrPatchHandler : IVmrPatchHandler
             return files;
         }
 
-        var result = await _processManager.ExecuteGit(_vmrInfo.VmrPath, ["apply", "--numstat", patchPath], cancellationToken: cancellationToken);
+        var result = await _processManager.ExecuteGit(_vmrInfo.TmpPath, ["apply", "--numstat", patchPath], cancellationToken: cancellationToken);
         result.ThrowIfFailed($"Failed to enumerate files from a patch at `{patchPath}`");
 
         foreach (var line in result.StandardOutput.Split(Environment.NewLine))


### PR DESCRIPTION
Adds a new option that only lists the differing file names

https://github.com/dotnet/source-build/issues/5201