### PR TITLE
Point references to UB documentation to new location

### DIFF
--- a/.github/ISSUE_TEMPLATE/codeflow-issue.yml
+++ b/.github/ISSUE_TEMPLATE/codeflow-issue.yml
@@ -33,4 +33,4 @@ body:
     attributes:
       value: |
         ## Additional information
-        If asking for general assistance, please make sure you've checked the [codeflow documentation](https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Full-Code-Flow.md)
+        If asking for general assistance, please make sure you've checked the [codeflow documentation](https://github.com/dotnet/dotnet/tree/main/docs/VMR-Full-Code-Flow.md)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repo is home of the services that help us construct .NET. Mainly, you can find the **Product Construction Service** (previously *Maestro*) dependency flow system and the Darc CLI tool.
 
-The service's main responsibility is opening and managing dependency update pull requests in .NET repositories. It is also responsible for [the code flow subscription between product repositories and the VMR](https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Full-Code-Flow.md).
+The service's main responsibility is opening and managing dependency update pull requests in .NET repositories. It is also responsible for [the code flow subscription between product repositories and the VMR](https://github.com/dotnet/dotnet/tree/main/docs/VMR-Full-Code-Flow.md).
 
 ## Development
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/SourceMappingParser.cs
@@ -22,7 +22,7 @@ public interface ISourceMappingParser
 /// <summary>
 /// Class responsible for parsing the source-mappings.json file.
 /// More details about source-mappings.json are directly in the file or at
-/// https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Design-And-Operation.md#repository-source-mappings
+/// https://github.com/dotnet/dotnet/tree/main/docs/VMR-Design-And-Operation.md#repository-source-mappings
 /// </summary>
 public class SourceMappingParser : ISourceMappingParser
 {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -244,7 +244,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             }
 
             // Otherwise, we have a conflicting change in the last backflow PR (before merging)
-            // The scenario is described here: https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Full-Code-Flow.md#conflicts
+            // The scenario is described here: https://github.com/dotnet/dotnet/tree/main/docs/VMR-Full-Code-Flow.md#conflicts
             await RecreatePreviousFlowAndApplyBuild(
                 mapping,
                 targetRepo,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -69,7 +69,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
     /// <summary>
     /// Main common entrypoint method that loads information about the last flow and calls the appropriate flow method.
     /// The algorithm is described in depth in the Unified Build documentation
-    /// https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Full-Code-Flow.md#the-code-flow-algorithm
+    /// https://github.com/dotnet/dotnet/tree/main/docs/VMR-Full-Code-Flow.md#the-code-flow-algorithm
     /// </summary>
     /// <returns>True if there were changes to flow</returns>
     public async Task<bool> FlowCodeAsync(

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -226,7 +226,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             }
 
             // This happens when a conflicting change was made in the last backflow PR (before merging)
-            // The scenario is described here: https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Full-Code-Flow.md#conflicts
+            // The scenario is described here: https://github.com/dotnet/dotnet/tree/main/docs/VMR-Full-Code-Flow.md#conflicts
             hadUpdates = await RecreatePreviousFlowAndApplyBuild(
                 mapping,
                 lastFlow,

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/Home.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/Home.razor
@@ -8,7 +8,7 @@
     Maestro++ is a service that help us construct .NET.
     The service's main responsibility is opening and managing dependency update pull requests in .NET repositories.
     It is also responsible for the
-    <FluentAnchor Href="https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Full-Code-Flow.md" Appearance="Appearance.Hypertext" Target="_blank">
+    <FluentAnchor Href="https://github.com/dotnet/dotnet/tree/main/docs/VMR-Full-Code-Flow.md" Appearance="Appearance.Hypertext" Target="_blank">
         code flow subscription between product repositories and the VMR.
     </FluentAnchor>
     The service's home repository is

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -66,7 +66,7 @@ internal interface IPullRequestBuilder
 internal class PullRequestBuilder : IPullRequestBuilder
 {
     public const int GitHubComparisonShaLength = 10;
-    public const string CodeFlowPrFaqUri = "https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Codeflow-PRs.md";
+    public const string CodeFlowPrFaqUri = "https://github.com/dotnet/dotnet/tree/main/docs/Codeflow-PRs.md";
 
     // PR description markers
     private const string DependencyUpdateBegin = "[DependencyUpdate]: <> (Begin)";

--- a/test/Microsoft.DotNet.Darc.Tests/inputs/source-mappings.json
+++ b/test/Microsoft.DotNet.Darc.Tests/inputs/source-mappings.json
@@ -8,7 +8,7 @@
 // Please check the source-manifest.json file for that purpose.
 //
 // More details on this file's mechanics:
-// https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Design-And-Operation.md#repository-source-mappings
+// https://github.com/dotnet/dotnet/tree/main/docs/VMR-Design-And-Operation.md#repository-source-mappings
 {
     // Location within the VMR where the source-build patches are stored
     // These patches are applied on top of the code synchronized into the VMR


### PR DESCRIPTION
The documents were moved in the VMR and this change is now being backflown: https://github.com/dotnet/arcade/issues/15853