### PR TITLE
Silence failures from test PRs

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/NonBatchedPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/NonBatchedPullRequestUpdater.cs
@@ -120,7 +120,9 @@ internal class NonBatchedPullRequestUpdater : PullRequestUpdater
         Subscription? subscription = await GetSubscription();
         if (subscription == null)
         {
-            return false;
+            // If the subscription was deleted during tests (a frequent occurrence when we delete subscriptions at the end),
+            // we don't want to report this as a failure. For real PRs, it might be good to learn about this. 
+            return pullRequestCheck.Url?.Contains("maestro-auth-test") ?? false;
         }
 
         return await base.CheckInProgressPullRequestAsync(pullRequestCheck, isCodeFlow);


### PR DESCRIPTION
During tests, we delete subscriptions while the service is still tracking open PRs.
This ends up in the background work item to end with a failure. Since the INT environment almost exclusively triggers for tests only, they make a majority of work items and trigger the alert for failed work items: https://github.com/dotnet/dnceng/issues/5769

This PR makes is so that these are considered successful.

