### PR TITLE
Do not keep bad policies in the policy results

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/MergePolicyEvaluator.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/MergePolicyEvaluator.cs
@@ -45,7 +45,8 @@ internal class MergePolicyEvaluator : IMergePolicyEvaluator
         MergePolicyEvaluationResults? cachedResults,
         string targetBranchSha)
     {
-        IDictionary<string, MergePolicyEvaluationResult> resultsByPolicyName =
+        Dictionary<string, MergePolicyEvaluationResult> resultsByPolicyName = new();
+        IDictionary<string, MergePolicyEvaluationResult> cachedResultsByPolicyName =
             cachedResults?.Results.ToDictionary(r => r.MergePolicyName, r => r) ?? [];
 
         foreach (MergePolicyDefinition definition in policyDefinitions)
@@ -56,7 +57,7 @@ internal class MergePolicyEvaluator : IMergePolicyEvaluator
                 var policies = await policyBuilder.BuildMergePoliciesAsync(new MergePolicyProperties(definition.Properties), pr);
                 foreach (var policy in policies)
                 {
-                    resultsByPolicyName.TryGetValue(policy.Name, out var cachedEvaluationResult);
+                    cachedResultsByPolicyName.TryGetValue(policy.Name, out var cachedEvaluationResult);
                     if (CanSkipRerunningPRCheck(cachedResults?.TargetCommitSha, cachedEvaluationResult, targetBranchSha))
                     {
                         continue;


### PR DESCRIPTION
This simple change should fix the bug that renaming merge policies causes cached merge policy results with the old 'deprecated' names to still be picked up by the evaluator and be pushed to github.

I decided not to implement clearing the cached merge policy states whenever we clear the PR state, based on these reasons:
1. A cached merge policy results simply says `The evaluation of merge policy X on commit Y gave this result`. This is a statement whose truth depends on the commit on which the policy was evaluated, and not on the PR. When a merge policy has a non-transitive `Success` or `Failure` on a given commit SHA, then this result is permanent. As such, the state of the PR does not influence the relevance of the cached result.
2. Clearing the PR state is not centralized - sometimes it happens in the PRUpdater through the injected cache client, and sometimes we manually recreate the updaterId to interact with the cache (eg in the API layer). I feel that clearing the cached policy state everywhere where we clear the PR state can lead to a drift - we will forget to do it everywhere, and eventually in our codebase we'll have places where both the PR and the cached policy results are cleared, and places where only the PR and not the policy results are cleared, leading to inconsistency. Because of point (1), clearing the cached policy result is not mandatory, so I think this should be avoided

Todo in this PR: add a test that injects an irrelevant merge policy result into the cache, and make sure that it is not sent through the github API

https://github.com/dotnet/arcade-services/issues/4913