### PR TITLE
Ignore deprecated merge policy results + add evaluation tests

### DIFF
--- a/src/Maestro/Maestro.MergePolicyEvaluation/MergePolicyEvaluationResults.cs
+++ b/src/Maestro/Maestro.MergePolicyEvaluation/MergePolicyEvaluationResults.cs
@@ -6,14 +6,11 @@ namespace Maestro.MergePolicyEvaluation;
 public class MergePolicyEvaluationResults
 {
 
-    public MergePolicyEvaluationResults(string id, IReadOnlyCollection<MergePolicyEvaluationResult> results, string targetCommitSha)
+    public MergePolicyEvaluationResults(IReadOnlyCollection<MergePolicyEvaluationResult> results, string targetCommitSha)
     {
-        Id = id;
         Results = results;
         TargetCommitSha = targetCommitSha;
     }
-
-    public string Id { get; set; }
 
     public IReadOnlyCollection<MergePolicyEvaluationResult> Results { get; set; }
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/MergePolicyEvaluator.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/MergePolicyEvaluator.cs
@@ -85,7 +85,7 @@ internal class MergePolicyEvaluator : IMergePolicyEvaluator
         MergePolicyEvaluationResult? cachedEvaluationValue,
         string targetBranchSha)
     {
-        if (cachedCommitSha == null || targetBranchSha == null || !targetBranchSha.Equals(cachedCommitSha))
+        if (cachedCommitSha == null || !cachedCommitSha.Equals(targetBranchSha))
         {
             return false;
         }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/MergePolicyEvaluator.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/MergePolicyEvaluator.cs
@@ -45,7 +45,8 @@ internal class MergePolicyEvaluator : IMergePolicyEvaluator
         MergePolicyEvaluationResults? cachedResults,
         string targetBranchSha)
     {
-        IDictionary<string, MergePolicyEvaluationResult> resultsByPolicyName =
+        Dictionary<string, MergePolicyEvaluationResult> resultsByPolicyName = new();
+        IDictionary<string, MergePolicyEvaluationResult> cachedResultsByPolicyName =
             cachedResults?.Results.ToDictionary(r => r.MergePolicyName, r => r) ?? [];
 
         foreach (MergePolicyDefinition definition in policyDefinitions)
@@ -56,7 +57,7 @@ internal class MergePolicyEvaluator : IMergePolicyEvaluator
                 var policies = await policyBuilder.BuildMergePoliciesAsync(new MergePolicyProperties(definition.Properties), pr);
                 foreach (var policy in policies)
                 {
-                    resultsByPolicyName.TryGetValue(policy.Name, out var cachedEvaluationResult);
+                    cachedResultsByPolicyName.TryGetValue(policy.Name, out var cachedEvaluationResult);
                     if (CanSkipRerunningPRCheck(cachedResults?.TargetCommitSha, cachedEvaluationResult, targetBranchSha))
                     {
                         continue;
@@ -84,7 +85,7 @@ internal class MergePolicyEvaluator : IMergePolicyEvaluator
         MergePolicyEvaluationResult? cachedEvaluationValue,
         string targetBranchSha)
     {
-        if (cachedCommitSha == null || !targetBranchSha.Equals(cachedCommitSha))
+        if (cachedCommitSha == null || targetBranchSha == null || !targetBranchSha.Equals(cachedCommitSha))
         {
             return false;
         }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -420,12 +420,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
             updatedMergePolicyResults.ToImmutableList(),
             prInfo.TargetBranchCommitSha);
 
-        if (!(cachedResults == null && !updatedResult.Results.Any()))
-        {
-            // if there were no cached results, and there's no new results, let's not cache anything
-            // in case there were cached results, we want to overwrite them even if new result list is empty
-            await _mergePolicyEvaluationState.SetAsync(updatedResult);
-        }
+        await _mergePolicyEvaluationState.SetAsync(updatedResult);
 
         await UpdateMergeStatusAsync(remote, pr.Url, updatedResult.Results);
 

--- a/test/ProductConstructionService.DependencyFlow.Tests/MergePolicyEvaluationTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/MergePolicyEvaluationTests.cs
@@ -13,23 +13,23 @@ using FluentAssertions;
 namespace ProductConstructionService.DependencyFlow.Tests;
 internal class MergePolicyEvaluationTests : PullRequestUpdaterTests
 {
-    internal static string DeprecatedMergePolicyName = "Deprecated";
-    internal static string DeprecatedMergePolicyDisplayName = "Deprecated Merge Policy";
+    protected static string DeprecatedMergePolicyName = "Deprecated";
+    protected static string DeprecatedMergePolicyDisplayName = "Deprecated Merge Policy";
 
-    internal static string AlwaysSucceedMergePolicyName = "AlwaysSucceed";
-    internal static string AlwaysSucceedMergePolicyDisplayName = "Always Succeed Merge Policy";
+    protected static string AlwaysSucceedMergePolicyName = "AlwaysSucceed";
+    protected static string AlwaysSucceedMergePolicyDisplayName = "Always Succeed Merge Policy";
 
-    internal static string AlwaysFailMergePolicyName = "AlwaysFail";
-    internal static string AlwaysFailMergePolicyDisplayName = "Always Fail Merge Policy";
+    protected static string AlwaysFailMergePolicyName = "AlwaysFail";
+    protected static string AlwaysFailMergePolicyDisplayName = "Always Fail Merge Policy";
 
-    internal static MergePolicyEvaluationResult AlwaysSucceedMergePolicyResult = new MergePolicyEvaluationResult(
+    protected static MergePolicyEvaluationResult AlwaysSucceedMergePolicyResult = new MergePolicyEvaluationResult(
         MergePolicyEvaluationStatus.DecisiveSuccess,
         "check succeeded :)",
         "yay :)",
         AlwaysSucceedMergePolicyName,
         AlwaysSucceedMergePolicyDisplayName);
 
-    internal static MergePolicyEvaluationResult AlwaysFailMergePolicyResult = new MergePolicyEvaluationResult(
+    protected static MergePolicyEvaluationResult AlwaysFailMergePolicyResult = new MergePolicyEvaluationResult(
         MergePolicyEvaluationStatus.DecisiveFailure,
         "check failed :(",
         "oh no :(",
@@ -37,7 +37,7 @@ internal class MergePolicyEvaluationTests : PullRequestUpdaterTests
         AlwaysSucceedMergePolicyDisplayName);
 
 
-    internal static MergePolicyEvaluationResult DeprecatedMergePolicyResult = new MergePolicyEvaluationResult(
+    protected static MergePolicyEvaluationResult DeprecatedMergePolicyResult = new MergePolicyEvaluationResult(
         MergePolicyEvaluationStatus.DecisiveFailure,
         "N/A",
         "This result should never exist after merge policy evaluation",
@@ -119,7 +119,7 @@ internal class MergePolicyEvaluationTests : PullRequestUpdaterTests
         Cache.Data.Where(pair => pair.Value is MergePolicyEvaluationResults).Should().BeEquivalentTo(ExpectedEvaluationResultCacheState);
     }
 
-    class AlwaysSucceedMergePolicy : MergePolicy
+    protected class AlwaysSucceedMergePolicy : MergePolicy
     {
         public override string Name => AlwaysSucceedMergePolicyName;
         public override string DisplayName => AlwaysSucceedMergePolicyDisplayName;
@@ -131,7 +131,7 @@ internal class MergePolicyEvaluationTests : PullRequestUpdaterTests
         }
     }
 
-    class AlwaysFailMergePolicy : MergePolicy
+    protected class AlwaysFailMergePolicy : MergePolicy
     {
         public override string Name => AlwaysFailMergePolicyName;
         public override string DisplayName => AlwaysFailMergePolicyDisplayName;
@@ -143,7 +143,7 @@ internal class MergePolicyEvaluationTests : PullRequestUpdaterTests
         }
     }
 
-    internal class DeprecatedMergePolicy : MergePolicy
+    protected class DeprecatedMergePolicy : MergePolicy
     {
         public override string Name => DeprecatedMergePolicyName;
         public override string DisplayName => DeprecatedMergePolicyDisplayName;
@@ -151,7 +151,7 @@ internal class MergePolicyEvaluationTests : PullRequestUpdaterTests
         public override Task<MergePolicyEvaluationResult> EvaluateAsync(PullRequestUpdateSummary pr, IRemote darc) => throw new NotImplementedException();
     }
 
-    public class DeprecatedMergePolicyBuilder : IMergePolicyBuilder
+    internal class DeprecatedMergePolicyBuilder : IMergePolicyBuilder
     {
         public string Name => DeprecatedMergePolicyName;
         public Task<IReadOnlyList<IMergePolicy>> BuildMergePoliciesAsync(MergePolicyProperties properties, PullRequestUpdateSummary pr)
@@ -161,7 +161,7 @@ internal class MergePolicyEvaluationTests : PullRequestUpdaterTests
         }
     }
 
-    public class AlwaysSucceedMergePolicyBuilder : IMergePolicyBuilder
+    internal class AlwaysSucceedMergePolicyBuilder : IMergePolicyBuilder
     {
         public string Name => AlwaysSucceedMergePolicyName;
         public Task<IReadOnlyList<IMergePolicy>> BuildMergePoliciesAsync(MergePolicyProperties properties, PullRequestUpdateSummary pr)
@@ -171,7 +171,7 @@ internal class MergePolicyEvaluationTests : PullRequestUpdaterTests
         }
     }
 
-    public class AlwaysFailMergePolicyBuilder : IMergePolicyBuilder
+    internal class AlwaysFailMergePolicyBuilder : IMergePolicyBuilder
     {
         public string Name => AlwaysFailMergePolicyName;
         public Task<IReadOnlyList<IMergePolicy>> BuildMergePoliciesAsync(MergePolicyProperties properties, PullRequestUpdateSummary pr)

--- a/test/ProductConstructionService.DependencyFlow.Tests/MergePolicyEvaluationTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/MergePolicyEvaluationTests.cs
@@ -110,8 +110,13 @@ internal class MergePolicyEvaluationTests : PullRequestUpdaterTests
             AndCodeShouldHaveBeenFlownForward(newBuild);
             AndShouldHavePullRequestCheckReminder();
 
-            Cache.Data.Where(pair => pair.Value is MergePolicyEvaluationResults).Should().BeEquivalentTo(ExpectedEvaluationResultCacheState);
+            VerifyCachedMergePolicyResults(expectedMergePolicyEvaluationResults);
         }
+    }
+
+    private void VerifyCachedMergePolicyResults(MergePolicyEvaluationResults expectedMergePolicyEvaluationResults)
+    {
+        Cache.Data.Where(pair => pair.Value is MergePolicyEvaluationResults).Should().BeEquivalentTo(ExpectedEvaluationResultCacheState);
     }
 
     class AlwaysSucceedMergePolicy : MergePolicy

--- a/test/ProductConstructionService.DependencyFlow.Tests/MergePolicyEvaluationTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/MergePolicyEvaluationTests.cs
@@ -6,24 +6,118 @@ using Maestro.MergePolicyEvaluation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.DotNet.DarcLib;
+using Maestro.Data.Models;
+using NUnit.Framework;
 
 
 namespace ProductConstructionService.DependencyFlow.Tests;
 internal class MergePolicyEvaluationTests : PullRequestUpdaterTests
 {
+    internal static string DeprecatedMergePolicyName = "Deprecated";
+    internal static string DeprecatedMergePolicyDisplayName = "Deprecated Merge Policy";
+
+    internal static string AlwaysSucceedMergePolicyName = "AlwaysSucceed";
+    internal static string AlwaysSucceedMergePolicyDisplayName = "Always Succeed Merge Policy";
+
+    internal static string AlwaysFailMergePolicyName = "AlwaysFail";
+    internal static string AlwaysFailMergePolicyDisplayName = "Always Fail Merge Policy";
+
+    MergePolicyEvaluationResult AlwaysSucceedMergePolicyResult = new MergePolicyEvaluationResult(
+        MergePolicyEvaluationStatus.DecisiveFailure,
+        "check succeeded :)",
+        "yay :)",
+        AlwaysSucceedMergePolicyName,
+        AlwaysSucceedMergePolicyDisplayName);
+
+    MergePolicyEvaluationResult AlwaysFailMergePolicyResult = new MergePolicyEvaluationResult(
+        MergePolicyEvaluationStatus.DecisiveFailure,
+        "check failed :(",
+        "oh no :(",
+        AlwaysSucceedMergePolicyName,
+        AlwaysSucceedMergePolicyDisplayName);
+
+
+    MergePolicyEvaluationResult DeprecatedMergePolicyResult = new MergePolicyEvaluationResult(
+        MergePolicyEvaluationStatus.DecisiveFailure,
+        "This text should never be returned",
+        "This merge policy is deprecated and cannot be evaluated",
+        DeprecatedMergePolicyName,
+        DeprecatedMergePolicyDisplayName);
+
     protected override void RegisterServices(IServiceCollection services)
     {
         base.RegisterServices(services);
         services.TryAddSingleton<IMergePolicyEvaluator, MergePolicyEvaluator>();
+        services.AddTransient<IMergePolicyBuilder, AlwaysSucceedMergePolicyBuilder>();
+        services.AddTransient<IMergePolicyBuilder, AlwaysFailMergePolicyBuilder>();
+        services.AddTransient<IMergePolicyBuilder, DeprecatedMergePolicyBuilder>();
     }
 
+    protected async Task WhenUpdateAssetsAsyncIsCalled(Build forBuild)
+    {
+        await Execute(
+            async context =>
+            {
+                IPullRequestUpdater updater = CreatePullRequestActor(context);
+                await updater.UpdateAssetsAsync(
+                    Subscription.Id,
+                    Subscription.SourceEnabled ? SubscriptionType.DependenciesAndSources : SubscriptionType.Dependencies,
+                    forBuild.Id,
+                    applyNewestOnly: false);
+            });
+    }
 
+    [Test]
+    public async Task TestPRUpdaterWithMergePolicyEvaluation()
+    {
+        GivenATestChannel();
 
+        var alwaysFailMergePolicyDefinition = new MergePolicyDefinition();
+        alwaysFailMergePolicyDefinition.Name = AlwaysFailMergePolicyName;
+
+        GivenACodeFlowSubscription(
+            new SubscriptionPolicy
+            {
+                Batchable = false,
+                UpdateFrequency = UpdateFrequency.EveryBuild,
+                MergePolicies = [alwaysFailMergePolicyDefinition]
+            });
+
+        Build oldBuild = GivenANewBuild(true);
+        Build newBuild = GivenANewBuild(true);
+        newBuild.Commit = "sha123456";
+
+        using (WithExistingCodeFlowPullRequest(oldBuild, canUpdate: true, willFlowNewBuild: true, mockMergePolicyEvaluator: false))
+        {
+            ExpectPrMetadataToBeUpdated();
+
+            MergePolicyEvaluationResults mergePolicyEvaluationResults = new MergePolicyEvaluationResults(
+                Subscription.Id.ToString(),
+                new List<MergePolicyEvaluationResult> { AlwaysFailMergePolicyResult, DeprecatedMergePolicyResult }.AsReadOnly(),
+                newBuild.Commit);
+
+            SetState(Subscription, mergePolicyEvaluationResults);
+
+            //todo find a way to inject a real mergepolicyevaluator
+            await WhenUpdateAssetsAsyncIsCalled(newBuild);
+
+            MergePolicyEvaluationResults expectedMergePolicyEvaluationResults = new MergePolicyEvaluationResults(
+                Subscription.Id.ToString(),
+                new List<MergePolicyEvaluationResult> { AlwaysFailMergePolicyResult }.AsReadOnly(),
+                newBuild.Commit);
+
+            ThenShouldHaveCachedMergePolicyResults(expectedMergePolicyEvaluationResults);
+
+            ThenShouldHaveInProgressPullRequestState(newBuild);
+            AndCodeShouldHaveBeenFlownForward(newBuild);
+            AndShouldHavePullRequestCheckReminder();
+        }
+    }
 
     class AlwaysSucceedMergePolicy : MergePolicy
     {
-        public override string Name => "AlwaysSucceed";
-        public override string DisplayName => "Always Succeed Merge Policy";
+        public override string Name => AlwaysSucceedMergePolicyName;
+        public override string DisplayName => AlwaysSucceedMergePolicyDisplayName;
         public override Task<MergePolicyEvaluationResult> EvaluateAsync(
             PullRequestUpdateSummary pullRequest,
             IRemote remote)
@@ -35,21 +129,60 @@ internal class MergePolicyEvaluationTests : PullRequestUpdaterTests
                 Name,
                 DisplayName));
         }
-        class AlwaysFailMergePolicy : MergePolicy
+    }
+
+    class AlwaysFailMergePolicy : MergePolicy
+    {
+        public override string Name => AlwaysFailMergePolicyName;
+        public override string DisplayName => AlwaysFailMergePolicyDisplayName;
+        public override Task<MergePolicyEvaluationResult> EvaluateAsync(
+            PullRequestUpdateSummary pullRequest,
+            IRemote remote)
         {
-            public override string Name => "AlwaysFail";
-            public override string DisplayName => "Always Fail Merge Policy";
-            public override Task<MergePolicyEvaluationResult> EvaluateAsync(
-                PullRequestUpdateSummary pullRequest,
-                IRemote remote)
-            {
-                return Task.FromResult(new MergePolicyEvaluationResult(
-                    MergePolicyEvaluationStatus.DecisiveSuccess,
-                    "Failure",
-                    "",
-                    Name,
-                    DisplayName));
-            }
+            return Task.FromResult(new MergePolicyEvaluationResult(
+                MergePolicyEvaluationStatus.DecisiveSuccess,
+                "Failure",
+                "",
+                Name,
+                DisplayName));
+        }
+    }
+
+    internal class DeprecatedMergePolicy : MergePolicy
+    {
+        public override string Name => DeprecatedMergePolicyName;
+        public override string DisplayName => DeprecatedMergePolicyDisplayName;
+
+        public override Task<MergePolicyEvaluationResult> EvaluateAsync(PullRequestUpdateSummary pr, IRemote darc) => throw new NotImplementedException();
+    }
+
+    public class DeprecatedMergePolicyBuilder : IMergePolicyBuilder
+    {
+        public string Name => DeprecatedMergePolicyName;
+        public Task<IReadOnlyList<IMergePolicy>> BuildMergePoliciesAsync(MergePolicyProperties properties, PullRequestUpdateSummary pr)
+        {
+            IReadOnlyList<IMergePolicy> policies = new List<IMergePolicy> { new DeprecatedMergePolicy() };
+            return Task.FromResult(policies);
+        }
+    }
+
+    public class AlwaysSucceedMergePolicyBuilder : IMergePolicyBuilder
+    {
+        public string Name => AlwaysSucceedMergePolicyName;
+        public Task<IReadOnlyList<IMergePolicy>> BuildMergePoliciesAsync(MergePolicyProperties properties, PullRequestUpdateSummary pr)
+        {
+            IReadOnlyList<IMergePolicy> policies = new List<IMergePolicy> { new AlwaysSucceedMergePolicy() };
+            return Task.FromResult(policies);
+        }
+    }
+
+    public class AlwaysFailMergePolicyBuilder : IMergePolicyBuilder
+    {
+        public string Name => AlwaysFailMergePolicyName;
+        public Task<IReadOnlyList<IMergePolicy>> BuildMergePoliciesAsync(MergePolicyProperties properties, PullRequestUpdateSummary pr)
+        {
+            IReadOnlyList<IMergePolicy> policies = new List<IMergePolicy> { new AlwaysFailMergePolicy() };
+            return Task.FromResult(policies);
         }
     }
 }

--- a/test/ProductConstructionService.DependencyFlow.Tests/MergePolicyEvaluationTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/MergePolicyEvaluationTests.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Maestro.MergePolicies;
+using Maestro.MergePolicyEvaluation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.DotNet.DarcLib;
+
+
+namespace ProductConstructionService.DependencyFlow.Tests;
+internal class MergePolicyEvaluationTests : PullRequestUpdaterTests
+{
+    protected override void RegisterServices(IServiceCollection services)
+    {
+        base.RegisterServices(services);
+        services.TryAddSingleton<IMergePolicyEvaluator, MergePolicyEvaluator>();
+    }
+
+
+
+
+    class AlwaysSucceedMergePolicy : MergePolicy
+    {
+        public override string Name => "AlwaysSucceed";
+        public override string DisplayName => "Always Succeed Merge Policy";
+        public override Task<MergePolicyEvaluationResult> EvaluateAsync(
+            PullRequestUpdateSummary pullRequest,
+            IRemote remote)
+        {
+            return Task.FromResult(new MergePolicyEvaluationResult(
+                MergePolicyEvaluationStatus.DecisiveSuccess,
+                "Success",
+                "",
+                Name,
+                DisplayName));
+        }
+        class AlwaysFailMergePolicy : MergePolicy
+        {
+            public override string Name => "AlwaysFail";
+            public override string DisplayName => "Always Fail Merge Policy";
+            public override Task<MergePolicyEvaluationResult> EvaluateAsync(
+                PullRequestUpdateSummary pullRequest,
+                IRemote remote)
+            {
+                return Task.FromResult(new MergePolicyEvaluationResult(
+                    MergePolicyEvaluationStatus.DecisiveSuccess,
+                    "Failure",
+                    "",
+                    Name,
+                    DisplayName));
+            }
+        }
+    }
+}

--- a/test/ProductConstructionService.DependencyFlow.Tests/PendingUpdatePullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PendingUpdatePullRequestUpdaterTests.cs
@@ -3,6 +3,7 @@
 
 using Maestro.Data.Models;
 using Maestro.DataProviders;
+using Microsoft.Extensions.DependencyInjection;
 using ProductConstructionService.DependencyFlow.WorkItems;
 using BuildDTO = Microsoft.DotNet.ProductConstructionService.Client.Models.Build;
 
@@ -10,6 +11,12 @@ namespace ProductConstructionService.DependencyFlow.Tests;
 
 internal abstract class PendingUpdatePullRequestUpdaterTests : PullRequestUpdaterTests
 {
+    protected override void RegisterServices(IServiceCollection services)
+    {
+        base.RegisterServices(services);
+        services.AddSingleton(MergePolicyEvaluator.Object);
+    }
+
     protected async Task WhenProcessPendingUpdatesAsyncIsCalled(
         Build forBuild,
         bool isCodeFlow = false,

--- a/test/ProductConstructionService.DependencyFlow.Tests/PendingUpdatePullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PendingUpdatePullRequestUpdaterTests.cs
@@ -30,12 +30,6 @@ internal abstract class PendingUpdatePullRequestUpdaterTests : PullRequestUpdate
         SetExpectedReminder(Subscription, CreateSubscriptionUpdate(forBuild, isCodeFlow));
     }
 
-    protected void AndNoPendingUpdates()
-    {
-        RemoveExpectedState<SubscriptionUpdateWorkItem>(Subscription);
-        RemoveState<SubscriptionUpdateWorkItem>(Subscription);
-    }
-
     protected void AndPendingUpdates(Build forBuild, bool isCodeFlow = false)
     {
         AfterDbUpdateActions.Add(

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -361,8 +361,6 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
 
         var results = policyEvaluationStatus.HasValue
             ? new MergePolicyEvaluationResults(
-                string.Empty,
-
                 [
                     new MergePolicyEvaluationResult(
                         policyEvaluationStatus.Value,
@@ -372,7 +370,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                         "Some policy")
                 ],
                 string.Empty)
-            : new MergePolicyEvaluationResults(string.Empty, [], string.Empty);
+            : new MergePolicyEvaluationResults([], string.Empty);
 
         remote
             .Setup(r => r.GetPullRequestAsync(prUrl))
@@ -462,7 +460,6 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
         {
             var results = policyEvaluationStatus.HasValue
                 ? new MergePolicyEvaluationResults(
-                    string.Empty,
                 [
                     new MergePolicyEvaluationResult(
                     policyEvaluationStatus.Value,
@@ -472,7 +469,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                     "Some policy")
                 ],
                 string.Empty)
-                : new MergePolicyEvaluationResults(string.Empty, [], string.Empty);
+                : new MergePolicyEvaluationResults([], string.Empty);
             MergePolicyEvaluator
                 .Setup(x => x.EvaluateAsync(
                     It.Is<PullRequestUpdateSummary>(pr => pr.Url == prUrl),
@@ -492,6 +489,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                 Status = prStatus,
                 HeadBranch = InProgressPrHeadBranch,
                 BaseBranch = TargetBranch,
+                TargetBranchCommitSha = "sha123456",
             });
 
         if (willFlowNewBuild

--- a/test/ProductConstructionService.DependencyFlow.Tests/SubscriptionOrPullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/SubscriptionOrPullRequestUpdaterTests.cs
@@ -5,6 +5,7 @@ using Maestro.Data;
 using Maestro.Data.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Moq;
 using NUnit.Framework;
@@ -88,7 +89,8 @@ internal abstract class SubscriptionOrPullRequestUpdaterTests : UpdaterTests
             SourceRepository = SourceRepo,
             TargetRepository = TargetRepo,
             TargetBranch = TargetBranch,
-            PolicyObject = policy
+            PolicyObject = policy,
+            Id = Guid.NewGuid()
         };
         ContextUpdates.Add(context => context.Subscriptions.Add(Subscription));
     }
@@ -97,6 +99,7 @@ internal abstract class SubscriptionOrPullRequestUpdaterTests : UpdaterTests
     {
         Subscription = new Subscription
         {
+            Id = Guid.NewGuid(),
             Channel = Channel,
             SourceRepository = SourceRepo,
             TargetRepository = VmrUri,

--- a/test/ProductConstructionService.DependencyFlow.Tests/SubscriptionOrPullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/SubscriptionOrPullRequestUpdaterTests.cs
@@ -32,8 +32,6 @@ internal abstract class SubscriptionOrPullRequestUpdaterTests : UpdaterTests
     protected override void RegisterServices(IServiceCollection services)
     {
         base.RegisterServices(services);
-
-        services.AddSingleton(MergePolicyEvaluator.Object);
         services.AddSingleton(UpdateResolver.Object);
         services.AddSingleton(HostingEnvironment.Object);
         services.AddBuildAssetRegistry(options =>

--- a/test/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsPullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsPullRequestUpdaterTests.cs
@@ -2,12 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Maestro.Data.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Asset = ProductConstructionService.DependencyFlow.Model.Asset;
 
 namespace ProductConstructionService.DependencyFlow.Tests;
 
 internal abstract class UpdateAssetsPullRequestUpdaterTests : PullRequestUpdaterTests
 {
+    protected override void RegisterServices(IServiceCollection services)
+    {
+        base.RegisterServices(services);
+        services.AddSingleton(MergePolicyEvaluator.Object);
+    }
+
     protected async Task WhenUpdateAssetsAsyncIsCalled(Build forBuild)
     {
         await Execute(

--- a/test/ProductConstructionService.DependencyFlow.Tests/UpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/UpdaterTests.cs
@@ -3,6 +3,7 @@
 
 using FluentAssertions;
 using Maestro.Data.Models;
+using Maestro.MergePolicyEvaluation;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Internal.Logging;
 using Microsoft.DotNet.Kusto;
@@ -33,6 +34,7 @@ internal abstract class UpdaterTests : TestsWithServices
 
     protected Dictionary<string, object> ExpectedPRCacheState { get; private set; } = null!;
     protected Dictionary<string, object> ExpectedReminders { get; private set; } = null!;
+    protected Dictionary<string, object> ExpectedEvaluationResultCacheState { get; private set; } = null!;
 
     protected MockReminderManagerFactory Reminders { get; private set; } = null!;
     protected MockRedisCacheFactory Cache { get; private set; } = null!;
@@ -53,7 +55,6 @@ internal abstract class UpdaterTests : TestsWithServices
         services.AddSingleton(Mock.Of<IPullRequestPolicyFailureNotifier>());
         services.AddSingleton(Mock.Of<IKustoClientProvider>());
         services.AddSingleton(RemoteFactory.Object);
-        services.AddSingleton(MergePolicyEvaluator.Object);
         services.AddSingleton(UpdateResolver.Object);
         services.AddLogging();
 
@@ -67,6 +68,7 @@ internal abstract class UpdaterTests : TestsWithServices
     {
         ExpectedPRCacheState = [];
         ExpectedReminders = [];
+        ExpectedEvaluationResultCacheState = [];
         Cache = new();
         Reminders = new();
         RemoteFactory = new();
@@ -91,6 +93,7 @@ internal abstract class UpdaterTests : TestsWithServices
             }
         }
         Cache.Data.Where(pair => pair.Value is InProgressPullRequest).Should().BeEquivalentTo(ExpectedPRCacheState);
+        Cache.Data.Where(pair => pair.Value is MergePolicyEvaluationResults).Should().BeEquivalentTo(ExpectedEvaluationResultCacheState);
         Reminders.Reminders.Should().BeEquivalentTo(ExpectedReminders);
     }
 
@@ -114,16 +117,25 @@ internal abstract class UpdaterTests : TestsWithServices
         ExpectedReminders.Remove(typeof(T).Name + "_" + GetPullRequestUpdaterId(subscription));
     }
 
-    protected void SetExpectedState<T>(Subscription subscription, T state) where T : class
+    protected void SetExpectedPullRequestState<T>(Subscription subscription, T state) where T : class
     {
         ExpectedPRCacheState[typeof(T).Name + "_" + GetPullRequestUpdaterId(subscription)] = state;
     }
 
-    protected void RemoveExpectedState<T>(Subscription subscription) where T : class
+    protected void RemoveExpectedPullRequestState<T>(Subscription subscription) where T : class
     {
         ExpectedPRCacheState.Remove(typeof(T).Name + "_" + GetPullRequestUpdaterId(subscription));
     }
 
+    protected void SetExpectedEvaluationResultsState<T>(Subscription subscription, T state) where T : class
+    {
+        ExpectedEvaluationResultCacheState[typeof(T).Name + "_" + GetPullRequestUpdaterId(subscription)] = state;
+    }
+
+    protected void RemoveExpectedEvaluationResultsState<T>(Subscription subscription) where T : class
+    {
+        ExpectedEvaluationResultCacheState.Remove(typeof(T).Name + "_" + GetPullRequestUpdaterId(subscription));
+    }
     protected static PullRequestUpdaterId GetPullRequestUpdaterId(Subscription subscription)
     {
         return subscription.PolicyObject.Batchable

--- a/test/ProductConstructionService.DependencyFlow.Tests/UpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/UpdaterTests.cs
@@ -3,7 +3,6 @@
 
 using FluentAssertions;
 using Maestro.Data.Models;
-using Maestro.MergePolicyEvaluation;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.Internal.Logging;
 using Microsoft.DotNet.Kusto;
@@ -93,7 +92,6 @@ internal abstract class UpdaterTests : TestsWithServices
             }
         }
         Cache.Data.Where(pair => pair.Value is InProgressPullRequest).Should().BeEquivalentTo(ExpectedPRCacheState);
-        Cache.Data.Where(pair => pair.Value is MergePolicyEvaluationResults).Should().BeEquivalentTo(ExpectedEvaluationResultCacheState);
         Reminders.Reminders.Should().BeEquivalentTo(ExpectedReminders);
     }
 


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/4913

The actual bug fix (plus a few minor changes) are in commit 4: [Merge policy evaluation fixes](https://github.com/dotnet/arcade-services/pull/4934/commits/c177273513b7ed22d66ccf56180e34253b85b2f7)