### PR TITLE
Avoid creating PRs with meaningless updates

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeflowChangeAnalyzer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeflowChangeAnalyzer.cs
@@ -1,0 +1,189 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.Models;
+using Microsoft.DotNet.ProductConstructionService.Client.Models;
+using Microsoft.Extensions.Logging;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+
+public interface ICodeflowChangeAnalyzer
+{
+    Task<bool> ForwardFlowHasMeaningfulChangesAsync(string mappingName, string headBranch, string targetBranch);
+}
+
+/// <summary>
+/// This class can analyze changes during codeflows and tell if there are any meaningful ones that are worth flowing.
+/// </summary>
+public class CodeflowChangeAnalyzer : ICodeflowChangeAnalyzer
+{
+    // List of characters that belong to the git diff format.
+    // Example diff output:
+    // diff --git a/src/product-repo1/eng/Versions.props b/src/product-repo1/eng/Versions.props
+    // index fb13f6d..76d73de 100644
+    // --- a/src/product-repo1/eng/Versions.props
+    // +++ b/src/product-repo1/eng/Versions.props
+    // @@ -10,2 +10,2 @@
+    // -    <PackageA1PackageVersion>1.0.0</PackageA1PackageVersion>
+    // -    <PackageB1PackageVersion>2.0.0</PackageB1PackageVersion>
+    // +    <PackageA1PackageVersion>2.0.1</PackageA1PackageVersion>
+    // +    <PackageB1PackageVersion>2.0.1</PackageB1PackageVersion>
+    private static readonly IReadOnlyCollection<string> ignoredDiffLines = ["diff --git", "index ", "@@ ", "--- ", "+++ "];
+
+    private readonly ILocalGitRepoFactory _localGitRepoFactory;
+    private readonly IVersionDetailsParser _versionDetailsParser;
+    private readonly IBasicBarClient _barClient;
+    private readonly IVmrInfo _vmrInfo;
+    private readonly ILogger<CodeflowChangeAnalyzer> _logger;
+
+    public CodeflowChangeAnalyzer(
+        ILocalGitRepoFactory localGitRepoFactory,
+        IVersionDetailsParser versionDetailsParser,
+        IBasicBarClient barClient,
+        IVmrInfo vmrInfo,
+        ILogger<CodeflowChangeAnalyzer> logger)
+    {
+        _localGitRepoFactory = localGitRepoFactory;
+        _versionDetailsParser = versionDetailsParser;
+        _barClient = barClient;
+        _vmrInfo = vmrInfo;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Checks whether the flow contains meaningful changes that warrant a PR creation.
+    /// If it only contains version file changes that happened during the last backflow, we can skip it.
+    /// Example:
+    ///   - Changed files are only `source-manifest.json` and version files (Version.Details.xml, Versions.props, global.json...)
+    ///   - The version file changes are only bumps of dependencies that were backflowed
+    /// </summary>
+    /// <returns>True, if there are no meaningful changes that warrant a PR creation</returns>
+    public async Task<bool> ForwardFlowHasMeaningfulChangesAsync(string mappingName, string headBranch, string targetBranch)
+    {
+        _logger.LogInformation("Checking if the flow can be skipped for {mappingName}", mappingName);
+
+        ILocalGitRepo vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
+
+        ProcessExecutionResult result = await vmr.ExecuteGitCommand("diff", "--name-only", $"{targetBranch}..{headBranch}");
+        result.ThrowIfFailed($"Failed to get the list of changed files between {targetBranch} and {headBranch}");
+
+        string[] ignoredChanges =
+        [
+            VmrInfo.DefaultRelativeSourceManifestPath,
+            $"{VmrInfo.GitInfoSourcesDir}/{mappingName}.props",
+        ];
+
+        string[] changedFiles = result.StandardOutput
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(file => !ignoredChanges.Contains(file))
+            .ToArray();
+
+        // Version files (Version.Details.xml, Versions.props, global.json...)
+        string[] allowedChanges = DependencyFileManager.DependencyFiles
+            .Select(f => (VmrInfo.GetRelativeRepoSourcesPath(mappingName) / f).Path)
+            .ToArray();
+
+        if (changedFiles.Any(file => !allowedChanges.Contains(file)))
+        {
+            _logger.LogInformation("Flow contains {count} changes that warrant PR creation", changedFiles.Length);
+            return true;
+        }
+
+        if (changedFiles.Length == 0)
+        {
+            _logger.LogInformation("No meaningful changes detected, code flow can be skipped");
+            return false;
+        }
+
+        result = await vmr.ExecuteGitCommand(
+        [
+            "diff",
+            "-U0",
+            $"{targetBranch}..{headBranch}",
+            "--",
+            ..ignoredChanges.Select(VmrPatchHandler.GetExclusionRule)
+        ]);
+        result.ThrowIfFailed($"Failed to get the changes between {targetBranch} and {headBranch}");
+
+        // We load all different pieces of build information that would be expected in the diff output
+        Build? build1 = await GetBuildFromSourceTag(vmr, mappingName, targetBranch);
+        Build? build2 = await GetBuildFromSourceTag(vmr, mappingName, headBranch);
+
+        List<string> expectedContents =
+        [
+            ..GetExpectedContentsForBuild(build1),
+            ..GetExpectedContentsForBuild(build2),
+        ];
+
+        IEnumerable<string> diffLines = result.StandardOutput
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+        if (diffLines.Any(line => ContainsUnexpectedChange(line, expectedContents)))
+        {
+            _logger.LogInformation("Unexpected changes detected, code flow will proceed");
+            return true;
+        }
+
+        _logger.LogInformation("No meaningful changes detected, code flow can be skipped");
+        return false;
+    }
+
+    private async Task<Build?> GetBuildFromSourceTag(ILocalGitRepo vmr, string mappingName, string branch)
+    {
+        string? versionDetailsContent = await vmr.GetFileFromGitAsync(
+            VmrInfo.GetRelativeRepoSourcesPath(mappingName) / VersionFiles.VersionDetailsXml,
+            branch);
+
+        if (versionDetailsContent == null)
+        {
+            _logger.LogWarning("Version details of repo {repo} in branch {branch} could not be loaded.",
+                mappingName,
+                branch);
+            return null;
+        }
+
+        VersionDetails versionDetails = _versionDetailsParser.ParseVersionDetailsXml(versionDetailsContent);
+
+        return versionDetails.Source?.BarId == null
+            ? null
+            : await _barClient.GetBuildAsync(versionDetails.Source.BarId.Value);
+    }
+
+    private static bool ContainsUnexpectedChange(string line, IEnumerable<string> expectedContents)
+    {
+        // Characters belonging to the diff command output
+        if (ignoredDiffLines.Any(line.StartsWith))
+        {
+            return false;
+        }
+
+        // Known build data that would appear if only build related changes were made
+        if (expectedContents.Any(c => line.Contains(c, StringComparison.InvariantCultureIgnoreCase)))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static IEnumerable<string> GetExpectedContentsForBuild(Build? b)
+    {
+        if (b == null)
+        {
+            return [];
+        }
+
+        return
+        [
+            b.Id.ToString(),
+            b.Commit,
+            b.GetRepository(),
+            ..b.Assets.Select(a => a.Version).Distinct(),
+        ];
+    }
+}

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrRegistrations.cs
@@ -115,6 +115,7 @@ public static class VmrRegistrations
         services.TryAddTransient<IVmrForwardFlower, VmrForwardFlower>();
         services.TryAddTransient<ICodeFlowVmrUpdater, CodeFlowVmrUpdater>();
         services.TryAddTransient<IVersionFileCodeFlowUpdater, VersionFileCodeFlowUpdater>();
+        services.TryAddTransient<ICodeflowChangeAnalyzer, CodeflowChangeAnalyzer>();
         services.TryAddTransient<IWorkBranchFactory, WorkBranchFactory>();
         services.TryAddTransient<IThirdPartyNoticesGenerator, ThirdPartyNoticesGenerator>();
         services.TryAddTransient<ICodeownersGenerator, CodeownersGenerator>();

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
@@ -31,9 +31,7 @@ internal interface IPcsVmrForwardFlower
 
 internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
 {
-    private readonly IVmrInfo _vmrInfo;
     private readonly IRepositoryCloneManager _repositoryCloneManager;
-    private readonly ILocalGitRepoFactory _localGitRepoFactory;
 
     public PcsVmrForwardFlower(
         IVmrInfo vmrInfo,
@@ -51,9 +49,7 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
         ILogger<VmrCodeFlower> logger)
         : base(vmrInfo, sourceManifest, vmrUpdater, dependencyTracker, vmrCloneManager, localGitClient, localGitRepoFactory, versionDetailsParser, processManager, fileSystem, barClient, logger)
     {
-        _vmrInfo = vmrInfo;
         _repositoryCloneManager = repositoryCloneManager;
-        _localGitRepoFactory = localGitRepoFactory;
     }
 
     public async Task<CodeFlowResult> FlowForwardAsync(

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
@@ -31,7 +31,9 @@ internal interface IPcsVmrForwardFlower
 
 internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
 {
+    private readonly IVmrInfo _vmrInfo;
     private readonly IRepositoryCloneManager _repositoryCloneManager;
+    private readonly ILocalGitRepoFactory _localGitRepoFactory;
 
     public PcsVmrForwardFlower(
         IVmrInfo vmrInfo,
@@ -49,7 +51,9 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
         ILogger<VmrCodeFlower> logger)
         : base(vmrInfo, sourceManifest, vmrUpdater, dependencyTracker, vmrCloneManager, localGitClient, localGitRepoFactory, versionDetailsParser, processManager, fileSystem, barClient, logger)
     {
+        _vmrInfo = vmrInfo;
         _repositoryCloneManager = repositoryCloneManager;
+        _localGitRepoFactory = localGitRepoFactory;
     }
 
     public async Task<CodeFlowResult> FlowForwardAsync(
@@ -73,6 +77,7 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
             headBranch,
             subscription.TargetRepository,
             discardPatches: true,
+            skipMeaninglessUpdates: true,
             cancellationToken);
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
@@ -45,11 +45,12 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
         ILocalGitClient localGitClient,
         ILocalGitRepoFactory localGitRepoFactory,
         IVersionDetailsParser versionDetailsParser,
+        ICodeflowChangeAnalyzer codeflowChangeAnalyzer,
         IProcessManager processManager,
         IFileSystem fileSystem,
         IBasicBarClient barClient,
         ILogger<VmrCodeFlower> logger)
-        : base(vmrInfo, sourceManifest, vmrUpdater, dependencyTracker, vmrCloneManager, localGitClient, localGitRepoFactory, versionDetailsParser, processManager, fileSystem, barClient, logger)
+        : base(vmrInfo, sourceManifest, vmrUpdater, dependencyTracker, vmrCloneManager, localGitClient, localGitRepoFactory, versionDetailsParser, codeflowChangeAnalyzer, processManager, fileSystem, barClient, logger)
     {
         _repositoryCloneManager = repositoryCloneManager;
     }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
@@ -22,10 +22,12 @@ internal interface IPcsVmrForwardFlower
     /// <param name="subscription">Subscription to flow</param>
     /// <param name="build">Build to flow</param>
     /// <param name="headBranch">Branch to flow to (or to create)</param>
+    /// <param name="skipMeaninglessUpdates">Skip creating PR if only insignificant changes are present</param>
     Task<CodeFlowResult> FlowForwardAsync(
         Subscription subscription,
         Build build,
         string headBranch,
+        bool skipMeaninglessUpdates,
         CancellationToken cancellationToken = default);
 }
 
@@ -56,6 +58,7 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
         Subscription subscription,
         Build build,
         string headBranch,
+        bool skipMeaninglessUpdates,
         CancellationToken cancellationToken = default)
     {
         ILocalGitRepo sourceRepo = await _repositoryCloneManager.PrepareCloneAsync(
@@ -73,7 +76,7 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
             headBranch,
             subscription.TargetRepository,
             discardPatches: true,
-            skipMeaninglessUpdates: true,
+            skipMeaninglessUpdates,
             cancellationToken);
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -105,8 +105,6 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
     /// </summary>
     /// <param name="subscriptionId">The id of the subscription the update comes from</param>
     /// <param name="buildId">The build that the updated assets came from</param>
-    /// <param name="sourceSha">The commit hash that built the assets</param>
-    /// <param name="assets">The list of assets</param>
     /// <remarks>
     ///     This function will queue updates if there is a pull request and it is currently not-updateable.
     ///     A pull request is considered "not-updateable" based on merge policies.
@@ -202,7 +200,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
 
         if (isCodeFlow)
         {
-            await ProcessCodeFlowUpdateAsync(update, pr, prInfo, build);
+            await ProcessCodeFlowUpdateAsync(update, pr, prInfo, build, forceUpdate);
         }
         else 
         {
@@ -993,7 +991,8 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         SubscriptionUpdateWorkItem update,
         InProgressPullRequest? pr,
         PullRequest? prInfo,
-        BuildDTO build)
+        BuildDTO build,
+        bool forceUpdate)
     {
         if (update.SourceSha == pr?.SourceSha)
         {
@@ -1037,7 +1036,12 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         {
             if (isForwardFlow)
             {
-                codeFlowRes = await _vmrForwardFlower.FlowForwardAsync(subscription, build, prHeadBranch, cancellationToken: default);
+                codeFlowRes = await _vmrForwardFlower.FlowForwardAsync(
+                    subscription,
+                    build,
+                    prHeadBranch,
+                    skipMeaninglessUpdates: !forceUpdate,
+                    cancellationToken: default);
                 localRepoPath = _vmrInfo.VmrPath;
 
                 SourceManifest? sourceManifest = await remote.GetSourceManifestAsync(

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrForwardFlowTest.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrForwardFlowTest.cs
@@ -197,7 +197,7 @@ internal class VmrForwardFlowTest : VmrCodeFlowTests
             ProductRepoPath,
             branchName,
             // This is what we're testing in this test
-            skipMeaningfulUpdates: true);
+            skipMeaninglessUpdates: true);
         hadUpdates.ShouldNotHaveUpdates();
     }
 }

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -252,7 +252,7 @@ internal abstract class VmrTestsBase
         string branch,
         Build? buildToFlow = null,
         IReadOnlyCollection<string>? excludedAssets = null,
-        bool skipMeaningfulUpdates = false)
+        bool skipMeaninglessUpdates = false)
     {
         using var scope = ServiceProvider.CreateScope();
         var codeflower = scope.ServiceProvider.GetRequiredService<IVmrForwardFlower>();
@@ -265,7 +265,7 @@ internal abstract class VmrTestsBase
             branch,
             VmrPath,
             discardPatches: false,
-            skipMeaningfulUpdates,
+            skipMeaninglessUpdates,
             cancellationToken: _cancellationToken.Token);
 
         return codeFlowRes.HadUpdates;

--- a/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.Darc.VirtualMonoRepo.E2E.Tests/VmrTestsBase.cs
@@ -251,7 +251,8 @@ internal abstract class VmrTestsBase
         NativePath repoPath,
         string branch,
         Build? buildToFlow = null,
-        IReadOnlyCollection<string>? excludedAssets = null)
+        IReadOnlyCollection<string>? excludedAssets = null,
+        bool skipMeaningfulUpdates = false)
     {
         using var scope = ServiceProvider.CreateScope();
         var codeflower = scope.ServiceProvider.GetRequiredService<IVmrForwardFlower>();
@@ -264,6 +265,7 @@ internal abstract class VmrTestsBase
             branch,
             VmrPath,
             discardPatches: false,
+            skipMeaningfulUpdates,
             cancellationToken: _cancellationToken.Token);
 
         return codeFlowRes.HadUpdates;

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/CodeflowChangeAnalyzerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/CodeflowChangeAnalyzerTests.cs
@@ -1,0 +1,296 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.Models;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using Microsoft.DotNet.ProductConstructionService.Client.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.Tests.VirtualMonoRepo;
+
+[TestFixture]
+public class CodeflowChangeAnalyzerTests
+{
+    private const string TestMappingName = "test-repo";
+    private const string TestHeadBranch = "feature-branch";
+    private const string TestTargetBranch = "main";
+    private static readonly NativePath TestVmrPath = new("/path/to/vmr");
+
+    private Mock<ILocalGitRepoFactory> _localGitRepoFactory = null!;
+    private Mock<ILocalGitRepo> _localGitRepo = null!;
+    private Mock<IVersionDetailsParser> _versionDetailsParser = null!;
+    private Mock<IBasicBarClient> _barClient = null!;
+    private IVmrInfo _vmrInfo = null!;
+    private CodeflowChangeAnalyzer _analyzer = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _localGitRepoFactory = new Mock<ILocalGitRepoFactory>();
+        _localGitRepo = new Mock<ILocalGitRepo>();
+        _versionDetailsParser = new Mock<IVersionDetailsParser>();
+        _barClient = new Mock<IBasicBarClient>();
+        _vmrInfo = Mock.Of<IVmrInfo>(x => x.VmrPath == TestVmrPath);
+
+        _localGitRepoFactory
+            .Setup(x => x.Create(TestVmrPath))
+            .Returns(_localGitRepo.Object);
+
+        _analyzer = new CodeflowChangeAnalyzer(
+            _localGitRepoFactory.Object,
+            _versionDetailsParser.Object,
+            _barClient.Object,
+            _vmrInfo,
+            NullLogger<CodeflowChangeAnalyzer>.Instance);
+    }
+
+    [Test]
+    public async Task ForwardFlowHasMeaningfulChangesAsync_WithUnexpectedChangedFiles_ShouldReturnTrue()
+    {
+        // Arrange
+        var gitDiffOutput =
+            """
+            src/test-repo/Program.cs
+            src/test-repo/Library.cs
+            src/source-manifest.json
+            src/test-repo/global.json
+            src/test-repo/eng/Version.Details.xml
+            src/test-repo/eng/Versions.props
+            """;
+
+        SetChangedFiles(gitDiffOutput);
+
+        // Act
+        var result = await _analyzer.ForwardFlowHasMeaningfulChangesAsync(TestMappingName, TestHeadBranch, TestTargetBranch);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ForwardFlowHasMeaningfulChangesAsync_WithExpectedChangedFiles_ShouldReturnFalse()
+    {
+        // Arrange
+        var gitDiffOutput =
+            """
+            src/source-manifest.json
+            """;
+
+        SetChangedFiles(gitDiffOutput);
+
+        // Act
+        var result = await _analyzer.ForwardFlowHasMeaningfulChangesAsync(TestMappingName, TestHeadBranch, TestTargetBranch);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task ForwardFlowHasMeaningfulChangesAsync_WithNoUnexpectedChanges_ShouldReturnFalse()
+    {
+        // Arrange
+        var gitDiffOutput =
+            """
+            src/source-manifest.json
+            src/test-repo/global.json
+            src/test-repo/eng/Version.Details.xml
+            src/test-repo/eng/Versions.props
+            """;
+
+        var gitDiffWithIgnoredOutput =
+            """
+            diff --git a/src/roslyn-analyzers/eng/Version.Details.xml b/src/roslyn-analyzers/eng/Version.Details.xml
+            index de02854b9db..05f32ddf7a6 100644
+            --- a/src/roslyn-analyzers/eng/Version.Details.xml
+            +++ b/src/roslyn-analyzers/eng/Version.Details.xml
+            @@ -3 +3 @@
+            -  <Source Uri="https://github.com/dotnet/dotnet" Mapping="roslyn-analyzers" Sha="7e27ec4c314eb774eae2c54ce4682c98973c7c60" BarId="270662" />
+            +  <Source Uri="https://github.com/dotnet/dotnet" Mapping="roslyn-analyzers" Sha="9a90ec1b43070dc3ee0f0b869a78a175c1d33b68" BarId="271018" />
+            @@ -11 +11 @@
+            -    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25304.106">
+            +    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25306.103">
+            @@ -13 +13 @@
+            -      <Sha>7e27ec4c314eb774eae2c54ce4682c98973c7c60</Sha>
+            +      <Sha>9a90ec1b43070dc3ee0f0b869a78a175c1d33b68</Sha>
+            @@ -15 +15 @@
+            -    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="10.0.0-beta.25304.106">
+            +    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="10.0.0-beta.25306.103">
+            @@ -17 +17 @@
+            -      <Sha>7e27ec4c314eb774eae2c54ce4682c98973c7c60</Sha>
+            +      <Sha>9a90ec1b43070dc3ee0f0b869a78a175c1d33b68</Sha>
+            diff --git a/src/roslyn-analyzers/eng/Versions.props b/src/roslyn-analyzers/eng/Versions.props
+            index 3d1c4193028..d6ba1d51912 100644
+            --- a/src/roslyn-analyzers/eng/Versions.props
+            +++ b/src/roslyn-analyzers/eng/Versions.props
+            @@ -78 +78 @@
+            -    <MicrosoftDotNetXliffTasksVersion>10.0.0-beta.25304.106</MicrosoftDotNetXliffTasksVersion>
+            +    <MicrosoftDotNetXliffTasksVersion>10.0.0-beta.25306.103</MicrosoftDotNetXliffTasksVersion>
+            diff --git a/src/roslyn-analyzers/global.json b/src/roslyn-analyzers/global.json
+            index 903c014977c..d8c8302c44b 100644
+            --- a/src/roslyn-analyzers/global.json
+            +++ b/src/roslyn-analyzers/global.json
+            @@ -21 +21 @@
+            -    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25304.106"
+            +    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25306.103"
+            diff --git a/src/source-manifest.json b/src/source-manifest.json
+            index 6cb979ccc3a..90ec6500113 100644
+            --- a/src/source-manifest.json
+            +++ b/src/source-manifest.json
+            @@ -102,2 +102,2 @@
+            -      "packageVersion": "10.0.0-preview.25305.2",
+            -      "barId": 270822,
+            +      "packageVersion": "10.0.0-preview.25309.1",
+            +      "barId": 271087,
+            @@ -106 +106 @@
+            -      "commitSha": "b5c183add7824375fb00c6f4a1614098555b3e62"
+            +      "commitSha": "d72f60b9124ae5a25538dbceab7b3590ce309641"
+            """;
+
+        SetChangedFiles(gitDiffOutput);
+        SetGitDiff(gitDiffWithIgnoredOutput);
+        SetupVersionDetailsAndBuilds();
+
+        // Act
+        var result = await _analyzer.ForwardFlowHasMeaningfulChangesAsync(TestMappingName, TestHeadBranch, TestTargetBranch);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ForwardFlowHasMeaningfulChangesAsync_WithUnexpectedChanges_ShouldReturnTrue()
+    {
+        // Arrange
+        var gitDiffOutput =
+            """
+            src/source-manifest.json
+            src/test-repo/global.json
+            src/test-repo/eng/Version.Details.xml
+            src/test-repo/eng/Versions.props
+            """;
+
+        var gitDiffWithIgnoredOutput =
+            """
+            diff --git a/src/test-repo/eng/Version.Details.xml b/src/test-repo/eng/Version.Details.xml
+            index bfc5f65e016..05f32ddf7a6 100644
+            --- a/src/test-repo/eng/Version.Details.xml
+            +++ b/src/test-repo/eng/Version.Details.xml
+            @@ -3,3 +3,3 @@
+            -    <SomeUnexpectedElement>OldValue</SomeUnexpectedElement>
+            +    <SomeUnexpectedElement>NewValue</SomeUnexpectedElement>";
+            """;
+
+        SetChangedFiles(gitDiffOutput);
+        SetGitDiff(gitDiffWithIgnoredOutput);
+        SetupVersionDetailsAndBuilds();
+
+        // Act
+        var result = await _analyzer.ForwardFlowHasMeaningfulChangesAsync(TestMappingName, TestHeadBranch, TestTargetBranch);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    private void SetChangedFiles(string output)
+    {
+        var result = new ProcessExecutionResult()
+        {
+            StandardOutput = output,
+            ExitCode = 0,
+        };
+
+        _localGitRepo
+            .Setup(x => x.ExecuteGitCommand("diff", "--name-only", $"{TestTargetBranch}..{TestHeadBranch}"))
+            .ReturnsAsync(result);
+    }
+
+    private void SetGitDiff(string output)
+    {
+        var result = new ProcessExecutionResult()
+        {
+            StandardOutput = output,
+            ExitCode = 0,
+        };
+
+        _localGitRepo
+            .Setup(x => x.ExecuteGitCommand(It.Is<string[]>(args =>
+                args.Length > 2 &&
+                args[0] == "diff" &&
+                args[1] == "-U0" &&
+                args[2] == $"{TestTargetBranch}..{TestHeadBranch}")))
+            .ReturnsAsync(result);
+    }
+
+    private void SetupVersionDetailsAndBuilds()
+    {
+        var versionDetails1 = new VersionDetails(
+            Dependencies: [],
+            Source: new SourceDependency("https://github.com/dotnet/dotnet", "test-repo", "abc123", 270662));
+
+        var versionDetails2 = new VersionDetails(
+            Dependencies: [],
+            Source: new SourceDependency("https://github.com/dotnet/dotnet", "test-repo", "def456", 271018));
+
+        _localGitRepo
+            .Setup(x => x.GetFileFromGitAsync("src/test-repo/eng/Version.Details.xml", TestTargetBranch, null))
+            .ReturnsAsync("<Dependencies><Source BarId=\"270662\" /></Dependencies>");
+
+        _localGitRepo
+            .Setup(x => x.GetFileFromGitAsync("src/test-repo/eng/Version.Details.xml", TestHeadBranch, null))
+            .ReturnsAsync("<Dependencies><Source BarId=\"271018\" /></Dependencies>");
+
+        _versionDetailsParser
+            .Setup(x => x.ParseVersionDetailsXml("<Dependencies><Source BarId=\"270662\" /></Dependencies>", true))
+            .Returns(versionDetails1);
+
+        _versionDetailsParser
+            .Setup(x => x.ParseVersionDetailsXml("<Dependencies><Source BarId=\"271018\" /></Dependencies>", true))
+            .Returns(versionDetails2);
+
+        var build1 = new Build(
+            id: 270662,
+            dateProduced: DateTimeOffset.Now.AddDays(-1),
+            staleness: 0,
+            released: false,
+            stable: true,
+            commit: "abc123",
+            channels: [],
+            assets:
+            [
+                new Asset(1, 270662, true, "Microsoft.DotNet.Arcade.Sdk", "10.0.0-beta.25304.106", null),
+            ],
+            dependencies: [],
+            incoherencies: [])
+        {
+            GitHubRepository = "https://github.com/dotnet/dotnet"
+        };
+
+        var build2 = new Build(
+            id: 271018,
+            dateProduced: DateTimeOffset.Now,
+            staleness: 0,
+            released: false,
+            stable: true,
+            commit: "def456",
+            channels: [],
+            assets:
+            [
+                new Asset(2, 271018, true, "Microsoft.DotNet.Arcade.Sdk", "10.0.0-beta.25306.103", null),
+            ],
+            dependencies: [],
+            incoherencies: [])
+        {
+            GitHubRepository = "https://github.com/dotnet/dotnet"
+        };
+
+        _barClient.Setup(x => x.GetBuildAsync(270662)).ReturnsAsync(build1);
+        _barClient.Setup(x => x.GetBuildAsync(271018)).ReturnsAsync(build2);
+    }
+}

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -213,6 +213,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                 It.Is<Microsoft.DotNet.ProductConstructionService.Client.Models.Subscription>(s => s.Id == Subscription.Id),
                 It.Is<Microsoft.DotNet.ProductConstructionService.Client.Models.Build>(b => b.Id == build.Id && b.Commit == build.Commit),
                 It.IsAny<string>(),
+                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
 
@@ -486,6 +487,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                     It.IsAny<Microsoft.DotNet.ProductConstructionService.Client.Models.Subscription>(),
                     It.IsAny<Microsoft.DotNet.ProductConstructionService.Client.Models.Build>(),
                     It.IsAny<string>(),
+                    It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(() => new ConflictInPrBranchException(
                     "error: patch failed: eng/common/build.ps1",


### PR DESCRIPTION
This PR adds a basic heuristic which will prevent no-op forward flows that only flow package updates that happened in the last backflow and no other changes.

https://github.com/dotnet/arcade-services/issues/4178