### PR TITLE
Recreate previous flow fix

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -460,7 +460,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         Build previouslyAppliedVmrBuild = new(-1, DateTimeOffset.Now, 0, false, false, lastLastFlow.SourceSha, [], [], [], [])
         {
             GitHubRepository = repoGitHubUri
-        }
+        };
 
         // Reconstruct the previous flow's branch
         await FlowCodeAsync(

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -585,7 +585,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             cancellationToken);
         await vmr.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
 
-        (Codeflow lastLastFlow, _, _) = await GetLastFlowsAsync(mapping, sourceRepo, currentIsBackflow: true);
+        (Codeflow lastLastFlow, _, _) = await GetLastFlowsAsync(mapping, sourceRepo, currentIsBackflow: false);
 
         // Reconstruct the previous flow's branch
         await FlowCodeAsync(

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -558,8 +558,6 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
     {
         _logger.LogInformation("Failed to create PR branch because of a conflict. Re-creating the previous flow..");
 
-        (Codeflow lastLastFlow, _, _) = await GetLastFlowsAsync(mapping, sourceRepo, currentIsBackflow: true);
-
         // Find the BarID of the last flown repo build
         RepositoryRecord previouslyAppliedRepositoryRecord = _sourceManifest.GetRepositoryRecord(mapping.Name);
         Build previouslyAppliedBuild;
@@ -567,7 +565,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
         {
             // If we don't find the previously applied build, we'll just use the previously flown sha to recreate the flow
             // We'll apply a new build on top of this one, so the source manifest will get updated anyway
-            previouslyAppliedBuild = new(-1, DateTimeOffset.Now, 0, false, false, lastLastFlow.SourceSha, [], [], [], []);
+            previouslyAppliedBuild = new(-1, DateTimeOffset.Now, 0, false, false, lastFlow.RepoSha, [], [], [], []);
         }
         else
         {
@@ -586,6 +584,8 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             resetToRemote: false,
             cancellationToken);
         await vmr.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
+
+        (Codeflow lastLastFlow, _, _) = await GetLastFlowsAsync(mapping, sourceRepo, currentIsBackflow: true);
 
         // Reconstruct the previous flow's branch
         await FlowCodeAsync(

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -565,7 +565,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
         {
             // If we don't find the previously applied build, we'll just use the previously flown sha to recreate the flow
             // We'll apply a new build on top of this one, so the source manifest will get updated anyway
-            previouslyAppliedBuild = new(-1, DateTimeOffset.Now, 0, false, false, lastFlow.RepoSha, [], [], [], []);
+            previouslyAppliedBuild = new(-1, DateTimeOffset.Now, 0, false, false, lastFlow.SourceSha, [], [], [], []);
         }
         else
         {
@@ -585,7 +585,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             cancellationToken);
         await vmr.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
 
-        (Codeflow lastLastFlow, _, _) = await GetLastFlowsAsync(mapping, sourceRepo, currentIsBackflow: false);
+        (Codeflow lastLastFlow, _, _) = await GetLastFlowsAsync(mapping, sourceRepo, currentIsBackflow: lastFlow is Backflow);
 
         // Reconstruct the previous flow's branch
         await FlowCodeAsync(

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -558,19 +558,12 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
     {
         _logger.LogInformation("Failed to create PR branch because of a conflict. Re-creating the previous flow..");
 
-        // Find the BarID of the last flown repo build
-        RepositoryRecord previouslyAppliedRepositoryRecord = _sourceManifest.GetRepositoryRecord(mapping.Name);
-        Build previouslyAppliedBuild;
-        if (previouslyAppliedRepositoryRecord.BarId == null)
+        // Create a fake previously applied build. We only care about the sha here, because it will get overwritten anyway
+        Build previouslyAppliedBuild = new(-1, DateTimeOffset.Now, 0, false, false, lastFlow.SourceSha, [], [], [], [])
         {
-            // If we don't find the previously applied build, we'll just use the previously flown sha to recreate the flow
-            // We'll apply a new build on top of this one, so the source manifest will get updated anyway
-            previouslyAppliedBuild = new(-1, DateTimeOffset.Now, 0, false, false, lastFlow.SourceSha, [], [], [], []);
-        }
-        else
-        {
-            previouslyAppliedBuild = await _barClient.GetBuildAsync(previouslyAppliedRepositoryRecord.BarId.Value);
-        }
+            GitHubRepository = build.GitHubRepository,
+            AzureDevOpsRepository = build.AzureDevOpsRepository
+        };
 
         // Find the VMR sha before the last successful flow
         var previousFlowTargetSha = await _localGitClient.BlameLineAsync(

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrBackflowTest.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrBackflowTest.cs
@@ -28,21 +28,21 @@ internal class VmrBackflowTest : VmrCodeFlowTests
 
         const string branchName = nameof(OnlyBackflowsTest);
 
-        var hadUpdates = await ChangeVmrFileAndFlowIt("New content from the VMR", branchName);
-        hadUpdates.ShouldHaveUpdates();
+        var codeFlowResult = await ChangeVmrFileAndFlowIt("New content from the VMR", branchName);
+        codeFlowResult.ShouldHaveUpdates();
 
         await GitOperations.MergePrBranch(ProductRepoPath, branchName);
         CheckFileContents(_productRepoFilePath, "New content from the VMR");
         // Backflow again - should be a no-op
         // We want to flow the same build again, so the BarId doesn't change
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName, useLatestBuild: true);
+        codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName, useLatestBuild: true);
         await GitOperations.Checkout(ProductRepoPath, "main");
         await GitOperations.DeleteBranch(ProductRepoPath, branchName);
         CheckFileContents(_productRepoFilePath, "New content from the VMR");
 
         // Make a change in the VMR again
-        hadUpdates = await ChangeVmrFileAndFlowIt("New content from the VMR again", branchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeVmrFileAndFlowIt("New content from the VMR again", branchName);
+        codeFlowResult.ShouldHaveUpdates();
         CheckFileContents(_productRepoFilePath, "New content from the VMR again");
 
         // Make an additional change in the PR branch before merging
@@ -53,15 +53,15 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         CheckFileContents(_productRepoFilePath, "Change that happened in the PR");
 
         // Make a conflicting change in the VMR
-        hadUpdates = await ChangeVmrFileAndFlowIt("A completely different change", branchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeVmrFileAndFlowIt("A completely different change", branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.VerifyMergeConflict(ProductRepoPath, branchName,
             mergeTheirs: true,
             expectedConflictingFile: _productRepoFileName);
 
         // We used the changes from the VMR - let's verify flowing to the VMR
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName);
         CheckFileContents(_productRepoVmrFilePath, "A completely different change");
     }
@@ -120,8 +120,8 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         await File.WriteAllTextAsync(ArcadeInVmrPath / VersionFiles.GlobalJson, Constants.GlobalJsonTemplate);
         await GitOperations.CommitAll(VmrPath, "Creating global.json in src/arcade");
 
-        var hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
-        hadUpdates.ShouldHaveUpdates();
+        var codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName);
 
         // Update global.json in the VMR
@@ -144,13 +144,13 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         ]);
 
         // Flow changes back from the VMR
-        hadUpdates = await CallDarcBackflow(
+        codeFlowResult = await CallDarcBackflow(
             Constants.ProductRepoName,
             ProductRepoPath,
             branchName + "-backflow",
             buildToFlow: build1,
             excludedAssets: ["Package.C2"]);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(ProductRepoPath, branchName + "-backflow");
 
         List<NativePath> expectedFiles = [
@@ -182,8 +182,8 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         dependencies.Should().BeEquivalentTo(expectedDependencies);
 
         // Flow the changes (updated versions files only) to the VMR - both repos should have equal content at that point
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName + "-forwardflow");
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName + "-forwardflow");
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName + "-forwardflow");
 
         NativePath versionDetailsPath = VmrPath / VmrInfo.SourcesDir / Constants.ProductRepoName / VersionFiles.VersionDetailsXml;
@@ -200,8 +200,8 @@ internal class VmrBackflowTest : VmrCodeFlowTests
             (DependencyFileManager.ArcadeSdkPackageName, "1.0.2"),
         ]);
 
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName + "-pr", buildToFlow: build2);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName + "-pr", buildToFlow: build2);
+        codeFlowResult.ShouldHaveUpdates();
         dependencies = await productRepo.GetDependenciesAsync();
         dependencies.Should().BeEquivalentTo(GetDependencies(build2));
 
@@ -211,8 +211,8 @@ internal class VmrBackflowTest : VmrCodeFlowTests
 
         // Then we flow another build into the VMR before merging the PR
         await GitOperations.Checkout(ProductRepoPath, "main");
-        hadUpdates = await ChangeRepoFileAndFlowIt("New content in the individual repo", branchName + "-forwardflow");
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeRepoFileAndFlowIt("New content in the individual repo", branchName + "-forwardflow");
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName + "-forwardflow");
 
         var build3 = await CreateNewVmrBuild(
@@ -249,8 +249,8 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         ];
 
         // We flow this latest build back into the PR that is waiting in the product repo
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName + "-pr", buildToFlow: build3);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName + "-pr", buildToFlow: build3);
+        codeFlowResult.ShouldHaveUpdates();
         dependencies = await productRepo.GetDependenciesAsync();
         dependencies.Should().BeEquivalentTo(expectedDependencies);
 
@@ -274,8 +274,8 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         CheckDirectoryContents(ProductRepoPath, expectedFiles);
 
         // Now we flow repo back to VMR to level the repos
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName + "-ff");
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName + "-ff");
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName + "-ff");
 
         // Now we will change something in the VMR and flow it back to the repo
@@ -304,8 +304,8 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         ]);
 
         // Flow the first build
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName + "-pr2", buildToFlow: build4);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName + "-pr2", buildToFlow: build4);
+        codeFlowResult.ShouldHaveUpdates();
 
         expectedDependencies =
         [
@@ -389,8 +389,8 @@ internal class VmrBackflowTest : VmrCodeFlowTests
 
         // 2. The commit is forward-flown into the VMR
         await GitOperations.Checkout(ProductRepoPath, "main");
-        var hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
-        hadUpdates.ShouldHaveUpdates();
+        var codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName);
 
         // 3. The VMR builds commit from 2. and produces packages
@@ -399,13 +399,13 @@ internal class VmrBackflowTest : VmrCodeFlowTests
 
         // 4. A backflow PR is created in the repo updating Arcade.Sdk from 1.0.0 to 1.0.1
         await GitOperations.Checkout(VmrPath, "main");
-        hadUpdates = await CallDarcBackflow(
+        codeFlowResult = await CallDarcBackflow(
             Constants.ProductRepoName,
             ProductRepoPath,
             backflowBranch,
             buildToFlow: build1);
 
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult.ShouldHaveUpdates();
 
         // Verify the version files are updated
         var productRepo = GetLocal(ProductRepoPath);
@@ -416,8 +416,8 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         // 6. The commit is forward-flown into the VMR
         var forwardFlowBranch = branchName + "-forwardflow";
         await GitOperations.Checkout(ProductRepoPath, "main");
-        hadUpdates = await ChangeRepoFileAndFlowIt("New content in the repo", forwardFlowBranch);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeRepoFileAndFlowIt("New content in the repo", forwardFlowBranch);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, forwardFlowBranch);
 
         // 7. The VMR builds commit from 6. and produces packages 1.0.2
@@ -425,8 +425,8 @@ internal class VmrBackflowTest : VmrCodeFlowTests
 
         // 8. A backflow PR opened in 4. is now getting updated with changes from 7
         await GitOperations.Checkout(VmrPath, "main");
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backflowBranch, buildToFlow: build2);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backflowBranch, buildToFlow: build2);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(ProductRepoPath, backflowBranch);
 
         dependencies = await productRepo.GetDependenciesAsync();
@@ -453,8 +453,8 @@ internal class VmrBackflowTest : VmrCodeFlowTests
 
         await GitOperations.CommitAll(ProductRepoPath, "Changing version files");
 
-        var hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
-        hadUpdates.ShouldHaveUpdates();
+        var codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName);
 
         var repoEngCommonFile = "a.txt";
@@ -475,12 +475,12 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         ]);
 
         // Flow changes back from the VMR
-        hadUpdates = await CallDarcBackflow(
+        codeFlowResult = await CallDarcBackflow(
             Constants.ProductRepoName,
             ProductRepoPath,
             branchName + "-backflow",
             buildToFlow: build1);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(ProductRepoPath, branchName + "-backflow");
 
         // Verify that the product repo has the eng/common from src/arcade
@@ -496,14 +496,14 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         const string branchName = nameof(DarcVmrBackflowCommandTest);
 
         // We flow the repo to make sure they are in sync
-        var hadUpdates = await ChangeVmrFileAndFlowIt("New content in the VMR", branchName);
-        hadUpdates.ShouldHaveUpdates();
+        var codeFlowResult = await ChangeVmrFileAndFlowIt("New content in the VMR", branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(ProductRepoPath, branchName);
         await GitOperations.Checkout(ProductRepoPath, "main");
         await GitOperations.Checkout(VmrPath, "main");
 
-        hadUpdates = await ChangeRepoFileAndFlowIt("New content in the individual repo", branchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeRepoFileAndFlowIt("New content in the individual repo", branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName);
 
         // Now we make several changes in the VMR and try to locally flow them via darc

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrForwardFlowTest.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrForwardFlowTest.cs
@@ -26,20 +26,20 @@ internal class VmrForwardFlowTest : VmrCodeFlowTests
 
         const string branchName = nameof(OnlyForwardflowsTest);
 
-        var hadUpdates = await ChangeRepoFileAndFlowIt("New content in the individual repo", branchName);
-        hadUpdates.ShouldHaveUpdates();
+        var codeFlowResult = await ChangeRepoFileAndFlowIt("New content in the individual repo", branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName);
 
         // Flow again - should be a no-op
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
-        hadUpdates.ShouldNotHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
+        codeFlowResult.ShouldNotHaveUpdates();
         await GitOperations.Checkout(VmrPath, "main");
         await GitOperations.DeleteBranch(VmrPath, branchName);
         CheckFileContents(_productRepoVmrFilePath, "New content in the individual repo");
 
         // Make a change in the repo again
-        hadUpdates = await ChangeRepoFileAndFlowIt("New content in the individual repo again", branchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeRepoFileAndFlowIt("New content in the individual repo again", branchName);
+        codeFlowResult.ShouldHaveUpdates();
         CheckFileContents(_productRepoVmrFilePath, "New content in the individual repo again");
 
         // Make an additional change in the PR branch before merging
@@ -49,15 +49,15 @@ internal class VmrForwardFlowTest : VmrCodeFlowTests
         CheckFileContents(_productRepoVmrFilePath, "Change that happened in the PR");
 
         // Make a conflicting change in the VMR
-        hadUpdates = await ChangeRepoFileAndFlowIt("A completely different change", branchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeRepoFileAndFlowIt("A completely different change", branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.VerifyMergeConflict(VmrPath, branchName,
             mergeTheirs: true,
             expectedConflictingFile: VmrInfo.SourcesDir / Constants.ProductRepoName / _productRepoFileName);
         CheckFileContents(_productRepoVmrFilePath, "A completely different change");
 
         // We used the changes from the repo - let's verify flowing back won't change anything
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName);
+        codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName);
         CheckFileContents(_productRepoVmrFilePath, "A completely different change");
     }
 
@@ -69,12 +69,12 @@ internal class VmrForwardFlowTest : VmrCodeFlowTests
         const string branchName = nameof(DarcVmrForwardFlowCommandTest);
 
         // We flow the repo to make sure they are in sync
-        var hadUpdates = await ChangeRepoFileAndFlowIt("New content in the individual repo", branchName);
-        hadUpdates.ShouldHaveUpdates();
+        var codeFlowResult = await ChangeRepoFileAndFlowIt("New content in the individual repo", branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName);
 
-        hadUpdates = await ChangeVmrFileAndFlowIt("New content in the VMR", branchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeVmrFileAndFlowIt("New content in the VMR", branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(ProductRepoPath, branchName);
         await GitOperations.Checkout(ProductRepoPath, "main");
         await GitOperations.Checkout(VmrPath, "main");
@@ -146,8 +146,8 @@ internal class VmrForwardFlowTest : VmrCodeFlowTests
 
         // Level the repo and the VMR
         const string branchName = nameof(MeaninglessChangesAreSkipped);
-        var hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
-        hadUpdates.ShouldHaveUpdates();
+        var codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName);
 
         // Now we flow a first build with no other changes (package updates only)
@@ -160,18 +160,18 @@ internal class VmrForwardFlowTest : VmrCodeFlowTests
                 ("Package.D3", "2.0.0"),
             ]);
 
-        hadUpdates = await CallDarcBackflow(
+        codeFlowResult = await CallDarcBackflow(
             Constants.ProductRepoName,
             ProductRepoPath,
             branchName + "-backflow",
             buildToFlow: firstBuild,
             excludedAssets: ["Package.C2"]);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(ProductRepoPath, branchName + "-backflow");
 
         // We flow to VMR again to level the content
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName);
 
         var secondBuild = await CreateNewVmrBuild(
@@ -182,23 +182,23 @@ internal class VmrForwardFlowTest : VmrCodeFlowTests
                 ("Package.D3", "3.0.0"),
             ]);
 
-        hadUpdates = await CallDarcBackflow(
+        codeFlowResult = await CallDarcBackflow(
             Constants.ProductRepoName,
             ProductRepoPath,
             branchName + "-backflow",
             buildToFlow: secondBuild,
             excludedAssets: ["Package.C2"]);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(ProductRepoPath, branchName + "-backflow");
 
         // Now we try to flow forward and expect no meaningful changes to be detected
-        hadUpdates = await CallDarcForwardflow(
+        codeFlowResult = await CallDarcForwardflow(
             Constants.ProductRepoName,
             ProductRepoPath,
             branchName,
             // This is what we're testing in this test
             skipMeaninglessUpdates: true);
-        hadUpdates.ShouldNotHaveUpdates();
+        codeFlowResult.ShouldNotHaveUpdates();
     }
 
     [Test]
@@ -215,12 +215,12 @@ internal class VmrForwardFlowTest : VmrCodeFlowTests
         await GitOperations.CommitAll(ProductRepoPath, "1a.txt");
 
         // Open a forward flow PR
-        var hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, forwardBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        var codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, forwardBranchName);
+        codeFlowResult.ShouldHaveUpdates();
 
         // Make a change in the VMR forward flow PR
         await GitOperations.Checkout(VmrPath, forwardBranchName);
-        await File.WriteAllTextAsync(VmrPath / VmrInfo.GetRelativeRepoSourcesPath(Constants.ProductRepoName) / "1a.txt", "one changed");
+        File.Delete(VmrPath / VmrInfo.GetRelativeRepoSourcesPath(Constants.ProductRepoName) / "1a.txt");
         await GitOperations.CommitAll(VmrPath, "Change in the VMR forward flow PR");
 
         // Merge the PR in the VMR
@@ -231,7 +231,9 @@ internal class VmrForwardFlowTest : VmrCodeFlowTests
         await File.WriteAllTextAsync(ProductRepoPath / "1a.txt", "two");
         await GitOperations.CommitAll(ProductRepoPath, "1a.txt");
 
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, forwardBranchName2);
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, forwardBranchName2);
+        codeFlowResult.ConflictedFiles.Count.Should().Be(3);
+        codeFlowResult.ConflictedFiles.Should().Contain(VmrInfo.GetRelativeRepoSourcesPath(Constants.ProductRepoName) / "1a.txt");
     }
 }
 

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrTestsBase.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrTestsBase.cs
@@ -219,7 +219,7 @@ internal abstract class VmrTestsBase
             cancellationToken: _cancellationToken.Token);
     }
 
-    protected async Task<bool> CallDarcBackflow(
+    protected async Task<CodeFlowResult> CallDarcBackflow(
         string mappingName,
         NativePath repoPath,
         string branch,
@@ -243,10 +243,10 @@ internal abstract class VmrTestsBase
             "main",
             branch,
             cancellationToken: _cancellationToken.Token);
-        return codeFlowResult.HadUpdates;
+        return codeFlowResult;
     }
 
-    protected async Task<bool> CallDarcForwardflow(
+    protected async Task<CodeFlowResult> CallDarcForwardflow(
         string mappingName,
         NativePath repoPath,
         string branch,
@@ -268,7 +268,7 @@ internal abstract class VmrTestsBase
             skipMeaninglessUpdates,
             cancellationToken: _cancellationToken.Token);
 
-        return codeFlowRes.HadUpdates;
+        return codeFlowRes;
     }
 
     protected async Task<List<string>> CallDarcCloakedFileScan(string baselinesFilePath)

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrTwoWayCodeflowTest.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrTwoWayCodeflowTest.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models.Darc;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
@@ -155,7 +154,7 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         // 2. Open a backflow PR
         var hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName);
         hadUpdates.ShouldHaveUpdates();
-        // We make another commit in the repo and add it to the PR branch (this is not in the diagram above)
+        // We make another commit in the vmr and add it to the PR branch (this is not in the diagram above)
         await GitOperations.Checkout(VmrPath, "main");
         await File.WriteAllTextAsync(_productRepoVmrPath / "1b.txt", "one again");
         await GitOperations.CommitAll(VmrPath, "1b.txt");

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrTwoWayCodeflowTest.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrTwoWayCodeflowTest.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models.Darc;
+using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,7 +33,7 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         await File.WriteAllTextAsync(_productRepoVmrPath / "we-will-delete-this-later.txt", "And it will stay deleted");
         await GitOperations.CommitAll(VmrPath, "Added a file that will be deleted later");
 
-        var hadUpdates = await ChangeRepoFileAndFlowIt("New content in the individual repo", branchName);
+        var codeFlowResult = await ChangeRepoFileAndFlowIt("New content in the individual repo", branchName);
         await GitOperations.MergePrBranch(VmrPath, branchName);
 
         // Make some changes in the product repo
@@ -41,8 +42,8 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         await GitOperations.CommitAll(ProductRepoPath, aFileContent);
 
         // Flow unrelated changes from the VMR
-        hadUpdates = await ChangeVmrFileAndFlowIt("New content from the VMR", branchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeVmrFileAndFlowIt("New content from the VMR", branchName);
+        codeFlowResult.ShouldHaveUpdates();
 
         // Before we merge the PR branch, make a change in the product repo
         await File.WriteAllTextAsync(ProductRepoPath / "b.txt", bFileContent);
@@ -55,8 +56,8 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         CheckFileContents(_productRepoFilePath, "New content from the VMR");
 
         // Make a change in the VMR again
-        hadUpdates = await ChangeVmrFileAndFlowIt("New content from the VMR again", branchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeVmrFileAndFlowIt("New content from the VMR again", branchName);
+        codeFlowResult.ShouldHaveUpdates();
 
         // Make an additional change in the PR branch before merging
         await File.WriteAllTextAsync(_productRepoFilePath, "Change that happened in the PR");
@@ -71,8 +72,8 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         // Forward flow
         await File.WriteAllTextAsync(ProductRepoPath / "b.txt", bFileContent2);
         await GitOperations.CommitAll(ProductRepoPath, bFileContent2);
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName);
         CheckFileContents(_productRepoVmrPath / "a.txt", aFileContent);
         CheckFileContents(_productRepoVmrPath / "b.txt", bFileContent2);
@@ -152,14 +153,14 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         await GitOperations.CommitAll(VmrPath, "1a.txt");
 
         // 2. Open a backflow PR
-        var hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        var codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName);
+        codeFlowResult.ShouldHaveUpdates();
         // We make another commit in the vmr and add it to the PR branch (this is not in the diagram above)
         await GitOperations.Checkout(VmrPath, "main");
         await File.WriteAllTextAsync(_productRepoVmrPath / "1b.txt", "one again");
         await GitOperations.CommitAll(VmrPath, "1b.txt");
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName);
+        codeFlowResult.ShouldHaveUpdates();
 
         // 3. Change file in the repo
         await GitOperations.Checkout(ProductRepoPath, "main");
@@ -167,14 +168,14 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         await GitOperations.CommitAll(ProductRepoPath, "3a.txt");
 
         // 4. Open a forward flow PR
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, forwardBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, forwardBranchName);
+        codeFlowResult.ShouldHaveUpdates();
         // We make another commit in the repo and add it to the PR branch (this is not in the diagram above)
         await GitOperations.Checkout(ProductRepoPath, "main");
         await File.WriteAllTextAsync(ProductRepoPath / "3b.txt", "three again");
         await GitOperations.CommitAll(ProductRepoPath, "3b.txt");
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, forwardBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, forwardBranchName);
+        codeFlowResult.ShouldHaveUpdates();
 
         // 5. Merge the backflow PR
         await GitOperations.MergePrBranch(ProductRepoPath, backBranchName);
@@ -186,8 +187,8 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         // While the VMR accepted the content from the repo but it will get overriden by the VMR content again
         await GitOperations.Checkout(ProductRepoPath, "main");
         await GitOperations.Checkout(VmrPath, "main");
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branch: forwardBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branch: forwardBranchName);
+        codeFlowResult.ShouldHaveUpdates();
 
         // 8. Merge the forward flow PR - any conflicts in version files are dealt with automatically
         // The conflict is described in the ForwardFlowConflictResolver class
@@ -245,12 +246,12 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         var backBranchName = GetTestBranchName(forwardFlow: false);
         var forwardBranchName = GetTestBranchName();
         Build build;
-        bool hadUpdates;
+        CodeFlowResult codeFlowResult;
 
         // 0. Backflow of a build to populate the version files in the repo with some values
         build = await CreateNewVmrBuild([(FakePackageName, FakePackageVersion)]);
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName, build);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName, build);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(ProductRepoPath, backBranchName);
 
         // 1. Change file in the repo
@@ -258,14 +259,14 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         await GitOperations.CommitAll(ProductRepoPath, "1a.txt");
 
         // 2. Open a forward flow PR
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, forwardBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, forwardBranchName);
+        codeFlowResult.ShouldHaveUpdates();
         // We make another commit in the repo and add it to the PR branch (this is not in the diagram above)
         await GitOperations.Checkout(ProductRepoPath, "main");
         await File.WriteAllTextAsync(ProductRepoPath / "1b.txt", "one again");
         await GitOperations.CommitAll(ProductRepoPath, "1b.txt");
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, forwardBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, forwardBranchName);
+        codeFlowResult.ShouldHaveUpdates();
 
         // 3. Change file in the VMR
         await GitOperations.Checkout(VmrPath, "main");
@@ -274,15 +275,15 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
 
         // 4. Open a backflow PR
         build = await CreateNewVmrBuild([(FakePackageName, "1.0.1")]);
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName, build);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName, build);
+        codeFlowResult.ShouldHaveUpdates();
         // We make another commit in the repo and add it to the PR branch (this is not in the diagram above)
         await GitOperations.Checkout(VmrPath, "main");
         await File.WriteAllTextAsync(_productRepoVmrPath / "3b.txt", "three again");
         await GitOperations.CommitAll(VmrPath, "3b.txt");
         build = await CreateNewVmrBuild([(FakePackageName, "1.0.2")]);
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName, build);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName, build);
+        codeFlowResult.ShouldHaveUpdates();
 
         // 5. Merge the forward flow PR
         await GitOperations.MergePrBranch(VmrPath, forwardBranchName);
@@ -296,8 +297,8 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         await GitOperations.Checkout(VmrPath, "main");
         build = await CreateNewVmrBuild([(FakePackageName, "1.0.3")]);
         backBranchName = GetTestBranchName(forwardFlow: false);
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName, build);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName, build);
+        codeFlowResult.ShouldHaveUpdates();
 
         var productRepo = GetLocal(ProductRepoPath);
 
@@ -318,8 +319,8 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         build = await CreateNewRepoBuild([], shaInStep6);
         forwardBranchName = GetTestBranchName();
         await GitOperations.Checkout(ProductRepoPath, "main");
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branch: forwardBranchName, build);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branch: forwardBranchName, build);
+        codeFlowResult.ShouldHaveUpdates();
 
         // 10. We make another change on the target branch in the repo
         var newDependencyInRepo = new DependencyDetail
@@ -340,8 +341,8 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         // This means there might be a conflict between these and we need to override what is in the repo
         await GitOperations.MergePrBranch(VmrPath, forwardBranchName);
         build = await CreateNewVmrBuild([(FakePackageName, "1.0.5")]);
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName, build);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backBranchName, build);
+        codeFlowResult.ShouldHaveUpdates();
 
         // 13. Merge the forward flow PR - any conflicts in version files are dealt with automatically
         // The conflict is described in the BackwardFlowConflictResolver class
@@ -409,32 +410,32 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         const string forwardBranchName = nameof(OutOfOrderMergesWithConflictsTest) + "-ff";
 
         // Do a forward flow once and merge so we have something to fall back on
-        var hadUpdates = await ChangeRepoFileAndFlowIt("New content in the individual repo", forwardBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        var codeFlowResult = await ChangeRepoFileAndFlowIt("New content in the individual repo", forwardBranchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, forwardBranchName);
 
         // 1. Change file in VMR
         // 2. Open a backflow PR
         await File.WriteAllTextAsync(_productRepoVmrPath / "b.txt", bFileContent);
         await GitOperations.CommitAll(VmrPath, bFileContent);
-        hadUpdates = await ChangeVmrFileAndFlowIt("New content from the VMR #1", backBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeVmrFileAndFlowIt("New content from the VMR #1", backBranchName);
+        codeFlowResult.ShouldHaveUpdates();
         // We make another commit in the repo and add it to the PR branch (this is not in the diagram above)
         await GitOperations.Checkout(ProductRepoPath, "main");
-        hadUpdates = await ChangeVmrFileAndFlowIt("New content from the VMR #2", backBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeVmrFileAndFlowIt("New content from the VMR #2", backBranchName);
+        codeFlowResult.ShouldHaveUpdates();
 
         // 3. Change file in the repo
         // 4. Open a forward flow PR
         await GitOperations.Checkout(ProductRepoPath, "main");
         await File.WriteAllTextAsync(ProductRepoPath / "a.txt", aFileContent);
         await GitOperations.CommitAll(ProductRepoPath, aFileContent);
-        hadUpdates = await ChangeRepoFileAndFlowIt("New content from the individual repo #1", forwardBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeRepoFileAndFlowIt("New content from the individual repo #1", forwardBranchName);
+        codeFlowResult.ShouldHaveUpdates();
         // We make another commit in the repo and add it to the PR branch (this is not in the diagram above)
         await GitOperations.Checkout(ProductRepoPath, "main");
-        hadUpdates = await ChangeRepoFileAndFlowIt("New content from the individual repo #2", forwardBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await ChangeRepoFileAndFlowIt("New content from the individual repo #2", forwardBranchName);
+        codeFlowResult.ShouldHaveUpdates();
 
         // 5. The backflow PR is now in conflict - repo has the content from step 3 but VMR has the one from step 1
         // 6. We resolve the conflict by using the content from the VMR
@@ -456,8 +457,8 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         // While the VMR accepted the content from the repo but it will get overriden by the VMR content again
         await GitOperations.Checkout(ProductRepoPath, "main");
         await GitOperations.Checkout(VmrPath, "main");
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branch: forwardBranchName);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branch: forwardBranchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.VerifyMergeConflict(VmrPath, forwardBranchName,
             mergeTheirs: true,
             expectedConflictingFile: VmrInfo.SourcesDir / Constants.ProductRepoName / _productRepoFileName);
@@ -591,8 +592,8 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
 
         // Level the repo and the VMR
         await GitOperations.CommitAll(ProductRepoPath, "Changing version files");
-        var hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
-        hadUpdates.ShouldHaveUpdates();
+        var codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName);
 
         // Update repo1 and repo3 dependencies in the product repo
@@ -643,14 +644,14 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         await GitOperations.CommitAll(VmrPath, "Update repo2 dependencies in the VMR");
 
         // Flow repo to the VMR
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName + "2");
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName + "2");
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName + "2");
 
         // Flow changes back from the VMR
         var build = await CreateNewVmrBuild([("Package.A1", "1.0.20")]);
-        hadUpdates = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName + "3", build);
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, branchName + "3", build);
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(ProductRepoPath, branchName + "3");
 
         // Verify the version files have both of the changes
@@ -697,8 +698,8 @@ internal class VmrTwoWayCodeflowTest : VmrCodeFlowTests
         await VerifyDependenciesInRepo(ProductRepoPath, expectedDependencies);
 
         // Flow repo to the VMR
-        hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName + "4");
-        hadUpdates.ShouldHaveUpdates();
+        codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName + "4");
+        codeFlowResult.ShouldHaveUpdates();
         await GitOperations.MergePrBranch(VmrPath, branchName + "4");
 
         new VersionDetailsParser()


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4947
Basically, we were calculating the lastCodeflow, and lastLastCodeflow from the same VMR commit, which gave us the same result.