### PR TITLE
Revert "Ignore whitespace changes when blaming files"

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -447,7 +447,7 @@ public class LocalGitClient : ILocalGitClient
             "blame",
             "--first-parent",
             blameFromCommit != null ? blameFromCommit + '^' : Constants.HEAD,
-            "-wslL",
+            "-slL",
             $"{line},{line}",
             relativeFilePath,
         };


### PR DESCRIPTION
Reverts https://github.com/dotnet/arcade-services/issues/4957

This started to fail the `Vmr_BackwardConflictFlowTest` test. I need to investigate why before re-introducing this.