### PR TITLE
Handle exceptions when target codeflow branch does not exist

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/TargetBranchNotFoundException.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/TargetBranchNotFoundException.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.DotNet.DarcLib;
+
+public class TargetBranchNotFoundException : DarcException
+{
+    public TargetBranchNotFoundException() : base()
+    {
+    }
+
+    public TargetBranchNotFoundException(string message) : base(message)
+    {
+    }
+
+    public TargetBranchNotFoundException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -186,12 +186,22 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
         catch (NotFoundException)
         {
             // If the head branch does not exist, we need to create it at the point of the last sync
-            var vmr = await _vmrCloneManager.PrepareVmrAsync(
-                [vmrUri],
-                [baseBranch],
-                baseBranch,
-                ShouldResetVmr,
-                cancellationToken);
+            ILocalGitRepo vmr;
+            try
+            {
+                vmr = await _vmrCloneManager.PrepareVmrAsync(
+                    [vmrUri],
+                    [baseBranch],
+                    baseBranch,
+                    ShouldResetVmr,
+                    cancellationToken);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Failed to find branch {branch} in {uri}", baseBranch, vmrUri);
+                throw new TargetBranchNotFoundException($"Failed to find target branch {baseBranch} in {vmrUri}");
+            }
+
             SourceMapping mapping = _dependencyTracker.GetMapping(mappingName);
             (Codeflow last, _, _) = await GetLastFlowsAsync(mapping, sourceRepo, currentIsBackflow: false);
             await vmr.CheckoutAsync(last.VmrSha);

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -1076,6 +1076,15 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
             }
             return;
         }
+        catch (TargetBranchNotFoundException)
+        {
+            if (pr != null)
+            {
+                // If PR already exists, this should not happen
+                throw;
+            }
+            return;
+        }
         catch (Exception)
         {
             _logger.LogError("Failed to flow source changes for build {buildId} in subscription {subscriptionId}",


### PR DESCRIPTION
This prevents exceptions and unhandled work items during codeflows when for instance the preview 6 subscriptions have been created but the VMR branch is not created yet.
