### PR TITLE
Always flow dotnet sdk version from VMRs root global.json

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/DependencyFileManager.cs
@@ -395,7 +395,8 @@ public class DependencyFileManager : IDependencyFileManager
         string repoUri,
         string branch,
         IEnumerable<DependencyDetail> oldDependencies,
-        SemanticVersion incomingDotNetSdkVersion)
+        SemanticVersion incomingDotNetSdkVersion,
+        bool forceGlobalJsonUpdate = false)
     {
         // When updating version files, we always want to look in the base folder, even when we're updating it in the VMR
         // src/arcade version files only get updated during arcade forward flows
@@ -446,7 +447,7 @@ public class DependencyFileManager : IDependencyFileManager
         Dictionary<GitFileMetadataName, string> globalJsonMetadata = null;
         if (incomingDotNetSdkVersion != null)
         {
-            globalJsonMetadata = UpdateDotnetVersionGlobalJson(incomingDotNetSdkVersion, globalJson);
+            globalJsonMetadata = UpdateDotnetVersionGlobalJson(incomingDotNetSdkVersion, globalJson, forceGlobalJsonUpdate);
         }
 
         var fileContainer = new GitFileContentContainer
@@ -470,15 +471,19 @@ public class DependencyFileManager : IDependencyFileManager
     /// Updates the global.json entries for tools.dotnet and sdk.version if they are older than an incoming version
     /// </summary>
     /// <param name="incomingDotnetVersion">version to compare against</param>
-    /// <param name="repoGlobalJson">Global.Json file to update</param>
+    /// <param name="globalJson">Global.Json file to update</param>
+    /// <param name="forceUpdate">Ignores version check and forces globalJson update</param>
     /// <returns>Updated global.json file if was able to update, or the unchanged global.json if unable to</returns>
-    private Dictionary<GitFileMetadataName, string> UpdateDotnetVersionGlobalJson(SemanticVersion incomingDotnetVersion, JObject globalJson)
+    private Dictionary<GitFileMetadataName, string> UpdateDotnetVersionGlobalJson(
+        SemanticVersion incomingDotnetVersion,
+        JObject globalJson,
+        bool forceUpdate = false)
     {
         try
         {
             if (SemanticVersion.TryParse(globalJson.SelectToken("tools.dotnet")?.ToString(), out SemanticVersion repoDotnetVersion))
             {
-                if (repoDotnetVersion.CompareTo(incomingDotnetVersion) < 0)
+                if (repoDotnetVersion.CompareTo(incomingDotnetVersion) < 0 || forceUpdate)
                 {
                     Dictionary<GitFileMetadataName, string> metadata = [];
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IDependencyFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/IDependencyFileManager.cs
@@ -58,7 +58,8 @@ public interface IDependencyFileManager
         string repoUri,
         string? branch,
         IEnumerable<DependencyDetail> oldDependencies,
-        SemanticVersion? incomingDotNetSdkVersion);
+        SemanticVersion? incomingDotNetSdkVersion,
+        bool forceGlobalJsonUpdate = false);
 
     XmlDocument UpdatePackageSources(XmlDocument nugetConfig, Dictionary<string, HashSet<string>> maestroManagedFeedsByRepo);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VersionFileCodeFlowUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VersionFileCodeFlowUpdater.cs
@@ -544,8 +544,14 @@ public class VersionFileCodeFlowUpdater : IVersionFileCodeFlowUpdater
         // If we are updating the arcade sdk we need to update the eng/common files as well
         DependencyDetail? arcadeItem = updates.GetArcadeUpdate();
 
-        // Even tho we are backflowing from the VMR, we want to get the sdk version from VMR`s global.json, not src/arcade's
-        SemanticVersion targetDotNetVersion = await _dependencyFileManager.ReadToolsDotnetVersionAsync(build.GetRepository(), build.Commit, repoIsVmr: false);
+        SemanticVersion? targetDotNetVersion = null;
+
+        // The arcade backflow subscriptions has all assets excluded, but we want to update the global.json sdk version anyway
+        if (arcadeItem != null || mappingName == "arcade")
+        {
+            // Even tho we are backflowing from the VMR, we want to get the sdk version from VMR`s global.json, not src/arcade's
+            targetDotNetVersion = await _dependencyFileManager.ReadToolsDotnetVersionAsync(build.GetRepository(), build.Commit, repoIsVmr: false);
+        }
 
         GitFileContentContainer updatedFiles = await _dependencyFileManager.UpdateDependencyFiles(
             updates,

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/Constants.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/Constants.cs
@@ -40,6 +40,14 @@ public class Constants
           }
         }
         """;
+    public const string GlobalJsonDotNetSdkPlaceholder = "{dotnet-sdk}";
+    public const string GlobalJsonWithVersionTemplate = """
+        {
+          "tools": {
+            "dotnet": "{dotnet-sdk}"
+          }
+        }
+        """;
 
     public const string NuGetConfigTemplate = """
         <?xml version="1.0" encoding="utf-8"?>

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/Constants.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/Constants.cs
@@ -40,11 +40,11 @@ public class Constants
           }
         }
         """;
-    public const string GlobalJsonDotNetSdkPlaceholder = "{dotnet-sdk}";
-    public const string GlobalJsonWithVersionTemplate = """
+    public const string VmrBaseDotnetSdkVersion = "9.0.101";
+    public const string VmrBaseGlobalJsonTemplate = """
         {
           "tools": {
-            "dotnet": "{dotnet-sdk}"
+            "dotnet": "9.0.101"
           }
         }
         """;

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrBackflowTest.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrBackflowTest.cs
@@ -28,11 +28,6 @@ internal class VmrBackflowTest : VmrCodeFlowTests
 
         const string branchName = nameof(OnlyBackflowsTest);
 
-        await File.WriteAllTextAsync(
-            VmrPath / VersionFiles.GlobalJson,
-            Constants.GlobalJsonTemplate);
-        await GitOperations.CommitAll(VmrPath, "Creating global.json in vmrs base");
-
         var hadUpdates = await ChangeVmrFileAndFlowIt("New content from the VMR", branchName);
         hadUpdates.ShouldHaveUpdates();
 
@@ -120,15 +115,14 @@ internal class VmrBackflowTest : VmrCodeFlowTests
 
         await GitOperations.CommitAll(ProductRepoPath, "Set up version files");
 
-        string vmrSdkVersion = "9.0.101";
         // Create global.json in src/arcade/ and in VMRs base
         Directory.CreateDirectory(ArcadeInVmrPath);
         await File.WriteAllTextAsync(
             ArcadeInVmrPath / VersionFiles.GlobalJson,
-            Constants.GlobalJsonWithVersionTemplate.Replace(Constants.GlobalJsonDotNetSdkPlaceholder, "9.0.100"));
+            Constants.GlobalJsonTemplate);
         await File.WriteAllTextAsync(
             VmrPath / VersionFiles.GlobalJson,
-            Constants.GlobalJsonWithVersionTemplate.Replace(Constants.GlobalJsonDotNetSdkPlaceholder, vmrSdkVersion));
+            Constants.VmrBaseGlobalJsonTemplate);
         await GitOperations.CommitAll(VmrPath, "Creating global.json in vmrs base and in src/arcade ");
 
         var hadUpdates = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branchName);
@@ -272,7 +266,7 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         arcadeVersion?.ToString().Should().Be("1.0.2");
 
         var dotnetVersion = await dependencyFileManager.ReadToolsDotnetVersionAsync(ProductRepoPath, branchName + "-pr", repoIsVmr: false);
-        dotnetVersion.ToString().Should().Be(vmrSdkVersion);
+        dotnetVersion.ToString().Should().Be(Constants.VmrBaseDotnetSdkVersion);
 
         await GitOperations.MergePrBranch(ProductRepoPath, branchName + "-pr");
 
@@ -390,9 +384,6 @@ internal class VmrBackflowTest : VmrCodeFlowTests
         // Update an eng/common file in the VMR
         Directory.CreateDirectory(ArcadeInVmrPath / DarcLib.Constants.CommonScriptFilesPath);
         await File.WriteAllTextAsync(ArcadeInVmrPath / VersionFiles.GlobalJson, Constants.GlobalJsonTemplate);
-        await File.WriteAllTextAsync(
-            VmrPath / VersionFiles.GlobalJson,
-            Constants.GlobalJsonTemplate);
         await File.WriteAllTextAsync(ArcadeInVmrPath / DarcLib.Constants.CommonScriptFilesPath / "darc-init.ps1", "Some other script file");
         await GitOperations.CommitAll(VmrPath, "Creating VMR's eng/common");
 
@@ -454,11 +445,6 @@ internal class VmrBackflowTest : VmrCodeFlowTests
 
         await EnsureTestRepoIsInitialized();
 
-        await File.WriteAllTextAsync(
-            VmrPath / VersionFiles.GlobalJson,
-            Constants.GlobalJsonTemplate);
-        await GitOperations.CommitAll(VmrPath, "Creating global.json in vmr`s base");
-
         var repo = GetLocal(ProductRepoPath);
         await repo.RemoveDependencyAsync(FakePackageName);
         await repo.AddDependencyAsync(new DependencyDetail
@@ -514,10 +500,6 @@ internal class VmrBackflowTest : VmrCodeFlowTests
 
         const string branchName = nameof(DarcVmrBackflowCommandTest);
 
-        await File.WriteAllTextAsync(
-            VmrPath / VersionFiles.GlobalJson,
-            Constants.GlobalJsonTemplate);
-        await GitOperations.CommitAll(VmrPath, "Creating global.json in vmr`s base");
         // We flow the repo to make sure they are in sync
         var hadUpdates = await ChangeVmrFileAndFlowIt("New content in the VMR", branchName);
         hadUpdates.ShouldHaveUpdates();

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrCodeFlowTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrCodeFlowTests.cs
@@ -82,7 +82,10 @@ internal abstract class VmrCodeFlowTests : VmrTestsBase
         var expectedFiles = GetExpectedFilesInVmr(
             VmrPath,
             [Constants.ProductRepoName],
-            [_productRepoVmrFilePath, _productRepoVmrPath / DarcLib.Constants.CommonScriptFilesPath / "build.ps1"]);
+            [
+                _productRepoVmrFilePath,
+                _productRepoVmrPath / DarcLib.Constants.CommonScriptFilesPath / "build.ps1",
+                VmrPath / VersionFiles.GlobalJson]);
 
         CheckDirectoryContents(VmrPath, expectedFiles);
         CompareFileContents(_productRepoVmrFilePath, _productRepoFileName);
@@ -194,6 +197,9 @@ internal abstract class VmrCodeFlowTests : VmrTestsBase
         ];
 
         await WriteSourceMappingsInVmr(sourceMappings);
+
+        await File.WriteAllTextAsync(VmrPath / VersionFiles.GlobalJson, Constants.VmrBaseGlobalJsonTemplate);
+        await GitOperations.CommitAll(VmrPath, "Create global json in vmr`s base");
     }
 }
 

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VersionFileCodeFlowUpdaterTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VersionFileCodeFlowUpdaterTests.cs
@@ -447,13 +447,15 @@ public class VersionFileCodeFlowUpdaterTests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<IEnumerable<DependencyDetail>>(),
-                null))
+                null,
+                It.IsAny<bool>()))
             .Callback((IEnumerable<DependencyDetail> itemsToUpdate,
                        SourceDependency? sourceDependency,
                        string repo,
                        string? commit,
                        IEnumerable<DependencyDetail> oldDependencies,
-                       SemanticVersion? incomingDotNetSdkVersion) =>
+                       SemanticVersion? incomingDotNetSdkVersion,
+                       bool forceUpdate) =>
             {
                 // Update dependencies in-memory
                 var key = (repo == _vmrPath ? "vmr" : "repo") + "/" + commit;


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/4847