### PR TITLE
Ignore differing EOLs when merging work branches

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/WorkBranch.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/WorkBranch.cs
@@ -55,6 +55,10 @@ public class WorkBranch(
                 result = await _repo.ExecuteGitCommand(mergeArgs);
                 result.ThrowIfFailed($"Failed to merge work branch {_workBranch} into {OriginalBranch}");
             }
+            else
+            {
+                result.ThrowIfFailed($"Failed to merge work branch {_workBranch} into {OriginalBranch}");
+            }
         }
 
         await _repo.CommitAsync(commitMessage, true);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/WorkBranch.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/WorkBranch.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -33,10 +34,28 @@ public class WorkBranch(
         _logger.LogInformation("Merging {branchName} into {mainBranch}", _workBranch, OriginalBranch);
 
         await _repo.CheckoutAsync(OriginalBranch);
-        var result = await _repo.ExecuteGitCommand(
-            [ "merge", _workBranch, "--no-commit", "--no-edit", "--squash", "-q" ]);
 
-        result.ThrowIfFailed($"Failed to merge work branch {_workBranch} into {OriginalBranch}");
+        var mergeArgs = new[] { "merge", _workBranch, "--no-commit", "--no-edit", "--squash", "-q" };
+
+        var result = await _repo.ExecuteGitCommand(mergeArgs);
+
+        // If we failed, it might be because the working tree is dirty because of EOL changes
+        // These are uninteresting because the index will have the correct EOLs
+        if (!result.Succeeded)
+        {
+            // Let's see if that is the case
+            var diffResult = await _repo.ExecuteGitCommand(["diff", "-w"]);
+            if (diffResult.Succeeded)
+            {
+                _logger.LogWarning("Update succeeded but some EOL file changes were not properly stashes. Ignoring these...");
+
+                // We stage those changes, they will get absorbed with upcoming merge
+                result = await _repo.ExecuteGitCommand(["add", "-A"]);
+                result.ThrowIfFailed($"Failed to merge work branch {_workBranch} into {OriginalBranch}");
+                result = await _repo.ExecuteGitCommand(mergeArgs);
+                result.ThrowIfFailed($"Failed to merge work branch {_workBranch} into {OriginalBranch}");
+            }
+        }
 
         await _repo.CommitAsync(commitMessage, true);
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/WorkBranch.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/WorkBranch.cs
@@ -51,7 +51,7 @@ public class WorkBranch(
 
                 // We stage those changes, they will get absorbed with upcoming merge
                 result = await _repo.ExecuteGitCommand(["add", "-A"]);
-                result.ThrowIfFailed($"Failed to merge work branch {_workBranch} into {OriginalBranch}");
+                result.ThrowIfFailed($"Failed to stage whitespace-only EOL changes while merging work branch {_workBranch} into {OriginalBranch}");
                 result = await _repo.ExecuteGitCommand(mergeArgs);
                 result.ThrowIfFailed($"Failed to merge work branch {_workBranch} into {OriginalBranch}");
             }


### PR DESCRIPTION
Handles a case when CRLF settings are changed on files to their default.
These files would then appear as dirty in the working tree while git would be unable to handle these properly.

This adds a check for whitespace changes only and allows to merge the work branch even when these changes are present only.


https://github.com/dotnet/source-build/issues/5207
