### PR TITLE
include cached PR check results in evals, but dont push them to GH

### DIFF
--- a/src/Maestro/Maestro.MergePolicyEvaluation/MergePolicyEvaluationResult.cs
+++ b/src/Maestro/Maestro.MergePolicyEvaluation/MergePolicyEvaluationResult.cs
@@ -21,4 +21,5 @@ public class MergePolicyEvaluationResult
     public string Message { get; }
     public string MergePolicyName { get; }
     public string MergePolicyDisplayName { get; }
+    public bool IsCachedResult { get; set; } = false;
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
@@ -492,6 +492,12 @@ public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
         foreach (var updatedCheckRun in toBeUpdated)
         {
             MergePolicyEvaluationResult eval = evaluations.Last(e => updatedCheckRun.ExternalId == CheckRunId(e, prSha));
+            if (eval.IsCachedResult)
+            {
+                _logger.LogInformation("Not updating check run {checkRunId} for PR {pullRequestUrl} because the merge policy was not re-evaluated.",
+                    updatedCheckRun.ExternalId, pullRequestUrl);
+                continue;
+            }
             CheckRunUpdate newCheckRunUpdateValidation = CheckRunForUpdate(eval);
             await client.Check.Run.Update(owner, repo, updatedCheckRun.Id, newCheckRunUpdateValidation);
         }


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/4974

The issue:
- when merge policy evaluation is skipped due to the existence of a cached result, the cached result is not added to the new list of evaluations
- the github client method considers that any maestro PR checks that have a value on the github PR but no value in the new list of evaluations are meant to be deleted
- this leads to a "status: skipped" for that PR check on github

The solution:
- When skipping evaluation due to a cached result, add the cached result into the new list of evaluations, and mark it "IsCachedResult"
- When sending the results through the github API, skip updating any evaluations that have the "IsCachedResult" flag