### PR TITLE
Fix link references during codeflow PR updates

### DIFF
--- a/src/Maestro/Maestro.MergePolicies/DependencyUpdateSummary.cs
+++ b/src/Maestro/Maestro.MergePolicies/DependencyUpdateSummary.cs
@@ -26,7 +26,7 @@ public class DependencyUpdateSummary
 
     public DependencyUpdateSummary(DependencyUpdate du)
     {
-        DependencyName = du.To?.Name;
+        DependencyName = du.DependencyName;
         FromVersion = du.From?.Version;
         ToVersion = du.To?.Version;
         FromCommitSha = du.From?.Commit;

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DependencyUpdate.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/Darc/DependencyUpdate.cs
@@ -16,8 +16,11 @@ public class DependencyUpdate
     ///     Current dependency
     /// </summary>
     public DependencyDetail From { get; set; }
+
     /// <summary>
     ///     Updated dependency
     /// </summary>
     public DependencyDetail To { get; set; }
+
+    public string DependencyName => From?.Name ?? To?.Name;
 }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -319,7 +319,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
 
     private static string GenerateUpstreamRepoDiffs(IReadOnlyCollection<UpstreamRepoDiff> upstreamRepoDiffs)
     {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new();
         foreach (UpstreamRepoDiff upstreamRepoDiff in upstreamRepoDiffs)
         {
             if (!string.IsNullOrEmpty(upstreamRepoDiff.RepoUri)
@@ -372,7 +372,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
 
         DependencyCategories dependencyCategories = CreateDependencyCategories(dependencyUpdateSummaries);
 
-        StringBuilder stringBuilder = new StringBuilder();
+        StringBuilder stringBuilder = new();
 
         if (dependencyCategories.NewDependencies.Count > 0)
         {
@@ -410,9 +410,9 @@ internal class PullRequestBuilder : IPullRequestBuilder
 
     private static DependencyCategories CreateDependencyCategories(List<DependencyUpdateSummary> dependencyUpdateSummaries)
     {
-        List<DependencyUpdateSummary> newDependencies = new();
-        List<DependencyUpdateSummary> removedDependencies = new();
-        List<DependencyUpdateSummary> updatedDependencies = new();
+        List<DependencyUpdateSummary> newDependencies = [];
+        List<DependencyUpdateSummary> removedDependencies = [];
+        List<DependencyUpdateSummary> updatedDependencies = [];
 
         foreach (DependencyUpdateSummary depUpdate in dependencyUpdateSummaries)
         {
@@ -505,7 +505,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
 
         var linkGroups = matches.GroupBy(link => link)
                                 .Where(group => group.Count() >= 2)
-                                .Select((group, index) => new { Link = group.Key, Index = index + 1 })
+                                .Select((group, index) => new { Link = group.Key, Index = index })
                                 .ToDictionary(x => x.Link, x => x.Index);
 
         if (linkGroups.Count == 0)
@@ -513,7 +513,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
             return description;
         }
 
-        var existingGroupCount = Regex.Count(description, @"$\[\d+\]: https?://");
+        var existingGroupCount = GetStartingReferenceId(description);
 
         foreach (var entry in linkGroups)
         {

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -738,6 +738,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         List<(DependencyUpdateSummary?, DependencyUpdateSummary?)> mergedUpdates = existingUpdates
             .Concat(incoming)
             .Select(update => update.DependencyName)
+            .Distinct()
             .Select(name => (existingUpdates.FirstOrDefault(u => u.DependencyName == name), incoming.FirstOrDefault(u => u.DependencyName == name)))
             .ToList();
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
-using System.Linq;
 using Maestro.Data.Models;
 using Maestro.DataProviders;
 using Maestro.MergePolicies;
@@ -14,7 +13,6 @@ using Microsoft.DotNet.DarcLib.Models.Darc;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.Services.Common;
 using ProductConstructionService.Common;
 using ProductConstructionService.DependencyFlow.Model;
 using ProductConstructionService.DependencyFlow.WorkItems;

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -733,7 +733,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         IEnumerable<DependencyUpdateSummary> mergedUpdates = existingUpdates
             .Select(u =>
             {
-                var matchingIncoming = incomingUpdates.FirstOrDefault(i => (i.From?.Name ?? i.To.Name) == u.DependencyName);
+                var matchingIncoming = incomingUpdates.FirstOrDefault(i => i.DependencyName == u.DependencyName);
                 return new DependencyUpdateSummary()
                 {
                     DependencyName = u.DependencyName,
@@ -745,7 +745,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
             });
 
         IEnumerable<DependencyUpdateSummary> newUpdates = incomingUpdates
-            .Where(u => !existingUpdates.Any(e => (u.From?.Name ?? u.To.Name) == e.DependencyName))
+            .Where(u => !existingUpdates.Any(e => u.DependencyName == e.DependencyName))
             .Select(update => new DependencyUpdateSummary(update));
 
         return [.. mergedUpdates, .. newUpdates];

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -461,18 +461,14 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
         """
         [1]:q
         [2]:1
-        [3]:q
         [4]:q
+        [3]:q
         """;
-    private static readonly object[] RegexTestCases =
-    [
-        new object[] { RegexTestString1, 43},
-        new object[] { RegexTestString2, 1},
-        new object[] { RegexTestString3, 1},
-        new object [] { RegexTestString4, 5},
-    ];
 
-    [TestCaseSource(nameof(RegexTestCases))]
+    [TestCase(RegexTestString1, 43)]
+    [TestCase(RegexTestString2, 1)]
+    [TestCase(RegexTestString3, 1)]
+    [TestCase(RegexTestString4, 5)]
     public void ShouldReturnCorrectMaximumIndex(string str, int expectedResult)
     {
         PullRequestBuilder.GetStartingReferenceId(str).Should().Be(expectedResult);

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -10,7 +10,6 @@ using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.Services.Common;
 using Moq;
-using NetTopologySuite.IO;
 using NUnit.Framework;
 using ProductConstructionService.DependencyFlow.WorkItems;
 

--- a/test/ProductConstructionService.DependencyFlow.Tests/SubscriptionOrPullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/SubscriptionOrPullRequestUpdaterTests.cs
@@ -115,7 +115,7 @@ internal abstract class SubscriptionOrPullRequestUpdaterTests : UpdaterTests
 
     internal Build GivenANewBuild(bool addToChannel, (string name, string version, bool nonShipping)[]? assets = null)
     {
-        assets ??= [("quail.eating.ducks", "1.1.0", false), ("quail.eating.ducks", "1.1.0", false), ("quite.expensive.device", "2.0.1", true)];
+        assets ??= [("quail.eating.ducks", "1.1.0", false), ("quite.expensive.device", "2.0.1", true)];
         var build = new Build
         {
             GitHubBranch = SourceBranch,


### PR DESCRIPTION
When we are updating the PR description, we create new link references counting again from `[1]` so the following happens:

![Image](https://github.com/user-attachments/assets/4df96082-6f92-4c9b-a6fe-22e1e38b5731)

So previous and new links both point to the first URL.

Instead, we count the links and add new references (keeping the old ones in case some packages didn't get updated).

Resolves https://github.com/dotnet/arcade-services/issues/4963
