### PR TITLE
Make scenario tests work when git blame uses the `-w` flag

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -447,7 +447,7 @@ public class LocalGitClient : ILocalGitClient
             "blame",
             "--first-parent",
             blameFromCommit != null ? blameFromCommit + '^' : Constants.HEAD,
-            "-slL",
+            "-wslL",
             $"{line},{line}",
             relativeFilePath,
         };

--- a/test/ProductConstructionService.ScenarioTests/CodeFlowScenarioTestBase.cs
+++ b/test/ProductConstructionService.ScenarioTests/CodeFlowScenarioTestBase.cs
@@ -36,7 +36,7 @@ internal class CodeFlowScenarioTestBase : ScenarioTestBase
 
             files.Count.Should().Be(
                 testFiles.Length
-                + 1 // source-manifest.json
+                + 34 // source-manifest.json and eng/common changes
                 + repoUpdates.Length); // 1 git-info file per repo
 
             // Verify source-manifest has changes

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -122,7 +122,7 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
 
                 using (ChangeDirectory(reposFolder.Directory))
                 {
-                    await WaitForNewCommitInPullRequest(TestRepository.VmrTestRepoName, pr, 5);
+                    await WaitForNewCommitInPullRequest(TestRepository.VmrTestRepoName, pr, 4);
                     await CheckForwardFlowGitHubPullRequest(
                         [(TestRepository.TestRepo1Name, (await GitGetCurrentSha()).TrimEnd())],
                         TestRepository.VmrTestRepoName,
@@ -419,7 +419,7 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
                         {
                             try
                             {
-                                await GitHubApi.Git.Reference.Delete(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, $"heads/{targetBranchName}");
+                                await GitHubApi.Git.Reference.Delete(TestParameters.GitHubTestOrg, TestRepository.TestRepo1Name, $"heads/{targetBranchName}");
                             }
                             catch
                             {


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
The root cause of the problem was calculating `lastLastFlows` in repos that only had one. So I had to make those flows happen and adjust some of the tests, but now all of them passed locally
https://github.com/dotnet/arcade-services/issues/4982