### PR TITLE
Do not display current repo in associated repo changes

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -310,7 +310,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
                 $"""
                 {FooterStartMarker}
 
-                ## Associated changes in original repos
+                ## Associated changes in source repos
                 {GenerateUpstreamRepoDiffs(upstreamRepoDiffs)}
                 {FooterEndMarker}
                 """;

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -310,7 +310,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
                 $"""
                 {FooterStartMarker}
 
-                ## Associated changes in original repos:
+                ## Associated changes in original repos
                 {GenerateUpstreamRepoDiffs(upstreamRepoDiffs)}
                 {FooterEndMarker}
                 """;

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -1066,6 +1066,9 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 previousSourceSha = sourceDependency?.Sha;
 
                 upstreamRepoDiffs = await ComputeRepoUpdatesAsync(previousSourceSha, build.Commit);
+
+                // Do not display the diff for which we're flowing back as the diff does not make a whole lot of sense
+                upstreamRepoDiffs = [..upstreamRepoDiffs.Where(diff => diff.RepoUri != subscription.TargetRepository)];
             }
         }
         catch (ConflictInPrBranchException conflictException)

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -175,7 +175,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             [1]: {build.GitHubRepository}/compare/abc123...def456
             [marker]: <> (Start:Footer:CodeFlow PR)
             
-            ## Associated changes in original repos
+            ## Associated changes in source repos
             - https://github.com/foo/bar/compare/oldSha123...newSha789
             - https://github.com/foo/boz/compare/oldSha234...newSha678
             - https://github.com/foo/baz/compare/oldSha345...newSha567

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -175,7 +175,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             [1]: {build.GitHubRepository}/compare/abc123...def456
             [marker]: <> (Start:Footer:CodeFlow PR)
             
-            ## Associated changes in original repos:
+            ## Associated changes in original repos
             - https://github.com/foo/bar/compare/oldSha123...newSha789
             - https://github.com/foo/boz/compare/oldSha234...newSha678
             - https://github.com/foo/baz/compare/oldSha345...newSha567


### PR DESCRIPTION
The SHA is sometimes confusing because technically it shows a diff from the last flow and can be totally different than the delta of the current repo in the VMR (we're often only flowing the delta between the VMR and the repo).

![image](https://github.com/user-attachments/assets/daa797e1-de2b-4306-b373-697093b377e4)

Example: https://github.com/dotnet/diagnostics/issues/5492