### PR TITLE
Stop publishing `artifacts/bin` in internal builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,6 @@ extends:
             publish:
               logs: true
               ${{ if in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/production') }}:
-                artifacts: true
                 manifests: true
           enableTelemetry: true
           enableMicrobuild: false


### PR DESCRIPTION
I noticed we're publishing the `bin/` folder with 2GB of files for no reason - it probably slows down our internal build considerably.

![image](https://github.com/user-attachments/assets/2dc6de47-6d5f-4ce9-85c0-928f92dcfab2)

<!-- https://github.com/dotnet/arcade-services/issues/5008 -->

