### PR TITLE
Increase Redis operation timeout to 10s

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Production.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Production.json
@@ -2,7 +2,7 @@
     "KeyVaultName": "ProductConstructionProd",
     "ConnectionStrings": {
         "queues": "https://productconstructionprod.queue.core.windows.net",
-        "redis": "product-construction-service-redis-prod.redis.cache.windows.net:6380,ssl=true"
+        "redis": "product-construction-service-redis-prod.redis.cache.windows.net:6380,ssl=true,syncTimeout=10000"
     },
     "ManagedIdentityClientId": "e49bf24a-ec75-490b-803b-6fad99d19159",
     "BuildAssetRegistrySqlConnectionString": "Data Source=tcp:maestro-prod.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False; User Id=USER_ID_PLACEHOLDER",

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
@@ -2,7 +2,7 @@
     "KeyVaultName": "ProductConstructionInt",
     "ConnectionStrings": {
         "queues": "https://productconstructionint.queue.core.windows.net",
-        "redis": "product-construction-service-redis-int.redis.cache.windows.net:6380,ssl=true"
+        "redis": "product-construction-service-redis-int.redis.cache.windows.net:6380,ssl=true,syncTimeout=10000"
     },
     "ManagedIdentityClientId": "1d43ba8a-c2a6-4fad-b064-6d8c16fc0745",
     "BuildAssetRegistrySqlConnectionString": "Data Source=tcp:maestro-int-server.database.windows.net,1433; Initial Catalog=BuildAssetRegistry; Authentication=Active Directory Managed Identity; Persist Security Info=False; MultipleActiveResultSets=True; Connect Timeout=30; Encrypt=True; TrustServerCertificate=False; User Id=USER_ID_PLACEHOLDER",


### PR DESCRIPTION
The most frequent exception in the service is RedisTimeout and based on https://stackexchange.github.io/StackExchange.Redis/Timeouts we can increase the timeout for operations that can take longer when the instance is under load.

I checked Azure monitoring for Redis and we do cause a high amount of reads during some spikes when these exceptions occur though we only go to 45% load at most. So maybe this will help.