### PR TITLE
Cache SourceManifests by their commit

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/CommandLineOptions.cs
@@ -182,6 +182,7 @@ public abstract class CommandLineOptions : ICommandLineOptions
         {
             return new VmrInfo(string.Empty, string.Empty);
         });
+        services.TryAddSingleton<IRedisCacheClient, NoOpRedisClient>();
 
         return services;
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/StringUtils.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/StringUtils.cs
@@ -79,4 +79,21 @@ public class StringUtils
         byte[] hashBytes = hasher.GetCurrentHash();
         return Convert.ToHexString(hashBytes);
     }
+    public static bool IsValidLongCommitSha(string input)
+    {
+        if (input == null || input.Length != 40)
+        {
+            return false;
+        }
+
+        foreach (char c in input)
+        {
+            if (!Uri.IsHexDigit(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/IRedisCacheClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IRedisCacheClient.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.DarcLib;
+public interface IRedisCacheClient
+{
+    Task<bool> TrySetAsync<T>(string key, T value, TimeSpan? expiration = null) where T : class;
+    Task<T> TryGetAsync<T>(string key) where T : class;
+    Task<bool> DeleteAsync(string key);
+}
+
+// This no-op redis client is used when DarcLib is invoked through CLI operations where redis is not available.
+public class NoOpRedisClient : IRedisCacheClient
+{
+    public Task<bool> TrySetAsync<T>(string key, T value, TimeSpan? expiration = null) where T : class
+    {
+        return Task.FromResult(false);
+    }
+    public Task<T> TryGetAsync<T>(string key) where T : class
+    {
+        return Task.FromResult<T>(null);
+    }
+    public Task<bool> DeleteAsync(string key)
+    {
+        return Task.FromResult(false);
+    }
+}

--- a/src/Microsoft.DotNet.Darc/DarcLib/IRedisCacheClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IRedisCacheClient.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace Microsoft.DotNet.DarcLib;
+
 public interface IRedisCacheClient
 {
     Task<bool> TrySetAsync<T>(string key, T value, TimeSpan? expiration = null) where T : class;
-    Task<T> TryGetAsync<T>(string key) where T : class;
+    Task<T?> TryGetAsync<T>(string key) where T : class;
     Task<bool> DeleteAsync(string key);
 }
 
@@ -19,9 +21,9 @@ public class NoOpRedisClient : IRedisCacheClient
     {
         return Task.FromResult(false);
     }
-    public Task<T> TryGetAsync<T>(string key) where T : class
+    public Task<T?> TryGetAsync<T>(string key) where T : class
     {
-        return Task.FromResult<T>(null);
+        return Task.FromResult<T?>(null);
     }
     public Task<bool> DeleteAsync(string key)
     {

--- a/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
@@ -196,7 +196,12 @@ public interface IRemote
     /// <summary>
     /// Returns the SourceManifest of a VMR on a given branch
     /// </summary>
-    Task<SourceManifest> GetSourceManifestAsync(string vmrUri, string branch);
+    Task<SourceManifest> GetSourceManifestAsync(string vmrUri, string branchOrCommit);
+
+    /// <summary>
+    /// Returns the SourceManifest of a VMR on a given commit, using cached data if available
+    /// </summary>
+    Task<SourceManifest> GetSourceManifestAtCommitAsync(string vmrUri, string commitSha);
 
     /// <summary>
     /// Returns the list of Source Mappings for a VMR on a given branch

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
@@ -110,13 +110,10 @@ public class SourceManifest : ISourceManifest
             WriteIndented = true,
         };
 
-        var data = new SourceManifestWrapper
-        {
-            Repositories = _repositories,
-            Submodules = _submodules,
-        };
+        // Wrap SourceManifest for serialization
+        var sourceManifestWrapper = ToWrapper();
 
-        return JsonSerializer.Serialize(data, options);
+        return JsonSerializer.Serialize(sourceManifestWrapper, options);
     }
 
     public void Refresh(string sourceManifestPath)
@@ -157,7 +154,15 @@ public class SourceManifest : ISourceManifest
         var wrapper = JsonSerializer.Deserialize<SourceManifestWrapper>(json, options)
             ?? throw new Exception("Failed to deserialize source-manifest.json");
 
-        return new SourceManifest(wrapper.Repositories, wrapper.Submodules);
+        return wrapper.ToSourceManifest();
+    }
+    internal SourceManifestWrapper ToWrapper()
+    {
+        return new SourceManifestWrapper
+        {
+            Repositories = _repositories,
+            Submodules = _submodules,
+        };
     }
 
     public VmrDependencyVersion? GetVersion(string repository)
@@ -178,13 +183,17 @@ public class SourceManifest : ISourceManifest
         return _repositories.FirstOrDefault(r => r.Path == mapppingName)
             ?? throw new Exception($"No repository record named {mapppingName} found");
     }
+}
 
-    /// <summary>
-    /// We use this for JSON deserialization because we're on .NET 6.0 and the ctor deserialization doesn't work.
-    /// </summary>
-    private class SourceManifestWrapper
+/// <summary>
+/// We use this for JSON deserialization because we're on .NET 6.0 and the ctor deserialization doesn't work.
+/// </summary>
+internal class SourceManifestWrapper
+{
+    public ICollection<RepositoryRecord> Repositories { get; init; } = [];
+    public ICollection<SubmoduleRecord> Submodules { get; init; } = [];
+    internal SourceManifest ToSourceManifest()
     {
-        public ICollection<RepositoryRecord> Repositories { get; init; } = [];
-        public ICollection<SubmoduleRecord> Submodules { get; init; } = [];
+        return new SourceManifest(Repositories, Submodules);
     }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Models/VirtualMonoRepo/SourceManifest.cs
@@ -111,7 +111,7 @@ public class SourceManifest : ISourceManifest
         };
 
         // Wrap SourceManifest for serialization
-        var sourceManifestWrapper = ToWrapper();
+        var sourceManifestWrapper = ToWrapper(this);
 
         return JsonSerializer.Serialize(sourceManifestWrapper, options);
     }
@@ -154,16 +154,16 @@ public class SourceManifest : ISourceManifest
         var wrapper = JsonSerializer.Deserialize<SourceManifestWrapper>(json, options)
             ?? throw new Exception("Failed to deserialize source-manifest.json");
 
-        return wrapper.ToSourceManifest();
+        return SourceManifestWrapper.ToSourceManifest(wrapper);
     }
-    internal SourceManifestWrapper ToWrapper()
-    {
-        return new SourceManifestWrapper
+
+    internal static SourceManifestWrapper ToWrapper(SourceManifest sourceManifest) =>
+        new()
         {
-            Repositories = _repositories,
-            Submodules = _submodules,
+            Repositories = sourceManifest._repositories,
+            Submodules = sourceManifest._submodules,
         };
-    }
+
 
     public VmrDependencyVersion? GetVersion(string repository)
     {
@@ -192,8 +192,6 @@ internal class SourceManifestWrapper
 {
     public ICollection<RepositoryRecord> Repositories { get; init; } = [];
     public ICollection<SubmoduleRecord> Submodules { get; init; } = [];
-    internal SourceManifest ToSourceManifest()
-    {
-        return new SourceManifest(Repositories, Submodules);
-    }
+    internal static SourceManifest ToSourceManifest(SourceManifestWrapper sourceManifestWrapper) =>
+        new (sourceManifestWrapper.Repositories, sourceManifestWrapper.Submodules);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
@@ -418,16 +418,18 @@ public sealed class Remote : IRemote
         {
             throw new ArgumentException($"The provided commit SHA `{commitSha}` is either not of length 40 or contains illegal characters.", nameof(commitSha));
         }
-        var cachedManifest = (await _cache.TryGetAsync<SourceManifestWrapper>(commitSha))?.ToSourceManifest();
 
-        if (cachedManifest != null)
+        var cachedManifestData = await _cache.TryGetAsync<SourceManifestWrapper>(commitSha);
+
+        if (cachedManifestData != null)
         {
+            var cachedManifest = SourceManifestWrapper.ToSourceManifest(cachedManifestData);
             return cachedManifest;
         }
 
         var sourceManifest = await GetSourceManifestAsync(vmrUri, commitSha);
 
-        await _cache.TrySetAsync(commitSha, sourceManifest.ToWrapper());
+        await _cache.TrySetAsync(commitSha, SourceManifest.ToWrapper(sourceManifest));
 
         return sourceManifest;
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
@@ -426,10 +426,6 @@ public sealed class Remote : IRemote
         }
 
         var sourceManifest = await GetSourceManifestAsync(vmrUri, commitSha);
-        if (sourceManifest == null)
-        {
-            return null;
-        }
 
         await _cache.TrySetAsync(commitSha, sourceManifest.ToWrapper());
 

--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/BuildsController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/BuildsController.cs
@@ -213,7 +213,7 @@ public class BuildsController : v2019_01_16.Controllers.BuildsController
         try
         {
             IRemote remote = await _factory.CreateRemoteAsync(repository);
-            SourceManifest sourceManifest = await remote.GetSourceManifestAsync(repository, build.Commit);
+            SourceManifest sourceManifest = await remote.GetSourceManifestAtCommitAsync(repository, build.Commit);
             
             var entries = sourceManifest.Repositories
                 .Select(r => new SourceManifestEntry(r.Path, r.RemoteUri, r.CommitSha, r.BarId))

--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/BuildsController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/BuildsController.cs
@@ -219,13 +219,17 @@ public class BuildsController : v2019_01_16.Controllers.BuildsController
                 .Select(r => new SourceManifestEntry(r.Path, r.RemoteUri, r.CommitSha, r.BarId))
                 .OrderBy(e => e.Path)
                 .ToList();
-            
+
             return Ok(entries);
         }
-        catch (Exception ex)
+        catch (DependencyFileNotFoundException)
         {
             // Source manifest may not exist for non-VMR builds
-            return NotFound($"Source manifest not found: {ex.Message}");
+            return NotFound("There is no source manifest associated with this build.");
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, "An unexpected error occurred.");
         }
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionService.Common.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionService.Common.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.Azure.StackExchangeRedis" />

--- a/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionServiceExtension.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionServiceExtension.cs
@@ -77,6 +77,7 @@ public static class ProductConstructionServiceExtension
 
         builder.Services.AddSingleton(redisConfig);
         builder.Services.AddSingleton<IRedisCacheFactory, RedisCacheFactory>();
+        builder.Services.AddSingleton<IRedisCacheClient, RedisCacheClient>();
     }
 
     public static void AddMetricRecorder(this IHostApplicationBuilder builder)

--- a/src/ProductConstructionService/ProductConstructionService.Common/RedisCacheClient.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/RedisCacheClient.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.DarcLib;
+using Microsoft.Extensions.Logging;
+namespace ProductConstructionService.Common;
+
+// <summary>
+// This class acts as a delegate for RedisCache and RedisCacheFactory.
+// It is needed is because DarcLib does not depend on ProductConstructionService and can only access caching through a delegate.
+// </summary>
+internal class RedisCacheClient : IRedisCacheClient
+{
+    private readonly IRedisCacheFactory _factory;
+    private readonly ILogger<RedisCacheClient> _logger;
+
+    public RedisCacheClient(IRedisCacheFactory factory, ILogger<RedisCacheClient> logger)
+    {
+        _factory = factory;
+        _logger = logger;
+    }
+
+    public async Task<T?> TryGetAsync<T>(string key) where T : class
+    {
+        return await _factory.Create<T>(key).TryGetStateAsync();
+    }
+
+    public async Task<bool> TrySetAsync<T>(string key, T value, TimeSpan? expiration = null) where T : class
+    {
+        try
+        {
+            await _factory.Create<T>(key).SetAsync(value, expiration);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to set value in Redis cache for key {Key}", key);
+            return false;
+        }
+        return true;
+    }
+
+    public async Task<bool> DeleteAsync(string key)
+    {
+        return await _factory.Create(key).TryDeleteAsync();
+    }
+}

--- a/src/ProductConstructionService/ProductConstructionService.Common/RedisCacheClient.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/RedisCacheClient.cs
@@ -5,10 +5,10 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.Extensions.Logging;
 namespace ProductConstructionService.Common;
 
-// <summary>
-// This class acts as a delegate for RedisCache and RedisCacheFactory.
-// It is needed is because DarcLib does not depend on ProductConstructionService and can only access caching through a delegate.
-// </summary>
+/// <summary>
+/// This class acts as a delegate for RedisCache and RedisCacheFactory.
+/// It is needed because DarcLib does not depend on ProductConstructionService and can only access caching through a delegate.
+/// </summary>
 internal class RedisCacheClient : IRedisCacheClient
 {
     private readonly IRedisCacheFactory _factory;

--- a/src/ProductConstructionService/ProductConstructionService.Common/RedisCacheClient.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Common/RedisCacheClient.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.DotNet.DarcLib;
 using Microsoft.Extensions.Logging;
+
 namespace ProductConstructionService.Common;
 
 /// <summary>

--- a/test/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/RemoteTests.cs
@@ -101,6 +101,7 @@ public class RemoteTests
             sourceMappingParser.Object,
             Mock.Of<IRemoteFactory>(),
             new AssetLocationResolver(barClient.Object),
+            new NoOpRedisClient(),
             logger);
 
         await remote.MergeDependencyPullRequestAsync("https://github.com/test/test2", mergePullRequest);

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestPolicyFailureNotifierTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestPolicyFailureNotifierTests.cs
@@ -101,6 +101,7 @@ internal class PullRequestPolicyFailureNotifierTests
             SourceMappingParser.Object,
             RemoteFactory.Object,
             new AssetLocationResolver(BarClient.Object),
+            new NoOpRedisClient(),
             NullLogger.Instance);
         RemoteFactory.Setup(m => m.CreateRemoteAsync(It.IsAny<string>())).ReturnsAsync(MockRemote);
 


### PR DESCRIPTION
For a given commit SHA, there can only be one source manifest. This commit adds SHA-based caching for SourceManifest files. It adds a redis cache client in DarcLib that acts as a no-op implementation in Darc, and the standard redis cache when called from the PCS.

https://github.com/dotnet/arcade-services/issues/4737#issue-3018184105