### PR TITLE
Retry on github rate limiting

### DIFF
--- a/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
+++ b/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs
@@ -657,7 +657,8 @@ namespace Microsoft.DotNet.Maestro.Tasks
                 string url = $"/repos/{repoIdentity}/commits/{manifest.Commit}";
                 HttpResponseMessage response = client.GetAsync(url).Result;
 
-                for (int retry = 1; retry <= 5 && response.StatusCode == System.Net.HttpStatusCode.TooManyRequests; retry++)
+                const int MaxRetries = 5;
+                for (int retry = 1; retry <= MaxRetries && response.StatusCode == System.Net.HttpStatusCode.TooManyRequests; retry++)
                 {
                     TimeSpan timeSpan;
                     if (response.Headers.RetryAfter?.Delta != null)
@@ -670,7 +671,8 @@ namespace Microsoft.DotNet.Maestro.Tasks
                     }
                     else
                     {
-                        timeSpan = TimeSpan.FromSeconds(5);
+                        const int defaultRetryAfterSeconds = 10;
+                        timeSpan = TimeSpan.FromSeconds(defaultRetryAfterSeconds);
                     }
 
                     Log.LogMessage(MessageImportance.High,


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/5062

There didn't appear to be any tests for the code modified, hence I don't have any test changes here.  It'd be quite a bit of work to refactor the code to make it possible to inject a mock http client for testing.