### PR TITLE
Use Windows 2022 in the deployment stage

### DIFF
--- a/eng/templates/stages/deploy.yaml
+++ b/eng/templates/stages/deploy.yaml
@@ -113,7 +113,7 @@ stages:
     - updateDatabase
     pool:
       name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals 1es-windows-2019
+      demands: ImageOverride -equals 1es-windows-2022
     variables:
       newDockerImageTag: $[stageDependencies.Build.BuildAndPublishDocker.outputs['DockerTag.newDockerImageTag']]
 


### PR DESCRIPTION
Missed in https://github.com/dotnet/arcade-services/issues/5051

