### PR TITLE
Stop using default azure credential in non-dev envs

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/AzureAuthentication.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/AzureAuthentication.cs
@@ -7,17 +7,24 @@ using Azure.Identity;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.Helpers;
+
 public static class AzureAuthentication
 {
-    public static TokenCredential GetCliCredential() => new ChainedTokenCredential(
+#if DEBUG
+    public static TokenCredential GetCliCredential()
+        => new ChainedTokenCredential(
             new AzureCliCredential(),
-            new DefaultAzureCredential());
+            new DefaultAzureCredential()); // CodeQL [SM05137] This is non-production testing code which is not deployed
+#else
+    public static TokenCredential GetCliCredential()
+        => new AzureCliCredential(); // CodeQL [SM05137] This is non-production testing code which is not deployed
+#endif
 
     public static TokenCredential GetServiceCredential(bool isDevelopment, string? managedIdentityClientId)
     {
         if (isDevelopment)
         {
-            return new DefaultAzureCredential();
+            return new DefaultAzureCredential(); // CodeQL [SM05137] This is non-production testing code which is not deployed
         }
         else
         {


### PR DESCRIPTION
Resolves alerts per guidance https://codeql.microsoft.com/issues/c38d4d50-a31c-491f-8517-6e256744d0b8 - not using default credentials in non-development scenarios
