### PR TITLE
Reconstruct previous flows iteratively until conflicts are cleared

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -238,7 +238,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
 
             // Otherwise, we have a conflicting change in the last backflow PR (before merging)
             // The scenario is described here: https://github.com/dotnet/dotnet/tree/main/docs/VMR-Full-Code-Flow.md#conflicts
-            await RecreatePreviousFlowAndApplyChanges(
+            await RecreatePreviousFlowsAndApplyChanges(
                 mapping,
                 build,
                 targetRepo,
@@ -462,7 +462,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         return [.. exclusions.Select(VmrPatchHandler.GetExclusionRule)];
     }
 
-    private async Task RecreatePreviousFlowAndApplyChanges(
+    private async Task RecreatePreviousFlowsAndApplyChanges(
         SourceMapping mapping,
         Build build,
         ILocalGitRepo targetRepo,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -101,7 +101,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
             _logger.LogInformation("Current flow is in the same direction");
             hasChanges = await SameDirectionFlowAsync(
                 mapping,
-                lastFlow,
+                lastFlows,
                 currentFlow,
                 repo,
                 build,
@@ -139,7 +139,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
     /// The changes that are flown are taken from a simple patch of changes that occurred since the last flow.
     /// </summary>
     /// <param name="mapping">Mapping to flow</param>
-    /// <param name="lastFlow">Last flow that happened for the given mapping</param>
+    /// <param name="lastFlows">Last flows that happened for the given mapping</param>
     /// <param name="currentFlow">Current flow that is being flown</param>
     /// <param name="repo">Local git repo clone of the source repo</param>
     /// <param name="build">Build with assets (dependencies) that is being flown</param>
@@ -150,7 +150,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
     /// <returns>True if there were changes to flow</returns>
     protected abstract Task<bool> SameDirectionFlowAsync(
         SourceMapping mapping,
-        Codeflow lastFlow,
+        LastFlows lastFlows,
         Codeflow currentFlow,
         ILocalGitRepo repo,
         Build build,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -367,7 +367,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
                 targetBranch,
                 cancellationToken);
 
-            // We reconstruct the previous flow's branch
+            // We replay the previous flows, excluding manual changes that might have caused the conflict
             await FlowCodeAsync(
                 previousFlows,
                 currentIsBackflow

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -242,7 +242,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
 
             // This happens when a conflicting change was made in the last backflow PR (before merging)
             // The scenario is described here: https://github.com/dotnet/dotnet/tree/main/docs/VMR-Full-Code-Flow.md#conflicts
-            return await RecreatePreviousFlowAndApplyChanges(
+            return await RecreatePreviousFlowsAndApplyChanges(
                 mapping,
                 build,
                 sourceRepo,
@@ -353,7 +353,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             : null;
     }
 
-    private async Task<bool> RecreatePreviousFlowAndApplyChanges(
+    private async Task<bool> RecreatePreviousFlowsAndApplyChanges(
         SourceMapping mapping,
         Build build,
         ILocalGitRepo sourceRepo,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -404,6 +404,8 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 resetToRemote: false,
                 cancellationToken);
 
+            await vmr.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
+
             // Create a fake previously applied build. We only care about the sha here, because it will get overwritten anyway
             Build previouslyAppliedBuild = new(-1, DateTimeOffset.Now, 0, false, false, lastFlows.LastForwardFlow.RepoSha, [], [], [], [])
             {

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/GitOperationsHelper.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/GitOperationsHelper.cs
@@ -164,7 +164,7 @@ internal class GitOperationsHelper
 
         if (expectedConflictingFile != null)
         {
-            result.StandardOutput.Should().Contain($"CONFLICT (content): Merge conflict in {expectedConflictingFile}");
+            result.StandardOutput.Should().Match($"*Merge conflict in {expectedConflictingFile}*");
         }
 
         if (mergeTheirs.HasValue)

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrCodeFlowUpdatingPRsTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrCodeFlowUpdatingPRsTests.cs
@@ -160,7 +160,7 @@ internal class VmrCodeFlowUpdatingPRsTests : VmrCodeFlowTests
         result.ShouldHaveUpdates();
 
         // Verify that there is a conflict in Foo.txt
-        await GitOperations.VerifyMergeConflict(VmrPath, forwardFlowBranch, "Foo.txt", mergeTheirs: true);
+        await GitOperations.VerifyMergeConflict(VmrPath, forwardFlowBranch, $"src/{Constants.ProductRepoName}/Foo.txt", mergeTheirs: true);
     }
 }
 

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrCodeFlowUpdatingPRsTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/VmrCodeFlowUpdatingPRsTests.cs
@@ -4,8 +4,6 @@
 using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Humanizer;
-using Kusto.Data.Common;
 using NUnit.Framework;
 
 namespace Microsoft.DotNet.DarcLib.Codeflow.Tests;
@@ -123,7 +121,7 @@ internal class VmrCodeFlowUpdatingPRsTests : VmrCodeFlowTests
 
     // This test simulates the following scenario:
     //   1. A change is made directly in the VMR, touching file Foo in repo A
-    //   2. A number forward flows come from repo A but they're not touching the file Foo
+    //   2. A number of forward flows come from repo A but they're not touching the file Foo
     //   3. Finally, Foo is changed in the repo A, and we try to open a FF PR.
     //   4. This fails because there's a conflict in file Foo, so we recreate the last FF and try to apply the diff again,
     //      but it fails again, because the last FF isn't old enough.
@@ -160,7 +158,67 @@ internal class VmrCodeFlowUpdatingPRsTests : VmrCodeFlowTests
         result.ShouldHaveUpdates();
 
         // Verify that there is a conflict in Foo.txt
-        await GitOperations.VerifyMergeConflict(VmrPath, forwardFlowBranch, $"src/{Constants.ProductRepoName}/Foo.txt", mergeTheirs: true);
+        await GitOperations.VerifyMergeConflict(
+            VmrPath,
+            forwardFlowBranch,
+            $"src/{Constants.ProductRepoName}/Foo.txt",
+            mergeTheirs: true);
+
+        var content = await File.ReadAllTextAsync(VmrPath / "src" / Constants.ProductRepoName / "Foo.txt");
+        content.Should().Be("Foo is changed in the repo");
+        content = await File.ReadAllTextAsync(_productRepoVmrFilePath);
+        content.Should().Be("Change three");
+    }
+
+    // This test simulates the following scenario:
+    //   1. A change is made directly in the product repo, touching file Foo
+    //   2. A number of backflows come from the VMR but they're not touching the file Foo
+    //   3. Finally, Foo is changed in the VMR, and we try to open a backflow PR.
+    //   4. This fails because there's a conflict in file Foo, so we recreate the last backflow and try to apply the diff again,
+    //      but it fails again, because the last backflow isn't old enough.
+    //      This test tests that we can go deeper in the past and recreate the flows correctly.
+    [Test]
+    public async Task BackflowWithConflictsDeepInPastTest()
+    {
+        await EnsureTestRepoIsInitialized();
+
+        const string backflowBranch = nameof(BackflowWithConflictsDeepInPastTest);
+
+        // 0. Make a baseline backflow as the pre-prepared repos don't have one
+        await ChangeVmrFileAndFlowIt("Baseline change", backflowBranch);
+        await GitOperations.MergePrBranch(ProductRepoPath, backflowBranch);
+
+        // 1. Create the Foo changes in the product repo
+        await GitOperations.Checkout(ProductRepoPath, "main");
+        await File.WriteAllTextAsync(ProductRepoPath / "Foo.txt", "A new file in the product repo");
+        await GitOperations.CommitAll(ProductRepoPath, "A new file in the product repo");
+
+        // 2. Make a number of backflows
+        await ChangeVmrFileAndFlowIt("Change one", backflowBranch);
+        await GitOperations.MergePrBranch(ProductRepoPath, backflowBranch);
+
+        await ChangeVmrFileAndFlowIt("Change two", backflowBranch);
+        await GitOperations.MergePrBranch(ProductRepoPath, backflowBranch);
+
+        await ChangeVmrFileAndFlowIt("Change three", backflowBranch);
+        await GitOperations.MergePrBranch(ProductRepoPath, backflowBranch);
+
+        // 3. Foo is changed in the VMR, and we try to open a backflow PR
+        await GitOperations.Checkout(VmrPath, "main");
+        await File.WriteAllTextAsync(_productRepoVmrPath / "Foo.txt", "Foo is changed in the VMR");
+        await GitOperations.CommitAll(VmrPath, "Foo is changed in the VMR");
+
+        // 4. Try to open a backflow PR
+        var result = await CallDarcBackflow(Constants.ProductRepoName, ProductRepoPath, backflowBranch);
+        result.ShouldHaveUpdates();
+
+        // Verify that there is a conflict in Foo.txt
+        await GitOperations.VerifyMergeConflict(ProductRepoPath, backflowBranch, "Foo.txt", mergeTheirs: true);
+
+        var content = await File.ReadAllTextAsync(ProductRepoPath / "Foo.txt");
+        content.Should().Be("Foo is changed in the VMR");
+        content = await File.ReadAllTextAsync(_productRepoFilePath);
+        content.Should().Be("Change three");
     }
 }
 


### PR DESCRIPTION
In https://github.com/dotnet/arcade-services/issues/5032, we found out that if we make a series of flows and the last one has a conflict with one that is not the most recent, we need to correctly reconstruct all the previous ones until we find the one that is conflicting with us. Then we base the PR branch before it and let users handle the config.

This PR makes the previous flow reconstructions algorithm work iteratively back until it finds the one where we can apply changes on top.