### PR TITLE
Don't return conflicted files if they're resolved

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/ForwardFlowConflictResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/ForwardFlowConflictResolver.cs
@@ -118,6 +118,7 @@ public class ForwardFlowConflictResolver : CodeFlowConflictResolver, IForwardFlo
                 headBranch);
             try
             {
+                conflictedFiles = [];
                 await vmr.CommitAsync(
                     $"Merge branch {branchToMerge} into {headBranch}",
                     allowEmpty: true,

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/TwoWayCodeflowTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/TwoWayCodeflowTests.cs
@@ -189,6 +189,7 @@ internal class TwoWayCodeflowTests : CodeFlowTests
         await GitOperations.Checkout(VmrPath, "main");
         codeFlowResult = await CallDarcForwardflow(Constants.ProductRepoName, ProductRepoPath, branch: forwardBranchName);
         codeFlowResult.ShouldHaveUpdates();
+        codeFlowResult.ConflictedFiles.Should().BeEmpty();
 
         // 8. Merge the forward flow PR - any conflicts in version files are dealt with automatically
         // The conflict is described in the ForwardFlowConflictResolver class


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
Resolves a bug created in https://github.com/dotnet/arcade-services/issues/4792