### PR TITLE
Speed up conflict PR creation in scenario tests

### DIFF
--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -283,6 +283,9 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
                TestContext.WriteLine("Merging the PR causing the conflict");
                await MergePullRequestAsync(TestRepository.VmrTestRepoName, pr);
 
+               TestContext.WriteLine("Triggering the subscription again (to speed things up)");
+               await TriggerSubscriptionAsync(subscriptionId.Value);
+
                try
                {
                    // The previous PR merged and the pending update should cause a new PR to open
@@ -409,6 +412,9 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
 
                         TestContext.WriteLine("Merging PR causing the conflict");
                         await MergePullRequestAsync(TestRepository.TestRepo1Name, pr);
+
+                        TestContext.WriteLine("Triggering the subscription again (to speed things up)");
+                        await TriggerSubscriptionAsync(subscriptionId.Value);
 
                         try
                         {


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/5120

I can see that the latest failure had the right PR created but the test ended checking a few seconds before it happened.

