### PR TITLE
Assure requested branch exists locally in a clone

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitObjectType.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/GitObjectType.cs
@@ -10,4 +10,5 @@ public enum GitObjectType
     Tree,
     Commit,
     Tag,
+    RemoteRef,
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitClient.cs
@@ -181,6 +181,15 @@ public interface ILocalGitClient
     Task<bool> GitRefExists(string repoPath, string gitRef, CancellationToken cancellationToken = default);
 
     /// <summary>
+    ///     Gets the type of a git reference (branch, tag, commit, remote branch, etc.).
+    /// </summary>
+    /// <param name="repoPath">Path to a git repository</param>
+    /// <param name="gitRef">Git reference to get the type for</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Type of the git reference, or Unknown if the reference doesn't exist</returns>
+    Task<GitObjectType> GetRefType(string repoPath, string gitRef, CancellationToken cancellationToken = default);
+
+    /// <summary>
     ///     Fetches from all remotes.
     /// </summary>
     /// <param name="repoPath">Path to a git repository</param>

--- a/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/ILocalGitRepo.cs
@@ -223,4 +223,12 @@ public interface ILocalGitRepo
     ///     Resolves a conflict in a given file to ours/theirs.
     /// </summary>
     Task ResolveConflict(string filePath, bool ours);
+
+    /// <summary>
+    ///     Gets the type of a git reference (branch, tag, commit, remote branch, etc.).
+    /// </summary>
+    /// <param name="gitRef">Git reference to get the type for</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Type of the git reference, or Unknown if the reference doesn't exist</returns>
+    Task<GitObjectType> GetRefType(string gitRef, CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitRepo.cs
@@ -114,6 +114,9 @@ public class LocalGitRepo(NativePath repoPath, ILocalGitClient localGitClient, I
     public async Task<bool> IsAncestorCommit(string ancestor, string descendant)
         => await _localGitClient.IsAncestorCommit(Path, ancestor, descendant);
 
+    public async Task<GitObjectType> GetRefType(string gitRef, CancellationToken cancellationToken = default)
+        => await _localGitClient.GetRefType(Path, gitRef, cancellationToken);
+
     public override string ToString() => Path;
 }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowConflictResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowConflictResolver.cs
@@ -40,9 +40,7 @@ public abstract class CodeFlowConflictResolver
     {
         _logger.LogInformation("Trying to merge {branchToMerge} into {headBranch}...", branchToMerge, headBranch);
 
-        await repo.CheckoutAsync(branchToMerge); // Create a local branch (without having to track down its remote)
         await repo.CheckoutAsync(headBranch);
-
         var result = await repo.RunGitCommandAsync(["merge", "--no-commit", "--no-ff", branchToMerge], cancellationToken);
         if (result.Succeeded)
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowConflictResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowConflictResolver.cs
@@ -40,7 +40,9 @@ public abstract class CodeFlowConflictResolver
     {
         _logger.LogInformation("Trying to merge {branchToMerge} into {headBranch}...", branchToMerge, headBranch);
 
+        await repo.CheckoutAsync(branchToMerge); // Create a local branch (without having to track down its remote)
         await repo.CheckoutAsync(headBranch);
+
         var result = await repo.RunGitCommandAsync(["merge", "--no-commit", "--no-ff", branchToMerge], cancellationToken);
         if (result.Succeeded)
         {


### PR DESCRIPTION
Fixes a problem where when an already existing PR had existed, we'd never check out the `targetBranch` of a clone.
Later, when we were trying to update its `global.json` and other files, we were not able to retrieve the files from that branch as it didn't exist locally.

This PR makes sure the desired branch is fetched locally in our clone during clone preparation.

#5098