### PR TITLE
Force-remove files when flowing opposite direction

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/ResetOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/ResetOperation.cs
@@ -121,7 +121,7 @@ internal class ResetOperation : Operation
             var targetDir = _vmrInfo.GetRepoSourcesPath(mapping);
             var result = await _processManager.Execute(
                 _processManager.GitExecutable,
-                ["rm", "-r", "-q", "--", .. removalFilters],
+                ["rm", "-r", "-q", "-f", "--", .. removalFilters],
                 workingDir: targetDir);
 
             result.ThrowIfFailed($"Failed to remove files in {targetDir}");

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -327,7 +327,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             .. exclusions,
         ];
 
-        string[] args = ["rm", "-r", "-q"];
+        string[] args = ["rm", "-r", "-q", "-f"];
         if (removalFilters.Count > 0)
         {
             args = [.. args, "--", .. removalFilters];

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -321,7 +321,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
 
         var result = await _processManager.Execute(
             _processManager.GitExecutable,
-            ["rm", "-r", "-q", "--", .. removalFilters],
+            ["rm", "-r", "-q", "-f", "--", .. removalFilters],
             workingDir: _vmrInfo.GetRepoSourcesPath(mapping),
             cancellationToken: cancellationToken);
 


### PR DESCRIPTION
Found an exception in the service:

```
"Problem": Microsoft.DotNet.DarcLib.Helpers.ProcessFailedException at Microsoft.DotNet.DarcLib.Helpers.ProcessExecutionResult.ThrowIfFailed:15,
"Message": Failed to remove files from /mnt/datadir/tmp/sdk
Exit code: 1
Std err:
error: the following file has local modifications:
    src/Microsoft.CodeAnalysis.NetAnalyzers/README.md
(use --cached to keep the file, or -f to force removal)
```

<!-- #0 -->
