### PR TITLE
Handle dirty working tree when checking out clones

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using LibGit2Sharp;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.VirtualMonoRepo;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
@@ -123,7 +123,7 @@ public abstract class CloneManager
         }
         catch (ProcessFailedException e) when (e.Message.Contains("files would be overwritten by checkout"))
         {
-            var result = await _localGitRepo.RunGitCommandAsync(path, ["clean", "-fdqx", "."], cancellationToken);
+            var result = await repo.RunGitCommandAsync(["clean", "-fdqx", "."], cancellationToken);
             result.ThrowIfFailed("Couldn't clean the repository");
             await repo.CheckoutAsync(checkoutRef);
         }


### PR DESCRIPTION
Resolves the following frequent exception:

> Failed to check out 3ac608c737eabed78486ee3fe598e76a889b6015 in /mnt/datadir/tmp/E1F74BB5AEE5F69C
Exit code: 1
Std err:
error: Your local changes to the following files would be overwritten by checkout:
	src/Microsoft.CodeAnalysis.NetAnalyzers/README.md
Please commit your changes or stash them before you switch branches.
Aborting

We do clean after the checkout but if the repo had all the right refs already and was dirty, it does not work