### PR TITLE
Fix formatting of XML/JSON hints in conflict comments

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
@@ -96,9 +96,6 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
                 });
         }
 
-        // Make the XML/JSON part of the quoted block correctly
-        correctContent = correctContent.Replace("\n", "\n> ");
-
         return $"""
                 There are conflicts with the `{subscription.TargetBranch}` branch in this PR. Apart from conflicts in the source files, this means there are unresolved conflicts in the codeflow metadata file `{metadataFile}`.
                 When resolving these, please use the (incoming/ours) version from the PR branch. The correct content should be this:


### PR DESCRIPTION
There is now double-quoting after we've changed how the comment collector works:
https://github.com/dotnet/dotnet/issues/2246#issuecomment-3249507102
