### PR TITLE
Fix Darc subscription creation bugs around target-directory

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Models/PopUps/SubscriptionPopUp.cs
@@ -225,11 +225,10 @@ internal abstract class SubscriptionPopUp<TData> : EditorPopUp where TData : Sub
             }
         }
 
-        // When we disable the source flow, we zero out the source/target directory
+        // When we disable the source flow, we zero out the source directory
         if (!sourceEnabled)
         {
             outputYamlData.SourceDirectory = null;
-            outputYamlData.TargetDirectory = null;
         }
 
         _data.FailureNotificationTags = ParseSetting(outputYamlData.FailureNotificationTags, _data.FailureNotificationTags, false);


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
There was a leftover bug from https://github.com/dotnet/arcade-services/issues/5220 around dependency flow subscription creation, with target-directories