### PR TITLE
Fix how we work with PR branch SHA

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/Model/InProgressPullRequest.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/Model/InProgressPullRequest.cs
@@ -9,10 +9,25 @@ namespace ProductConstructionService.DependencyFlow.Model;
 
 public class InProgressPullRequest : DependencyFlowWorkItem
 {
+    /// <summary>
+    /// URL of the pull request.
+    /// Note: not the regular URL you'd visit in your browser, but the API URL.
+    /// </summary>
     public required string Url { get; set; }
 
+    /// <summary>
+    /// Name of the branch from which changes are proposed.
+    /// </summary>
     public required string HeadBranch { get; set; }
 
+    /// <summary>
+    /// SHA of the head commit of the PR branch.
+    /// </summary>
+    public required string HeadBranchSha { get; set; }
+
+    /// <summary>
+    /// SHA of the commit the update is coming from.
+    /// </summary>
     public required string SourceSha { get; set; }
 
     public bool? CoherencyCheckSuccessful { get; set; }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -1472,10 +1472,18 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
 
             await RegisterSubscriptionUpdateAction(SubscriptionUpdateAction.ApplyingUpdates, update.SubscriptionId);
         }
+
         if (!codeFlowRes.HadUpdates)
         {
             _logger.LogInformation("There were no code-flow updates for subscription {subscriptionId}", subscription.Id);
         }
+
+        // The head branch SHA might have been changed by the latest flow so we need to refresh it before we store it in Redis
+        if (prInfo != null)
+        {
+            prInfo.HeadBranchSha = await _gitClient.GetShaForRefAsync(codeFlowRes.RepoPath, prHeadBranch);
+        }
+
         return codeFlowRes;
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -294,6 +294,12 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
 
         _logger.LogInformation("Pull request {url} is {status}", pr.Url, prInfo.Status);
 
+        // If we're about to update the PR, we should set the default reminder delay,
+        // otherwise we should use the time since the last update to determine when to check again
+        var delay = tryingToUpdate
+            ? DefaultReminderDelay
+            : GetReminderDelay(prInfo.UpdatedAt);
+
         switch (prInfo.Status)
         {
             // If the PR is currently open, then evaluate the merge policies, which will potentially
@@ -326,43 +332,30 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                     case MergePolicyCheckResult.NoPolicies:
                     case MergePolicyCheckResult.FailedToMerge:
                         _logger.LogInformation("Pull request {url} still active (updatable) - keeping tracking it", pr.Url);
+
                         // Check if we think the PR has a conflict
                         if (pr.MergeState == InProgressPullRequestState.Conflict)
                         {
                             // If we think so, check if the PR head branch still has the same commit as the one we remembered.
                             // If it doesn't, we should try to update the PR again, the conflicts might be resolved
-                            var latestCommit = await remote.GetLatestCommitAsync(targetRepository, pr.HeadBranch);
-                            if (latestCommit == pr.SourceSha)
+                            if (pr.HeadBranchSha == prInfo.HeadBranchSha)
                             {
                                 return (PullRequestStatus.InProgressCannotUpdate, prInfo);
                             }
                         }
-                        // If we're about to update the PR, we should set the default reminder delay
-                        await SetPullRequestCheckReminder(
-                            pr,
-                            isCodeFlow,
-                            tryingToUpdate ?
-                                DefaultReminderDelay :
-                                GetReminderDelay(prInfo.UpdatedAt));
+
+                        await SetPullRequestCheckReminder(pr, prInfo, isCodeFlow, delay);
+
                         return (PullRequestStatus.InProgressCanUpdate, prInfo);
 
                     case MergePolicyCheckResult.PendingPolicies:
                         _logger.LogInformation("Pull request {url} still active (not updatable at the moment) - keeping tracking it", pr.Url);
-                        await SetPullRequestCheckReminder(
-                            pr,
-                            isCodeFlow,
-                            tryingToUpdate ?
-                                DefaultReminderDelay :
-                                GetReminderDelay(prInfo.UpdatedAt));
+                        await SetPullRequestCheckReminder(pr, prInfo, isCodeFlow, delay);
+
                         return (PullRequestStatus.InProgressCannotUpdate, prInfo);
 
                     default:
-                        await SetPullRequestCheckReminder(
-                            pr,
-                            isCodeFlow,
-                            tryingToUpdate ?
-                                DefaultReminderDelay :
-                                GetReminderDelay(prInfo.UpdatedAt));
+                        await SetPullRequestCheckReminder(pr, prInfo, isCodeFlow, delay);
                         throw new NotImplementedException($"Unknown merge policy check result {mergePolicyResult}");
                 }
 
@@ -592,6 +585,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 UpdaterId = Id.ToString(),
                 Url = pr.Url,
                 HeadBranch = newBranchName,
+                HeadBranchSha = pr.HeadBranchSha,
                 SourceSha = update.SourceSha,
                 ContainedSubscriptions = [],
                 RequiredUpdates = [],
@@ -600,7 +594,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 CodeFlowDirection = CodeFlowDirection.None,
             };
 
-            await SetPullRequestCheckReminder(inProgressPr, isCodeFlow);
+            await SetPullRequestCheckReminder(inProgressPr, pr, isCodeFlow);
             return pr;
         }
 
@@ -637,6 +631,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 UpdaterId = Id.ToString(),
                 Url = pr.Url,
                 HeadBranch = newBranchName,
+                HeadBranchSha = pr.HeadBranchSha,
                 SourceSha = update.SourceSha,
 
                 ContainedSubscriptions = [subscriptionUpdate],
@@ -662,7 +657,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                     MergePolicyCheckResult.PendingPolicies,
                     pr.Url);
 
-                await SetPullRequestCheckReminder(inProgressPr, isCodeFlow);
+                await SetPullRequestCheckReminder(inProgressPr, pr, isCodeFlow);
                 return pr;
             }
 
@@ -781,7 +776,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
         await darcRemote.UpdatePullRequestAsync(pr.Url, prInfo);
         pr.LastUpdate = DateTime.UtcNow;
         pr.NextBuildsToProcess.Remove(update.SubscriptionId);
-        await SetPullRequestCheckReminder(pr, isCodeFlow: update.SubscriptionType == SubscriptionType.DependenciesAndSources);
+        await SetPullRequestCheckReminder(pr, prInfo, isCodeFlow: update.SubscriptionType == SubscriptionType.DependenciesAndSources);
 
         _logger.LogInformation("Pull request '{prUrl}' updated", pr.Url);
     }
@@ -975,7 +970,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
 
     private static string GetNewBranchName(string targetBranch) => $"darc-{targetBranch}-{Guid.NewGuid()}";
 
-    private async Task SetPullRequestCheckReminder(InProgressPullRequest prState, bool isCodeFlow, TimeSpan reminderDelay)
+    private async Task SetPullRequestCheckReminder(InProgressPullRequest prState, PullRequest prInfo, bool isCodeFlow, TimeSpan reminderDelay)
     {
         var reminder = new PullRequestCheck()
         {
@@ -986,13 +981,14 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
 
         prState.LastCheck = DateTime.UtcNow;
         prState.NextCheck = prState.LastCheck + reminderDelay;
+        prState.HeadBranchSha = prInfo.HeadBranchSha;
 
         await _pullRequestCheckReminders.SetReminderAsync(reminder, reminderDelay, isCodeFlow);
         await _pullRequestState.SetAsync(prState);
     }
 
-   private async Task SetPullRequestCheckReminder(InProgressPullRequest prSate, bool isCodeFlow) =>
-        await SetPullRequestCheckReminder(prSate, isCodeFlow, DefaultReminderDelay);
+   private async Task SetPullRequestCheckReminder(InProgressPullRequest prSate, PullRequest prInfo, bool isCodeFlow) =>
+        await SetPullRequestCheckReminder(prSate, prInfo, isCodeFlow, DefaultReminderDelay);
 
     private async Task ClearAllStateAsync(bool isCodeFlow, bool clearPendingUpdates)
     {
@@ -1131,7 +1127,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 update.SubscriptionId,
                 update.SourceSha);
 
-            await SetPullRequestCheckReminder(pr, isCodeFlow: true);
+            await SetPullRequestCheckReminder(pr, prInfo!, isCodeFlow: true);
             await _pullRequestUpdateReminders.UnsetReminderAsync(isCodeFlow: true);
             return;
         }
@@ -1141,7 +1137,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
             _logger.LogInformation("Failed to update pr {url} for {subscription} because it is blocked from future updates",
                 pr.Url,
                 update.SubscriptionId);
-            await SetPullRequestCheckReminder(pr, isCodeFlow: true);
+            await SetPullRequestCheckReminder(pr, prInfo!, isCodeFlow: true);
             await _pullRequestUpdateReminders.UnsetReminderAsync(isCodeFlow: true);
             return;
         }
@@ -1305,7 +1301,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
             pullRequest.LastUpdate = DateTime.UtcNow;
             pullRequest.MergeState = InProgressPullRequestState.Mergeable;
             pullRequest.NextBuildsToProcess.Remove(update.SubscriptionId);
-            await SetPullRequestCheckReminder(pullRequest, isCodeFlow: true);
+            await SetPullRequestCheckReminder(pullRequest, prInfo!, isCodeFlow: true);
             await _pullRequestUpdateReminders.UnsetReminderAsync(isCodeFlow: true);
         }
     }
@@ -1349,6 +1345,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 UpdaterId = Id.ToString(),
                 Url = pr.Url,
                 HeadBranch = prBranch,
+                HeadBranchSha = pr.HeadBranchSha,
                 SourceSha = update.SourceSha,
                 ContainedSubscriptions =
                 [
@@ -1374,7 +1371,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 pr.Url);
 
             inProgressPr.LastUpdate = DateTime.UtcNow;
-            await SetPullRequestCheckReminder(inProgressPr, isCodeFlow: true);
+            await SetPullRequestCheckReminder(inProgressPr, pr, isCodeFlow: true);
             await _pullRequestUpdateReminders.UnsetReminderAsync(isCodeFlow: true);
 
             _logger.LogInformation("Code flow pull request created: {prUrl}", pr.Url);
@@ -1501,25 +1498,9 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                 prHeadBranch),
             CommentType.Warning);
 
-        // If the headBranch gets updated, we will retry to update it with previously conflicting changes. If these changes still cause a conflict, we should update the
-        // InProgressPullRequest with the latest commit from the remote branch
-        var remoteCommit = pr.SourceSha;
-        var remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
-        try
-        {
-            remoteCommit = await remote.GetLatestCommitAsync(subscription.TargetRepository, pr.HeadBranch);
-        }
-        catch (Exception e)
-        {
-            _logger.LogWarning("Couldn't get latest commit of {repo}/{commit}. Failed with exception {message}",
-                subscription.TargetRepository,
-                pr.HeadBranch,
-                e.Message);
-        }
-
         pr.MergeState = InProgressPullRequestState.Conflict;
-        pr.SourceSha = remoteCommit;
         pr.NextBuildsToProcess[update.SubscriptionId] = update.BuildId;
+
         await _pullRequestState.SetAsync(pr);
         await _pullRequestUpdateReminders.SetReminderAsync(update, DefaultReminderDelay, isCodeFlow: true);
         await _pullRequestCheckReminders.UnsetReminderAsync(isCodeFlow: true);

--- a/test/ProductConstructionService.DependencyFlow.Tests/MergePolicyEvaluationTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/MergePolicyEvaluationTests.cs
@@ -6,7 +6,6 @@ using Maestro.Data.Models;
 using Maestro.MergePolicies;
 using Maestro.MergePolicyEvaluation;
 using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using NUnit.Framework;
@@ -93,18 +92,18 @@ internal class MergePolicyEvaluationTests : PullRequestUpdaterTests
         {
             ExpectPrMetadataToBeUpdated();
 
-            MergePolicyEvaluationResults mergePolicyEvaluationResults = new MergePolicyEvaluationResults(
-                new List<MergePolicyEvaluationResult> { AlwaysFailMergePolicyResult, DeprecatedMergePolicyResult }.AsReadOnly(),
-                newBuild.Commit);
+            var mergePolicyEvaluationResults = new MergePolicyEvaluationResults(
+                [ AlwaysFailMergePolicyResult, DeprecatedMergePolicyResult ],
+                InProgressPrHeadBranchSha);
 
             SetState(Subscription, mergePolicyEvaluationResults);
 
             //todo find a way to inject a real mergepolicyevaluator
             await WhenUpdateAssetsAsyncIsCalled(newBuild);
 
-            MergePolicyEvaluationResults expectedMergePolicyEvaluationResults = new MergePolicyEvaluationResults(
-                new List<MergePolicyEvaluationResult> { AlwaysFailMergePolicyResult }.AsReadOnly(),
-                newBuild.Commit);
+            var expectedMergePolicyEvaluationResults = new MergePolicyEvaluationResults(
+                [ AlwaysFailMergePolicyResult ],
+                InProgressPrHeadBranchSha);
 
             ThenShouldHaveCachedMergePolicyResults(expectedMergePolicyEvaluationResults);
 

--- a/test/ProductConstructionService.DependencyFlow.Tests/PendingCodeFlowUpdatesTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PendingCodeFlowUpdatesTests.cs
@@ -102,7 +102,7 @@ internal class PendingCodeFlowUpdatesTests : PendingUpdatePullRequestUpdaterTest
             AndShouldHaveInProgressPullRequestState(
                 oldBuild,
                 nextBuildToProcess: newBuild.Id,
-                overwriteBuildCommit: ConflictPRRemoteSha,
+                headBranchSha: ConflictPRRemoteSha,
                 prState: InProgressPullRequestState.Conflict);
         }
     }
@@ -128,7 +128,7 @@ internal class PendingCodeFlowUpdatesTests : PendingUpdatePullRequestUpdaterTest
             AndShouldHaveInProgressPullRequestState(
                 build,
                 nextBuildToProcess: build.Id,
-                overwriteBuildCommit: ConflictPRRemoteSha,
+                headBranchSha: ConflictPRRemoteSha,
                 prState: InProgressPullRequestState.Conflict);
         }
     }
@@ -147,14 +147,14 @@ internal class PendingCodeFlowUpdatesTests : PendingUpdatePullRequestUpdaterTest
         Build oldBuild = GivenANewBuild(true);
         Build newBuild = GivenANewBuild(true);
         newBuild.Commit = "sha123456";
-        using (WithExistingCodeFlowPullRequest(oldBuild, canUpdate: true, prAlreadyHasConflict: true, latestCommitToReturn: "sha4444", willFlowNewBuild: true))
+        using (WithExistingCodeFlowPullRequest(oldBuild, canUpdate: true, prAlreadyHasConflict: true, headBranchSha: "sha4444", willFlowNewBuild: true))
         {
             ExpectPrMetadataToBeUpdated();
             await WhenProcessPendingUpdatesAsyncIsCalled(newBuild, isCodeFlow: true);
             ThenCodeShouldHaveBeenFlownForward(newBuild);
             AndShouldHaveNoPendingUpdateState();
             AndShouldHavePullRequestCheckReminder();
-            AndShouldHaveInProgressPullRequestState(newBuild);
+            AndShouldHaveInProgressPullRequestState(newBuild, headBranchSha: "sha4444");
         }
     }
 }

--- a/test/ProductConstructionService.DependencyFlow.Tests/PendingCodeFlowUpdatesTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PendingCodeFlowUpdatesTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Maestro.Data.Models;
-using Microsoft.DotNet.DarcLib.Helpers;
 using NUnit.Framework;
 using ProductConstructionService.DependencyFlow.Model;
 

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestCommentBuilderTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestCommentBuilderTests.cs
@@ -143,7 +143,8 @@ public class PullRequestCommentBuilderTests
             UpdaterId = new BatchedPullRequestUpdaterId(FakeRepoName, "main").Id,
             Url = url,
             HeadBranch = "pr.head.branch",
-            SourceSha = "pr.head.sha",
+            HeadBranchSha = "pr.head.sha",
+            SourceSha = "update.source.sha",
             ContainedSubscriptions = containedSubscriptions,
             SourceRepoNotified = false
         };
@@ -167,7 +168,8 @@ public class PullRequestCommentBuilderTests
             UpdaterId = new BatchedPullRequestUpdaterId(FakeRepoName, "main").Id,
             Url = url,
             HeadBranch = "pr.head.branch",
-            SourceSha = "pr.head.sha",
+            HeadBranchSha = "pr.head.sha",
+            SourceSha = "update.source.sha",
             ContainedSubscriptions = containedSubscriptions,
             SourceRepoNotified = false
         };

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -31,7 +31,8 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
 {
     private const long InstallationId = 1174;
     protected const string InProgressPrUrl = "https://github.com/owner/repo/pull/10";
-    protected string? InProgressPrHeadBranch { get; private set; } = "pr.head.branch";
+    protected string InProgressPrHeadBranch { get; private set; } = "pr.head.branch";
+    protected string InProgressPrHeadBranchSha { get; private set; } = "pr.head.branch.sha";
     protected const string ConflictPRRemoteSha = "sha3333";
 
     private Mock<IPcsVmrBackFlower> _backFlower = null!;
@@ -396,6 +397,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                 new PullRequest
                 {
                     HeadBranch = InProgressPrHeadBranch,
+                    HeadBranchSha = InProgressPrHeadBranchSha,
                     BaseBranch = TargetBranch,
                     Status = prStatus,
                 });
@@ -484,8 +486,8 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
             {
                 Status = prStatus,
                 HeadBranch = InProgressPrHeadBranch,
+                HeadBranchSha = InProgressPrHeadBranchSha,
                 BaseBranch = TargetBranch,
-                HeadBranchSha = "sha123456",
             });
 
         if (willFlowNewBuild
@@ -520,11 +522,11 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
 
         if (flowerWillHaveConflict || prAlreadyHasConflict)
         {
-            remote
-                .Setup(x => x.GetLatestCommitAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync(latestCommitToReturn);
+            // TODO - this doesn't get called anymore but I guess we should mock something else?
+            //remote
+            //    .Setup(x => x.GetLatestCommitAsync(It.IsAny<string>(), It.IsAny<string>()))
+            //    .ReturnsAsync(latestCommitToReturn);
         }
-
 
         if (mockMergePolicyEvaluator)
         {
@@ -546,8 +548,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                     It.IsAny<IRemote>(),
                     It.IsAny<IReadOnlyList<MergePolicyDefinition>>(),
                     It.IsAny<MergePolicyEvaluationResults?>(),
-                    It.IsAny<string>()
-                    ))
+                    It.IsAny<string>()))
                 .ReturnsAsync(results.Results);
 
             if (prStatus == PrStatus.Open)
@@ -686,6 +687,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
         {
             UpdaterId = GetPullRequestUpdaterId().ToString(),
             HeadBranch = InProgressPrHeadBranch,
+            HeadBranchSha = InProgressPrHeadBranchSha,
             SourceSha = overwriteBuildCommit ?? forBuild.Commit,
             ContainedSubscriptions =
             [

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -260,6 +260,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
             {
                 Url = url,
                 HeadBranch = InProgressPrHeadBranch,
+                HeadBranchSha = InProgressPrHeadBranchSha,
                 BaseBranch = TargetBranch,
                 Status = PrStatus.Open,
             });

--- a/test/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsForCodeFlowTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsForCodeFlowTests.cs
@@ -45,6 +45,7 @@ internal class UpdateAssetsForCodeFlowTests : UpdateAssetsPullRequestUpdaterTest
             UpdaterId = GetPullRequestUpdaterId(Subscription).Id,
             Url = VmrPullRequestUrl,
             HeadBranch = InProgressPrHeadBranch,
+            HeadBranchSha = InProgressPrHeadBranchSha,
             SourceSha = build.Commit,
             ContainedSubscriptions =
             [
@@ -172,6 +173,7 @@ internal class UpdateAssetsForCodeFlowTests : UpdateAssetsPullRequestUpdaterTest
                 UpdaterId = GetPullRequestUpdaterId(Subscription).Id,
                 Url = VmrPullRequestUrl,
                 HeadBranch = InProgressPrHeadBranch,
+                HeadBranchSha = InProgressPrHeadBranchSha,
                 SourceSha = build2.Commit,
                 ContainedSubscriptions =
                 [


### PR DESCRIPTION
- We store the PR head branch SHA in a dedicated field
- We fetch the head branch SHA when we are fetching the PR information (so less queries to GitHub)
- We update the SHA in Redis accordingly so that later it can be used by merge policies or the codeflow logic where until now we were "abusing" the source SHA field for that.

https://github.com/dotnet/arcade-services/issues/5046
