### PR TITLE
Set C# version to 12.0 in `Directory.Build.props`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     -->
     <NoWarn>$(NoWarn);MSB3270</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <IsShipping>false</IsShipping>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <!-- 


### PR DESCRIPTION
Visual Studio was recommending C# 14 features which would not build in CI and in the docker container that has .NET 8

