### PR TITLE
Allow keeping conflicts in working tree

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/CodeFlowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/CodeFlowOperation.cs
@@ -126,6 +126,7 @@ internal abstract class CodeFlowOperation(
                     tmpTargetBranch,
                     tmpHeadBranch,
                     headBranchExisted: false,
+                    keepConflicts: true,
                     forceUpdate: false,
                     cancellationToken);
             }
@@ -232,10 +233,12 @@ internal abstract class CodeFlowOperation(
             ignoreLineEndings: false,
             cancellationToken);
 
-        foreach (VmrIngestionPatch patch in patches)
-        {
-            await _patchHandler.ApplyPatch(patch, targetRepo.Path, removePatchAfter: true, cancellationToken: cancellationToken);
-        }
+        await _patchHandler.ApplyPatches(
+            patches,
+            targetRepo.Path,
+            removePatchAfter: true,
+            keepConflicts: true,
+            cancellationToken: cancellationToken);
     }
 
     private async Task CleanUp(

--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/ResetOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/ResetOperation.cs
@@ -140,6 +140,7 @@ internal class ResetOperation : Operation
                 targetSha,
                 codeFlowParameters,
                 resetToRemoteWhenCloningRepo: false,
+                keepConflicts: false,
                 CancellationToken.None);
 
             _logger.LogInformation("Successfully reset {mapping} to {sha}", mappingName, targetSha);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowConflictResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowConflictResolver.cs
@@ -154,8 +154,8 @@ public abstract class CodeFlowConflictResolver
                 patches[0],
                 isForwardFlow ? vmr.Path : repo.Path,
                 removePatchAfter: true,
-                reverseApply: false,
-                cancellationToken);
+                keepConflicts: false,
+                cancellationToken: cancellationToken);
             _logger.LogInformation("Successfully auto-resolved a conflict in {filePath} based on a crossing flow", conflictedFile);
             return true;
         }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowVmrUpdater.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,14 +27,15 @@ public interface ICodeFlowVmrUpdater
     /// In some cases, we set the source-manifest json current sha to the git empty commit.
     /// When this happens, this parameter should be used to generate the correct commit message</param>
     /// <param name="additionalFileExclusions">List of files we don't want to update</param>
-    /// <param name="resetToRemoteWhenCloningRepo">Weather or not to reset the branch to remote during cloning.
-    /// Should be set to false when cloning a specific sha</param>
+    /// <param name="resetToRemoteWhenCloningRepo">Weather or not to reset the branch to remote during cloning. Should be set to false when cloning a specific sha</param>
+    /// <param name="keepConflicts">Preserve file changes with conflict markers when conflicts occur</param>
     Task<bool> UpdateRepository(
         SourceMapping mapping,
         Build build,
         string[]? additionalFileExclusions = null,
         string? fromSha = null,
         bool resetToRemoteWhenCloningRepo = false,
+        bool keepConflicts = false,
         CancellationToken cancellationToken = default);
 }
 
@@ -92,6 +92,7 @@ public class CodeFlowVmrUpdater : VmrManagerBase, ICodeFlowVmrUpdater
         string[]? additionalFileExclusions = null,
         string? fromSha = null,
         bool resetToRemoteWhenCloningRepo = false,
+        bool keepConflicts = false,
         CancellationToken cancellationToken = default)
     {
         await _dependencyTracker.RefreshMetadataAsync();
@@ -163,6 +164,7 @@ public class CodeFlowVmrUpdater : VmrManagerBase, ICodeFlowVmrUpdater
                 currentVersion.Sha,
                 commitMessage,
                 restoreVmrPatches: false,
+                keepConflicts,
                 new CodeFlowParameters(
                     AdditionalRemotes: [.. remotes.Select(r => new AdditionalRemote(mapping.Name, r))],
                     TpnTemplatePath: _vmrInfo.ThirdPartyNoticesTemplateFullPath,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrPatchHandler.cs
@@ -16,6 +16,15 @@ public interface IVmrPatchHandler
         VmrIngestionPatch patch,
         NativePath targetDirectory,
         bool removePatchAfter,
+        bool keepConflicts,
+        bool reverseApply = false,
+        CancellationToken cancellationToken = default);
+
+    Task ApplyPatches(
+        IEnumerable<VmrIngestionPatch> patches,
+        NativePath targetDirectory,
+        bool removePatchAfter,
+        bool keepConflicts,
         bool reverseApply = false,
         CancellationToken cancellationToken = default);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/IVmrUpdater.cs
@@ -16,11 +16,14 @@ public interface IVmrUpdater
     /// <param name="mappingName">Name of a repository mapping</param>
     /// <param name="targetRevision">Revision (commit SHA, branch, tag..) onto which to synchronize, leave empty for HEAD</param>
     /// <param name="codeFlowParameters">Record containing parameters for VMR updates</param>
+    /// <param name="resetToRemoteWhenCloningRepo">Whether to reset local clone to remote state when cloning the repo</param>
+    /// <param name="keepConflicts">Preserve file changes with conflict markers when conflicts occur</param>
     /// <returns>True if the repository was updated, false if it was already up to date</returns>
     Task<bool> UpdateRepository(
         string mappingName,
         string? targetRevision,
         CodeFlowParameters codeFlowParameters,
         bool resetToRemoteWhenCloningRepo = false,
+        bool keepConflicts = false,
         CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -32,6 +32,7 @@ public interface IVmrCodeFlower
         string targetBranch,
         string headBranch,
         bool headBranchExisted,
+        bool keepConflicts,
         bool forceUpdate,
         CancellationToken cancellationToken = default);
 }
@@ -102,6 +103,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
         string targetBranch,
         string headBranch,
         bool headBranchExisted,
+        bool keepConflicts,
         bool forceUpdate,
         CancellationToken cancellationToken = default)
     {
@@ -139,6 +141,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
                 targetBranch,
                 headBranch,
                 headBranchExisted,
+                keepConflicts,
                 forceUpdate,
                 cancellationToken);
         }
@@ -189,6 +192,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
         string targetBranch,
         string headBranch,
         bool headBranchExisted,
+        bool keepConflicts,
         bool forceUpdate,
         CancellationToken cancellationToken);
 
@@ -418,6 +422,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
                 targetBranch,
                 headBranch,
                 headBranchExisted: true, // Head branch was created when we rewound to the previous flow
+                keepConflicts: false,
                 forceUpdate,
                 cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrInitializer.cs
@@ -184,6 +184,7 @@ public class VmrInitializer : VmrManagerBase, IVmrInitializer
             Constants.EmptyGitObject,
             commitMessage,
             restoreVmrPatches: false,
+            keepConflicts: false,
             codeFlowParameters,
             cancellationToken: cancellationToken);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrManagerBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.Extensions.Logging;
 
@@ -59,6 +60,7 @@ public abstract class VmrManagerBase
         string fromRevision,
         string commitMessage,
         bool restoreVmrPatches,
+        bool keepConflicts,
         CodeFlowParameters codeFlowParameters,
         string[]? additionalFileExclusions = null,
         CancellationToken cancellationToken = default)
@@ -74,11 +76,12 @@ public abstract class VmrManagerBase
             cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 
-        foreach (var patch in patches)
-        {
-            await _patchHandler.ApplyPatch(patch, _vmrInfo.VmrPath, removePatchAfter: true, reverseApply: false, cancellationToken);
-            cancellationToken.ThrowIfCancellationRequested();
-        }
+        await _patchHandler.ApplyPatches(
+            patches,
+            _vmrInfo.VmrPath,
+            removePatchAfter: true,
+            keepConflicts: keepConflicts,
+            cancellationToken: cancellationToken);
 
         _dependencyInfo.UpdateDependencyVersion(update);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrUpdater.cs
@@ -61,6 +61,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         string? targetRevision,
         CodeFlowParameters codeFlowParameters,
         bool resetToRemoteWhenCloningRepo = false,
+        bool keepConflicts = false,
         CancellationToken cancellationToken = default)
     {
         await _dependencyTracker.RefreshMetadataAsync();
@@ -82,6 +83,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
                 restoreVmrPatches: true,
                 codeFlowParameters,
                 resetToRemoteWhenCloningRepo,
+                keepConflicts,
                 cancellationToken);
             return true;
         }
@@ -97,6 +99,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
         bool restoreVmrPatches,
         CodeFlowParameters codeFlowParameters,
         bool resetToRemoteWhenCloningRepo = false,
+        bool keepConflicts = false,
         CancellationToken cancellationToken = default)
     {
         VmrDependencyVersion currentVersion = _dependencyTracker.GetDependencyVersion(update.Mapping)
@@ -160,6 +163,7 @@ public class VmrUpdater : VmrManagerBase, IVmrUpdater
             currentVersion.Sha,
             commitMessage,
             restoreVmrPatches,
+            keepConflicts,
             codeFlowParameters,
             cancellationToken: cancellationToken);
     }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
@@ -25,15 +25,14 @@ internal interface IPcsVmrBackFlower : IVmrBackFlower
     /// <param name="subscription">Subscription to flow</param>
     /// <param name="build">Build to flow</param>
     /// <param name="targetBranch">Target branch to make the changes on</param>
-    /// <returns>
-    ///     Boolean whether there were any changes to be flown
-    ///     and a path to the local repo where the new branch is created
-    ///  </returns>
+    /// <param name="keepConflicts">Preserve file changes with conflict markers when conflicts occur</param>
+    /// <param name="forceUpdate">Force the update to be performed</param>
     Task<CodeFlowResult> FlowBackAsync(
         Subscription subscription,
         Build build,
         string targetBranch,
-        bool forceApply,
+        bool keepConflicts,
+        bool forceUpdate,
         CancellationToken cancellationToken = default);
 }
 
@@ -74,6 +73,7 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
         Subscription subscription,
         Build build,
         string targetBranch,
+        bool keepConflicts,
         bool forceUpdate,
         CancellationToken cancellationToken = default)
     {
@@ -94,6 +94,7 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
             subscription.TargetBranch,
             targetBranch,
             headBranchExisted,
+            keepConflicts,
             forceUpdate,
             cancellationToken);
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
@@ -22,11 +22,13 @@ internal interface IPcsVmrForwardFlower
     /// <param name="subscription">Subscription to flow</param>
     /// <param name="build">Build to flow</param>
     /// <param name="headBranch">Branch to flow to (or to create)</param>
+    /// <param name="keepConflicts">Preserve file changes with conflict markers when conflicts occur</param>
     /// <param name="forceUpdate">Force the update to be performed</param>
     Task<CodeFlowResult> FlowForwardAsync(
         Subscription subscription,
         Build build,
         string headBranch,
+        bool keepConflicts,
         bool forceUpdate,
         CancellationToken cancellationToken = default);
 }
@@ -62,6 +64,7 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
         Subscription subscription,
         Build build,
         string headBranch,
+        bool keepConflicts,
         bool forceUpdate,
         CancellationToken cancellationToken = default)
     {
@@ -79,6 +82,7 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
             subscription.TargetBranch,
             headBranch,
             subscription.TargetRepository,
+            keepConflicts,
             forceUpdate,
             cancellationToken);
     }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdater.cs
@@ -1416,6 +1416,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                     subscription,
                     build,
                     prHeadBranch,
+                    keepConflicts: false,
                     forceUpdate,
                     cancellationToken: default);
             }
@@ -1425,6 +1426,7 @@ internal abstract class PullRequestUpdater : IPullRequestUpdater
                     subscription,
                     build,
                     prHeadBranch,
+                    keepConflicts: false,
                     forceUpdate,
                     cancellationToken: default);
             }

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/CodeFlowTestsBase.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/CodeFlowTestsBase.cs
@@ -232,6 +232,7 @@ internal abstract class CodeFlowTestsBase
             excludedAssets,
             "main",
             branch,
+            keepConflicts: false,
             forceUpdate: forceUpdate,
             cancellationToken: _cancellationToken.Token);
 
@@ -262,6 +263,7 @@ internal abstract class CodeFlowTestsBase
             "main",
             branch,
             VmrPath,
+            keepConflicts: false,
             forceUpdate,
             cancellationToken: _cancellationToken.Token);
 

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -138,7 +138,7 @@ public class VmrPatchHandlerTests
         _fileSystem.SetReturnsDefault(Mock.Of<IFileInfo>(x => x.Exists == true && x.Length == 1243));
 
         // Act
-        await _patchHandler.ApplyPatch(patch, _vmrInfo.Object.VmrPath, true, false, new CancellationToken());
+        await _patchHandler.ApplyPatch(patch, _vmrInfo.Object.VmrPath, true, false, false, new CancellationToken());
 
         // Verify
         VerifyGitCall(new List<string>
@@ -734,7 +734,7 @@ public class VmrPatchHandlerTests
         _fileSystem.SetReturnsDefault(Mock.Of<IFileInfo>(x => x.Exists == true && x.Length == 1243));
 
         // Act
-        await _patchHandler.ApplyPatch(patch, _vmrInfo.Object.VmrPath, false, false, new CancellationToken());
+        await _patchHandler.ApplyPatch(patch, _vmrInfo.Object.VmrPath, false, false, false, new CancellationToken());
 
         // Verify
         VerifyGitCall(new List<string>

--- a/test/ProductConstructionService.DependencyFlow.Tests/Mocks/Disposable.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/Mocks/Disposable.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace ProductConstructionService.DependencyFlow.Tests;
+namespace ProductConstructionService.DependencyFlow.Tests.Mocks;
 
 internal class Disposable : IDisposable
 {

--- a/test/ProductConstructionService.DependencyFlow.Tests/Mocks/MockRedisCache.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/Mocks/MockRedisCache.cs
@@ -1,9 +1,13 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using ProductConstructionService.Common;
 
-namespace ProductConstructionService.DependencyFlow.Tests;
+namespace ProductConstructionService.DependencyFlow.Tests.Mocks;
 
 internal class MockRedisCache : IRedisCache
 {

--- a/test/ProductConstructionService.DependencyFlow.Tests/Mocks/MockRedisCacheFactory.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/Mocks/MockRedisCacheFactory.cs
@@ -4,7 +4,7 @@
 using Moq;
 using ProductConstructionService.Common;
 
-namespace ProductConstructionService.DependencyFlow.Tests;
+namespace ProductConstructionService.DependencyFlow.Tests.Mocks;
 
 internal class MockRedisCacheFactory : IRedisCacheFactory
 {

--- a/test/ProductConstructionService.DependencyFlow.Tests/Mocks/MockReminderManager.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/Mocks/MockReminderManager.cs
@@ -3,7 +3,7 @@
 
 using ProductConstructionService.WorkItems;
 
-namespace ProductConstructionService.DependencyFlow.Tests;
+namespace ProductConstructionService.DependencyFlow.Tests.Mocks;
 
 internal abstract class MockReminderManager
 {

--- a/test/ProductConstructionService.DependencyFlow.Tests/Mocks/MockReminderManagerFactory.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/Mocks/MockReminderManagerFactory.cs
@@ -3,7 +3,7 @@
 
 using ProductConstructionService.WorkItems;
 
-namespace ProductConstructionService.DependencyFlow.Tests;
+namespace ProductConstructionService.DependencyFlow.Tests.Mocks;
 
 internal class MockReminderManagerFactory : IReminderManagerFactory
 {

--- a/test/ProductConstructionService.DependencyFlow.Tests/Mocks/VerifyableMockRepository.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/Mocks/VerifyableMockRepository.cs
@@ -3,7 +3,7 @@
 
 using Moq;
 
-namespace ProductConstructionService.DependencyFlow.Tests;
+namespace ProductConstructionService.DependencyFlow.Tests.Mocks;
 
 public class VerifyableMockRepository : MockRepository
 {

--- a/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -20,6 +20,7 @@ using Microsoft.VisualStudio.Services.Common;
 using Moq;
 using NUnit.Framework;
 using ProductConstructionService.DependencyFlow.Model;
+using ProductConstructionService.DependencyFlow.Tests.Mocks;
 using ProductConstructionService.DependencyFlow.WorkItems;
 
 using Asset = Maestro.Data.Models.Asset;
@@ -168,7 +169,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                     new()
                     {
                         BaseBranch = TargetBranch,
-                        HeadBranch = InProgressPrHeadBranch
+                        HeadBranch = InProgressPrHeadBranch,
                     }
                 },
                 options => options.Excluding(pr => pr.Title).Excluding(pr => pr.Description));
@@ -205,6 +206,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                 It.Is<Microsoft.DotNet.ProductConstructionService.Client.Models.Build>(b => b.Id == build.Id && b.Commit == build.Commit),
                 It.IsAny<string>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
 
@@ -220,6 +222,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                 It.Is<Microsoft.DotNet.ProductConstructionService.Client.Models.Subscription>(s => s.Id == Subscription.Id),
                 It.Is<Microsoft.DotNet.ProductConstructionService.Client.Models.Build>(b => b.Id == build.Id && b.Commit == build.Commit),
                 It.IsAny<string>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -517,6 +520,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                     It.IsAny<Microsoft.DotNet.ProductConstructionService.Client.Models.Subscription>(),
                     It.IsAny<Microsoft.DotNet.ProductConstructionService.Client.Models.Build>(),
                     It.IsAny<string>(),
+                    It.IsAny<bool>(),
                     It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(() => new ConflictInPrBranchException(

--- a/test/ProductConstructionService.DependencyFlow.Tests/TestsWithMocks.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/TestsWithMocks.cs
@@ -3,6 +3,7 @@
 
 using Moq;
 using NUnit.Framework;
+using ProductConstructionService.DependencyFlow.Tests.Mocks;
 
 namespace ProductConstructionService.DependencyFlow.Tests;
 

--- a/test/ProductConstructionService.DependencyFlow.Tests/UpdaterTests.cs
+++ b/test/ProductConstructionService.DependencyFlow.Tests/UpdaterTests.cs
@@ -13,6 +13,7 @@ using Moq;
 using NUnit.Framework;
 using ProductConstructionService.Common;
 using ProductConstructionService.DependencyFlow.Model;
+using ProductConstructionService.DependencyFlow.Tests.Mocks;
 using ProductConstructionService.WorkItems;
 
 namespace ProductConstructionService.DependencyFlow.Tests;

--- a/tools/ProductConstructionService.ReproTool/Operations/ReproOperation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/ReproOperation.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ServiceModel.Channels;
 using Maestro.Common;
 using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.ProductConstructionService.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -17,15 +15,18 @@ using Subscription = Microsoft.DotNet.ProductConstructionService.Client.Models.S
 namespace ProductConstructionService.ReproTool.Operations;
 
 internal class ReproOperation(
-    IBarApiClient prodBarClient,
-    ReproOptions options,
-    DarcProcessManager darcProcessManager,
-    [FromKeyedServices("local")] IProductConstructionServiceApi localPcsApi,
-    GitHubClient ghClient,
-    ILogger<ReproOperation> logger) : Operation(logger, ghClient, localPcsApi)
+        IBarApiClient prodBarClient,
+        ReproOptions options,
+        DarcProcessManager darcProcessManager,
+        [FromKeyedServices("local")] IProductConstructionServiceApi localPcsApi,
+        GitHubClient ghClient,
+        ILogger<ReproOperation> logger)
+    : Operation(logger, ghClient, localPcsApi)
 {
     internal override async Task RunAsync()
     {
+        await darcProcessManager.InitializeAsync();
+
         logger.LogInformation("Fetching {subscriptionId} subscription from BAR",
             options.Subscription);
         var subscription = await prodBarClient.GetSubscriptionAsync(options.Subscription);
@@ -41,7 +42,7 @@ internal class ReproOperation(
         }
         else
         {
-             await ReproDependencyFlowSubscription(subscription);
+            await ReproDependencyFlowSubscription(subscription);
         }
 
     }
@@ -170,7 +171,7 @@ internal class ReproOperation(
 
         if (options.BuildId == null)
         {
-             throw new ArgumentException("A buildId must be provided to flow a dependency update subscription");
+            throw new ArgumentException("A buildId must be provided to flow a dependency update subscription");
         }
         var build = await prodBarClient.GetBuildAsync(options.BuildId.Value);
 


### PR DESCRIPTION
Prepares the code flower logic for the new rebase strategy which applies changes on top of target branch and leaves conflicts in place. Code path is currently not triggered until we implement the behaviour in `PullRequestUpdater` which will set `keepConflicts = true` based on a feature flag on a given subscription.

Tests will be added later once we have a more complete flow.

#5046
