### PR TITLE
Fix re-use of existing clones

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
@@ -47,6 +47,22 @@ public abstract class CloneManager
         _logger = logger;
     }
 
+    protected async Task<ILocalGitRepo> PrepareCloneInternalAsync(
+        NativePath clonePath,
+        IReadOnlyCollection<string> remoteUris,
+        IReadOnlyCollection<string> requestedRefs,
+        string checkoutRef,
+        bool resetToRemote = false,
+        CancellationToken cancellationToken = default)
+    {
+        foreach (var uri in remoteUris)
+        {
+            _clones[uri] = clonePath;
+        }
+
+        return await PrepareCloneInternalAsync(_fileSystem.GetDirectoryName(clonePath.Path)!, remoteUris, requestedRefs, checkoutRef, resetToRemote, cancellationToken);
+    }
+
     /// <summary>
     /// Prepares a clone of a repository by fetching from given remotes one-by-one until all requested commits are available.
     /// Then checks out the given ref.

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
@@ -172,6 +172,8 @@ public abstract class CloneManager
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        NativePath clonePath;
+
         if (_upToDateRepos.Contains(remoteUri))
         {
             var path = _clones[remoteUri];
@@ -181,11 +183,14 @@ public abstract class CloneManager
             }
 
             _upToDateRepos.Remove(remoteUri);
+            clonePath = path;
         }
-
-        var clonePath = _clones.TryGetValue(remoteUri, out var cachedPath)
-            ? cachedPath
-            : GetClonePath(dirName);
+        else
+        {
+            clonePath = _clones.TryGetValue(remoteUri, out var cachedPath)
+                ? cachedPath
+                : GetClonePath(dirName);
+        }
 
         if (!_fileSystem.DirectoryExists(clonePath))
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/RepositoryCloneManager.cs
@@ -65,6 +65,25 @@ public interface IRepositoryCloneManager
         string checkoutRef,
         bool resetToRemote = false,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Uses an existing clone of a repository and prepares it by fetching from given remotes one-by-one until all requested commits are available.
+    /// Then checks out the given ref.
+    /// </summary>
+    /// <param name="clonePath">Path to an existing clone</param>
+    /// <param name="mapping">Mapping that clone is associated with</param>
+    /// <param name="remoteUris">Remotes to fetch one by one</param>
+    /// <param name="requestedRefs">List of refs that need to be available</param>
+    /// <param name="checkoutRef">Ref to check out at the end</param>
+    /// <param name="resetToRemote">Whether to reset the branch to the remote one</param>
+    /// <returns>Path to the clone</returns>
+    Task<ILocalGitRepo> PrepareCloneAsync(
+        NativePath clonePath,
+        IReadOnlyCollection<string> remoteUris,
+        IReadOnlyCollection<string> requestedRefs,
+        string checkoutRef,
+        bool resetToRemote = false,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -121,4 +140,15 @@ public class RepositoryCloneManager : CloneManager, IRepositoryCloneManager
         bool resetToRemote = false,
         CancellationToken cancellationToken = default)
         => PrepareCloneInternalAsync(mapping.Name, remoteUris, requestedRefs, checkoutRef, resetToRemote, cancellationToken);
+
+    public Task<ILocalGitRepo> PrepareCloneAsync(
+        NativePath clonePath,
+        IReadOnlyCollection<string> remoteUris,
+        IReadOnlyCollection<string> requestedRefs,
+        string checkoutRef,
+        bool resetToRemote = false,
+        CancellationToken cancellationToken = default)
+    {
+        return PrepareCloneInternalAsync(clonePath, remoteUris, requestedRefs, checkoutRef, resetToRemote, cancellationToken);
+    }
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -106,7 +106,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
 
         return await FlowBackAsync(
             mapping,
-            _localGitRepoFactory.Create(targetRepoPath),
+            targetRepo,
             lastFlows,
             build,
             excludedAssets,
@@ -427,7 +427,6 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             }
             else
             {
-
                 targetRepo = await _repositoryCloneManager.PrepareCloneAsync(
                     targetRepoPath,
                     remotes,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -412,9 +412,9 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
 
         ILocalGitRepo targetRepo;
 
+        // Try to see if both base and target branch are available
         try
         {
-            // Try to see if both base and target branch are available
             if (targetRepoPath == null)
             {
                 targetRepo = await _repositoryCloneManager.PrepareCloneAsync(
@@ -441,9 +441,9 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         }
         catch (NotFoundException)
         {
+            // If target branch does not exist, we create it off of the base branch
             try
             {
-                // If target branch does not exist, we create it off of the base branch
                 if (targetRepoPath == null)
                 {
                     targetRepo = await _repositoryCloneManager.PrepareCloneAsync(

--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/MaestroAuthTestRepositoryExtensions.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/MaestroAuthTestRepositoryExtensions.cs
@@ -4,6 +4,7 @@
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
 
 namespace ProductConstructionService.Api.Configuration;
 
@@ -38,8 +39,7 @@ public static class MaestroAuthTestRepositoryExtensions
             bool resetToRemote = false,
             CancellationToken cancellationToken = default)
         {
-            remoteUris = [.. remoteUris.Select(uri => uri.Replace("github.com/dotnet/", "github.com/maestro-auth-test/"))];
-            return await _cloneManager.PrepareCloneAsync(mapping, remoteUris, requestedRefs, checkoutRef, resetToRemote, cancellationToken);
+            return await _cloneManager.PrepareCloneAsync(mapping, ReplaceDotnetWithMaestroAuthTest(remoteUris), requestedRefs, checkoutRef, resetToRemote, cancellationToken);
         }
 
         public async Task<ILocalGitRepo> PrepareCloneAsync(
@@ -48,8 +48,7 @@ public static class MaestroAuthTestRepositoryExtensions
             bool resetToRemote = false,
             CancellationToken cancellationToken = default)
         {
-            repoUri = repoUri.Replace("github.com/dotnet/", "github.com/maestro-auth-test/");
-            return await _cloneManager.PrepareCloneAsync(repoUri, checkoutRef, resetToRemote, cancellationToken);
+            return await _cloneManager.PrepareCloneAsync(ReplaceDotnetWithMaestroAuthTest(repoUri), checkoutRef, resetToRemote, cancellationToken);
         }
 
         public async Task<ILocalGitRepo> PrepareCloneAsync(
@@ -59,8 +58,18 @@ public static class MaestroAuthTestRepositoryExtensions
             bool resetToRemote = false,
             CancellationToken cancellationToken = default)
         {
-            remoteUris = [.. remoteUris.Select(uri => uri.Replace("github.com/dotnet/", "github.com/maestro-auth-test/"))];
-            return await _cloneManager.PrepareCloneAsync(mapping, remoteUris, checkoutRef, resetToRemote, cancellationToken);
+            return await _cloneManager.PrepareCloneAsync(mapping, ReplaceDotnetWithMaestroAuthTest(remoteUris), checkoutRef, resetToRemote, cancellationToken);
         }
+
+        public Task<ILocalGitRepo> PrepareCloneAsync(NativePath clonePath, IReadOnlyCollection<string> remoteUris, IReadOnlyCollection<string> requestedRefs, string checkoutRef, bool resetToRemote = false, CancellationToken cancellationToken = default)
+        {
+            return _cloneManager.PrepareCloneAsync(clonePath, ReplaceDotnetWithMaestroAuthTest(remoteUris), requestedRefs, checkoutRef, resetToRemote, cancellationToken);
+        }
+
+        private static IReadOnlyCollection<string> ReplaceDotnetWithMaestroAuthTest(IReadOnlyCollection<string> uris)
+            => [.. uris.Select(ReplaceDotnetWithMaestroAuthTest)];
+
+        private static string ReplaceDotnetWithMaestroAuthTest(string uri)
+            => uri.Replace("github.com/dotnet/", "github.com/maestro-auth-test/");
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using LibGit2Sharp;
-using Maestro.Common;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
@@ -73,17 +71,17 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
     public async Task<CodeFlowResult> FlowBackAsync(
         Subscription subscription,
         Build build,
-        string targetBranch,
+        string headBranch,
         bool forceUpdate,
         CancellationToken cancellationToken = default)
     {
-        (var headBranchExisted, SourceMapping mapping, ILocalGitRepo targetRepo) = await PrepareVmrAndRepo(
-            subscription,
+        (bool headBranchExisted, SourceMapping mapping, LastFlows lastFlows, ILocalGitRepo targetRepo) = await PrepareVmrAndRepo(
+            subscription.SourceDirectory,
             build,
-            targetBranch,
+            subscription.TargetBranch,
+            headBranch,
+            targetRepoPath: null,
             cancellationToken);
-
-        var lastFlows = await GetLastFlowsAsync(mapping, targetRepo, currentIsBackflow: true);
 
         var result = await FlowBackAsync(
             mapping,
@@ -92,7 +90,7 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
             build,
             subscription.ExcludedAssets,
             subscription.TargetBranch,
-            targetBranch,
+            headBranch,
             headBranchExisted,
             forceUpdate,
             cancellationToken);
@@ -104,72 +102,5 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
         };
     }
 
-    private async Task<(bool, SourceMapping, ILocalGitRepo)> PrepareVmrAndRepo(
-        Subscription subscription,
-        Build build,
-        string targetBranch,
-        CancellationToken cancellationToken)
-    {
-        // Prepare the VMR
-        await _vmrCloneManager.PrepareVmrAsync(
-            [build.GetRepository()],
-            [build.Commit],
-            build.Commit,
-            ShouldResetVmr,
-            cancellationToken);
-
-        // Prepare repo
-        SourceMapping mapping = _dependencyTracker.GetMapping(subscription.SourceDirectory);
-        var remotes = new[]
-            {
-                mapping.DefaultRemote,
-                _sourceManifest.GetRepoVersion(mapping.Name).RemoteUri,
-                subscription.TargetRepository
-            }
-            .Distinct()
-            .OrderRemotesByLocalPublicOther()
-            .ToList();
-
-        ILocalGitRepo targetRepo;
-        bool headBranchExisted;
-
-        // Now try to see if the target branch exists already
-        try
-        {
-            targetRepo = await _repositoryCloneManager.PrepareCloneAsync(
-                mapping,
-                remotes,
-                [subscription.TargetBranch, targetBranch],
-                targetBranch,
-                ShouldResetClones,
-                cancellationToken);
-            headBranchExisted = true;
-        }
-        catch (NotFoundException)
-        {
-            try
-            {
-                // If target branch does not exist, we create it off of the base branch
-                targetRepo = await _repositoryCloneManager.PrepareCloneAsync(
-                    mapping,
-                    remotes,
-                    subscription.TargetBranch,
-                    ShouldResetClones,
-                    cancellationToken);
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Failed to find branch {branch} in {uri}", targetBranch, string.Join(", ", remotes));
-                throw new TargetBranchNotFoundException($"Failed to find target branch {targetBranch} in {string.Join(", ", remotes)}", e);
-            }
-
-            await targetRepo.CreateBranchAsync(targetBranch);
-            headBranchExisted = false;
-        }
-
-        return (headBranchExisted, mapping, targetRepo);
-    }
-
-    // During backflow, we're targeting a specific repo branch, so we should make sure we reset local branch to the remote one
-    private const bool ShouldResetClones = true;
+    protected override bool ShouldResetClones => true;
 }


### PR DESCRIPTION
I found 2 problems in how we handle cloning:
- `PcsVmrBackflower` has its own `PrepareRepoAndVmr` which is almost the same as `VmrBackflower` except it does not check out the SHA of the last flow correctly. I guess we do check it out later somewhere because otherwise I don't know how this would work.
- When calling `darc vmr backflow`, we might end up cloning the repo into TMP instead of properly using the one the user is targeting with the command. Then we fetch the needed commits into the TMP one and fail to find the commits later in the one the user specified.

#5312
