### PR TITLE
Make HeadBranchSha property optional

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/Model/InProgressPullRequest.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/Model/InProgressPullRequest.cs
@@ -23,7 +23,7 @@ public class InProgressPullRequest : DependencyFlowWorkItem
     /// <summary>
     /// SHA of the head commit of the PR branch.
     /// </summary>
-    public required string HeadBranchSha { get; set; }
+    public string HeadBranchSha { get; set; }
 
     /// <summary>
     /// SHA of the commit the update is coming from.


### PR DESCRIPTION
This broke deserialization of redis objects that don't have this property yet.

We don't really use it yet, will use it more in future so making it non-required for the time being.

#5325 
