### PR TITLE
Fix darc update-dependencies NRE

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
@@ -57,7 +57,8 @@ internal class UpdateDependenciesOperation : Operation
         try
         {
             var local = new Local(_options.GetRemoteTokenProvider(), _logger);
-            var excludedAssetsMatcher = _options.ExcludedAssets?.Split(';').GetAssetMatcher();
+            var excludedAssetsMatcher = _options.ExcludedAssets?.Split(';').GetAssetMatcher()
+                ?? new AssetMatcher(null);
             List<UnixPath> targetDirectories = ResolveTargetDirectories(local);
 
             ConcurrentDictionary<string, Task<Build>> latestBuildTaskDictionary = new();


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/5221 fixes a bug introduced in https://github.com/dotnet/arcade-services/pull/5340 where there's an NRE if there are no excluded assets