### PR TITLE
Darc vmr commands should use darc tmp folder

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Constants.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Constants.cs
@@ -14,6 +14,7 @@ public class Constants
     public const int ErrorCode = 42;
     public const int SuccessCode = 0;
     public const int MaxPopupTries = 3;
+    public const string DefaultDarcClonesDirectoryName = "darc-clones";
     public static readonly string DarcDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".darc");
 
     /// <summary>

--- a/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrCommandLineOptionsBase.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Options/VirtualMonoRepo/VmrCommandLineOptionsBase.cs
@@ -7,6 +7,7 @@ using CommandLine;
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.DotNet.Darc.Operations;
 using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -44,7 +45,7 @@ internal abstract class VmrCommandLineOptionsBase<T> : CommandLineOptions<T> whe
             azureDevOpsToken ??= localDarcSettings?.AzureDevOpsToken;
         }
 
-        tmpPath = Path.GetFullPath(tmpPath ?? Path.GetTempPath());
+        tmpPath = Path.GetFullPath(tmpPath ?? new NativePath(Path.GetTempPath()) / Constants.DefaultDarcClonesDirectoryName);
 
         services.AddSingleVmrSupport(GitLocation, VmrPath, tmpPath, gitHubToken, azureDevOpsToken);
         services.TryAddTransient<IVmrScanner, VmrCloakedFileScanner>();


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/5134