### PR TITLE
Don't open the darc popup if target-directory or source-directory are provided

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateSubscriptionOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateSubscriptionOperation.cs
@@ -386,7 +386,6 @@ internal class UpdateSubscriptionOperation : SubscriptionOperationBase
            || _options.SourceDirectory != null
            || _options.ExcludedAssets != null
            || _options.TargetDirectory != null
-           || _options.SourceDirectory != null
            || UpdatingMergePoliciesViaCommandLine();
 
     private bool UpdatingMergePoliciesViaCommandLine()


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/5220
a small UX fix that makes updating subscriptions a better experience