### PR TITLE
Make help comments not mention the team

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommenter.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommenter.cs
@@ -31,7 +31,7 @@ internal class PullRequestCommenter : IPullRequestCommenter
     private readonly ICommentCollector _commentService;
     private readonly ILogger<PullRequestCommenter> _logger;
 
-    private const string HelpLine = $"> In case of unclarities, consult the [FAQ]({PullRequestBuilder.CodeFlowPrFaqUri}) or tag **\\@dotnet/product-construction** for assistance.";
+    private const string HelpLine = $"> In case of unclarities, consult the [FAQ]({PullRequestBuilder.CodeFlowPrFaqUri}) or tag **<b>@</b>dotnet/product-construction** for assistance.";
 
     public PullRequestCommenter(
         IRemoteFactory remoteFactory,


### PR DESCRIPTION
Uses HTML `<b>@</b>` tags instead of markdown to prevent GitHub from treating it as a mention.
It looks like even comments such as https://github.com/dotnet/dotnet/issues/2849#issuecomment-3399383977 cause the team to be mentioned now.
