### PR TITLE
Unify several codeflow arguments into a single POCO

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/VirtualMonoRepo/BackflowOperation.cs
@@ -90,9 +90,8 @@ internal class BackflowOperation(
         {
             await _backflowConflictResolver.TryMergingBranchAndUpdateDependencies(
                 // TODO (https://github.com/dotnet/arcade-services/issues/5313): Fill excludedAssets from subscription
-                new CodeflowOptions(mapping, headBranch, headBranch, build, [], true, false),
+                new CodeflowOptions(mapping, currentFlow, headBranch, headBranch, build, [], true, false),
                 lastFlows,
-                (Backflow)currentFlow,
                 productRepo,
                 headBranch,
                 headBranchExisted: true,

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
@@ -74,7 +74,15 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
             cancellationToken);
 
         var result = await FlowBackAsync(
-            new CodeflowOptions(mapping, subscription.TargetBranch, headBranch, build, subscription.ExcludedAssets, enableRebase, forceUpdate),
+            new CodeflowOptions(
+                mapping,
+                new Backflow(build.Commit, lastFlows.LastFlow.RepoSha),
+                subscription.TargetBranch,
+                headBranch,
+                build,
+                subscription.ExcludedAssets,
+                enableRebase,
+                forceUpdate),
             targetRepo,
             lastFlows,
             headBranchExisted,

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/BackflowConflictResolverTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/BackflowConflictResolverTests.cs
@@ -416,6 +416,7 @@ public class BackflowConflictResolverTests
         VersionFileUpdateResult mergeResult = await _conflictResolver.TryMergingBranchAndUpdateDependencies(
             new CodeflowOptions(
                 new SourceMapping(MappingName, "https://github/repo1", "main", [], [], false),
+                currentFlow,
                 TargetBranch,
                 PrBranch,
                 build,
@@ -423,7 +424,6 @@ public class BackflowConflictResolverTests
                 EnableRebase: false,
                 ForceUpdate: false),
             lastFlows,
-            currentFlow,
             _localRepo.Object,
             TargetBranch,
             headBranchExisted,


### PR DESCRIPTION
Follow-up for #5341 that declutters the code a bit.
No functional changes, just fewer args to pass around.