### PR TITLE
Fix double `/` in conflict PR comments

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
@@ -272,7 +272,7 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
             string relativeFilePath = filePath.ToString();
             if (subscription.IsForwardFlow())
             {
-                relativeFilePath = relativeFilePath.Length > srcDir.Length ? relativeFilePath.Substring(srcDir.Length) : relativeFilePath;
+                relativeFilePath = relativeFilePath.Length > srcDir.Length + 1 ? relativeFilePath.Substring(srcDir.Length + 1) : relativeFilePath;
             }
 
             var (fileUrlInVmr, fileUrlInRepo) = GetFileUrls(update, subscription, relativeFilePath, prHeadBranch);

--- a/test/ProductConstructionService.ScenarioTests/CodeFlowScenarioTestBase.cs
+++ b/test/ProductConstructionService.ScenarioTests/CodeFlowScenarioTestBase.cs
@@ -225,9 +225,11 @@ internal class CodeFlowScenarioTestBase : ScenarioTestBase
     {
         IReadOnlyList<IssueComment> comments = await GitHubApi.Issue.Comment.GetAllForIssue(TestParameters.GitHubTestOrg, targetRepo, pullRequest.Number);
 
-        foreach (var s in stringsExpectedInComment)
+        var allCommentBodies = string.Join(Environment.NewLine, comments.Select(c => c.Body));
+
+        foreach (var expected in stringsExpectedInComment)
         {
-            comments.Any(c => c.Body.Contains(s)).Should().BeTrue();
+            allCommentBodies.Should().Contain(expected);
         }
     }
 }


### PR DESCRIPTION
The bug got introduced in #5387 (and broke scenario tests)

Also mades it easier to understand the failing test exception

https://github.com/dotnet/arcade-services/issues/5333