### PR TITLE
Run E2E tests using repo's .NET

### DIFF
--- a/eng/pipelines/templates/jobs/e2e-pcs-tests.yml
+++ b/eng/pipelines/templates/jobs/e2e-pcs-tests.yml
@@ -75,8 +75,8 @@ jobs:
 
   - template: /eng/common/templates-official/steps/get-federated-access-token.yml
     parameters:
-      federatedServiceConnection: "ArcadeServicesInternal"
-      outputVariableName: "AzdoToken"
+      federatedServiceConnection: ArcadeServicesInternal
+      outputVariableName: AzdoToken
 
   - powershell: >
       .\.dotnet\dotnet test


### PR DESCRIPTION
The pipeline was failing because our `global.json` had a newer SDK than the one in the AzDO agent which uncovered the fact we're using the global .NET instead of the repo one.
This uses the one in `.dotnet/dotnet`.

<!-- #1 -->