### PR TITLE
Downgrade `Microsoft.Azure.StackExchangeRedis`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,7 +40,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.WebHooks.Receivers.GitHub" Version="1.0.0-preview2-final" />
     <PackageVersion Include="Microsoft.AspNetCore.WebHooks.Receivers" Version="1.0.0-preview2-final" />
-    <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.0" />
+    <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.1.0" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />


### PR DESCRIPTION
Bumped in #5467 but broke the CG in the official build