### PR TITLE
Call darc via local .NET installation during E2E tests

### DIFF
--- a/eng/pipelines/templates/jobs/darc-and-api-tests.yml
+++ b/eng/pipelines/templates/jobs/darc-and-api-tests.yml
@@ -68,14 +68,15 @@ jobs:
         scriptType: ps
         scriptLocation: inlineScript
         inlineScript: |
-          $darcBuild = .\.dotnet\dotnet darc get-build `
+          $env:DOTNET_ROOT = (Resolve-Path ".\.dotnet").Path
+          $darcBuild = .\darc\darc.exe get-build `
             --repo "https://github.com/dotnet/arcade-services" `
             --commit $(Build.SourceVersion) `
             --ci `
             --output-format json |
             ConvertFrom-Json
 
-          .\.dotnet\dotnet darc add-build-to-channel `
+          .\darc\darc.exe add-build-to-channel `
             --id $darcBuild[0].id `
             --channel "General Testing" `
             --ci `


### PR DESCRIPTION
Regression from #5467 when `darc` became 8.0 and 10.0
