### PR TITLE
Fix rebase backflow scenario test

### DIFF
--- a/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
@@ -1151,7 +1151,7 @@ internal abstract partial class ScenarioTestBase
         throw new ScenarioTestException($"No Maestro Merge Policy checks were found in the PR ({prUrl}) during the allotted time.");
     }
 
-    protected async Task WaitForFileContentInPullRequest(
+    protected async Task<Octokit.PullRequest> WaitForFileContentInPullRequest(
         string repoDir,
         string targetRepoName,
         string targetBranch,
@@ -1167,7 +1167,7 @@ internal abstract partial class ScenarioTestBase
             var content = await File.ReadAllTextAsync(filePath);
             if (content == expectedContent)
             {
-                return;
+                return pr;
             }
         }
 

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowRebase.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowRebase.cs
@@ -133,7 +133,7 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
             await TriggerSubscriptionAsync(subscriptionId.Value);
 
             // We verify the file got there + make a conflicting change for future
-            await WaitForFileContentInPullRequest(
+            pr = await WaitForFileContentInPullRequest(
                 vmrDir,
                 TestRepository.VmrTestRepoName,
                 targetBranchName,
@@ -298,10 +298,8 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
             await AddBuildToChannelAsync(build.Id, channelName);
             await TriggerSubscriptionAsync(subscriptionId.Value);
 
-            pr = await WaitForUpdatedPullRequestAsync(TestRepository.TestRepo1Name, targetBranchName);
-
             // We verify the file got there + make a conflicting change for future
-            await WaitForFileContentInPullRequest(
+            pr = await WaitForFileContentInPullRequest(
                 repoDir,
                 TestRepository.TestRepo1Name,
                 targetBranchName,


### PR DESCRIPTION
#5362

There was a difference in backflow and ff rebase test in this where we wait for an update and the later call that waits for a file also waits for an update but that update already happened and no other update will happen again.