### PR TITLE
Handle dependency casing during backflow dependency updates

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/BackflowConflictResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/BackflowConflictResolver.cs
@@ -417,7 +417,7 @@ public class BackflowConflictResolver : CodeFlowConflictResolver, IBackflowConfl
 
         await targetRepo.StageAsync([..filesToCommit.Select(f => f.FilePath)], cancellationToken);
 
-        Dictionary<string, DependencyDetail> allUpdates = buildUpdates.ToDictionary(u => u.Name);
+        Dictionary<string, DependencyDetail> allUpdates = buildUpdates.ToDictionary(u => u.Name, comparer: StringComparer.OrdinalIgnoreCase);
 
         // if a repo was added during the merge and then updated, it's not an update, but an addition
         foreach ((var key, var addition) in versionDetailsChanges.Additions)


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
https://github.com/dotnet/arcade-services/issues/5539

If a dependency that was added and a dependency from the build had the same name, but different casing, we'd get an exception because it wouldn't get removed from the 'updates' dictionary