### PR TITLE
Order release branches in BarViz in decending order as well

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/Codeflows.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/Codeflows.razor
@@ -258,7 +258,7 @@
                 // Make the main branch go first
                 return defaultChannels
                     .OrderByDescending(c => c.Branch == "main")
-                    .ThenBy(c => c.Branch)
+                    .ThenByDescending(c => c.Branch)
                     .ToList();
             }
         }


### PR DESCRIPTION
Makes the most recent branch show up first and orders the .100/101 last which is more useful.

Before:
```
main
release/10.0.100
release/10.0.101
release/10.0.1xx
release/10.0.2xx
release/11.0.1xx
```

After:
```
main
release/11.0.1xx
release/10.0.2xx
release/10.0.1xx
release/10.0.101
release/10.0.100
```
