### PR TITLE
Changes to improve update-dependencies

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Operations/UpdateDependenciesOperation.cs
@@ -262,7 +262,9 @@ internal class UpdateDependenciesOperation : Operation
 
         if (!_options.DryRun)
         {
+            Console.Write("    Applying updates...");
             await local.UpdateDependenciesAsync(dependenciesToUpdate, _remoteFactory, _gitRepoFactory, _barClient, relativeBasePath);
+            Console.WriteLine("    done.");
         }
     }
 
@@ -276,16 +278,18 @@ internal class UpdateDependenciesOperation : Operation
             return Constants.SuccessCode;
         }
 
-        Console.WriteLine("    Checking for coherency updates...");
+        Console.Write("    Checking for coherency updates...");
 
         List<DependencyUpdate> coherencyUpdates = null;
         try
         {
             // Now run a coherency update based on the current set of dependencies updated from the previous pass.
             coherencyUpdates = await _coherencyUpdateResolver.GetRequiredCoherencyUpdatesAsync(currentDependencies);
+            Console.WriteLine("done.");
         }
         catch (DarcCoherencyException e)
         {
+            Console.WriteLine("failed.");
             PrettyPrintCoherencyErrors(e);
             return Constants.ErrorCode;
         }

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
 using Maestro.Common;
@@ -51,55 +52,70 @@ public class LocalLibGit2Client : LocalGitClient, ILocalLibGit2Client
 
     public async Task CommitFilesAsync(List<GitFile> filesToCommit, string repoPath, string branch, string commitMessage)
     {
+        SemaphoreSlim commitThrottle = new SemaphoreSlim(16, 16);
         repoPath = await GetRootDirAsync(repoPath);
+        List<Task> commitTasks = new List<Task>();
         try
         {
             using (var localRepo = new Repository(repoPath))
-            foreach (GitFile file in filesToCommit)
             {
-                Debug.Assert(file != null, $"Passed in a null {nameof(GitFile)} in {nameof(filesToCommit)}");
-                switch (file.Operation)
+                commitTasks = filesToCommit.Select(async file =>
                 {
-                    case GitFileOperation.Add:
-                        var parentDirectoryInfo = Directory.GetParent(file.FilePath)
-                            ?? throw new Exception($"Cannot find parent directory of {file.FilePath}.");
+                    try
+                    {
+                        await commitThrottle.WaitAsync();
 
-                        string parentDirectory = parentDirectoryInfo.FullName;
-
-                        if (!Directory.Exists(parentDirectory))
+                        Debug.Assert(file != null, $"Passed in a null {nameof(GitFile)} in {nameof(filesToCommit)}");
+                        switch (file.Operation)
                         {
-                            Directory.CreateDirectory(parentDirectory);
-                        }
+                            case GitFileOperation.Add:
+                                var parentDirectoryInfo = Directory.GetParent(file.FilePath)
+                                    ?? throw new Exception($"Cannot find parent directory of {file.FilePath}.");
 
-                        string fullPath = Path.Combine(repoPath, file.FilePath);
-                        using (var streamWriter = new StreamWriter(fullPath))
-                        {
-                            string finalContent;
-                            switch (file.ContentEncoding)
-                            {
-                                case ContentEncoding.Utf8:
-                                    finalContent = file.Content;
-                                    break;
-                                case ContentEncoding.Base64:
-                                    byte[] bytes = Convert.FromBase64String(file.Content);
-                                    finalContent = Encoding.UTF8.GetString(bytes);
-                                    break;
-                                default:
-                                    throw new DarcException($"Unknown file content encoding {file.ContentEncoding}");
-                            }
-                            finalContent = await NormalizeLineEndingsAsync(repoPath, fullPath, finalContent);
-                            await streamWriter.WriteAsync(finalContent);
+                                string parentDirectory = parentDirectoryInfo.FullName;
 
-                            AddFileToIndex(localRepo, file, fullPath);
+                                if (!Directory.Exists(parentDirectory))
+                                {
+                                    Directory.CreateDirectory(parentDirectory);
+                                }
+
+                                string fullPath = Path.Combine(repoPath, file.FilePath);
+                                using (var streamWriter = new StreamWriter(fullPath))
+                                {
+                                    string finalContent;
+                                    switch (file.ContentEncoding)
+                                    {
+                                        case ContentEncoding.Utf8:
+                                            finalContent = file.Content;
+                                            break;
+                                        case ContentEncoding.Base64:
+                                            byte[] bytes = Convert.FromBase64String(file.Content);
+                                            finalContent = Encoding.UTF8.GetString(bytes);
+                                            break;
+                                        default:
+                                            throw new DarcException($"Unknown file content encoding {file.ContentEncoding}");
+                                    }
+                                    finalContent = await NormalizeLineEndingsAsync(repoPath, fullPath, finalContent);
+                                    await streamWriter.WriteAsync(finalContent);
+
+                                    AddFileToIndex(localRepo, file, fullPath);
+                                }
+                                break;
+                            case GitFileOperation.Delete:
+                                if (File.Exists(file.FilePath))
+                                {
+                                    File.Delete(file.FilePath);
+                                }
+                                break;
                         }
-                        break;
-                    case GitFileOperation.Delete:
-                        if (File.Exists(file.FilePath))
-                        {
-                            File.Delete(file.FilePath);
-                        }
-                        break;
-                }
+                    }
+                    finally
+                    {
+                        commitThrottle.Release();
+                    }
+                }).ToList();
+
+                await Task.WhenAll(commitTasks);
             }
         }
         catch (Exception exc)

--- a/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
@@ -431,14 +431,14 @@ public sealed class Remote : IRemote
 
     public async Task<List<GitFile>> GetCommonScriptFilesAsync(string repoUri, string commit, LocalPath relativeBasePath = null)
     {
-        _logger.LogInformation("Generating commits for script files");
+        _logger.LogInformation("Retrieving eng/common script files");
         string path = relativeBasePath == null
             ? Constants.CommonScriptFilesPath
             : relativeBasePath / Constants.CommonScriptFilesPath;
 
         List<GitFile> files = await _remoteGitClient.GetFilesAtCommitAsync(repoUri, commit, path);
 
-        _logger.LogInformation("Generating commits for script files succeeded!");
+        _logger.LogInformation("Retrieving eng/common script files succeeded!");
 
         return files;
     }


### PR DESCRIPTION
Fixes:

https://github.com/dotnet/arcade-services/issues/4231

- Improve logging to make it clearer when various steps begin/end.
- Parallize the git update section. When a repo is updating arcade we run hundreds of git commands. Parallelize them.

Before/after timings. Uploading the workload-versions repo to a VMR build. First two runs excluded as warm up

| Run # | Before (ms) | After (ms) |
|------:|-------:|------:|
| 3 | 119864.81 | 25418.32 |
| 4 | 113986.70 | 25036.59 |
| 5 | 97362.74  | 25374.59 |
| 6 | 97602.10  | 24882.10 |
| 7 | 111447.00 | 25253.46 |
| 8 | 114023.31 | 25251.93 |
| 9 | 131853.62 | 24383.28 |
|10 | 127390.98 | 25073.68 |

<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
