### PR TITLE
Force-checkout when recreating previous flows

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -508,7 +508,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         CancellationToken cancellationToken)
     {
         await targetRepo.ResetWorkingTree();
-        await targetRepo.CheckoutAsync(targetBranch);
+        await targetRepo.ForceCheckoutAsync(targetBranch);
 
         Backflow previousFlow = previousFlows.LastBackFlow
             ?? throw new DarcException("No more backflows found to recreate");
@@ -521,7 +521,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
                 previousFlow.RepoSha);
 
             await targetRepo.ResetWorkingTree();
-            await targetRepo.CheckoutAsync(previousFlowSha);
+            await targetRepo.ForceCheckoutAsync(previousFlowSha);
             await _vmrCloneManager.PrepareVmrAsync(
                 [_vmrInfo.VmrUri],
                 [previousFlow.VmrSha],
@@ -535,7 +535,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         }
 
         // Check out the repo before the flows we want to recreate
-        await targetRepo.CheckoutAsync(previousFlow.RepoSha);
+        await targetRepo.ForceCheckoutAsync(previousFlow.RepoSha);
         await targetRepo.CreateBranchAsync(branchToCreate, overwriteExistingBranch: true);
 
         return (previousFlow, previousFlows);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -446,7 +446,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
         var previousFlow = previousFlows.LastForwardFlow;
         var vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
         await vmr.ResetWorkingTree();
-        await vmr.CheckoutAsync(targetBranch);
+        await vmr.ForceCheckoutAsync(targetBranch);
 
         for (int i = 1; i < depth; i++)
         {
@@ -463,7 +463,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 resetToRemote: false,
                 cancellationToken);
 
-            await sourceRepo.CheckoutAsync(_sourceManifest.GetRepoVersion(mapping.Name).CommitSha);
+            await sourceRepo.ForceCheckoutAsync(_sourceManifest.GetRepoVersion(mapping.Name).CommitSha);
             previousFlows = await GetLastFlowsAsync(mapping.Name, sourceRepo, currentIsBackflow: false);
             previousFlow = previousFlows.LastForwardFlow;
         }


### PR DESCRIPTION
Found when recreating SDK flows which had an EOL change of a README file and we failed to check out an older commit during flow recreation.

<!-- #1 -->
