### PR TITLE
Extend codeflow tests with different types of conflicts

### DIFF
--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/BackflowTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/BackflowTests.cs
@@ -968,18 +968,19 @@ internal class BackflowTests : CodeFlowTests
         File.Delete(_productRepoVmrPath / Revert_FileAddedAndRemovedName);
         await GitOperations.CommitAll(VmrPath, "Revert changes", allowEmpty: false);
 
-        // Step 5: Backflow with reverts and conflicts
-        stagedFiles = await CallDarcBackflow(expectedConflicts: [Conflict_FileChangedInBoth]);
-        expectedStagedFiles.Add(Conflict_FileRenamedNewName);
         expectedStagedFiles.Add(Revert_FileRemovedAndAddedName);
+        expectedStagedFiles.Add(Conflict_FileRenamedNewName);
         expectedStagedFiles.Add(Conflict_FileAddedInBoth);
         expectedStagedFiles.Add(Conflict_FileRemovedInSourceAndChangedInTarget);
         expectedStagedFiles.Add(Conflict_FileChangedInBoth);
 
+        string[] expectedConflictedFiles = [.. expectedStagedFiles.Skip(5)];
+
+        // Step 5: Backflow with reverts and conflicts
+        stagedFiles = await CallDarcBackflow(expectedConflicts: expectedConflictedFiles);
+
         stagedFiles.Should().BeEquivalentTo(expectedStagedFiles, "There should be staged files after backflow");
 
-        // Conflict markers only in Conflict file (we have to exclude it plus exclude non-existent files
-        IReadOnlyCollection<string> expectedConflictedFiles = [..expectedStagedFiles.Skip(4)];
         await Helpers.GitOperationsHelper.VerifyNoConflictMarkers(
             ProductRepoPath,
             expectedStagedFiles

--- a/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/ForwardFlowTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Codeflow.Tests/ForwardFlowTests.cs
@@ -665,18 +665,18 @@ internal class ForwardFlowTests : CodeFlowTests
         File.Delete(ProductRepoPath / Revert_FileAddedAndRemovedName);
         await GitOperations.CommitAll(ProductRepoPath, "Revert changes", allowEmpty: false);
 
-        // Step 5: Forward flow with reverts and conflicts
-        stagedFiles = await CallDarcForwardflow(expectedConflicts: [VmrInfo.SourcesDir / Constants.ProductRepoName / Conflict_FileChangedInBoth]);
         expectedStagedFiles[1] = VmrInfo.SourcesDir / Constants.ProductRepoName / Conflict_FileRenamedNewName; // no more Version.Details.xml changes
         expectedStagedFiles.Add(VmrInfo.SourcesDir / Constants.ProductRepoName / Revert_FileRemovedAndAddedName);
         expectedStagedFiles.Add(VmrInfo.SourcesDir / Constants.ProductRepoName / Conflict_FileAddedInBoth);
         expectedStagedFiles.Add(VmrInfo.SourcesDir / Constants.ProductRepoName / Conflict_FileRemovedInSourceAndChangedInTarget);
         expectedStagedFiles.Add(VmrInfo.SourcesDir / Constants.ProductRepoName / Conflict_FileChangedInBoth);
 
+        string[] expectedConflictedFiles = [.. expectedStagedFiles.Skip(5)];
+
+        // Step 5: Forward flow with reverts and conflicts
+        stagedFiles = await CallDarcForwardflow(expectedConflicts: expectedConflictedFiles);
         stagedFiles.Should().BeEquivalentTo(expectedStagedFiles, "There should be staged files after forward flow");
 
-        // Conflict markers only in Conflict file (we have to exclude it plus exclude non-existent files
-        IReadOnlyCollection<string> expectedConflictedFiles = [..expectedStagedFiles.Skip(5)];
         await GitOperationsHelper.VerifyNoConflictMarkers(
             VmrPath,
             expectedStagedFiles


### PR DESCRIPTION
Extended a test and it will be useful to have regardless of how we move changes.

#5650 