### PR TITLE
Fix NRE in case file content is empty

### DIFF
--- a/src/MaestroConfiguration/src/Microsoft.DotNet.MaestroConfiguration.Client/ConfigurationRepositoryManager.cs
+++ b/src/MaestroConfiguration/src/Microsoft.DotNet.MaestroConfiguration.Client/ConfigurationRepositoryManager.cs
@@ -471,7 +471,8 @@ public class ConfigurationRepositoryManager : IConfigurationRepositoryManager
             try
             {
                 var fileContent = await gitRepo.GetFileContentsAsync(repositoryUri, workingBranch, filePath);
-                var deserializedYamls = _yamlDeserializer.Deserialize<List<TModel>>(fileContent);
+                var deserializedYamls = _yamlDeserializer.Deserialize<List<TModel>>(fileContent)
+                    ?? [];
 
                 if (deserializedYamls.Any(y => searchKey.Equals(getUniqueKey(y))))
                 {


### PR DESCRIPTION
#5711

When the file contents are empty, the deserializer returns null instead of empty list. This leads to an NRE being thrown on the .Any() check, hiding the real exception that should be thrown at the end of the method.

