### PR TITLE
Publish PCS common

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionService.Common.csproj
+++ b/src/ProductConstructionService/ProductConstructionService.Common/ProductConstructionService.Common.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
     <SignAssembly>False</SignAssembly>
   </PropertyGroup>


### PR DESCRIPTION
Publish PCS.Common, because Maestro.DataProviders depends on it

<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
