### PR TITLE
Disable external diffing tools

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrPatchHandler.cs
@@ -512,8 +512,8 @@ public class VmrPatchHandler : IVmrPatchHandler
             "--patch",
             "--binary", // Include binary contents as base64
             "--no-color", // Don't colorize the output, it will be stored in a file
-            "--no-ext-diff", // Don't use external diffing tools defined in .gitattributes
-            "--no-textconv", // These external tools might not be available in Maestro
+            "--no-ext-diff", "--no-textconv", // Don't use external diffing tools defined in .gitattributes
+                                              // These external tools might not be available in Maestro
             "--output", // Store the diff in a .patch file
             patchName,
         };

--- a/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
+++ b/test/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrPatchHandlerTests.cs
@@ -313,7 +313,7 @@ public class VmrPatchHandlerTests
         // Verify diff for the submodule
         expectedArgs = GetExpectedGitDiffArguments(
             expectedSubmodulePatchName, Constants.EmptyGitObject, SubmoduleSha1, null)
-            .Take(8)
+            .Take(10)
             .Append(VmrPatchHandler.GetInclusionRule("**/*"))
             .Append(VmrPatchHandler.GetExclusionRule("LICENSE.md"));
 
@@ -405,7 +405,7 @@ public class VmrPatchHandlerTests
         // Verify diff for the submodule
         expectedArgs = GetExpectedGitDiffArguments(
             expectedSubmodulePatchName, Constants.EmptyGitObject, SubmoduleSha1, new[] { nestedSubmoduleInfo.Path })
-            .Take(8)
+            .Take(10)
             .Append(VmrPatchHandler.GetInclusionRule("**/*"))
             .Append(VmrPatchHandler.GetExclusionRule("LICENSE.md"))
             .Append(":(exclude)external-2");
@@ -425,7 +425,7 @@ public class VmrPatchHandlerTests
         // Verify diff for the nested submodule
         expectedArgs = GetExpectedGitDiffArguments(
             expectedNestedSubmodulePatchName, Constants.EmptyGitObject, nestedSubmoduleSha1, null)
-            .Take(8)
+            .Take(10)
             .Append(VmrPatchHandler.GetInclusionRule("**/*"));
 
         _processManager
@@ -513,7 +513,7 @@ public class VmrPatchHandlerTests
         // Verify diff for the submodule
         expectedArgs = GetExpectedGitDiffArguments(
             expectedSubmodulePatchName, SubmoduleSha1, Constants.EmptyGitObject, null)
-            .Take(8)
+            .Take(10)
             .Append(VmrPatchHandler.GetInclusionRule("**/*"))
             .Append(VmrPatchHandler.GetExclusionRule("LICENSE.md"));
 
@@ -591,7 +591,7 @@ public class VmrPatchHandlerTests
         // Verify diff for the submodule
         expectedArgs = GetExpectedGitDiffArguments(
             expectedSubmodulePatchName, SubmoduleSha1, SubmoduleSha2, null)
-            .Take(8)
+            .Take(10)
             .Append(VmrPatchHandler.GetInclusionRule("**/*"))
             .Append(VmrPatchHandler.GetExclusionRule("LICENSE.md"));
 
@@ -670,7 +670,7 @@ public class VmrPatchHandlerTests
         // Verify diff for the submodule
         expectedArgs = GetExpectedGitDiffArguments(
             expectedSubmodulePatchName1, SubmoduleSha1, Constants.EmptyGitObject, null)
-            .Take(8)
+            .Take(10)
             .Append(VmrPatchHandler.GetInclusionRule("**/*"))
             .Append(VmrPatchHandler.GetExclusionRule("LICENSE.md"));
 
@@ -685,7 +685,7 @@ public class VmrPatchHandlerTests
 
         expectedArgs = GetExpectedGitDiffArguments(
             expectedSubmodulePatchName2, Constants.EmptyGitObject, SubmoduleSha2, null)
-            .Take(8)
+            .Take(10)
             .Append(VmrPatchHandler.GetInclusionRule("**/*"))
             .Append(VmrPatchHandler.GetExclusionRule("LICENSE.md"));
 
@@ -874,6 +874,8 @@ public class VmrPatchHandlerTests
             "--patch",
             "--binary",
             "--no-color",
+            "--no-ext-diff",
+            "--no-textconv",
             "--output",
             new NativePath(patchPath),
             $"{Sha1}..{Sha2}",


### PR DESCRIPTION
Some files might have predefined diffing tools in `.gitattributes` and when you try to run those in an environment without those tools available, the diff will fail to run. This turns those off.

Found when resolving roslyn flow for #5794 
