### PR TITLE
BarViz: Change dismiss icon to one that works everywhere

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.BarViz/wwwroot/index.html
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/wwwroot/index.html
@@ -28,7 +28,7 @@
     <div id="blazor-error-ui">
         An unhandled error has occurred.
         <a href="." class="reload">Reload</a>
-        <span class="dismiss">🗙</span>
+        <span class="dismiss">X</span>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>


### PR DESCRIPTION
On macOS I just see this:
<img width="406" height="44" alt="image" src="https://github.com/user-attachments/assets/b1337a52-7375-4b7c-9172-0ca04e9ed71f" />

Changing it to use a normal X char (this PR) looks like this:
<img width="416" height="42" alt="image" src="https://github.com/user-attachments/assets/10c1f542-4e08-48ad-8d9c-a7cee1ec77a1" />

For comparison this is what it looked on Windows:
<img width="494" height="45" alt="image" src="https://github.com/user-attachments/assets/0bc2ba32-1708-4933-a8eb-27141e80c75a" />

Found while looking at https://github.com/dotnet/arcade-services/issues/5800
