### PR TITLE
Commit forward flow only when there's changes

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
@@ -161,6 +161,11 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
             return result;
         }
 
+        if (!await vmr.HasStagedChangesAsync())
+        {
+            return result;
+        }
+
         string commitMessage;
 
         if (hadSourceConflicts)

--- a/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -29,7 +29,7 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
     - Verify mergeability
     */
     [Test]
-    public async Task Vmr_ConflictNoPrForwardFlowWithRebaseTest()
+    public async Task Vmr_ConflictNoPrForwardFlowTest()
     {
         var channelName = GetTestChannelName();
         var sourceBranchName = GetTestBranchName();
@@ -193,7 +193,7 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
     - Verify mergeability
     */
     [Test]
-    public async Task Vmr_ConflictNoPrBackFlowWithRebaseTest()
+    public async Task Vmr_ConflictNoPrBackFlowTest()
     {
         var channelName = GetTestChannelName();
         var sourceBranchName = GetTestBranchName();


### PR DESCRIPTION
Fixes a case when there were no additional changes by dependency updater (no V.D.xml changes) and no conflicts at the same time.

#5363
