### PR TITLE
Properly handle github urls when calculating repo and owner

### DIFF
--- a/src/Maestro/Maestro.Common/GitRepoUrlUtils.cs
+++ b/src/Maestro/Maestro.Common/GitRepoUrlUtils.cs
@@ -103,7 +103,7 @@ public static class GitRepoUrlUtils
 
         if (repoType == GitRepoType.GitHub)
         {
-            string[] repoParts = uri.Substring(uri.IndexOf(GitHubComString) + GitHubComString.Length).Split(['/'], StringSplitOptions.RemoveEmptyEntries);
+            string[] repoParts = uri.Substring(uri.IndexOf(GitHubComString, StringComparison.OrdinalIgnoreCase) + GitHubComString.Length).Split(['/'], StringSplitOptions.RemoveEmptyEntries);
 
             if (repoParts.Length != 2)
             {


### PR DESCRIPTION
<!-- Link the GitHub or AzDO issue this pull request is associated with. Please copy and paste the full URL rather than using the dotnet/arcade-services# syntax -->
For example this would cause `http://github.com/dotnet/maui` to be parsed as `otnet` and `maui`