### PR TITLE
Use codeflow dependency update commit message builder

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
@@ -95,7 +95,7 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
                 var commitMessage = new StringBuilder();
                 commitMessage.Append("Update dependencies from build ");
                 commitMessage.AppendLine(build.Id.ToString());
-                PullRequestBuilder.AppendCoherencyCommitMessage(string.Empty, result.DependencyUpdates, commitMessage);
+                commitMessage.AppendLine(BackflowConflictResolver.BuildDependencyUpdateCommitMessage(result.DependencyUpdates));
                 commitMessage.AppendLine(Constants.AUTOMATION_COMMIT_TAG);
 
                 await targetRepo.CommitAsync(commitMessage.ToString(), allowEmpty: false, cancellationToken: cancellationToken);


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/5955#issue-3937673962

This unblocks SDK 3xx that was failing due to NRE on `dependencyUpdate.From`

Repro'd PR + commit message: https://github.com/maestro-auth-test/sdk/pull/56/commits