### PR TITLE
Fix wrong reference

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Components/BuildInfo.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Components/BuildInfo.razor
@@ -180,7 +180,7 @@ else
                             <FluentIcon Value="@(new Icons.Regular.Size20.ArrowSync())" Color="Color.Info" />
                             <FluentLabel Typo="Typography.Body">
                                 There is an ongoing build from branch <code>@GetTrimmedBranchName()</code>
-                                <a href="@GetBuildUri(_latestCompletedBuild!.Id)" target="_blank" class="commit-link">
+                                <a href="@GetBuildUri(_ongoingBuild.Id)" target="_blank" class="commit-link">
                                     (View latest ongoing build)
                                     <FluentIcon Value="@(new Icons.Regular.Size16.WindowNew())" Color="Color.Accent" />
                                 </a>


### PR DESCRIPTION
#5802 
The ongoing build section is accidentally made to display the latest build, not the ongoing build.
This results in the link being wrong, and also in an NRE being thrown whenever the ongoing build is fetched earlier than the latest build is fetched.