### PR TITLE
Handle git merge errors gracefully

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -121,7 +121,7 @@ public class LocalGitClient : ILocalGitClient
                 _fileSystem.DeleteDirectory(repoPath / relativePath, true);
             }
         }
-        else if (result.StandardError.Contains("is unmerged"))
+        else if (result.StandardError.Contains("is unmerged") || result.StandardError.Contains("needs merge"))
         {
             var unstagedNonConflictingFiles = await GetUnstagedFilesAsync(repoPath, relativePath);
             args = ["checkout", .. unstagedNonConflictingFiles];


### PR DESCRIPTION
Fixes a bunch of exceptions in the service:
```
"Problem": Microsoft.DotNet.DarcLib.Helpers.ProcessFailedException at Microsoft.DotNet.DarcLib.Helpers.ProcessExecutionResult.ThrowIfFailed:15,
"Message": failed to clean unmerged non conflicting files from the working tree
Exit code: 1
Std out:
src/roslyn/src/Features/ExternalAccess/HotReload/Api/HotReloadMSBuildWorkspace.cs: needs merge
src/sdk/source-build.slnf: needs merge
```

Either it's a new version of `git` or it seems like there are two ways the error can be formatted

Also makes `ReproTool` be able to use `gh` CLI to get GitHub tokens.

<!-- #1 -->