### PR TITLE
Wire up ICodeflow on ProductConstructionServiceApi

### DIFF
--- a/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/Generated/ProductConstructionServiceApi.cs
+++ b/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/Generated/ProductConstructionServiceApi.cs
@@ -31,6 +31,7 @@ namespace Microsoft.DotNet.ProductConstructionService.Client
         IBuilds Builds { get; }
         IBuildTime BuildTime { get; }
         IChannels Channels { get; }
+        ICodeflow Codeflow { get; }
         IConfigurationIngestion Ingestion { get; }
         IDefaultChannels DefaultChannels { get; }
         IFeatureFlags FeatureFlags { get; }
@@ -127,6 +128,8 @@ namespace Microsoft.DotNet.ProductConstructionService.Client
 
         public IChannels Channels { get; }
 
+        public ICodeflow Codeflow { get; }
+
         public IDefaultChannels DefaultChannels { get; }
 
         public IFeatureFlags FeatureFlags { get; }
@@ -160,6 +163,7 @@ namespace Microsoft.DotNet.ProductConstructionService.Client
             Builds = new Builds(this);
             BuildTime = new BuildTime(this);
             Channels = new Channels(this);
+            Codeflow = new Codeflow(this);
             DefaultChannels = new DefaultChannels(this);
             FeatureFlags = new FeatureFlags(this);
             Goal = new Goal(this);


### PR DESCRIPTION
The `Codeflow` generated client class and `ICodeflow` interface were added in #6034 but were not wired up on `IProductConstructionServiceApi` or `ProductConstructionServiceApi`, making the new codeflow statuses endpoint inaccessible through the typed client.

This adds:
- `ICodeflow Codeflow { get; }` to `IProductConstructionServiceApi`
- `public ICodeflow Codeflow { get; }` property to `ProductConstructionServiceApi`
- `Codeflow = new Codeflow(this);` in the constructor

4 lines, mirrors the pattern used by all other service operations (Assets, Builds, Subscriptions, etc.).