### PR TITLE
Reset working tree before rebasing

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/WorkBranch.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/WorkBranch.cs
@@ -104,6 +104,8 @@ public class WorkBranch(
         _logger.LogInformation("Rebasing {branchName} onto {mainBranch}...", WorkBranchName, OriginalBranchName);
 
         cancellationToken.ThrowIfCancellationRequested();
+
+        await _repo.ResetWorkingTree();
         await _repo.CheckoutAsync(OriginalBranchName);
 
         try


### PR DESCRIPTION
This appears to be enough, I'm able to repro the sub locally when running in the service https://github.com/maestro-auth-test/dotnet/pull/242

https://github.com/dotnet/arcade-services/issues/6052