### PR TITLE
Properly handle no unstaged files when resetting working tree

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -124,9 +124,12 @@ public class LocalGitClient : ILocalGitClient
         else if (result.StandardError.Contains("is unmerged") || result.StandardError.Contains("needs merge"))
         {
             var unstagedNonConflictingFiles = await GetUnstagedFilesAsync(repoPath, relativePath);
-            args = ["checkout", .. unstagedNonConflictingFiles];
-            result = await _processManager.ExecuteGit(repoPath, args);
-            result.ThrowIfFailed("failed to clean unmerged non conflicting files from the working tree");
+            if (unstagedNonConflictingFiles.Count > 0)
+            {
+                args = ["checkout", .. unstagedNonConflictingFiles];
+                result = await _processManager.ExecuteGit(repoPath, args);
+                result.ThrowIfFailed("failed to clean unmerged non conflicting files from the working tree"); 
+            }
         }
 
         // Also remove untracked files (in case files were removed in index)


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/6077
When we were attempting to reset the working tree, if we didn't find any unstaged files, we'd just call `checkout`, which would fail because there's unmerged paths.
Instead we should not do it, and let the `clean` bellow handle untracked files