### PR TITLE
Chose correct branch when resolving source-manifest changes

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/ForwardFlowConflictResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/ForwardFlowConflictResolver.cs
@@ -165,7 +165,7 @@ public class ForwardFlowConflictResolver : CodeFlowConflictResolver, IForwardFlo
         // Known conflict in source-manifest.json
         if (string.Equals(conflictedFile, VmrInfo.DefaultRelativeSourceManifestPath, StringComparison.OrdinalIgnoreCase))
         {
-            await TryResolvingSourceManifestConflict(vmr, codeflowOptions, headBranchExisted, cancellationToken);
+            await TryResolvingSourceManifestConflict(vmr, codeflowOptions, cancellationToken);
             return true;
         }
 
@@ -197,17 +197,15 @@ public class ForwardFlowConflictResolver : CodeFlowConflictResolver, IForwardFlo
     private async Task TryResolvingSourceManifestConflict(
         ILocalGitRepo vmr,
         CodeflowOptions codeflowOptions,
-        bool headBranchExisted,
         CancellationToken cancellationToken)
     {
         var mappingName = codeflowOptions.Mapping.Name!;
         _logger.LogDebug("Auto-resolving conflict in {file}", VmrInfo.DefaultRelativeSourceManifestPath);
 
-        // We load the source manifest from the target branch (or head branch if it existed) and replace the
+        // We load the source manifest from the target branch and replace the
         // current mapping (and its submodules) with our branches' information
-        var branchName = headBranchExisted ? codeflowOptions.HeadBranch : codeflowOptions.TargetBranch;
         var result = await vmr.RunGitCommandAsync(
-            ["show", $"{branchName}:{VmrInfo.DefaultRelativeSourceManifestPath}"],
+            ["show", $"{codeflowOptions.TargetBranch}:{VmrInfo.DefaultRelativeSourceManifestPath}"],
             cancellationToken);
 
         var targetBranchSourceManifest = SourceManifest.FromJson(result.StandardOutput);


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/5943
It's possible something changed when we went from merging to rebasing. This should be a safer option, to always take the version from the target branch (or head if it existed) and apply the change we want on top