### PR TITLE
Downgrade Newtonsoft.Json to version 13.0.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,7 +76,7 @@
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="20.264.0-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NRedisStack" Version="0.12.0" />
     <PackageVersion Include="NuGet.Packaging" Version="7.0.1" />
     <PackageVersion Include="NUnit" Version="4.4.0" />


### PR DESCRIPTION
This seems to be causing issues in arcade because msbuild redistributes 13.0.3 and 13.0.4 introduced a new API that will get bound and then cause:

```
System.MissingMethodException->Microsoft.Build.Framework.BuildException.GenericBuildTransferredException: Method not found: 'System.String Newtonsoft.Json.Linq.JToken.ToString(Newtonsoft.Json.Formatting)'.
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\11.0.0-beta.26180.3\tools\VisualStudio.VsixBuild.targets(155,5): error MSB4018: The "Microsoft.DotNet.Build.Tasks.VisualStudio.FinalizeInsertionVsixFile" task failed unexpectedly.
```

Let's downgrade it for now. See [FR thread](https://teams.microsoft.com/l/message/19:afba3d1545dd45d7b79f34c1821f6055@thread.skype/1774983457993?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&parentMessageId=1774983457993&teamName=.NET%20Core%20Eng%20Services%20Partners&channelName=First%20Responders&createdTime=1774983457993).