### PR TITLE
Don't fail silently on server side git push rejections

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
@@ -418,7 +418,7 @@ public class LocalLibGit2Client : LocalGitClient, ILocalLibGit2Client
                 },
             OnPushStatusError = error =>
             {
-                throw new LibGit2SharpException($"Failed to push {error.Reference}: {error.Message}");
+                throw new DarcException($"Failed to push {error.Reference}: {error.Message}");
             }
         };
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalLibGit2Client.cs
@@ -415,7 +415,11 @@ public class LocalLibGit2Client : LocalGitClient, ILocalLibGit2Client
                 {
                     Username = Constants.GitHubBotUserName,
                     Password = _remoteTokenProvider.GetTokenForRepository(remoteUrl),
-                }
+                },
+            OnPushStatusError = error =>
+            {
+                throw new LibGit2SharpException($"Failed to push {error.Reference}: {error.Message}");
+            }
         };
 
         var refSpec = force


### PR DESCRIPTION
This makes it so we don't fail silently on server side rejections. Previously we were only getting transport related errors
https://github.com/dotnet/arcade-services/issues/6181