### PR TITLE
Automatically open reset PRs after codeflow source branch changes

### DIFF
--- a/docs/Darc.md
+++ b/docs/Darc.md
@@ -74,7 +74,7 @@ use darc to achieve them, as well as a general reference guide to darc commands.
   - [generate-tpn](#generate-tpn) - Generates a new THIRD-PARTY-NOTICES.txt.
   - [get-version](#get-version) - Gets the current version (a SHA) of a repository in the VMR.
   - [push](#push) - Pushes given VMR branch to a given remote.
-  - [reset](#reset) - Resets the contents of a VMR mapping to match a specific commit SHA from the source repository.
+  - [reset](#reset) - Resets the contents of a VMR mapping to match a specific source repository state, effectively restoring the mapping to a known good state. Changes are staged only.
   - [diff](#diff) - Diffs the VMR and the product repositories.
 
 ## Scenarios
@@ -1896,8 +1896,8 @@ Looking up build 2038 in Build Asset Registry...
 Finding build for Microsoft.DotNet.Cli.Runtime@3.0.100-preview.19075.1...
 Looking up Microsoft.DotNet.Cli.Runtime@3.0.100-preview.19075.1 in Build Asset Registry...
 Looking up build 1946 in Build Asset Registry...
-Finding build for Microsoft.NET.Sdk@3.0.100-preview.19075.2...
-Looking up Microsoft.NET.Sdk@3.0.100-preview.19075.2 in Build Asset Registry...
+Finding build for Microsoft.NETSdk@3.0.100-preview.19075.2...
+Looking up Microsoft.NETSdk@3.0.100-preview.19075.2 in Build Asset Registry...
 Looking up build 1931 in Build Asset Registry...
 Finding build for Microsoft.Build@16.0.0-preview.386...
 Looking up Microsoft.Build@16.0.0-preview.386 in Build Asset Registry...
@@ -3239,12 +3239,26 @@ darc vmr push --remote-url https://github.com/myfork/dotnet --branch main --skip
 
 ### **`reset`**
 
-Resets the contents of a VMR mapping to match a specific commit SHA from the source repository, effectively restoring the mapping to a known good state. This command takes a single parameter in the format `[mapping]:[sha]`.
+Resets the contents of a VMR mapping to match a specific source repository state, effectively restoring the mapping to a known good state. Changes are staged only.
+
+The command accepts the following forms:
+- `[mapping]:[sha]` to reset to a specific commit
+- `[mapping] --build <barBuildId>` to reset to the commit associated with a BAR build
+- `[mapping] --channel <channelName>` to reset to the latest build from a channel
+
+`--build` and `--channel` are mutually exclusive. When using either of them, the positional parameter should be just the mapping name.
 
 **Sample**
 ```
 # Reset runtime mapping to specific commit
 darc vmr reset runtime:abc123def456
+
+# Reset runtime mapping to the commit from BAR build 123456
+darc vmr reset runtime --build 123456
+
+# Reset runtime mapping to the latest build from a channel
+darc vmr reset runtime --channel ".NET 10"
+
 # Invalid format - shows clear error
 darc vmr reset invalid-format
 # Output: fail: Invalid format. Expected [mapping]:[sha] but got: invalid-format

--- a/src/Microsoft.DotNet.Darc/DarcLib/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/AzureDevOpsClient.cs
@@ -463,6 +463,23 @@ public class AzureDevOpsClient : RemoteRepoBase, IRemoteGitRepo, IAzureDevOpsCli
             id);
     }
 
+    public async Task ClosePullRequestAsync(string pullRequestUri)
+    {
+        (string accountName, string projectName, string repoName, int id) = ParsePullRequestUri(pullRequestUri);
+
+        using VssConnection connection = CreateVssConnection(accountName);
+        using GitHttpClient client = await connection.GetClientAsync<GitHttpClient>();
+
+        await client.UpdatePullRequestAsync(
+            new GitPullRequest
+            {
+                Status = PullRequestStatus.Abandoned
+            },
+            projectName,
+            repoName,
+            id);
+    }
+
     /// <summary>
     /// Gets all the commits related to the pull request
     /// </summary>

--- a/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/GitHubClient.cs
@@ -383,6 +383,20 @@ public class GitHubClient : RemoteRepoBase, IRemoteGitRepo
             });
     }
 
+    public async Task ClosePullRequestAsync(string pullRequestUri)
+    {
+        (string owner, string repo, int id) = ParsePullRequestUri(pullRequestUri);
+
+        await GetClient(owner, repo).PullRequest.Update(
+            owner,
+            repo,
+            id,
+            new PullRequestUpdate
+            {
+                State = ItemState.Closed
+            });
+    }
+
     /// <summary>
     /// Gets all the commits related to the pull request
     /// </summary>

--- a/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IRemote.cs
@@ -83,6 +83,12 @@ public interface IRemote
     Task UpdatePullRequestAsync(string pullRequestUri, PullRequest pullRequest);
 
     /// <summary>
+    ///     Close an existing pull request without merging it.
+    /// </summary>
+    /// <param name="pullRequestUri">URI of pull request to close.</param>
+    Task ClosePullRequestAsync(string pullRequestUri);
+
+    /// <summary>
     ///     Delete a Pull Request branch
     /// </summary>
     /// <param name="pullRequestUri">URI of pull request to delete branch for</param>

--- a/src/Microsoft.DotNet.Darc/DarcLib/IRemoteGitRepo.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/IRemoteGitRepo.cs
@@ -91,6 +91,12 @@ public interface IRemoteGitRepo : IGitRepoCloner, IGitRepo
     /// <param name="pullRequest">Pull request info to update</param>
     Task UpdatePullRequestAsync(string pullRequestUri, PullRequest pullRequest);
 
+    /// <summary>
+    ///     Close an existing pull request without merging it.
+    /// </summary>
+    /// <param name="pullRequestUri">Uri of pull request to close</param>
+    Task ClosePullRequestAsync(string pullRequestUri);
+
 
     /// <summary>
     ///     Merges a Dependency update pull request

--- a/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Remote.cs
@@ -105,6 +105,9 @@ public sealed class Remote : IRemote
         return _remoteGitClient.UpdatePullRequestAsync(pullRequestUri, pullRequest);
     }
 
+    public Task ClosePullRequestAsync(string pullRequestUri) =>
+        _remoteGitClient.ClosePullRequestAsync(pullRequestUri);
+
     /// <summary>
     ///     Delete a Pull Request branch
     /// </summary>

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/Exceptions.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/Exceptions.cs
@@ -92,7 +92,7 @@ public class NonLinearCodeflowException(bool flowingOldBuild = false) : DarcExce
 }
 
 public class BackflowNonContinuableNonLinearCodeflowException(string currentVmrSha, string lastFFRepoSha, string currentRepoSha)
-    : DarcException($"Cannot unsafe backflow commit {currentVmrSha} as the repo contents we're trying to backflow {lastFFRepoSha} are not the descendant of {currentRepoSha}."
+    : DarcException($"Cannot unsafe backflow commit {currentVmrSha} because the current repo SHA {currentRepoSha} is not a descendant of the last fast-forwarded repo SHA {lastFFRepoSha}. "
         + "Doing so would attempt to 'reset' the repo branch to a different branch")
 {
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/Exceptions.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/Exceptions.cs
@@ -92,6 +92,12 @@ public class NonLinearCodeflowException(string currentSha, string previousSha, b
     public bool FlowingOldBuild { get; } = flowingOldBuild;
 }
 
+public class BackflowNonContinuableNonLinearCodeflowException(string currentVmrSha, string lastFFRepoSha, string currentRepoSha)
+    : DarcException($"Cannot unsafe backflow commit {currentVmrSha} as the repo contents we're trying to backflow {lastFFRepoSha} are not the descendant of {currentRepoSha}."
+        + "Doing so would attempt to 'reset' the repo branch to a different branch")
+{
+}
+
 /// <summary>
 /// This exception is used when the current codeflow cannot be applied, and if a codeflow PR already exists, then it
 /// is blocked from receiving new flows.

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/Exceptions.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/Exceptions.cs
@@ -86,9 +86,10 @@ public class ConflictInPrBranchException : DarcException
     }
 }
 
-public class NonLinearCodeflowException(string currentSha, string previousSha)
+public class NonLinearCodeflowException(string currentSha, string previousSha, bool flowingOldBuild)
     : DarcException($"Cannot flow commit {currentSha} as it's not a descendant of previously flown commit {previousSha}")
 {
+    public bool FlowingOldBuild { get; } = flowingOldBuild;
 }
 
 /// <summary>

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/Exceptions.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/Exceptions.cs
@@ -86,8 +86,7 @@ public class ConflictInPrBranchException : DarcException
     }
 }
 
-public class NonLinearCodeflowException(string currentSha, string previousSha, bool flowingOldBuild)
-    : DarcException($"Cannot flow commit {currentSha} as it's not a descendant of previously flown commit {previousSha}")
+public class NonLinearCodeflowException(bool flowingOldBuild = false) : DarcException()
 {
     public bool FlowingOldBuild { get; } = flowingOldBuild;
 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -580,6 +580,16 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         var vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
         if (!await vmr.IsAncestorCommit(lastBackFlowVmrSha, currentFlow.VmrSha))
         {
+            // before we return this non LinearCodeflowException and continue with the unsafe flow
+            // we need to check if the commit we'd backflow is safe to apply
+            // to do this we need to check if the last forward flow repo sha is ancestor to the current backflow repo sha
+            // if it is, we can continue with the unsafe flow, if it's not, that means we'll try to overwrite the branch contents
+            // with a different branch
+            if (await vmr.IsAncestorCommit(lastFlows.LastForwardFlow.RepoSha, currentFlow.RepoSha))
+            {
+                throw new BackflowNonContinuableNonLinearCodeflowException(currentFlow.VmrSha, lastFlows.LastForwardFlow.RepoSha, currentFlow.RepoSha);
+            }
+
             throw new NonLinearCodeflowException(currentFlow.VmrSha, lastBackFlowVmrSha, await vmr.IsAncestorCommit(currentFlow.VmrSha, lastBackFlowVmrSha));
         }
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -591,7 +591,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             }
 
             _logger.LogInformation("Cannot flow commit {currentSha} as it's not a descendant of previously flown commit {previousSha}", currentFlow.VmrSha, lastBackFlowVmrSha);
-            throw new NonLinearCodeflowException(currentFlow.VmrSha, lastBackFlowVmrSha, await vmr.IsAncestorCommit(currentFlow.VmrSha, lastBackFlowVmrSha));
+            throw new NonLinearCodeflowException(await vmr.IsAncestorCommit(currentFlow.VmrSha, lastBackFlowVmrSha));
         }
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -584,7 +584,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             // to do this we need to check if the last forward flow repo sha is ancestor to the current backflow repo sha
             // if it is, we can continue with the unsafe flow, if it's not, that means we'll try to overwrite the branch contents
             // with a different branch
-            if (await vmr.IsAncestorCommit(lastFlows.LastForwardFlow.RepoSha, currentFlow.RepoSha))
+            if (await repo.IsAncestorCommit(lastFlows.LastForwardFlow.RepoSha, currentFlow.RepoSha))
             {
                 throw new BackflowNonContinuableNonLinearCodeflowException(currentFlow.VmrSha, lastFlows.LastForwardFlow.RepoSha, currentFlow.RepoSha);
             }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -133,6 +133,16 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         bool headBranchExisted,
         CancellationToken cancellationToken)
     {
+        // We need to check if the commit we'd backflow won't try to override the target repo branch with a different one,
+        // to do this we need to check if the last forward flow repo sha is ancestor to the current backflow repo sha
+        // if it is, we can continue with the unsafe flow, if it's not, that means we'll try to overwrite the branch contents
+        // with a different branch
+        var targetRepoHeadBranchSha = await targetRepo.GetShaForRefAsync(codeflowOptions.HeadBranch);
+        if (!await targetRepo.IsAncestorCommit(lastFlows.LastForwardFlow.RepoSha, targetRepoHeadBranchSha))
+        {
+            throw new BackflowNonContinuableNonLinearCodeflowException(codeflowOptions.Build.Commit, lastFlows.LastForwardFlow.RepoSha, targetRepoHeadBranchSha);
+        }
+
         CodeFlowResult result = await FlowCodeAsync(
             codeflowOptions,
             lastFlows,
@@ -578,17 +588,9 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         }
 
         var vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
+
         if (!await vmr.IsAncestorCommit(lastBackFlowVmrSha, currentFlow.VmrSha))
         {
-            // We need to check if the commit we'd backflow won't try to override the target repo branch with a different one,
-            // to do this we need to check if the last forward flow repo sha is ancestor to the current backflow repo sha
-            // if it is, we can continue with the unsafe flow, if it's not, that means we'll try to overwrite the branch contents
-            // with a different branch
-            if (await repo.IsAncestorCommit(lastFlows.LastForwardFlow.RepoSha, currentFlow.RepoSha))
-            {
-                throw new BackflowNonContinuableNonLinearCodeflowException(currentFlow.VmrSha, lastFlows.LastForwardFlow.RepoSha, currentFlow.RepoSha);
-            }
-
             _logger.LogInformation("Cannot flow commit {currentSha} as it's not a descendant of previously flown commit {previousSha}", currentFlow.VmrSha, lastBackFlowVmrSha);
             throw new NonLinearCodeflowException(await vmr.IsAncestorCommit(currentFlow.VmrSha, lastBackFlowVmrSha));
         }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -591,7 +591,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
 
         if (!await vmr.IsAncestorCommit(lastBackFlowVmrSha, currentFlow.VmrSha))
         {
-            _logger.LogInformation("Cannot flow commit {currentSha} as it's not a descendant of previously flown commit {previousSha}", currentFlow.VmrSha, lastBackFlowVmrSha);
+            _logger.LogInformation("Cannot safely flow commit {currentSha} as it's not a descendant of previously flown commit {previousSha}", currentFlow.VmrSha, lastBackFlowVmrSha);
             throw new NonLinearCodeflowException(await vmr.IsAncestorCommit(currentFlow.VmrSha, lastBackFlowVmrSha));
         }
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -590,6 +590,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
                 throw new BackflowNonContinuableNonLinearCodeflowException(currentFlow.VmrSha, lastFlows.LastForwardFlow.RepoSha, currentFlow.RepoSha);
             }
 
+            _logger.LogInformation("Cannot flow commit {currentSha} as it's not a descendant of previously flown commit {previousSha}", currentFlow.VmrSha, lastBackFlowVmrSha);
             throw new NonLinearCodeflowException(currentFlow.VmrSha, lastBackFlowVmrSha, await vmr.IsAncestorCommit(currentFlow.VmrSha, lastBackFlowVmrSha));
         }
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -133,14 +133,17 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         bool headBranchExisted,
         CancellationToken cancellationToken)
     {
-        // We need to check if the commit we'd backflow won't try to override the target repo branch with a different one,
-        // to do this we need to check if the last forward flow repo sha is ancestor to the current backflow repo sha
-        // if it is, we can continue with the unsafe flow, if it's not, that means we'll try to overwrite the branch contents
-        // with a different branch
-        var targetRepoHeadBranchSha = await targetRepo.GetShaForRefAsync(codeflowOptions.HeadBranch);
-        if (!await targetRepo.IsAncestorCommit(lastFlows.LastForwardFlow.RepoSha, targetRepoHeadBranchSha))
+        if (!codeflowOptions.UnsafeFlow)
         {
-            throw new BackflowNonContinuableNonLinearCodeflowException(codeflowOptions.Build.Commit, lastFlows.LastForwardFlow.RepoSha, targetRepoHeadBranchSha);
+            // We need to check if the commit we'd backflow won't try to override the target repo branch with a different one,
+            // to do this we need to check if the last forward flow repo sha is ancestor to the current backflow repo sha
+            // if it is, we can continue with the unsafe flow, if it's not, that means we'll try to overwrite the branch contents
+            // with a different branch
+            var targetRepoHeadBranchSha = await targetRepo.GetShaForRefAsync(codeflowOptions.HeadBranch);
+            if (!await targetRepo.IsAncestorCommit(lastFlows.LastForwardFlow.RepoSha, targetRepoHeadBranchSha))
+            {
+                throw new BackflowNonContinuableNonLinearCodeflowException(codeflowOptions.Build.Commit, lastFlows.LastForwardFlow.RepoSha, targetRepoHeadBranchSha);
+            }
         }
 
         CodeFlowResult result = await FlowCodeAsync(

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -580,7 +580,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         var vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
         if (!await vmr.IsAncestorCommit(lastBackFlowVmrSha, currentFlow.VmrSha))
         {
-            throw new NonLinearCodeflowException(currentFlow.VmrSha, lastBackFlowVmrSha);
+            throw new NonLinearCodeflowException(currentFlow.VmrSha, lastBackFlowVmrSha, await vmr.IsAncestorCommit(currentFlow.VmrSha, lastBackFlowVmrSha));
         }
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -580,8 +580,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         var vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
         if (!await vmr.IsAncestorCommit(lastBackFlowVmrSha, currentFlow.VmrSha))
         {
-            // before we return this non LinearCodeflowException and continue with the unsafe flow
-            // we need to check if the commit we'd backflow is safe to apply
+            // We need to check if the commit we'd backflow won't try to override the target repo branch with a different one,
             // to do this we need to check if the last forward flow repo sha is ancestor to the current backflow repo sha
             // if it is, we can continue with the unsafe flow, if it's not, that means we'll try to overwrite the branch contents
             // with a different branch

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -133,17 +133,15 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         bool headBranchExisted,
         CancellationToken cancellationToken)
     {
-        if (!codeflowOptions.UnsafeFlow)
+
+        // We need to check if the commit we'd backflow won't try to override the target repo branch with a different one,
+        // to do this we need to check if the last forward flow repo sha is ancestor to the current backflow repo sha
+        // if it is, we can continue with the unsafe flow, if it's not, that means we'll try to overwrite the branch contents
+        // with a different branch
+        var targetRepoHeadBranchSha = await targetRepo.GetShaForRefAsync(codeflowOptions.TargetBranch);
+        if (!await targetRepo.IsAncestorCommit(lastFlows.LastForwardFlow.RepoSha, targetRepoHeadBranchSha))
         {
-            // We need to check if the commit we'd backflow won't try to override the target repo branch with a different one,
-            // to do this we need to check if the last forward flow repo sha is ancestor to the current backflow repo sha
-            // if it is, we can continue with the unsafe flow, if it's not, that means we'll try to overwrite the branch contents
-            // with a different branch
-            var targetRepoHeadBranchSha = await targetRepo.GetShaForRefAsync(codeflowOptions.TargetBranch);
-            if (!await targetRepo.IsAncestorCommit(lastFlows.LastForwardFlow.RepoSha, targetRepoHeadBranchSha))
-            {
-                throw new BackflowNonContinuableNonLinearCodeflowException(codeflowOptions.Build.Commit, lastFlows.LastForwardFlow.RepoSha, targetRepoHeadBranchSha);
-            }
+            throw new BackflowNonContinuableNonLinearCodeflowException(codeflowOptions.Build.Commit, lastFlows.LastForwardFlow.RepoSha, targetRepoHeadBranchSha);
         }
 
         CodeFlowResult result = await FlowCodeAsync(

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -139,7 +139,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             // to do this we need to check if the last forward flow repo sha is ancestor to the current backflow repo sha
             // if it is, we can continue with the unsafe flow, if it's not, that means we'll try to overwrite the branch contents
             // with a different branch
-            var targetRepoHeadBranchSha = await targetRepo.GetShaForRefAsync(codeflowOptions.HeadBranch);
+            var targetRepoHeadBranchSha = await targetRepo.GetShaForRefAsync(codeflowOptions.TargetBranch);
             if (!await targetRepo.IsAncestorCommit(lastFlows.LastForwardFlow.RepoSha, targetRepoHeadBranchSha))
             {
                 throw new BackflowNonContinuableNonLinearCodeflowException(codeflowOptions.Build.Commit, lastFlows.LastForwardFlow.RepoSha, targetRepoHeadBranchSha);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -338,7 +338,6 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
         // In such a case, we cannot compare commits 2. and 4.
         if (isBackwardOlder == isForwardOlder)
         {
-            ignoreNonLinearFlow = true;
             if (ignoreNonLinearFlow)
             {
                 _logger.LogWarning("Encountered problems with commit history linearity but will bypass because of the unsafe mode override");
@@ -351,7 +350,8 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
                     CrossingFlow: null);
             }
 
-            throw new InvalidSynchronizationException($"Failed to determine which commit of {sourceRepo} is older ({backwardSha}, {forwardSha})");
+            _logger.LogInformation("Failed to determine which commit of {sourceRepo} is older ({backwardSha}, {forwardSha})", sourceRepo, backwardSha, forwardSha);
+            throw new NonLinearCodeflowException();
         }
 
         // When the last backflow to our repo came from a different branch, we ignore it and return the last forward flow.

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -338,6 +338,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
         // In such a case, we cannot compare commits 2. and 4.
         if (isBackwardOlder == isForwardOlder)
         {
+            ignoreNonLinearFlow = true;
             if (ignoreNonLinearFlow)
             {
                 _logger.LogWarning("Encountered problems with commit history linearity but will bypass because of the unsafe mode override");

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -555,7 +555,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
 
         if (!await repo.IsAncestorCommit(lastFlowRepoSha, currentFlow.RepoSha))
         {
-            throw new NonLinearCodeflowException(currentFlow.RepoSha, lastFlowRepoSha);
+            throw new NonLinearCodeflowException(currentFlow.RepoSha, lastFlowRepoSha, await repo.IsAncestorCommit(currentFlow.RepoSha, lastFlowRepoSha));
         }
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -555,7 +555,8 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
 
         if (!await repo.IsAncestorCommit(lastFlowRepoSha, currentFlow.RepoSha))
         {
-            throw new NonLinearCodeflowException(currentFlow.RepoSha, lastFlowRepoSha, await repo.IsAncestorCommit(currentFlow.RepoSha, lastFlowRepoSha));
+            _logger.LogInformation("Cannot flow commit {currentSha} as it's not a descendant of previously flown commit {previousSha}", currentFlow.RepoSha, lastFlowRepoSha);
+            throw new NonLinearCodeflowException(await repo.IsAncestorCommit(currentFlow.RepoSha, lastFlowRepoSha));
         }
     }
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -555,7 +555,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
 
         if (!await repo.IsAncestorCommit(lastFlowRepoSha, currentFlow.RepoSha))
         {
-            _logger.LogInformation("Cannot flow commit {currentSha} as it's not a descendant of previously flown commit {previousSha}", currentFlow.RepoSha, lastFlowRepoSha);
+            _logger.LogInformation("Cannot safely flow commit {currentSha} as it's not a descendant of previously flown commit {previousSha}", currentFlow.RepoSha, lastFlowRepoSha);
             throw new NonLinearCodeflowException(await repo.IsAncestorCommit(currentFlow.RepoSha, lastFlowRepoSha));
         }
     }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/Model/InProgressPullRequest.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/Model/InProgressPullRequest.cs
@@ -55,4 +55,6 @@ public class InProgressPullRequest : DependencyFlowWorkItem
     public bool BlockedFromFutureUpdates { get; set; } = false;
 
     public DateTime CreationDate { get; set; }
+
+    public bool UnsafeFlow { get; set; } = false;
 }

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrBackFlower.cs
@@ -30,6 +30,7 @@ internal interface IPcsVmrBackFlower : IVmrBackFlower
         Build build,
         string targetBranch,
         bool forceUpdate,
+        bool unsafeFlow,
         CancellationToken cancellationToken = default);
 }
 
@@ -59,6 +60,7 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
         Build build,
         string headBranch,
         bool forceUpdate,
+        bool unsafeFlow,
         CancellationToken cancellationToken = default)
     {
         (bool headBranchExisted, SourceMapping mapping, LastFlows lastFlows, ILocalGitRepo targetRepo) = await PrepareVmrAndRepo(
@@ -67,7 +69,7 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
             subscription.TargetBranch,
             headBranch,
             targetRepoPath: null,
-            unsafeFlow: false,
+            unsafeFlow,
             cancellationToken);
 
         CodeFlowResult result = await FlowBackAsync(
@@ -80,7 +82,7 @@ internal class PcsVmrBackFlower : VmrBackFlower, IPcsVmrBackFlower
                 subscription.ExcludedAssets,
                 KeepConflicts: true,
                 forceUpdate,
-                UnsafeFlow: false,
+                unsafeFlow,
                 UseRecreationFallback: true),
             targetRepo,
             lastFlows,

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PcsVmrForwardFlower.cs
@@ -28,6 +28,7 @@ internal interface IPcsVmrForwardFlower
         Build build,
         string headBranch,
         bool forceUpdate,
+        bool unsafeFlow,
         CancellationToken cancellationToken = default);
 }
 
@@ -67,6 +68,7 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
         Build build,
         string headBranch,
         bool forceUpdate,
+        bool unsafeFlow,
         CancellationToken cancellationToken = default)
     {
         ILocalGitRepo sourceRepo = await _repositoryCloneManager.PrepareCloneAsync(
@@ -81,7 +83,7 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
             sourceRepo,
             subscription.TargetBranch,
             headBranch,
-            unsafeFlow: false,
+            unsafeFlow,
             cancellationToken);
 
         CodeFlowResult result = await FlowForwardAsync(
@@ -94,7 +96,7 @@ internal class PcsVmrForwardFlower : VmrForwardFlower, IPcsVmrForwardFlower
             lastFlows,
             headBranchExisted,
             forceUpdate,
-            unsafeFlow: false,
+            unsafeFlow,
             cancellationToken);
 
         result = result with

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -73,6 +73,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
 {
     public const int GitHubComparisonShaLength = 10;
     public const string CodeFlowPrFaqUri = "https://github.com/dotnet/dotnet/tree/main/docs/Codeflow-PRs.md";
+    public const string UnsafeCodeflowPrFaqUri = CodeFlowPrFaqUri + "#unsafe-prs";
 
     // PR description markers
     private const string DependencyUpdateBegin = "[DependencyUpdate]: <> (Begin)";
@@ -284,12 +285,19 @@ internal class PullRequestBuilder : IPullRequestBuilder
                 > This PR is a self-corrective attempt caused most likely by a recent change in codeflow subscriptions which results in the currently flown branch `{build.GetBranch()}` being divergent from the previously flown `{fromBranch}`.
                 >
                 > It may contain both source code changes from [{(subscription.IsForwardFlow() ? "the source repo" : "the VMR")}]({build.GetRepository()})
-                > as well as dependency updates. Learn more [here]({CodeFlowPrFaqUri}).
+                > as well as dependency updates. Learn more [here]({UnsafeCodeflowPrFaqUri}).
                 > 
                 > If the changes in this PR look wrong, you also have the option to reset the VMR's contents to match the repository:
                 > ```bash
                 > darc vmr reset --build {build.Id} {subscription.TargetDirectory ?? subscription.SourceDirectory}
                 > ```
+                """
+                : $"""
+                
+                > [!NOTE]
+                > This is a codeflow update. It may contain both source code changes from
+                > [{(subscription.IsForwardFlow() ? "the source repo" : "the VMR")}]({build.GetRepository()})
+                > as well as dependency updates. Learn more [here]({CodeFlowPrFaqUri}).
                 """;
 
             return $"""

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -65,7 +65,8 @@ internal interface IPullRequestBuilder
         string? previousSourceCommit,
         List<DependencyUpdateSummary> dependencyUpdates,
         IReadOnlyCollection<UpstreamRepoDiff>? upstreamRepoDiffs,
-        string? currentDescription);
+        string? currentDescription,
+        bool unsafeFlow);
 }
 
 internal class PullRequestBuilder : IPullRequestBuilder
@@ -247,14 +248,16 @@ internal class PullRequestBuilder : IPullRequestBuilder
         string? previousSourceCommit,
         List<DependencyUpdateSummary> dependencyUpdates,
         IReadOnlyCollection<UpstreamRepoDiff>? upstreamRepoDiffs,
-        string? currentDescription)
+        string? currentDescription,
+        bool unsafeFlow)
     {
         string description = await GenerateCodeFlowPRDescriptionInternal(
             subscription,
             build,
             previousSourceCommit,
             dependencyUpdates,
-            currentDescription);
+            currentDescription,
+            unsafeFlow);
 
         description = CompressRepeatedLinksInDescription(description);
 
@@ -266,17 +269,33 @@ internal class PullRequestBuilder : IPullRequestBuilder
         BuildDTO build,
         string? previousSourceCommit,
         List<DependencyUpdateSummary> dependencyUpdates,
-        string? currentDescription)
+        string? currentDescription,
+        bool unsafeFlow)
     {
         if (string.IsNullOrEmpty(currentDescription))
         {
             // if PR is new, create the new subscription update section along with the PR header
-            return $"""
+            string fromBranch = subscription.LastAppliedBuild != null ? $"from {subscription.LastAppliedBuild.GetBranch()}" : string.Empty;
+            var prHeader = unsafeFlow
+                ? $"""
+
+                > [!WARNING]
+                > This is an unsafe codeflow update caused by changing the flown branch {fromBranch} to {build.GetBranch()}.
+                > Please review carefully as it may contain undesirable changes.
+                > It may contain both source code changes from
+                > [{(subscription.IsForwardFlow() ? "the source repo" : "the VMR")}]({build.GetRepository()})
+                > as well as dependency updates. Learn more [here]({CodeFlowPrFaqUri}).
+                """
+                : $"""
                 
                 > [!NOTE]
                 > This is a codeflow update. It may contain both source code changes from
                 > [{(subscription.IsForwardFlow() ? "the source repo" : "the VMR")}]({build.GetRepository()})
                 > as well as dependency updates. Learn more [here]({CodeFlowPrFaqUri}).
+                """;
+
+            return $"""
+                {prHeader}
 
                 This pull request brings the following source code changes
                 {await GenerateCodeFlowDescriptionForSubscription(subscription.Id, previousSourceCommit, build, dependencyUpdates)}

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -275,12 +275,12 @@ internal class PullRequestBuilder : IPullRequestBuilder
         if (string.IsNullOrEmpty(currentDescription))
         {
             // if PR is new, create the new subscription update section along with the PR header
-            string fromBranch = subscription.LastAppliedBuild != null ? $"from {subscription.LastAppliedBuild.GetBranch()}" : string.Empty;
+            string fromBranch = subscription.LastAppliedBuild != null ? $"from `{subscription.LastAppliedBuild.GetBranch()}`" : string.Empty;
             var prHeader = unsafeFlow
                 ? $"""
 
                 > [!WARNING]
-                > This is an unsafe codeflow update caused by changing the flown branch {fromBranch} to {build.GetBranch()}.
+                > This is an unsafe codeflow update caused by changing the flown branch {fromBranch} to `{build.GetBranch()}`.
                 > Please review carefully as it may contain undesirable changes.
                 > It may contain both source code changes from
                 > [{(subscription.IsForwardFlow() ? "the source repo" : "the VMR")}]({build.GetRepository()})

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -275,23 +275,21 @@ internal class PullRequestBuilder : IPullRequestBuilder
         if (string.IsNullOrEmpty(currentDescription))
         {
             // if PR is new, create the new subscription update section along with the PR header
-            string fromBranch = subscription.LastAppliedBuild != null ? $"from `{subscription.LastAppliedBuild.GetBranch()}`" : string.Empty;
+            string fromBranch = subscription.LastAppliedBuild != null ? $"`{subscription.LastAppliedBuild.GetBranch()}`" : "branch";
             var prHeader = unsafeFlow
                 ? $"""
 
-                > [!WARNING]
-                > This is an unsafe codeflow update caused by changing the flown branch {fromBranch} to `{build.GetBranch()}`.
-                > Please review carefully as it may contain undesirable changes.
-                > It may contain both source code changes from
-                > [{(subscription.IsForwardFlow() ? "the source repo" : "the VMR")}]({build.GetRepository()})
+                > [!CAUTION]
+                > This is an **unsafe codeflow update** ⚠️ Please review carefully as it may contain undesirable changes and/or reverts.
+                > This PR is a self-corrective attempt caused most likely by a recent change in codeflow subscriptions which results in the currently flown branch `{build.GetBranch()}` being divergent from the previously flown `{fromBranch}`.
+                >
+                > It may contain both source code changes from [{(subscription.IsForwardFlow() ? "the source repo" : "the VMR")}]({build.GetRepository()})
                 > as well as dependency updates. Learn more [here]({CodeFlowPrFaqUri}).
-                """
-                : $"""
-                
-                > [!NOTE]
-                > This is a codeflow update. It may contain both source code changes from
-                > [{(subscription.IsForwardFlow() ? "the source repo" : "the VMR")}]({build.GetRepository()})
-                > as well as dependency updates. Learn more [here]({CodeFlowPrFaqUri}).
+                > 
+                > If the changes in this PR look wrong, you also have the option to reset the VMR's contents to match the repository:
+                > ```bash
+                > darc vmr reset --build {build.Id} {subscription.TargetDirectory ?? subscription.SourceDirectory}
+                > ```
                 """;
 
             return $"""

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -282,7 +282,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
 
                 > [!CAUTION]
                 > This is an **unsafe codeflow update** ⚠️ Please review carefully as it may contain undesirable changes and/or reverts.
-                > This PR is a self-corrective attempt caused most likely by a recent change in codeflow subscriptions which results in the currently flown branch `{build.GetBranch()}` being divergent from the previously flown `{fromBranch}`.
+                > This PR is a self-corrective attempt most likely caused by a recent change in codeflow subscriptions which results in the currently flown branch `{build.GetBranch()}` being divergent from the previously flown `{fromBranch}`.
                 >
                 > It may contain both source code changes from [{(subscription.IsForwardFlow() ? "the source repo" : "the VMR")}]({build.GetRepository()})
                 > as well as dependency updates. Learn more [here]({UnsafeCodeflowPrFaqUri}).

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
@@ -83,6 +83,17 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
             .Split('+')
             .First();
 
+        var unsafeMessage = unsafeFlown
+            ? $"""
+
+            If you don't care about about the changes made in the VMR, and just want the vmr branch to match your repo you can use
+            ```bash
+            darc vmr reset --build {update.BuildId} {subscription.TargetDirectory ?? subscription.SourceDirectory}
+            ```
+            from the local vmr clone.
+            """
+            : string.Empty;
+
         comment
             .AppendLine(
             $"""
@@ -103,7 +114,7 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
             3. Run from repo's git clone and follow the instructions provided by the command to stage the conflict locally
                 ```bash
                 darc vmr resolve-conflict --subscription {subscription.Id} {(unsafeFlown ? "--unsafe" : "")}
-                ```
+                ```{unsafeMessage}
                 This should apply the build `{update.BuildId}` with sources from [`{Microsoft.DotNet.DarcLib.Commit.GetShortSha(update.SourceSha)}`]({GitRepoUrlUtils.GetRepoAtCommitUri(update.SourceRepo, update.SourceSha)})
             4. Resolve the conflicts, commit & push the changes
             5. Once pushed, the `Codeflow verification` check will turn green.  

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
@@ -133,9 +133,6 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
            ```
         """;
 
-    public static string BuildSourceBranchChangedNotification() =>
-        "Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply.";
-
     public async Task<string?> BuildTagSourceRepositoryGitHubContactsCommentAsync(InProgressPullRequest pr)
     {
         // We'll try to notify the source repo if the subscription provided a list of aliases to tag.

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
@@ -129,9 +129,12 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
         - Force a codeflow into this PR at your own risk if you want the new changes.
           User commits made to this PR might be reverted.
           ```
-          darc trigger-subscriptions --id <subscriptionId> --force
-          ```
+           darc trigger-subscriptions --id <subscriptionId> --force
+           ```
         """;
+
+    public static string BuildSourceBranchChangedNotification() =>
+        "Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply.";
 
     public async Task<string?> BuildTagSourceRepositoryGitHubContactsCommentAsync(InProgressPullRequest pr)
     {

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
@@ -42,7 +42,8 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
         Subscription subscription,
         IReadOnlyCollection<UnixPath> conflictedFiles,
         string prHeadBranch,
-        bool prIsEmpty)
+        bool prIsEmpty,
+        bool unsafeFlown)
     {
         var comment = new StringBuilder()
             .Append(prIsEmpty ? "# :rotating_light: Action Required" : "# :stop_sign: Codeflow Paused")
@@ -101,7 +102,7 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
                 ```
             3. Run from repo's git clone and follow the instructions provided by the command to stage the conflict locally
                 ```bash
-                darc vmr resolve-conflict --subscription {subscription.Id}
+                darc vmr resolve-conflict --subscription {subscription.Id} {(unsafeFlown ? "--unsafe" : "")}
                 ```
                 This should apply the build `{update.BuildId}` with sources from [`{Microsoft.DotNet.DarcLib.Commit.GetShortSha(update.SourceSha)}`]({GitRepoUrlUtils.GetRepoAtCommitUri(update.SourceRepo, update.SourceSha)})
             4. Resolve the conflicts, commit & push the changes
@@ -111,6 +112,9 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
 
         return comment.ToString();
     }
+
+    private static string BuildAlternativeVmrResetMessage(int buildId) =>
+        $"Alternatively, if you don't care about losing any Vmr side changes, you can use `darc vmr reset --build {buildId} from the local vmr clone`";
 
     public static string BuildOppositeCodeflowMergedNotification() =>
         """

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
@@ -124,9 +124,6 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
         return comment.ToString();
     }
 
-    private static string BuildAlternativeVmrResetMessage(int buildId) =>
-        $"Alternatively, if you don't care about losing changes done in the VMR directly, you can use `darc vmr reset --build {buildId}` from a local VMR clone. This will level the contents of the VMR and the product repository.";
-
     public static string BuildOppositeCodeflowMergedNotification() =>
         """
         While this PR was open, the source repository has received code changes from this repository (an opposite codeflow merged).

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
@@ -144,8 +144,8 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
         - Force a codeflow into this PR at your own risk if you want the new changes.
           User commits made to this PR might be reverted.
           ```
-           darc trigger-subscriptions --id <subscriptionId> --force
-           ```
+          darc trigger-subscriptions --id <subscriptionId> --force
+          ```
         """;
 
     public async Task<string?> BuildTagSourceRepositoryGitHubContactsCommentAsync(InProgressPullRequest pr)

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
@@ -125,7 +125,7 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
     }
 
     private static string BuildAlternativeVmrResetMessage(int buildId) =>
-        $"Alternatively, if you don't care about losing any Vmr side changes, you can use `darc vmr reset --build {buildId} from the local vmr clone`";
+        $"Alternatively, if you don't care about losing changes done in the VMR directly, you can use `darc vmr reset --build {buildId}` from a local VMR clone. This will level the contents of the VMR and the product repository.";
 
     public static string BuildOppositeCodeflowMergedNotification() =>
         """

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestCommentBuilder.cs
@@ -43,7 +43,7 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
         IReadOnlyCollection<UnixPath> conflictedFiles,
         string prHeadBranch,
         bool prIsEmpty,
-        bool unsafeFlown)
+        bool unsafeFlow)
     {
         var comment = new StringBuilder()
             .Append(prIsEmpty ? "# :rotating_light: Action Required" : "# :stop_sign: Codeflow Paused")
@@ -83,7 +83,7 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
             .Split('+')
             .First();
 
-        var unsafeMessage = unsafeFlown
+        var unsafeMessage = unsafeFlow
             ? $"""
 
             If you don't care about about the changes made in the VMR, and just want the vmr branch to match your repo you can use
@@ -113,7 +113,7 @@ public class PullRequestCommentBuilder : IPullRequestCommentBuilder
                 ```
             3. Run from repo's git clone and follow the instructions provided by the command to stage the conflict locally
                 ```bash
-                darc vmr resolve-conflict --subscription {subscription.Id} {(unsafeFlown ? "--unsafe" : "")}
+                darc vmr resolve-conflict --subscription {subscription.Id} {(unsafeFlow ? "--unsafe" : "")}
                 ```{unsafeMessage}
                 This should apply the build `{update.BuildId}` with sources from [`{Microsoft.DotNet.DarcLib.Commit.GetShortSha(update.SourceSha)}`]({GitRepoUrlUtils.GetRepoAtCommitUri(update.SourceRepo, update.SourceSha)})
             4. Resolve the conflicts, commit & push the changes

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -111,7 +111,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         IReadOnlyCollection<UpstreamRepoDiff> upstreamRepoDiffs;
         string? previousSourceSha; // is null in some edge cases like onboarding a new repository
 
-        var (codeFlowRes, unsafeFlown, prHeadBranch) = await ExecuteCodeFlowAsync(
+        var (codeFlowRes, unsafeFlow, prHeadBranch) = await ExecuteCodeFlowAsync(
             pr,
             prInfo,
             update,
@@ -161,14 +161,14 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                 prHeadBranch,
                 codeFlowRes,
                 upstreamRepoDiffs,
-                unsafeFlown);
+                unsafeFlow);
             return;
         }
 
         // TODO Figure out if we want to close
         // Unsafe flow PRs that when a new unsafe update comes in..
         string? oldPrUrl = null;
-        if (unsafeFlown && pr != null)
+        if (unsafeFlow && pr != null)
         {
             oldPrUrl = pr.Url;
             await _stateManager.ClearAllStateAsync(isCodeFlow: true, clearPendingUpdates: true);
@@ -185,7 +185,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                 prHeadBranch,
                 codeFlowRes.DependencyUpdates,
                 upstreamRepoDiffs,
-                unsafeFlown);
+                unsafeFlow);
 
             if (oldPrUrl != null)
             {
@@ -431,12 +431,12 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         string prHeadBranch,
         CodeFlowResult codeFlowRes,
         IReadOnlyCollection<UpstreamRepoDiff> upstreamRepoDiffs,
-        bool unsafeFlown)
+        bool unsafeFlow)
     {
         var manualResolutionBranch = prHeadBranch;
         string? oldPrUrl = null;
 
-        if (unsafeFlown && pr != null)
+        if (unsafeFlow && pr != null)
         {
             var localRepo = subscription.IsForwardFlow() ? _vmrInfo.VmrPath : codeFlowRes.RepoPath;
             var shouldReuseExistingPr = await IsExistingUnsafeConflictPrStillEmptyAsync(pr, subscription, localRepo);
@@ -463,7 +463,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
             manualResolutionBranch,
             codeFlowRes,
             upstreamRepoDiffs,
-            unsafeFlown);
+            unsafeFlow);
 
         if (oldPrUrl != null)
         {

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -113,7 +113,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         IReadOnlyCollection<UpstreamRepoDiff> upstreamRepoDiffs;
         string? previousSourceSha; // is null in some edge cases like onboarding a new repository
 
-        var (codeFlowRes, unsafeFlown, updatedPrHeadBranch) = await ExecuteCodeFlowAsync(
+        var (codeFlowRes, unsafeFlow, updatedPrHeadBranch) = await ExecuteCodeFlowAsync(
             pr,
             prInfo,
             update,
@@ -132,7 +132,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
             return;
         }
 
-        if (unsafeFlown)
+        if (unsafeFlow)
         {
             // if we had an existing PR and we had to unsafe flow, we closed the PR and had to create a different head branch
             if (pr != null)
@@ -176,7 +176,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                 prHeadBranch,
                 codeFlowRes,
                 upstreamRepoDiffs,
-                unsafeFlown);
+                unsafeFlow);
 
             return;
         }
@@ -189,7 +189,8 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                 subscription,
                 prHeadBranch,
                 codeFlowRes.DependencyUpdates,
-                upstreamRepoDiffs);
+                upstreamRepoDiffs,
+                unsafeFlow);
         }
         else if (pr != null && prInfo != null)
         {
@@ -423,7 +424,8 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                 subscription,
                 prHeadBranch,
                 codeFlowResult.DependencyUpdates,
-                upstreamRepoDiffs);
+                upstreamRepoDiffs,
+                unsafeFlown);
         }
         else
         {
@@ -503,7 +505,8 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         SubscriptionDTO subscription,
         string prBranch,
         List<DependencyUpdate> dependencyUpdates,
-        IReadOnlyCollection<UpstreamRepoDiff>? upstreamRepoDiffs)
+        IReadOnlyCollection<UpstreamRepoDiff>? upstreamRepoDiffs,
+        bool unsafeFlow)
     {
         IRemote darcRemote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
         var build = await _sqlClient.GetBuildAsync(update.BuildId);
@@ -518,7 +521,8 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                 previousSourceSha,
                 requiredUpdates,
                 upstreamRepoDiffs,
-                currentDescription: null);
+                currentDescription: null,
+                unsafeFlow: unsafeFlow);
 
             PullRequest pr = await darcRemote.CreatePullRequestAsync(
                 subscription.TargetRepository,
@@ -617,7 +621,8 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
             previousSourceSha,
             pullRequest.RequiredUpdates,
             upstreamRepoDiffs,
-            prInfo?.Description);
+            prInfo?.Description,
+            unsafeFlow: false /* we never update PRs with unsafe flow */);
 
         try
         {

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -349,17 +349,25 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         var (owner, repo, id) = GitHubClient.ParsePullRequestUri(newPrUrl);
         var newPrHtmlUrl = $"https://github.com/{owner}/{repo}/pull/{id}";
 
-        try
+        await TryAsync(
+            () => remote.CommentPullRequestAsync(
+                oldPrUrl,
+                $"Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply. A new PR has been opened: {newPrHtmlUrl}"),
+            "comment on");
+        await TryAsync(() => remote.ClosePullRequestAsync(oldPrUrl), "close");
+        await TryAsync(() => remote.DeletePullRequestBranchAsync(oldPrUrl), "delete branch of");
+
+        async Task TryAsync(Func<Task> op, string verb)
         {
-            await remote.CommentPullRequestAsync(oldPrUrl,
-                $"Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply. A new PR has been opened: {newPrHtmlUrl}");
-            await remote.ClosePullRequestAsync(oldPrUrl);
-            await remote.DeletePullRequestBranchAsync(oldPrUrl);
-        }
-        catch (Exception e)
-        {
-            _logger.LogError("Failed to cleanup old PR during unsafe flow: {message}", e.Message);
-            throw;
+            try
+            {
+                await op();
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Failed to {verb} old PR {oldPrUrl} after unsafe flow for subscription {subscriptionId}",
+                    verb, oldPrUrl, subscription.Id);
+            }
         }
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -335,7 +335,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         }
         catch (Exception e) when (e is not NonLinearCodeflowException)
         {
-            _logger.LogError(e, "Failed to flow source changes for build {buildId} in subscription {subscriptionId}",
+            _logger.LogError("Failed to flow source changes for build {buildId} in subscription {subscriptionId}",
                 build.Id,
                 subscription.Id);
             throw;
@@ -349,10 +349,18 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         var (owner, repo, id) = GitHubClient.ParsePullRequestUri(newPrUrl);
         var newPrHtmlUrl = $"https://github.com/{owner}/{repo}/pull/{id}";
 
-        await remote.CommentPullRequestAsync(oldPrUrl,
-            $"Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply. A new PR has been opened: {newPrHtmlUrl}");
-        await remote.ClosePullRequestAsync(oldPrUrl);
-        await remote.DeletePullRequestBranchAsync(oldPrUrl);
+        try
+        {
+            await remote.CommentPullRequestAsync(oldPrUrl,
+                $"Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply. A new PR has been opened: {newPrHtmlUrl}");
+            await remote.ClosePullRequestAsync(oldPrUrl);
+            await remote.DeletePullRequestBranchAsync(oldPrUrl);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError("Failed to cleanup old PR during unsafe flow: {message}", e.Message);
+            throw;
+        }
     }
 
     private async Task<bool> IsExistingUnsafeConflictPrStillEmptyAsync(

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -318,8 +318,11 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
     {
         IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
 
+        var (owner, repo, id) = GitHubClient.ParsePullRequestUri(newPrUrl);
+        var newPrHtmlUrl = $"https://github.com/{owner}/{repo}/pull/{id}";
+
         await remote.CommentPullRequestAsync(oldPrUrl,
-            $"Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply. A new PR has been opened: {newPrUrl}");
+            $"Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply. A new PR has been opened: {newPrHtmlUrl}");
         await remote.ClosePullRequestAsync(oldPrUrl);
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -175,7 +175,8 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                 subscription,
                 prHeadBranch,
                 codeFlowRes,
-                upstreamRepoDiffs);
+                upstreamRepoDiffs,
+                unsafeFlown);
 
             return;
         }
@@ -401,7 +402,8 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         SubscriptionDTO subscription,
         string prHeadBranch,
         CodeFlowResult codeFlowResult,
-        IReadOnlyCollection<UpstreamRepoDiff> upstreamRepoDiffs)
+        IReadOnlyCollection<UpstreamRepoDiff> upstreamRepoDiffs,
+        bool unsafeFlown)
     {
         PullRequest prInfo;
         IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
@@ -469,7 +471,8 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                 subscription,
                 codeFlowResult.ConflictedFiles,
                 prHeadBranch,
-                prIsEmpty),
+                prIsEmpty,
+                unsafeFlown),
             CommentType.Caution);
 
         // We know for sure that we will fail the codeflow checks (codeflow metadata will be expected to match the new build)

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -165,8 +165,6 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
             return;
         }
 
-        // TODO Figure out if we want to close
-        // Unsafe flow PRs that when a new unsafe update comes in..
         string? oldPrUrl = null;
         if (unsafeFlow && pr != null)
         {

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -113,7 +113,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         IReadOnlyCollection<UpstreamRepoDiff> upstreamRepoDiffs;
         string? previousSourceSha; // is null in some edge cases like onboarding a new repository
 
-        var (codeFlowRes, unsafeFlown) = await ExecuteCodeFlowAsync(
+        var (codeFlowRes, unsafeFlown, updatedPrHeadBranch) = await ExecuteCodeFlowAsync(
             pr,
             prInfo,
             update,
@@ -130,6 +130,17 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         if (!codeFlowRes.HadUpdates)
         {
             return;
+        }
+
+        if (unsafeFlown)
+        {
+            // if we had an existing PR and we had to unsafe flow, we closed the PR and had to create a different head branch
+            if (pr != null)
+            {
+                prHeadBranch = updatedPrHeadBranch;
+            }
+            pr = null;
+            prInfo = null;
         }
 
         if (isForwardFlow)
@@ -192,7 +203,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         }
     }
 
-    private async Task<(CodeFlowResult? codeflowRes, bool unsafeFlown)> ExecuteCodeFlowAsync(
+    private async Task<(CodeFlowResult? codeflowRes, bool unsafeFlown, string prHeadBranch)> ExecuteCodeFlowAsync(
         InProgressPullRequest? pr,
         PullRequest? prInfo,
         SubscriptionUpdateWorkItem update,
@@ -234,25 +245,33 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         catch (BlockingCodeflowException) when (pr != null)
         {
             await HandleBlockingCodeflowException(pr);
-            return (null, false);
+            return (null, false, prHeadBranch);
         }
         catch (TargetBranchNotFoundException)
         {
             _logger.LogWarning("Target branch {targetBranch} not found for subscription {subscriptionId}.",
                 subscription.TargetBranch,
                 subscription.Id);
-            return (null, false);
+            return (null, false, prHeadBranch);
         }
         catch (NonLinearCodeflowException e)
         {
             if (e.FlowingOldBuild)
             {
                 _logger.LogInformation("Attempted to flow an older commit for subscription {subscriptionId}, giving up", subscription.Id);
-                return (null, false);
+                return (null, false, prHeadBranch);
             }
 
             unsafeFlown = true;
-            codeFlowRes = await ExecuteUnsafeCodeFlowAsync(pr, prInfo, update, subscription, build, prHeadBranch, forceUpdate);
+            if (pr != null)
+            {
+                prHeadBranch = GetNewBranchName(subscription.TargetBranch);
+                IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
+                await remote.CommentPullRequestAsync(pr.Url, "Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply.");
+                await remote.ClosePullRequestAsync(pr.Url);
+                await _stateManager.ClearAllStateAsync(isCodeFlow: true, clearPendingUpdates: true);
+            }
+            codeFlowRes = await ExecuteUnsafeCodeFlowAsync(pr, subscription, build, prHeadBranch, forceUpdate);
         }
         catch (Exception)
         {
@@ -265,13 +284,13 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         if (codeFlowRes.HadConflicts)
         {
             _logger.LogInformation("Detected conflicts while rebasing new changes");
-            return (codeFlowRes, unsafeFlown);
+            return (codeFlowRes, unsafeFlown, prHeadBranch);
         }
 
         if (!codeFlowRes.HadUpdates)
         {
             _logger.LogInformation("There were no code-flow updates for subscription {subscriptionId}", subscription.Id);
-            return (codeFlowRes, unsafeFlown);
+            return (codeFlowRes, unsafeFlown, prHeadBranch);
         }
 
         _logger.LogInformation("Code changes for {subscriptionId} ready in local branch {branch}",
@@ -290,26 +309,16 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
 
         await _subscriptionEventRecorder.RegisterSubscriptionUpdateAction(SubscriptionUpdateAction.ApplyingUpdates, update.SubscriptionId);
 
-        return (codeFlowRes, unsafeFlown);
+        return (codeFlowRes, unsafeFlown, prHeadBranch);
     }
 
     private async Task<CodeFlowResult> ExecuteUnsafeCodeFlowAsync(
         InProgressPullRequest? pr,
-        PullRequest? prInfo,
-        SubscriptionUpdateWorkItem update,
         SubscriptionDTO subscription,
         BuildDTO build,
         string prHeadBranch,
         bool forceUpdate)
     {
-        if (pr != null)
-        {
-            IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
-            await remote.CommentPullRequestAsync(pr.Url, "Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply.");
-            await remote.ClosePullRequestAsync(pr.Url);
-            await _stateManager.ClearAllStateAsync(isCodeFlow: true, clearPendingUpdates: true);
-        }
-
         _logger.LogInformation(
             "Unsafe {direction}-flowing build {buildId} of {sourceRepo} for subscription {subscriptionId} targeting {targetRepo} / {targetBranch} to new branch {newBranch}",
             subscription.IsForwardFlow() ? "Forward" : "Back",

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -240,6 +240,16 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                 subscription.Id);
             return null;
         }
+        catch (NonLinearCodeflowException e)
+        {
+            if (e.FlowingOldBuild)
+            {
+                _logger.LogInformation("Attempted to flow an older commit for subscription {subscriptionId}, giving up", subscription.Id);
+                return null;
+            }
+
+            return await ExecuteUnsafeCodeFlowAsync(pr, prInfo, update, subscription, build, prHeadBranch, forceUpdate);
+        }
         catch (Exception)
         {
             _logger.LogError("Failed to flow source changes for build {buildId} in subscription {subscriptionId}",
@@ -277,6 +287,31 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         await _subscriptionEventRecorder.RegisterSubscriptionUpdateAction(SubscriptionUpdateAction.ApplyingUpdates, update.SubscriptionId);
 
         return codeFlowRes;
+    }
+
+    private async Task<CodeFlowResult?> ExecuteUnsafeCodeFlowAsync(
+        InProgressPullRequest? pr,
+        PullRequest? prInfo,
+        SubscriptionUpdateWorkItem update,
+        SubscriptionDTO subscription,
+        BuildDTO build,
+        string prHeadBranch,
+        bool forceUpdate)
+    {
+        if (pr != null)
+        {
+
+        }
+
+        _logger.LogInformation(
+            "{direction}-flowing build {buildId} of {sourceRepo} for subscription {subscriptionId} targeting {targetRepo} / {targetBranch} to new branch {newBranch}",
+            subscription.IsForwardFlow() ? "Forward" : "Back",
+            build.Id,
+            subscription.SourceRepository,
+            subscription.Id,
+            subscription.TargetRepository,
+            subscription.TargetBranch,
+            prHeadBranch);
     }
 
     // <summary>

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -153,51 +153,32 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
 
         if (codeFlowRes.HadConflicts)
         {
-            var manualResolutionBranch = prHeadBranch;
-
-            if (unsafeFlown && pr != null)
-            {
-                var localRepo = subscription.IsForwardFlow() ? _vmrInfo.VmrPath : codeFlowRes.RepoPath;
-                var shouldReuseExistingPr = await IsExistingUnsafeConflictPrStillEmptyAsync(pr, subscription, localRepo);
-
-                if (shouldReuseExistingPr)
-                {
-                    // Unsafe flow generates a fresh branch name when a PR already exists, but
-                    // in the reusable empty-PR case that new branch was never pushed anywhere.
-                    manualResolutionBranch = pr.HeadBranch;
-                }
-                else
-                {
-                    await ClosePullRequestAfterUnsafeFlowAsync(pr, subscription);
-                    pr = null;
-                }
-            }
-
-            await RequestManualConflictResolutionAsync(
+            await HandleConflictsAsync(
                 update,
                 pr,
                 previousSourceSha,
                 subscription,
-                manualResolutionBranch,
+                prHeadBranch,
                 codeFlowRes,
                 upstreamRepoDiffs,
                 unsafeFlown);
-
             return;
         }
 
         // TODO Figure out if we want to close
         // Unsafe flow PRs that when a new unsafe update comes in..
+        string? oldPrUrl = null;
         if (unsafeFlown && pr != null)
         {
-            await ClosePullRequestAfterUnsafeFlowAsync(pr, subscription);
+            oldPrUrl = pr.Url;
+            await _stateManager.ClearAllStateAsync(isCodeFlow: true, clearPendingUpdates: true);
             pr = null;
             prInfo = null;
         }
 
         if (pr == null)
         {
-            await CreateCodeFlowPullRequestAsync(
+            var (newPr, _) = await CreateCodeFlowPullRequestAsync(
                 update,
                 previousSourceSha,
                 subscription,
@@ -205,6 +186,11 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                 codeFlowRes.DependencyUpdates,
                 upstreamRepoDiffs,
                 unsafeFlown);
+
+            if (oldPrUrl != null)
+            {
+                await ClosePullRequestAfterUnsafeFlowAsync(oldPrUrl, subscription, newPr.Url);
+            }
         }
         else if (prInfo != null)
         {
@@ -328,13 +314,13 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         return (codeFlowRes, unsafeFlown, prHeadBranch);
     }
 
-    private async Task ClosePullRequestAfterUnsafeFlowAsync(InProgressPullRequest pr, SubscriptionDTO subscription)
+    private async Task ClosePullRequestAfterUnsafeFlowAsync(string oldPrUrl, SubscriptionDTO subscription, string newPrUrl)
     {
         IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
 
-        await remote.CommentPullRequestAsync(pr.Url, "Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply.");
-        await remote.ClosePullRequestAsync(pr.Url);
-        await _stateManager.ClearAllStateAsync(isCodeFlow: true, clearPendingUpdates: true);
+        await remote.CommentPullRequestAsync(oldPrUrl,
+            $"Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply. A new PR has been opened: {newPrUrl}");
+        await remote.ClosePullRequestAsync(oldPrUrl);
     }
 
     private async Task<bool> IsExistingUnsafeConflictPrStillEmptyAsync(
@@ -437,7 +423,55 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         return upstreamRepoDiffs;
     }
 
-    private async Task RequestManualConflictResolutionAsync(
+    private async Task HandleConflictsAsync(
+        SubscriptionUpdateWorkItem update,
+        InProgressPullRequest? pr,
+        string? previousSourceSha,
+        SubscriptionDTO subscription,
+        string prHeadBranch,
+        CodeFlowResult codeFlowRes,
+        IReadOnlyCollection<UpstreamRepoDiff> upstreamRepoDiffs,
+        bool unsafeFlown)
+    {
+        var manualResolutionBranch = prHeadBranch;
+        string? oldPrUrl = null;
+
+        if (unsafeFlown && pr != null)
+        {
+            var localRepo = subscription.IsForwardFlow() ? _vmrInfo.VmrPath : codeFlowRes.RepoPath;
+            var shouldReuseExistingPr = await IsExistingUnsafeConflictPrStillEmptyAsync(pr, subscription, localRepo);
+
+            if (shouldReuseExistingPr)
+            {
+                // Unsafe flow generates a fresh branch name when a PR already exists, but
+                // in the reusable empty-PR case that new branch was never pushed anywhere.
+                manualResolutionBranch = pr.HeadBranch;
+            }
+            else
+            {
+                oldPrUrl = pr.Url;
+                await _stateManager.ClearAllStateAsync(isCodeFlow: true, clearPendingUpdates: true);
+                pr = null;
+            }
+        }
+
+        string newPrUrl = await RequestManualConflictResolutionAsync(
+            update,
+            pr,
+            previousSourceSha,
+            subscription,
+            manualResolutionBranch,
+            codeFlowRes,
+            upstreamRepoDiffs,
+            unsafeFlown);
+
+        if (oldPrUrl != null)
+        {
+            await ClosePullRequestAfterUnsafeFlowAsync(oldPrUrl, subscription, newPrUrl);
+        }
+    }
+
+    private async Task<string> RequestManualConflictResolutionAsync(
         SubscriptionUpdateWorkItem update,
         InProgressPullRequest? pr,
         string? previousSourceSha,
@@ -516,6 +550,8 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         // We know for sure that we will fail the codeflow checks (codeflow metadata will be expected to match the new build)
         // So we trigger the evaluation right away
         await RunMergePolicyEvaluation(pr, prInfo, remote);
+
+        return pr.Url;
     }
 
     private async Task<(bool prIsEmpty, string latestPrCommit, string latestTargetBranchCommit)> GetManualConflictResolutionPrStateAsync(

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -223,37 +223,12 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
             subscription.TargetBranch,
             prHeadBranch);
 
-        CodeFlowResult codeFlowRes;
+        CodeFlowResult? codeFlowRes;
         bool unsafeFlown = false;
+
         try
         {
-            codeFlowRes = subscription.IsForwardFlow()
-                ? await _vmrForwardFlower.FlowForwardAsync(
-                    subscription,
-                    build,
-                    prHeadBranch,
-                    forceUpdate,
-                    unsafeFlow: false,
-                    cancellationToken: default)
-                : await _vmrBackFlower.FlowBackAsync(
-                    subscription,
-                    build,
-                    prHeadBranch,
-                    forceUpdate,
-                    unsafeFlow: false,
-                    cancellationToken: default);
-        }
-        catch (BlockingCodeflowException) when (pr != null)
-        {
-            await HandleBlockingCodeflowException(pr);
-            return (null, false, prHeadBranch);
-        }
-        catch (TargetBranchNotFoundException)
-        {
-            _logger.LogWarning("Target branch {targetBranch} not found for subscription {subscriptionId}.",
-                subscription.TargetBranch,
-                subscription.Id);
-            return (null, false, prHeadBranch);
+            codeFlowRes = await InvokeFlowAsync(subscription, build, pr, prHeadBranch, forceUpdate, unsafeFlow: false);
         }
         catch (NonLinearCodeflowException e)
         {
@@ -269,14 +244,22 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                 prHeadBranch = GetNewBranchName(subscription.TargetBranch);
             }
 
-            codeFlowRes = await ExecuteUnsafeCodeFlowAsync(subscription, build, prHeadBranch, forceUpdate);
-        }
-        catch (Exception)
-        {
-            _logger.LogError("Failed to flow source changes for build {buildId} in subscription {subscriptionId}",
+            _logger.LogInformation(
+                "Unsafe {direction}-flowing build {buildId} of {sourceRepo} for subscription {subscriptionId} targeting {targetRepo} / {targetBranch} to new branch {newBranch}",
+                subscription.IsForwardFlow() ? "Forward" : "Back",
                 build.Id,
-                subscription.Id);
-            throw;
+                subscription.SourceRepository,
+                subscription.Id,
+                subscription.TargetRepository,
+                subscription.TargetBranch,
+                prHeadBranch);
+
+            codeFlowRes = await InvokeFlowAsync(subscription, build, pr, prHeadBranch, forceUpdate, unsafeFlow: true);
+        }
+
+        if (codeFlowRes is null)
+        {
+            return (null, unsafeFlown, prHeadBranch);
         }
 
         if (codeFlowRes.HadConflicts)
@@ -312,6 +295,53 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         return (codeFlowRes, unsafeFlown, prHeadBranch);
     }
 
+    private async Task<CodeFlowResult?> InvokeFlowAsync(
+        SubscriptionDTO subscription,
+        BuildDTO build,
+        InProgressPullRequest? pr,
+        string branch,
+        bool forceUpdate,
+        bool unsafeFlow)
+    {
+        try
+        {
+            return subscription.IsForwardFlow()
+                ? await _vmrForwardFlower.FlowForwardAsync(
+                    subscription,
+                    build,
+                    branch,
+                    forceUpdate,
+                    unsafeFlow: unsafeFlow,
+                    cancellationToken: default)
+                : await _vmrBackFlower.FlowBackAsync(
+                    subscription,
+                    build,
+                    branch,
+                    forceUpdate,
+                    unsafeFlow: unsafeFlow,
+                    cancellationToken: default);
+        }
+        catch (BlockingCodeflowException) when (pr != null)
+        {
+            await HandleBlockingCodeflowException(pr);
+            return null;
+        }
+        catch (TargetBranchNotFoundException)
+        {
+            _logger.LogWarning("Target branch {targetBranch} not found for subscription {subscriptionId}.",
+                subscription.TargetBranch,
+                subscription.Id);
+            return null;
+        }
+        catch (Exception e) when (e is not NonLinearCodeflowException)
+        {
+            _logger.LogError(e, "Failed to flow source changes for build {buildId} in subscription {subscriptionId}",
+                build.Id,
+                subscription.Id);
+            throw;
+        }
+    }
+
     private async Task ClosePullRequestAfterUnsafeFlowAsync(string oldPrUrl, SubscriptionDTO subscription, string newPrUrl)
     {
         IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
@@ -342,49 +372,6 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
             GetManualConflictResolutionInitialCommitMessage(subscription));
 
         return prIsEmpty;
-    }
-
-    private async Task<CodeFlowResult> ExecuteUnsafeCodeFlowAsync(
-        SubscriptionDTO subscription,
-        BuildDTO build,
-        string prHeadBranch,
-        bool forceUpdate)
-    {
-        _logger.LogInformation(
-            "Unsafe {direction}-flowing build {buildId} of {sourceRepo} for subscription {subscriptionId} targeting {targetRepo} / {targetBranch} to new branch {newBranch}",
-            subscription.IsForwardFlow() ? "Forward" : "Back",
-            build.Id,
-            subscription.SourceRepository,
-            subscription.Id,
-            subscription.TargetRepository,
-            subscription.TargetBranch,
-            prHeadBranch);
-
-        try
-        {
-            return subscription.IsForwardFlow()
-                ? await _vmrForwardFlower.FlowForwardAsync(
-                    subscription,
-                    build,
-                    prHeadBranch,
-                    forceUpdate,
-                    unsafeFlow: true,
-                    cancellationToken: default)
-                : await _vmrBackFlower.FlowBackAsync(
-                    subscription,
-                    build,
-                    prHeadBranch,
-                    forceUpdate,
-                    unsafeFlow: true,
-                    cancellationToken: default);
-        }
-        catch (Exception)
-        {
-            _logger.LogError("Failed to unsafe flow source changes for build {buildId} in subscription {subscriptionId}",
-                build.Id,
-                subscription.Id);
-            throw;
-        }
     }
 
     // <summary>

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -119,13 +119,6 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
             build,
             forceUpdate);
 
-        if (unsafeFlown && pr != null)
-        {
-            await ClosePullRequestAfterUnsafeFlowAsync(pr, subscription);
-            pr = null;
-            prInfo = null;
-        }
-
         if (codeFlowRes == null)
         {
             return;
@@ -160,17 +153,46 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
 
         if (codeFlowRes.HadConflicts)
         {
+            var manualResolutionBranch = prHeadBranch;
+
+            if (unsafeFlown && pr != null)
+            {
+                var localRepo = subscription.IsForwardFlow() ? _vmrInfo.VmrPath : codeFlowRes.RepoPath;
+                var shouldReuseExistingPr = await IsExistingUnsafeConflictPrStillEmptyAsync(pr, subscription, localRepo);
+
+                if (shouldReuseExistingPr)
+                {
+                    // Unsafe flow generates a fresh branch name when a PR already exists, but
+                    // in the reusable empty-PR case that new branch was never pushed anywhere.
+                    manualResolutionBranch = pr.HeadBranch;
+                }
+                else
+                {
+                    await ClosePullRequestAfterUnsafeFlowAsync(pr, subscription);
+                    pr = null;
+                }
+            }
+
             await RequestManualConflictResolutionAsync(
                 update,
                 pr,
                 previousSourceSha,
                 subscription,
-                prHeadBranch,
+                manualResolutionBranch,
                 codeFlowRes,
                 upstreamRepoDiffs,
                 unsafeFlown);
 
             return;
+        }
+
+        // TODO Figure out if we want to close
+        // Unsafe flow PRs that when a new unsafe update comes in..
+        if (unsafeFlown && pr != null)
+        {
+            await ClosePullRequestAfterUnsafeFlowAsync(pr, subscription);
+            pr = null;
+            prInfo = null;
         }
 
         if (pr == null)
@@ -315,6 +337,25 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         await _stateManager.ClearAllStateAsync(isCodeFlow: true, clearPendingUpdates: true);
     }
 
+    private async Task<bool> IsExistingUnsafeConflictPrStillEmptyAsync(
+        InProgressPullRequest pr,
+        SubscriptionDTO subscription,
+        NativePath localRepo)
+    {
+        if (!pr.UnsafeFlow)
+        {
+            return false;
+        }
+
+        var (prIsEmpty, _, _) = await GetManualConflictResolutionPrStateAsync(
+            subscription,
+            localRepo,
+            pr.HeadBranch,
+            GetManualConflictResolutionInitialCommitMessage(subscription));
+
+        return prIsEmpty;
+    }
+
     private async Task<CodeFlowResult> ExecuteUnsafeCodeFlowAsync(
         SubscriptionDTO subscription,
         BuildDTO build,
@@ -410,7 +451,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
         NativePath localRepo = subscription.IsForwardFlow() ? _vmrInfo.VmrPath : codeFlowResult.RepoPath;
         bool prIsEmpty;
-        string initialCommitMessage = $"Initial commit for subscription {subscription.Id}";
+        string initialCommitMessage = GetManualConflictResolutionInitialCommitMessage(subscription);
 
         if (pr == null)
         {
@@ -429,17 +470,12 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         }
         else
         {
-            // We get the latest SHAs of the PR branch and the target branch
-            var remoteName = (await _gitClient.GetRemotesAsync(localRepo))
-                .First(r => r.Uri.Equals(subscription.TargetRepository))
-                .Name;
-            await _gitClient.UpdateRemoteAsync(localRepo, remoteName);
-            var latestPrCommit = await _gitClient.GetShaForRefAsync(localRepo, $"{remoteName}/{prHeadBranch}");
-            var latestTargetBranchCommit = await _gitClient.GetShaForRefAsync(localRepo, $"{remoteName}/{subscription.TargetBranch}");
-
-            // We check if the PR branch still only contains the empty commit only
-            var latestCommitMessage = await _gitClient.RunGitCommandAsync(localRepo, [$"log", "-1", "--pretty=%B", latestPrCommit]);
-            prIsEmpty = latestCommitMessage.StandardOutput.Trim().StartsWith(initialCommitMessage);
+            var (existingPrIsEmpty, latestPrCommit, latestTargetBranchCommit) = await GetManualConflictResolutionPrStateAsync(
+                subscription,
+                localRepo,
+                prHeadBranch,
+                initialCommitMessage);
+            prIsEmpty = existingPrIsEmpty;
 
             // When the PR is empty but a new build has flown in, we should rebase the PR branch onto the target branch and force-push
             if (prIsEmpty && !await _gitClient.IsAncestorCommit(localRepo, latestTargetBranchCommit, latestPrCommit))
@@ -481,6 +517,30 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         // So we trigger the evaluation right away
         await RunMergePolicyEvaluation(pr, prInfo, remote);
     }
+
+    private async Task<(bool prIsEmpty, string latestPrCommit, string latestTargetBranchCommit)> GetManualConflictResolutionPrStateAsync(
+        SubscriptionDTO subscription,
+        NativePath localRepo,
+        string prHeadBranch,
+        string initialCommitMessage)
+    {
+        var remoteName = (await _gitClient.GetRemotesAsync(localRepo))
+            .First(r => r.Uri.Equals(subscription.TargetRepository))
+            .Name;
+        await _gitClient.UpdateRemoteAsync(localRepo, remoteName);
+
+        var latestPrCommit = await _gitClient.GetShaForRefAsync(localRepo, $"{remoteName}/{prHeadBranch}");
+        var latestTargetBranchCommit = await _gitClient.GetShaForRefAsync(localRepo, $"{remoteName}/{subscription.TargetBranch}");
+        var latestCommitMessage = await _gitClient.RunGitCommandAsync(localRepo, [$"log", "-1", "--pretty=%B", latestPrCommit]);
+
+        return (
+            latestCommitMessage.StandardOutput.Trim().StartsWith(initialCommitMessage),
+            latestPrCommit,
+            latestTargetBranchCommit);
+    }
+
+    private static string GetManualConflictResolutionInitialCommitMessage(SubscriptionDTO subscription)
+        => $"Initial commit for subscription {subscription.Id}";
 
     /// <summary>
     /// Creates and pushes a new branch.
@@ -556,6 +616,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                     ? CodeFlowDirection.ForwardFlow
                     : CodeFlowDirection.BackFlow,
                 CreationDate = DateTime.UtcNow,
+                UnsafeFlow = unsafeFlow
             };
 
             await _subscriptionEventRecorder.AddDependencyFlowEventsAsync(

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -300,7 +300,10 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
     {
         if (pr != null)
         {
-
+            IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
+            await remote.CommentPullRequestAsync(pr.Url, PullRequestCommentBuilder.BuildSourceBranchChangedNotification());
+            await remote.ClosePullRequestAsync(pr.Url);
+            await _stateManager.ClearAllStateAsync(isCodeFlow: true, clearPendingUpdates: true);
         }
 
         _logger.LogInformation(

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -113,7 +113,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         IReadOnlyCollection<UpstreamRepoDiff> upstreamRepoDiffs;
         string? previousSourceSha; // is null in some edge cases like onboarding a new repository
 
-        var codeFlowRes = await ExecuteCodeFlowAsync(
+        var (codeFlowRes, unsafeFlown) = await ExecuteCodeFlowAsync(
             pr,
             prInfo,
             update,
@@ -192,7 +192,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         }
     }
 
-    private async Task<CodeFlowResult?> ExecuteCodeFlowAsync(
+    private async Task<(CodeFlowResult? codeflowRes, bool unsafeFlown)> ExecuteCodeFlowAsync(
         InProgressPullRequest? pr,
         PullRequest? prInfo,
         SubscriptionUpdateWorkItem update,
@@ -212,6 +212,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
             prHeadBranch);
 
         CodeFlowResult codeFlowRes;
+        bool unsafeFlown = false;
         try
         {
             codeFlowRes = subscription.IsForwardFlow()
@@ -220,35 +221,38 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                     build,
                     prHeadBranch,
                     forceUpdate,
+                    unsafeFlow: false,
                     cancellationToken: default)
                 : await _vmrBackFlower.FlowBackAsync(
                     subscription,
                     build,
                     prHeadBranch,
                     forceUpdate,
+                    unsafeFlow: false,
                     cancellationToken: default);
         }
         catch (BlockingCodeflowException) when (pr != null)
         {
             await HandleBlockingCodeflowException(pr);
-            return null;
+            return (null, false);
         }
         catch (TargetBranchNotFoundException)
         {
             _logger.LogWarning("Target branch {targetBranch} not found for subscription {subscriptionId}.",
                 subscription.TargetBranch,
                 subscription.Id);
-            return null;
+            return (null, false);
         }
         catch (NonLinearCodeflowException e)
         {
             if (e.FlowingOldBuild)
             {
                 _logger.LogInformation("Attempted to flow an older commit for subscription {subscriptionId}, giving up", subscription.Id);
-                return null;
+                return (null, false);
             }
 
-            return await ExecuteUnsafeCodeFlowAsync(pr, prInfo, update, subscription, build, prHeadBranch, forceUpdate);
+            unsafeFlown = true;
+            codeFlowRes = await ExecuteUnsafeCodeFlowAsync(pr, prInfo, update, subscription, build, prHeadBranch, forceUpdate);
         }
         catch (Exception)
         {
@@ -261,13 +265,13 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         if (codeFlowRes.HadConflicts)
         {
             _logger.LogInformation("Detected conflicts while rebasing new changes");
-            return codeFlowRes;
+            return (codeFlowRes, unsafeFlown);
         }
 
         if (!codeFlowRes.HadUpdates)
         {
             _logger.LogInformation("There were no code-flow updates for subscription {subscriptionId}", subscription.Id);
-            return codeFlowRes;
+            return (codeFlowRes, unsafeFlown);
         }
 
         _logger.LogInformation("Code changes for {subscriptionId} ready in local branch {branch}",
@@ -286,10 +290,10 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
 
         await _subscriptionEventRecorder.RegisterSubscriptionUpdateAction(SubscriptionUpdateAction.ApplyingUpdates, update.SubscriptionId);
 
-        return codeFlowRes;
+        return (codeFlowRes, unsafeFlown);
     }
 
-    private async Task<CodeFlowResult?> ExecuteUnsafeCodeFlowAsync(
+    private async Task<CodeFlowResult> ExecuteUnsafeCodeFlowAsync(
         InProgressPullRequest? pr,
         PullRequest? prInfo,
         SubscriptionUpdateWorkItem update,
@@ -301,13 +305,13 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         if (pr != null)
         {
             IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
-            await remote.CommentPullRequestAsync(pr.Url, PullRequestCommentBuilder.BuildSourceBranchChangedNotification());
+            await remote.CommentPullRequestAsync(pr.Url, "Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply.");
             await remote.ClosePullRequestAsync(pr.Url);
             await _stateManager.ClearAllStateAsync(isCodeFlow: true, clearPendingUpdates: true);
         }
 
         _logger.LogInformation(
-            "{direction}-flowing build {buildId} of {sourceRepo} for subscription {subscriptionId} targeting {targetRepo} / {targetBranch} to new branch {newBranch}",
+            "Unsafe {direction}-flowing build {buildId} of {sourceRepo} for subscription {subscriptionId} targeting {targetRepo} / {targetBranch} to new branch {newBranch}",
             subscription.IsForwardFlow() ? "Forward" : "Back",
             build.Id,
             subscription.SourceRepository,
@@ -315,6 +319,32 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
             subscription.TargetRepository,
             subscription.TargetBranch,
             prHeadBranch);
+
+        try
+        {
+            return subscription.IsForwardFlow()
+                ? await _vmrForwardFlower.FlowForwardAsync(
+                    subscription,
+                    build,
+                    prHeadBranch,
+                    forceUpdate,
+                    unsafeFlow: true,
+                    cancellationToken: default)
+                : await _vmrBackFlower.FlowBackAsync(
+                    subscription,
+                    build,
+                    prHeadBranch,
+                    forceUpdate,
+                    unsafeFlow: true,
+                    cancellationToken: default);
+        }
+        catch (Exception)
+        {
+            _logger.LogError("Failed to unsafe flow source changes for build {buildId} in subscription {subscriptionId}",
+                build.Id,
+                subscription.Id);
+            throw;
+        }
     }
 
     // <summary>

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -324,6 +324,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         await remote.CommentPullRequestAsync(oldPrUrl,
             $"Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply. A new PR has been opened: {newPrHtmlUrl}");
         await remote.ClosePullRequestAsync(oldPrUrl);
+        await remote.DeletePullRequestBranchAsync(oldPrUrl);
     }
 
     private async Task<bool> IsExistingUnsafeConflictPrStillEmptyAsync(

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -106,21 +106,25 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         }
 
         var isForwardFlow = subscription.IsForwardFlow();
-        string prHeadBranch = pr?.HeadBranch ?? GetNewBranchName(subscription.TargetBranch);
-
         IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
 
         IReadOnlyCollection<UpstreamRepoDiff> upstreamRepoDiffs;
         string? previousSourceSha; // is null in some edge cases like onboarding a new repository
 
-        var (codeFlowRes, unsafeFlow, updatedPrHeadBranch) = await ExecuteCodeFlowAsync(
+        var (codeFlowRes, unsafeFlown, prHeadBranch) = await ExecuteCodeFlowAsync(
             pr,
             prInfo,
             update,
             subscription,
             build,
-            prHeadBranch,
             forceUpdate);
+
+        if (unsafeFlown && pr != null)
+        {
+            await ClosePullRequestAfterUnsafeFlowAsync(pr, subscription);
+            pr = null;
+            prInfo = null;
+        }
 
         if (codeFlowRes == null)
         {
@@ -130,17 +134,6 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         if (!codeFlowRes.HadUpdates)
         {
             return;
-        }
-
-        if (unsafeFlow)
-        {
-            // if we had an existing PR and we had to unsafe flow, we closed the PR and had to create a different head branch
-            if (pr != null)
-            {
-                prHeadBranch = updatedPrHeadBranch;
-            }
-            pr = null;
-            prInfo = null;
         }
 
         if (isForwardFlow)
@@ -165,7 +158,6 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
             upstreamRepoDiffs = await ComputeRepoUpdatesAsync(previousSourceSha, build.Commit);
         }
 
-        // Conflicts + rebase means we have to block the PR until a human resolves the conflicts manually
         if (codeFlowRes.HadConflicts)
         {
             await RequestManualConflictResolutionAsync(
@@ -176,7 +168,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                 prHeadBranch,
                 codeFlowRes,
                 upstreamRepoDiffs,
-                unsafeFlow);
+                unsafeFlown);
 
             return;
         }
@@ -190,9 +182,9 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
                 prHeadBranch,
                 codeFlowRes.DependencyUpdates,
                 upstreamRepoDiffs,
-                unsafeFlow);
+                unsafeFlown);
         }
-        else if (pr != null && prInfo != null)
+        else if (prInfo != null)
         {
             await UpdateCodeFlowPullRequestAsync(
                 update,
@@ -205,15 +197,16 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         }
     }
 
-    private async Task<(CodeFlowResult? codeflowRes, bool unsafeFlown, string prHeadBranch)> ExecuteCodeFlowAsync(
+    private async Task<(CodeFlowResult? codeFlowRes, bool unsafeFlown, string prHeadBranch)> ExecuteCodeFlowAsync(
         InProgressPullRequest? pr,
         PullRequest? prInfo,
         SubscriptionUpdateWorkItem update,
         SubscriptionDTO subscription,
         BuildDTO build,
-        string prHeadBranch,
         bool forceUpdate)
     {
+        string prHeadBranch = pr?.HeadBranch ?? GetNewBranchName(subscription.TargetBranch);
+
         _logger.LogInformation(
             "{direction}-flowing build {buildId} of {sourceRepo} for subscription {subscriptionId} targeting {targetRepo} / {targetBranch} to new branch {newBranch}",
             subscription.IsForwardFlow() ? "Forward" : "Back",
@@ -268,12 +261,9 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
             if (pr != null)
             {
                 prHeadBranch = GetNewBranchName(subscription.TargetBranch);
-                IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
-                await remote.CommentPullRequestAsync(pr.Url, "Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply.");
-                await remote.ClosePullRequestAsync(pr.Url);
-                await _stateManager.ClearAllStateAsync(isCodeFlow: true, clearPendingUpdates: true);
             }
-            codeFlowRes = await ExecuteUnsafeCodeFlowAsync(pr, subscription, build, prHeadBranch, forceUpdate);
+
+            codeFlowRes = await ExecuteUnsafeCodeFlowAsync(subscription, build, prHeadBranch, forceUpdate);
         }
         catch (Exception)
         {
@@ -307,15 +297,25 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
         }
 
         // We store it the new head branch SHA in Redis (without having to have to query the remote repo)
-        prInfo?.HeadBranchSha = await _gitClient.GetShaForRefAsync(subscription.IsForwardFlow() ? _vmrInfo.VmrPath : codeFlowRes.RepoPath, prHeadBranch);
+        prInfo?.HeadBranchSha = await _gitClient.GetShaForRefAsync(
+            subscription.IsForwardFlow() ? _vmrInfo.VmrPath : codeFlowRes.RepoPath,
+            prHeadBranch);
 
         await _subscriptionEventRecorder.RegisterSubscriptionUpdateAction(SubscriptionUpdateAction.ApplyingUpdates, update.SubscriptionId);
 
         return (codeFlowRes, unsafeFlown, prHeadBranch);
     }
 
+    private async Task ClosePullRequestAfterUnsafeFlowAsync(InProgressPullRequest pr, SubscriptionDTO subscription)
+    {
+        IRemote remote = await _remoteFactory.CreateRemoteAsync(subscription.TargetRepository);
+
+        await remote.CommentPullRequestAsync(pr.Url, "Closing this PR because the branch we're flowing from has changed, and the changes in this PR no longer apply.");
+        await remote.ClosePullRequestAsync(pr.Url);
+        await _stateManager.ClearAllStateAsync(isCodeFlow: true, clearPendingUpdates: true);
+    }
+
     private async Task<CodeFlowResult> ExecuteUnsafeCodeFlowAsync(
-        InProgressPullRequest? pr,
         SubscriptionDTO subscription,
         BuildDTO build,
         string prHeadBranch,

--- a/test/Darc/Microsoft.DotNet.DarcLib.Codeflow.Tests/BackflowTests.cs
+++ b/test/Darc/Microsoft.DotNet.DarcLib.Codeflow.Tests/BackflowTests.cs
@@ -1024,4 +1024,25 @@ internal class BackflowTests : CodeFlowTests
         var result = await CallBackflow("arcade", arcadeRepoPath, "backflow");
         result.ShouldHaveUpdates();
     }
+
+    [Test]
+    public async Task BackflowDoesntFlowOlderBuilds()
+    {
+        const string bfBranch = nameof(BackflowDoesntFlowOlderBuilds) + "-bf";
+
+        await EnsureTestRepoIsInitialized();
+
+        await File.WriteAllTextAsync(_productRepoVmrFilePath, "first change");
+        await GitOperations.CommitAll(VmrPath, "first change");
+        var oldBuild = await CreateNewVmrBuild([]);
+
+        var codeflowRes = await ChangeVmrFileAndFlowIt("second change", bfBranch);
+
+        codeflowRes.ShouldHaveUpdates();
+        await FinalizeBackFlow(bfBranch);
+
+        var act = () => CallBackflow(Constants.ProductRepoName, ProductRepoPath, bfBranch, buildToFlow: oldBuild);
+        var exceptionAssertion = await act.Should().ThrowAsync<NonLinearCodeflowException>();
+        exceptionAssertion.Which.FlowingOldBuild.Should().BeTrue();
+    }
 }

--- a/test/Darc/Microsoft.DotNet.DarcLib.Codeflow.Tests/BackflowTests.cs
+++ b/test/Darc/Microsoft.DotNet.DarcLib.Codeflow.Tests/BackflowTests.cs
@@ -690,7 +690,7 @@ internal class BackflowTests : CodeFlowTests
 
         await GitOperations.Checkout(VmrPath, branch2Name);
         var act = () => CallBackflow(Constants.ProductRepoName, ProductRepoPath, backflowBranch);
-        await act.Should().ThrowAsync<NonLinearCodeflowException>("The backflow should fail as the target branch already has changes from another VMR branch");
+        await act.Should().ThrowAsync<BackflowNonContinuableNonLinearCodeflowException>("The backflow should fail as the target branch already has changes from another VMR branch");
     }
 
     // Test that the bug https://github.com/dotnet/arcade-services/issues/5331 doesn't happen

--- a/test/Darc/Microsoft.DotNet.DarcLib.Codeflow.Tests/BackflowTests.cs
+++ b/test/Darc/Microsoft.DotNet.DarcLib.Codeflow.Tests/BackflowTests.cs
@@ -690,7 +690,7 @@ internal class BackflowTests : CodeFlowTests
 
         await GitOperations.Checkout(VmrPath, branch2Name);
         var act = () => CallBackflow(Constants.ProductRepoName, ProductRepoPath, backflowBranch);
-        await act.Should().ThrowAsync<BackflowNonContinuableNonLinearCodeflowException>("The backflow should fail as the target branch already has changes from another VMR branch");
+        await act.Should().ThrowAsync<NonLinearCodeflowException>("The backflow should fail as the target branch already has changes from another VMR branch");
     }
 
     // Test that the bug https://github.com/dotnet/arcade-services/issues/5331 doesn't happen

--- a/test/Darc/Microsoft.DotNet.DarcLib.Codeflow.Tests/ForwardFlowTests.cs
+++ b/test/Darc/Microsoft.DotNet.DarcLib.Codeflow.Tests/ForwardFlowTests.cs
@@ -723,4 +723,24 @@ internal class ForwardFlowTests : CodeFlowTests
         (await File.ReadAllTextAsync(_productRepoVmrPath / Conflict_FileRemovedInSourceAndChangedInTarget)).Should().Be(
             "This file has been changed in target");
     }
+
+    [Test]
+    public async Task ForwardflowDoesntFlowOlderBuilds()
+    {
+        const string branch = nameof(ForwardflowDoesntFlowOlderBuilds);
+
+        await EnsureTestRepoIsInitialized();
+
+        await File.WriteAllTextAsync(ProductRepoPath / "file.txt", "first change");
+        await GitOperations.CommitAll(ProductRepoPath, "first change");
+        var oldBuild = await CreateNewRepoBuild([]);
+
+        var codeFlowChange = await ChangeRepoFileAndFlowIt("second change", branch);
+        codeFlowChange.ShouldHaveUpdates();
+        await FinalizeForwardFlow(branch);
+
+        var act = () => CallForwardflow(Constants.ProductRepoName, ProductRepoPath, branch, oldBuild);
+        var exception = await act.Should().ThrowAsync<NonLinearCodeflowException>();
+        exception.Which.FlowingOldBuild.Should().BeTrue();
+    }
 }

--- a/test/Darc/Microsoft.DotNet.DarcLib.Codeflow.Tests/TwoWayCodeflowTests.cs
+++ b/test/Darc/Microsoft.DotNet.DarcLib.Codeflow.Tests/TwoWayCodeflowTests.cs
@@ -1562,4 +1562,38 @@ internal class TwoWayCodeflowTests : CodeFlowTests
         File.Exists(_productRepoVmrPath / fileAddedBackInBFPR).Should().BeTrue();
         File.ReadAllText(_productRepoVmrPath / fileAddedBackInBFPR).Should().Be(fileAddedBackInBFPRContent);
     }
+
+    [Test]
+    public async Task BackflowThrowsBackflowNonContinuableNonLinearCodeflowException()
+    {
+        const string ffBranchName = nameof(BackflowThrowsBackflowNonContinuableNonLinearCodeflowException);
+        const string bfBranchName = nameof(BackflowThrowsBackflowNonContinuableNonLinearCodeflowException) + "bf";
+
+        const string repoBranchName1 = "repoBranch1";
+        const string repoBranchName2 = "repoBranch2";
+
+        // Flow the first time, then create two branches that will diverge
+        await EnsureTestRepoIsInitialized();
+
+        var codeFlowResult = await ChangeVmrFileAndFlowIt("0", bfBranchName);
+        codeFlowResult.ShouldHaveUpdates();
+        await FinalizeBackFlow(bfBranchName);
+
+        await GitOperations.CreateBranch(ProductRepoPath, repoBranchName2);
+        await GitOperations.CreateBranch(ProductRepoPath, repoBranchName1);
+
+        await GitOperations.Checkout(ProductRepoPath, repoBranchName1);
+        await File.WriteAllTextAsync(ProductRepoPath / "random_file.txt", "not important123");
+        await GitOperations.CommitAll(ProductRepoPath, "change on repo branch1");
+        codeFlowResult = await CallForwardflow(Constants.ProductRepoName, ProductRepoPath, ffBranchName);
+        codeFlowResult.ShouldHaveUpdates();
+        await FinalizeForwardFlow(ffBranchName);
+
+        // now checkout the second branch, make a change to it, and try backflowing
+        await GitOperations.Checkout(ProductRepoPath, repoBranchName2);
+        await File.WriteAllTextAsync(ProductRepoPath / "random_file.txt", "not important");
+        await GitOperations.CommitAll(ProductRepoPath, "change on repo branch2");
+        var act = () => ChangeVmrFileAndFlowIt("2", repoBranchName2);
+        await act.Should().ThrowAsync<BackflowNonContinuableNonLinearCodeflowException>();
+    }
 }

--- a/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -186,7 +186,8 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
                     mockPreviousCommitSha,
                     dependencyUpdates,
                     upstreamRepoDiffs,
-                    currentDescription: null);
+                    currentDescription: null,
+                    unsafeFlow:false);
             });
 
         string shortCommitSha = commitSha.Substring(0, 7);
@@ -269,7 +270,8 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
                     mockPreviousCommitSha,
                     dependencyUpdates,
                     upstreamRepoDiffs,
-                    description);
+                    description,
+                    unsafeFlow: false);
             });
 
         description.Should().Be(
@@ -902,7 +904,8 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
                     "previoussha123",
                     dependencyUpdates: [],
                     upstreamRepoDiffs: [],
-                    currentDescription: null);
+                    currentDescription: null,
+                    unsafeFlow: false);
             });
 
         // Then - Should contain enhanced build link with BAR details
@@ -946,7 +949,8 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
                     "previoussha456",
                     dependencyUpdates: [],
                     upstreamRepoDiffs: [],
-                    currentDescription: null);
+                    currentDescription: null,
+                    unsafeFlow: false);
             });
 
         // Then - Should contain enhanced build link with BAR details for Azure DevOps repo

--- a/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestCommentBuilderTests.cs
+++ b/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestCommentBuilderTests.cs
@@ -215,7 +215,8 @@ public class PullRequestCommentBuilderTests
             forwardFlowSubscription,
             conflictedFiles,
             "pr-head-branch",
-            true);
+            prIsEmpty: true,
+            unsafeFlow: false);
 
         // Verify only files under src/sdk/ are included
         comment.Should().Contain("file1.cs");

--- a/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -205,6 +205,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
             It.IsAny<Microsoft.DotNet.ProductConstructionService.Client.Models.Build>(),
             It.IsAny<string>(),
             It.IsAny<bool>(),
+            It.IsAny<bool>(),
             It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CodeFlowResult(false, [], new NativePath(VmrPath), []));
     }
@@ -216,6 +217,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                 It.Is<Microsoft.DotNet.ProductConstructionService.Client.Models.Subscription>(s => s.Id == Subscription.Id),
                 It.Is<Microsoft.DotNet.ProductConstructionService.Client.Models.Build>(b => b.Id == build.Id && b.Commit == build.Commit),
                 It.IsAny<string>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -232,6 +234,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                 It.Is<Microsoft.DotNet.ProductConstructionService.Client.Models.Subscription>(s => s.Id == Subscription.Id),
                 It.Is<Microsoft.DotNet.ProductConstructionService.Client.Models.Build>(b => b.Id == build.Id && b.Commit == build.Commit),
                 It.IsAny<string>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -578,6 +581,7 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
             It.IsAny<Microsoft.DotNet.ProductConstructionService.Client.Models.Subscription>(),
             It.IsAny<Microsoft.DotNet.ProductConstructionService.Client.Models.Build>(),
             It.IsAny<string>(),
+            It.IsAny<bool>(),
             It.IsAny<bool>(),
             It.IsAny<CancellationToken>()));
 

--- a/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -627,6 +627,8 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
 
         DarcRemotes[VmrUri]
             .Verify(r => r.ClosePullRequestAsync(oldPrUrl));
+        DarcRemotes[VmrUri]
+            .Verify(r => r.DeletePullRequestBranchAsync(oldPrUrl));
     }
 
     protected void AndShouldHavePullRequestCheckReminder(string? url = null)

--- a/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -588,6 +588,47 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
         setup.ReturnsAsync(new CodeFlowResult(true, conflictedFiles, new NativePath(VmrPath), []));
     }
 
+    /// <summary>
+    /// Sets up the forward flower to throw NonLinearCodeflowException on safe flow,
+    /// then succeed on unsafe flow.
+    /// </summary>
+    protected void WithForwardFlowThrowingNonLinearException()
+    {
+        // Safe flow (unsafeFlow: false) throws NonLinearCodeflowException
+        _forwardFlower.Setup(x => x.FlowForwardAsync(
+            It.IsAny<Microsoft.DotNet.ProductConstructionService.Client.Models.Subscription>(),
+            It.IsAny<Microsoft.DotNet.ProductConstructionService.Client.Models.Build>(),
+            It.IsAny<string>(),
+            It.IsAny<bool>(),
+            false,
+            It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new NonLinearCodeflowException());
+
+        // Unsafe flow (unsafeFlow: true) succeeds
+        _forwardFlower.Setup(x => x.FlowForwardAsync(
+            It.IsAny<Microsoft.DotNet.ProductConstructionService.Client.Models.Subscription>(),
+            It.IsAny<Microsoft.DotNet.ProductConstructionService.Client.Models.Build>(),
+            It.IsAny<string>(),
+            It.IsAny<bool>(),
+            true,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CodeFlowResult(true, [], new NativePath(VmrPath), []));
+    }
+
+    protected void AndOldPullRequestShouldHaveBeenClosed(string oldPrUrl, string newPrUrl)
+    {
+        var (owner, repo, id) = GitHubClient.ParsePullRequestUri(newPrUrl);
+        var newPrHtmlUrl = $"https://github.com/{owner}/{repo}/pull/{id}";
+
+        DarcRemotes[VmrUri]
+            .Verify(r => r.CommentPullRequestAsync(
+                oldPrUrl,
+                It.Is<string>(comment => comment.Contains("Closing this PR") && comment.Contains(newPrHtmlUrl))));
+
+        DarcRemotes[VmrUri]
+            .Verify(r => r.ClosePullRequestAsync(oldPrUrl));
+    }
+
     protected void AndShouldHavePullRequestCheckReminder(string? url = null)
     {
         var prUrl = string.IsNullOrEmpty(url)

--- a/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsForCodeFlowTests.cs
+++ b/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/UpdateAssetsForCodeFlowTests.cs
@@ -354,6 +354,63 @@ internal class UpdateAssetsForCodeFlowTests : UpdateAssetsPullRequestUpdaterTest
         }
     }
 
+    [Test]
+    public async Task UnsafeFlowClosesOldPrAndOpensNewOne()
+    {
+        GivenATestChannel();
+        GivenACodeFlowSubscription(
+            new SubscriptionPolicy
+            {
+                Batchable = false,
+                UpdateFrequency = UpdateFrequency.EveryBuild,
+            });
+
+        Build oldBuild = GivenANewBuild(true);
+        Build newBuild = GivenANewBuild(true);
+        newBuild.Commit = "sha123456";
+
+        var oldPrUrl = VmrPullRequestUrl;
+
+        using (WithExistingCodeFlowPullRequest(oldBuild, canUpdate: true, willFlowNewBuild: true))
+        {
+            WithForwardFlowThrowingNonLinearException();
+
+            // Set up the new PR URL
+            var newPrUrl = $"{VmrUri}/pulls/2";
+            VmrPullRequestUrl = newPrUrl;
+            CreatePullRequestShouldReturnAValidValue();
+
+            await WhenUpdateAssetsAsyncIsCalled(newBuild, isCodeflow: true);
+
+            var expectedState = new InProgressPullRequest()
+            {
+                UpdaterId = GetPullRequestUpdaterId(Subscription).Id,
+                Url = newPrUrl,
+                HeadBranch = InProgressPrHeadBranch,
+                HeadBranchSha = InProgressPrHeadBranchSha,
+                SourceSha = newBuild.Commit,
+                ContainedSubscriptions =
+                [
+                    new()
+                    {
+                        SubscriptionId = Subscription.Id,
+                        BuildId = newBuild.Id,
+                        SourceRepo = newBuild.GetRepository(),
+                        CommitSha = newBuild.Commit
+                    }
+                ],
+                RequiredUpdates = [],
+                CodeFlowDirection = CodeFlowDirection.ForwardFlow,
+                UnsafeFlow = true,
+            };
+
+            AndCodeFlowPullRequestShouldHaveBeenCreated();
+            AndOldPullRequestShouldHaveBeenClosed(oldPrUrl, newPrUrl);
+            AndShouldHavePullRequestCheckReminder();
+            AndShouldHaveInProgressPullRequestState(newBuild, expectedState: expectedState);
+        }
+    }
+
     protected override void ThenShouldHavePendingUpdateState(Build forBuild, bool _ = false)
     {
         base.ThenShouldHavePendingUpdateState(forBuild, true);

--- a/test/ProductConstructionService/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
+++ b/test/ProductConstructionService/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
@@ -75,7 +75,10 @@ internal abstract partial class ScenarioTestBase
         _temporaryDirectory.Dispose();
     }
 
-    protected async Task<Octokit.PullRequest> WaitForPullRequestAsync(string targetRepo, string targetBranch)
+    protected async Task<Octokit.PullRequest> WaitForPullRequestAsync(
+        string targetRepo,
+        string targetBranch,
+        IReadOnlyCollection<int>? excludedPrNumbers = null)
     {
         Octokit.Repository repo = await GitHubApi.Repository.Get(TestParameters.GitHubTestOrg, targetRepo);
 
@@ -86,6 +89,11 @@ internal abstract partial class ScenarioTestBase
             {
                 Base = targetBranch,
             });
+
+            if (excludedPrNumbers != null)
+            {
+                prs = prs.Where(p => !excludedPrNumbers.Contains(p.Number)).ToList();
+            }
 
             if (prs.Count == 1)
             {

--- a/test/ProductConstructionService/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -183,7 +183,140 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
 
     /*
     This test does the following
-    - Create an (empty) PR with awaiting conflict resolution
+    - Create two source branches in maestro-test1 from the same existing history
+    - Let them diverge with different commits
+    - Flow the first branch and merge the resulting PR
+    - Flow a build from the second diverged branch
+    - Verify the new PR is marked as an unsafe flow
+    */
+    [Test]
+    public async Task Vmr_UnsafeForwardFlowOnDivergedBranchesTest()
+    {
+        var channelName = GetTestChannelName();
+        var firstSourceBranchName = GetTestBranchName();
+        var secondSourceBranchName = GetTestBranchName();
+        var targetBranchName = GetTestBranchName();
+
+        await CreateTestChannelAsync(channelName);
+
+        var subscriptionId = await CreateForwardFlowSubscriptionAsync(
+            channelName,
+            TestRepository.TestRepo1Name,
+            TestRepository.VmrTestRepoName,
+            targetBranchName,
+            UpdateFrequency.None.ToString(),
+            TestParameters.GitHubTestOrg,
+            targetDirectory: TestRepository.TestRepo1Name);
+
+        using TemporaryDirectory vmrDirectory = await CloneRepositoryAsync(TestRepository.VmrTestRepoName);
+        using TemporaryDirectory repoDirectory = await CloneRepositoryAsync(TestRepository.TestRepo1Name);
+
+        var vmrDir = new NativePath(vmrDirectory.Directory);
+        var repoDir = new NativePath(repoDirectory.Directory);
+        var firstFilePath = repoDir / TestFile1Name;
+        var secondFilePath = repoDir / TestFile2Name;
+
+        await CreateTargetBranchAndExecuteTest(targetBranchName, vmrDir, async () =>
+        {
+            using var _ = ChangeDirectory(repoDir);
+
+            await using var firstSourceBranch = await CheckoutBranchAsync(firstSourceBranchName);
+            await using var secondSourceBranch = await CheckoutBranchAsync(secondSourceBranchName);
+            await RunGitAsync("checkout", firstSourceBranchName);
+
+            await File.WriteAllTextAsync(firstFilePath, "content from the first diverged branch");
+            await GitAddAllAsync();
+            await GitCommitAsync("First divergent change");
+            await using var firstSourceRemoteBranch = await PushGitBranchAsync("origin", firstSourceBranchName);
+
+            Build firstBuild = await CreateBuildAsync(
+                GetGitHubRepoUrl(TestRepository.TestRepo1Name),
+                firstSourceBranchName,
+                (await GitGetCurrentSha()).TrimEnd(),
+                "5",
+                []);
+
+            await AddBuildToChannelAsync(firstBuild.Id, channelName);
+            await TriggerSubscriptionAsync(subscriptionId);
+
+            TestContext.WriteLine("Waiting for the first codeflow PR and merging it");
+            PullRequest firstPr = await WaitForPullRequestAsync(TestRepository.VmrTestRepoName, targetBranchName);
+            await using (CleanUpPullRequestAfter(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, firstPr))
+            {
+                firstPr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, firstPr.Number);
+                firstPr.Body.Should().NotContain("This is an unsafe codeflow update");
+                await MergePullRequestAsync(TestRepository.VmrTestRepoName, firstPr);
+            }
+
+            TestContext.WriteLine("Pushing another change to the first branch to open a new PR");
+            await RunGitAsync("checkout", firstSourceBranchName);
+            await File.WriteAllTextAsync(firstFilePath, "follow-up content from the first branch");
+            await GitAddAllAsync();
+            await GitCommitAsync("Follow-up change on first branch");
+            await RunGitAsync("push");
+
+            Build followUpBuild = await CreateBuildAsync(
+                GetGitHubRepoUrl(TestRepository.TestRepo1Name),
+                firstSourceBranchName,
+                (await GitGetCurrentSha()).TrimEnd(),
+                "6",
+                []);
+
+            await AddBuildToChannelAsync(followUpBuild.Id, channelName);
+            await TriggerSubscriptionAsync(subscriptionId);
+
+            TestContext.WriteLine("Waiting for the second PR from the first branch to show up");
+            PullRequest replacedPr = await WaitForPullRequestAsync(TestRepository.VmrTestRepoName, targetBranchName);
+            await using var replacedPrCleanup = CleanUpPullRequestAfter(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, replacedPr);
+            replacedPr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, replacedPr.Number);
+            replacedPr.Body.Should().NotContain("This is an unsafe codeflow update");
+
+            await RunGitAsync("checkout", secondSourceBranchName);
+            await File.WriteAllTextAsync(secondFilePath, "content from the second diverged branch");
+            await GitAddAllAsync();
+            await GitCommitAsync("Second divergent change");
+            await using var secondSourceRemoteBranch = await PushGitBranchAsync("origin", secondSourceBranchName);
+
+            Build secondBuild = await CreateBuildAsync(
+                GetGitHubRepoUrl(TestRepository.TestRepo1Name),
+                secondSourceBranchName,
+                (await GitGetCurrentSha()).TrimEnd(),
+                "7",
+                []);
+
+            await AddBuildToChannelAsync(secondBuild.Id, channelName);
+            await TriggerSubscriptionAsync(subscriptionId);
+
+            TestContext.WriteLine("Waiting for the existing PR to be closed and a new unsafe codeflow PR to show up");
+            PullRequest unsafePr = replacedPr;
+            for (var attempts = 0; attempts < 20; attempts++)
+            {
+                replacedPr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, replacedPr.Number);
+                var openPr = await WaitForPullRequestAsync(TestRepository.VmrTestRepoName, targetBranchName);
+
+                if (replacedPr.State == ItemState.Closed && openPr.Number != replacedPr.Number)
+                {
+                    unsafePr = openPr;
+                    break;
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(5));
+            }
+
+            await using (CleanUpPullRequestAfter(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, unsafePr))
+            {
+                unsafePr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, unsafePr.Number);
+                replacedPr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, replacedPr.Number);
+                replacedPr.State.Should().Be(ItemState.Closed);
+                unsafePr.Number.Should().NotBe(replacedPr.Number);
+                unsafePr.Body.Should().Contain("This is an unsafe codeflow update");
+            }
+        });
+    }
+
+    /*
+     This test does the following
+     - Create an (empty) PR with awaiting conflict resolution
     - Call `darc vmr resolve-conflicts`
     - Verify mergeability
     - Push a new update into the PR

--- a/test/ProductConstructionService/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -292,7 +292,7 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
 
             await using (CleanUpPullRequestAfter(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, unsafePr))
             {
-                unsafePr.Body.Should().Contain("This is an unsafe codeflow update");
+                unsafePr.Body.Should().Contain("This is an **unsafe codeflow update**");
 
                 replacedPr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, replacedPr.Number);
                 replacedPr.State.Value.Should().Be(ItemState.Closed);

--- a/test/ProductConstructionService/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
+++ b/test/ProductConstructionService/ProductConstructionService.ScenarioTests/ScenarioTests/ScenarioTests_CodeFlowConflicts.cs
@@ -287,29 +287,20 @@ internal partial class ScenarioTests_CodeFlow : CodeFlowScenarioTestBase
             await AddBuildToChannelAsync(secondBuild.Id, channelName);
             await TriggerSubscriptionAsync(subscriptionId);
 
-            TestContext.WriteLine("Waiting for the existing PR to be closed and a new unsafe codeflow PR to show up");
-            PullRequest unsafePr = replacedPr;
-            for (var attempts = 0; attempts < 20; attempts++)
-            {
-                replacedPr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, replacedPr.Number);
-                var openPr = await WaitForPullRequestAsync(TestRepository.VmrTestRepoName, targetBranchName);
-
-                if (replacedPr.State == ItemState.Closed && openPr.Number != replacedPr.Number)
-                {
-                    unsafePr = openPr;
-                    break;
-                }
-
-                await Task.Delay(TimeSpan.FromSeconds(5));
-            }
+            TestContext.WriteLine("Waiting for the new unsafe codeflow PR to show up");
+            PullRequest unsafePr = await WaitForPullRequestAsync(TestRepository.VmrTestRepoName, targetBranchName, [replacedPr.Number]);
 
             await using (CleanUpPullRequestAfter(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, unsafePr))
             {
-                unsafePr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, unsafePr.Number);
-                replacedPr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, replacedPr.Number);
-                replacedPr.State.Should().Be(ItemState.Closed);
-                unsafePr.Number.Should().NotBe(replacedPr.Number);
                 unsafePr.Body.Should().Contain("This is an unsafe codeflow update");
+
+                replacedPr = await GitHubApi.PullRequest.Get(TestParameters.GitHubTestOrg, TestRepository.VmrTestRepoName, replacedPr.Number);
+                replacedPr.State.Value.Should().Be(ItemState.Closed);
+
+                await CheckIfPullRequestCommentExists(
+                    TestRepository.VmrTestRepoName,
+                    replacedPr,
+                    ["Closing this PR", unsafePr.HtmlUrl]);
             }
         });
     }


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/6135
When we either:
 - can't determine if lastFlow was a FF or a backflow
 - Try to flow a non ancestor commit to the previously flown source commit
we throw a `NonLinearFlow` exception, which is caught by the `CodeFlowPullRequestUpdater`

When this happens, we create a new local branch, and do an unsafe flow.
Afterwards there's a few scenarios:
- If there was no PR, we just open an unsafe marked PR
- If there was a PR, and it contained any changes, we close it and open an unsafe one
- If there was an empty PRs, asking for manual conflict resolution, but it wasn't unsafe, we close it and open an unsafe one
- If there was an empty PR, asking for manual conflict resolution, marked as unsafe, we rebase the PR branch on top of the target one and leave a comment (like we usually do)

