### PR TITLE
Set GH check for every scenario test PR

### DIFF
--- a/test/ProductConstructionService/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
+++ b/test/ProductConstructionService/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
@@ -93,11 +93,12 @@ internal abstract partial class ScenarioTestBase
                 // We only want to set the Creation time when we're creating it
                 if (!_lastUpdatedPrTimes.ContainsKey(prs[0].Id))
                 {
-                    // some maestro policies require a successful non Maestro check, so just set it for every PR
-                    await CreateSuccessfulExternalStatusCheckAsync(targetRepo, prs[0]);
-
                     _lastUpdatedPrTimes[prs[0].Id] = prs[0].CreatedAt;
                 }
+
+                // some Maestro policies require a successful non Maestro check, so just set it for every PR
+                await CreateSuccessfulExternalStatusCheckAsync(targetRepo, prs[0]);
+
                 return prs[0];
             }
 

--- a/test/ProductConstructionService/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
+++ b/test/ProductConstructionService/ProductConstructionService.ScenarioTests/ScenarioTestBase.cs
@@ -93,6 +93,9 @@ internal abstract partial class ScenarioTestBase
                 // We only want to set the Creation time when we're creating it
                 if (!_lastUpdatedPrTimes.ContainsKey(prs[0].Id))
                 {
+                    // some maestro policies require a successful non Maestro check, so just set it for every PR
+                    await CreateSuccessfulExternalStatusCheckAsync(targetRepo, prs[0]);
+
                     _lastUpdatedPrTimes[prs[0].Id] = prs[0].CreatedAt;
                 }
                 return prs[0];
@@ -1123,6 +1126,19 @@ internal abstract partial class ScenarioTestBase
             await Task.Delay(WAIT_DELAY);
         }
         throw new ScenarioTestException($"No Maestro Merge Policy checks were found in the PR ({prUrl}) during the allotted time.");
+    }
+
+    protected static async Task CreateSuccessfulExternalStatusCheckAsync(string targetRepoName, Octokit.PullRequest pullRequest)
+    {
+        var commitStatus = new Octokit.NewCommitStatus
+        {
+            State = Octokit.CommitState.Success,
+            Context = "scenario-test/auto-check",
+            Description = "Scenario-test status used to satisfy Maestro merge policies",
+            TargetUrl = pullRequest.HtmlUrl
+        };
+
+        await GitHubApi.Repository.Status.Create(TestParameters.GitHubTestOrg, targetRepoName, pullRequest.Head.Sha, commitStatus);
     }
 
     protected async Task<Octokit.PullRequest> WaitForFileContentInPullRequest(


### PR DESCRIPTION
Adds a check to every scenario test PR 
<img width="1268" height="92" alt="image" src="https://github.com/user-attachments/assets/7ff2cd25-8683-42b1-981d-f56cd34cf1b0" />
so Maestros All Checks Successful doesn't rely on the WIP check
https://github.com/dotnet/arcade-services/issues/6183