### PR TITLE
include source repo commit links in backflow commit message

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -246,6 +246,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
                 workBranch,
                 async keepConflicts => await ApplyPatchesAndCommitAsync(
                     patches,
+                    lastFlows,
                     targetRepo,
                     codeflowOptions,
                     keepConflicts,
@@ -256,6 +257,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         {
             result = await ApplyPatchesAndCommitAsync(
                 patches,
+                lastFlows,
                 targetRepo,
                 codeflowOptions,
                 codeflowOptions.KeepConflicts,
@@ -283,6 +285,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
 
     private async Task<CodeFlowResult> ApplyPatchesAndCommitAsync(
         List<VmrIngestionPatch> patches,
+        LastFlows lastFlows,
         ILocalGitRepo targetRepo,
         CodeflowOptions codeflowOptions,
         bool keepConflicts,
@@ -300,6 +303,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         {
             await CommitBackflow(
                 codeflowOptions.CurrentFlow,
+                lastFlows,
                 targetRepo,
                 codeflowOptions.Build,
                 cancellationToken);
@@ -384,7 +388,12 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             return new CodeFlowResult(false, [], targetRepo.Path, []);
         }
 
-        var commitMessage = await CommitBackflow(codeflowOptions.CurrentFlow, targetRepo, codeflowOptions.Build, cancellationToken);
+        var commitMessage = await CommitBackflow(
+            codeflowOptions.CurrentFlow,
+            lastFlows,
+            targetRepo,
+            codeflowOptions.Build,
+            cancellationToken);
 
         var conflictedFiles = await MergeWorkBranchAsync(
             codeflowOptions,
@@ -597,10 +606,20 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         }
     }
 
-    private static async Task<string> CommitBackflow(Codeflow currentFlow, ILocalGitRepo targetRepo, Build build, CancellationToken cancellationToken)
+    private static async Task<string> CommitBackflow(
+        Codeflow currentFlow,
+        LastFlows lastFlows,
+        ILocalGitRepo targetRepo,
+        Build build,
+        CancellationToken cancellationToken)
     {
         var commitMessage = $"""
             Backflow from {build.GetRepository()} / {Commit.GetShortSha(currentFlow.VmrSha)} build {build.Id}
+
+            Diff: {build.GetRepository()}/compare/{lastFlows.LastFlow.VmrSha}..{currentFlow.VmrSha}
+
+            From: {build.GetRepository()}/commit/{lastFlows.LastFlow.VmrSha}
+            To: {build.GetRepository()}/commit/{currentFlow.VmrSha}
 
             {Constants.AUTOMATION_COMMIT_TAG}
             """;


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/5317

Add the last SHA and currently flowing SHA from the source repo, with their diff. Just like in forward flows.

Repro: https://github.com/maestro-auth-test/sdk/pull/60/changes/0b8620b5e8324a24d347cf67ae6a8fb54dfa22a8