### PR TITLE
Fix source-manifest.json conflict resolution when head branch 

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/ForwardFlowConflictResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/ForwardFlowConflictResolver.cs
@@ -165,7 +165,7 @@ public class ForwardFlowConflictResolver : CodeFlowConflictResolver, IForwardFlo
         // Known conflict in source-manifest.json
         if (string.Equals(conflictedFile, VmrInfo.DefaultRelativeSourceManifestPath, StringComparison.OrdinalIgnoreCase))
         {
-            await TryResolvingSourceManifestConflict(vmr, codeflowOptions, cancellationToken);
+            await TryResolvingSourceManifestConflict(vmr, codeflowOptions, headBranchExisted, cancellationToken);
             return true;
         }
 
@@ -197,6 +197,7 @@ public class ForwardFlowConflictResolver : CodeFlowConflictResolver, IForwardFlo
     private async Task TryResolvingSourceManifestConflict(
         ILocalGitRepo vmr,
         CodeflowOptions codeflowOptions,
+        bool headBranchExisted,
         CancellationToken cancellationToken)
     {
         var mappingName = codeflowOptions.Mapping.Name!;
@@ -204,8 +205,9 @@ public class ForwardFlowConflictResolver : CodeFlowConflictResolver, IForwardFlo
 
         // We load the source manifest from the target branch and replace the
         // current mapping (and its submodules) with our branches' information
+        var branchToShow = headBranchExisted ? codeflowOptions.HeadBranch : codeflowOptions.TargetBranch;
         var result = await vmr.RunGitCommandAsync(
-            ["show", $"{codeflowOptions.TargetBranch}:{VmrInfo.DefaultRelativeSourceManifestPath}"],
+            ["show", $"{branchToShow}:{VmrInfo.DefaultRelativeSourceManifestPath}"],
             cancellationToken);
 
         var targetBranchSourceManifest = SourceManifest.FromJson(result.StandardOutput);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -246,6 +246,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
                 workBranch,
                 async keepConflicts => await ApplyPatchesAndCommitAsync(
                     patches,
+                    lastFlows,
                     targetRepo,
                     codeflowOptions,
                     keepConflicts,
@@ -256,6 +257,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         {
             result = await ApplyPatchesAndCommitAsync(
                 patches,
+                lastFlows,
                 targetRepo,
                 codeflowOptions,
                 codeflowOptions.KeepConflicts,
@@ -283,6 +285,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
 
     private async Task<CodeFlowResult> ApplyPatchesAndCommitAsync(
         List<VmrIngestionPatch> patches,
+        LastFlows lastFlows,
         ILocalGitRepo targetRepo,
         CodeflowOptions codeflowOptions,
         bool keepConflicts,
@@ -300,6 +303,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         {
             await CommitBackflow(
                 codeflowOptions.CurrentFlow,
+                lastFlows,
                 targetRepo,
                 codeflowOptions.Build,
                 cancellationToken);
@@ -384,7 +388,12 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             return new CodeFlowResult(false, [], targetRepo.Path, []);
         }
 
-        var commitMessage = await CommitBackflow(codeflowOptions.CurrentFlow, targetRepo, codeflowOptions.Build, cancellationToken);
+        var commitMessage = await CommitBackflow(
+            codeflowOptions.CurrentFlow,
+            lastFlows,
+            targetRepo,
+            codeflowOptions.Build,
+            cancellationToken);
 
         var conflictedFiles = await MergeWorkBranchAsync(
             codeflowOptions,
@@ -448,6 +457,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             .ToArray();
 
         ILocalGitRepo targetRepo;
+        bool headBranchExisted = true;
 
         // Try to see if both base and target branch are available
         try
@@ -473,12 +483,13 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
                     cancellationToken);
             }
 
-            LastFlows lastFlows = await GetLastFlowsAsync(mapping.Name, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: true);
-            return (true, mapping, lastFlows, targetRepo);
+            LastFlows lastFlows = await GetLastFlowsAsync(mapping.Name, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow, headBranchExisted);
+            return (headBranchExisted, mapping, lastFlows, targetRepo);
         }
         catch (NotFoundException)
         {
             // If target branch does not exist, we create it off of the base branch
+            headBranchExisted = false;
             try
             {
                 if (targetRepoPath == null)
@@ -508,11 +519,11 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
                 throw new TargetBranchNotFoundException($"Failed to find target branch {targetBranch} in {string.Join(", ", remotes)}", e);
             }
 
-            LastFlows lastFlows = await GetLastFlowsAsync(mapping.Name, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: false);
+            LastFlows lastFlows = await GetLastFlowsAsync(mapping.Name, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow, headBranchExisted);
 
             await targetRepo.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
 
-            return (false, mapping, lastFlows, targetRepo);
+            return (headBranchExisted, mapping, lastFlows, targetRepo);
         }
     }
 
@@ -597,10 +608,20 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         }
     }
 
-    private static async Task<string> CommitBackflow(Codeflow currentFlow, ILocalGitRepo targetRepo, Build build, CancellationToken cancellationToken)
+    private static async Task<string> CommitBackflow(
+        Codeflow currentFlow,
+        LastFlows lastFlows,
+        ILocalGitRepo targetRepo,
+        Build build,
+        CancellationToken cancellationToken)
     {
         var commitMessage = $"""
             Backflow from {build.GetRepository()} / {Commit.GetShortSha(currentFlow.VmrSha)} build {build.Id}
+
+            Diff: {build.GetRepository()}/compare/{lastFlows.LastFlow.VmrSha}..{currentFlow.VmrSha}
+
+            From: {build.GetRepository()}/commit/{lastFlows.LastFlow.VmrSha}
+            To: {build.GetRepository()}/commit/{currentFlow.VmrSha}
 
             {Constants.AUTOMATION_COMMIT_TAG}
             """;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -246,7 +246,6 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
                 workBranch,
                 async keepConflicts => await ApplyPatchesAndCommitAsync(
                     patches,
-                    lastFlows,
                     targetRepo,
                     codeflowOptions,
                     keepConflicts,
@@ -257,7 +256,6 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         {
             result = await ApplyPatchesAndCommitAsync(
                 patches,
-                lastFlows,
                 targetRepo,
                 codeflowOptions,
                 codeflowOptions.KeepConflicts,
@@ -285,7 +283,6 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
 
     private async Task<CodeFlowResult> ApplyPatchesAndCommitAsync(
         List<VmrIngestionPatch> patches,
-        LastFlows lastFlows,
         ILocalGitRepo targetRepo,
         CodeflowOptions codeflowOptions,
         bool keepConflicts,
@@ -303,7 +300,6 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         {
             await CommitBackflow(
                 codeflowOptions.CurrentFlow,
-                lastFlows,
                 targetRepo,
                 codeflowOptions.Build,
                 cancellationToken);
@@ -388,12 +384,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             return new CodeFlowResult(false, [], targetRepo.Path, []);
         }
 
-        var commitMessage = await CommitBackflow(
-            codeflowOptions.CurrentFlow,
-            lastFlows,
-            targetRepo,
-            codeflowOptions.Build,
-            cancellationToken);
+        var commitMessage = await CommitBackflow(codeflowOptions.CurrentFlow, targetRepo, codeflowOptions.Build, cancellationToken);
 
         var conflictedFiles = await MergeWorkBranchAsync(
             codeflowOptions,
@@ -482,7 +473,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
                     cancellationToken);
             }
 
-            LastFlows lastFlows = await GetLastFlowsAsync(mapping.Name, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow);
+            LastFlows lastFlows = await GetLastFlowsAsync(mapping.Name, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: true);
             return (true, mapping, lastFlows, targetRepo);
         }
         catch (NotFoundException)
@@ -517,7 +508,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
                 throw new TargetBranchNotFoundException($"Failed to find target branch {targetBranch} in {string.Join(", ", remotes)}", e);
             }
 
-            LastFlows lastFlows = await GetLastFlowsAsync(mapping.Name, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow);
+            LastFlows lastFlows = await GetLastFlowsAsync(mapping.Name, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: false);
 
             await targetRepo.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
 
@@ -577,7 +568,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             resetToRemote: false,
             cancellationToken);
 
-        previousFlows = await GetLastFlowsAsync(mapping.Name, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow);
+        previousFlows = await GetLastFlowsAsync(mapping.Name, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: true);
         previousFlow = previousFlows.LastBackFlow
             ?? throw new DarcException($"No more backflows found to recreate from {previousFlowSha}");
 
@@ -606,20 +597,10 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         }
     }
 
-    private static async Task<string> CommitBackflow(
-        Codeflow currentFlow,
-        LastFlows lastFlows,
-        ILocalGitRepo targetRepo,
-        Build build,
-        CancellationToken cancellationToken)
+    private static async Task<string> CommitBackflow(Codeflow currentFlow, ILocalGitRepo targetRepo, Build build, CancellationToken cancellationToken)
     {
         var commitMessage = $"""
             Backflow from {build.GetRepository()} / {Commit.GetShortSha(currentFlow.VmrSha)} build {build.Id}
-
-            Diff: {build.GetRepository()}/compare/{lastFlows.LastFlow.VmrSha}..{currentFlow.VmrSha}
-
-            From: {build.GetRepository()}/commit/{lastFlows.LastFlow.VmrSha}
-            To: {build.GetRepository()}/commit/{currentFlow.VmrSha}
 
             {Constants.AUTOMATION_COMMIT_TAG}
             """;

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -21,7 +21,8 @@ public interface IVmrCodeFlower
         string mappingName,
         ILocalGitRepo repoClone,
         bool currentIsBackflow,
-        bool ignoreNonLinearFlow);
+        bool ignoreNonLinearFlow,
+        bool headBranchExisted);
 }
 
 public record CodeflowOptions(
@@ -273,7 +274,8 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
         string mappingName,
         ILocalGitRepo repoClone,
         bool currentIsBackflow,
-        bool ignoreNonLinearFlow)
+        bool ignoreNonLinearFlow,
+        bool headBranchExisted)
     {
         await _dependencyTracker.RefreshMetadataAsync();
         _sourceManifest.Refresh(_vmrInfo.SourceManifestPath);
@@ -367,7 +369,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
 
             // We can tell the above by checking if the current target VMR commit is a child of the last backflow commit.
             // For normal flows it should be, but for the case described above it will be on a different branch.
-            if (!await vmr.IsAncestorCommit(lastBackflow.VmrSha, currentVmrSha))
+            if (!headBranchExisted && !await vmr.IsAncestorCommit(lastBackflow.VmrSha, currentVmrSha))
             {
                 _logger.LogWarning("Last detected backflow ({sha1}) from VMR is from a different branch than target VMR sha ({sha2}). " +
                     "Ignoring backflow and considering the last forward flow to be the last flow.",

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -226,7 +226,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 ShouldResetVmr,
                 cancellationToken);
 
-            LastFlows lastFlows = await GetLastFlowsAsync(mappingName, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow);
+            LastFlows lastFlows = await GetLastFlowsAsync(mappingName, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: true);
             return (true, lastFlows);
         }
         catch (NotFoundException)
@@ -248,7 +248,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 throw new TargetBranchNotFoundException($"Failed to find target branch {baseBranch} in {vmrUri}", e);
             }
 
-            LastFlows lastFlows = await GetLastFlowsAsync(mappingName, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow);
+            LastFlows lastFlows = await GetLastFlowsAsync(mappingName, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: false);
 
             await vmr.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
 
@@ -541,7 +541,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             cancellationToken);
 
         await sourceRepo.ForceCheckoutAsync(_sourceManifest.GetRepoVersion(mapping.Name).CommitSha);
-        previousFlows = await GetLastFlowsAsync(mapping.Name, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow);
+        previousFlows = await GetLastFlowsAsync(mapping.Name, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: true);
         previousFlow = previousFlows.LastForwardFlow;
 
         await vmr.CreateBranchAsync(branchToCreate, overwriteExistingBranch: true);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -216,6 +216,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
         CancellationToken cancellationToken)
     {
         _vmrInfo.VmrUri = vmrUri;
+        bool headBranchExisted = true;
 
         try
         {
@@ -226,11 +227,12 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 ShouldResetVmr,
                 cancellationToken);
 
-            LastFlows lastFlows = await GetLastFlowsAsync(mappingName, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: true);
-            return (true, lastFlows);
+            LastFlows lastFlows = await GetLastFlowsAsync(mappingName, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow, headBranchExisted);
+            return (headBranchExisted, lastFlows);
         }
         catch (NotFoundException)
         {
+            headBranchExisted = false;
             // If the head branch does not exist, we need to create it at the point of the last sync
             ILocalGitRepo vmr;
             try
@@ -248,11 +250,11 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 throw new TargetBranchNotFoundException($"Failed to find target branch {baseBranch} in {vmrUri}", e);
             }
 
-            LastFlows lastFlows = await GetLastFlowsAsync(mappingName, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: false);
+            LastFlows lastFlows = await GetLastFlowsAsync(mappingName, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow, headBranchExisted);
 
             await vmr.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
 
-            return (false, lastFlows);
+            return (headBranchExisted, lastFlows);
         }
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -92,6 +92,7 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
             _logger.LogInformation("Failed to update pr {url} for {subscription} because it is blocked from future updates",
                 pr.Url,
                 update.SubscriptionId);
+            _commentCollector.AddComment(PullRequestCommentBuilder.BuildOppositeCodeflowMergedNotification(), CommentType.Warning);
             await _stateManager.SetCheckReminderAsync(pr, prInfo!, isCodeFlow: true);
             await _stateManager.UnsetUpdateReminderAsync(isCodeFlow: true);
             return;

--- a/test/Darc/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrCodeFlowerGetLastFlowsTests.cs
+++ b/test/Darc/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrCodeFlowerGetLastFlowsTests.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using AwesomeAssertions;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models;
@@ -14,6 +11,7 @@ using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
+using System.Threading.Tasks;
 
 #nullable enable
 namespace Microsoft.DotNet.DarcLib.Tests.VirtualMonoRepo;
@@ -43,7 +41,7 @@ public class VmrCodeFlowerGetLastFlowsTests
     private Mock<ILocalGitRepo> _vmrRepo = null!;
     private Mock<ISourceComponent> _repoInVmr = null!;
 
-    private TestVmrCodeFlower _sut = null!;
+    private IVmrCodeFlower _codeFlower = null!;
 
     [SetUp]
     public void SetUp()
@@ -92,14 +90,23 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         _fileSystem = new Mock<IFileSystem>();
 
-        _sut = new TestVmrCodeFlower(
+        _codeFlower = new VmrForwardFlower(
             _vmrInfo.Object,
             _sourceManifest.Object,
+            Mock.Of<ICodeFlowVmrUpdater>(),
             _dependencyTracker.Object,
+            Mock.Of<IVmrCloneManager>(),
             _localGitClient.Object,
             _localGitRepoFactory.Object,
             _versionDetailsParser.Object,
-            _fileSystem.Object);
+            Mock.Of<ICodeflowChangeAnalyzer>(),
+            Mock.Of<IForwardFlowConflictResolver>(),
+            Mock.Of<IWorkBranchFactory>(),
+            Mock.Of<IProcessManager>(),
+            Mock.Of<IBasicBarClient>(),
+            _fileSystem.Object,
+            Mock.Of<ICommentCollector>(),
+            NullLogger<VmrCodeFlower>.Instance);
     }
 
     [Test]
@@ -107,7 +114,7 @@ public class VmrCodeFlowerGetLastFlowsTests
     {
         SetBackflowInVersionDetails(null);
 
-        var result = await _sut.GetLastFlowsAsync(
+        var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
             _repoClone.Object,
             currentIsBackflow: false,
@@ -133,7 +140,7 @@ public class VmrCodeFlowerGetLastFlowsTests
             .Setup(x => x.IsAncestorCommit(LastBackflowRepoSha, LastForwardRepoSha))
             .ReturnsAsync(false);
 
-        var result = await _sut.GetLastFlowsAsync(
+        var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
             _repoClone.Object,
             currentIsBackflow: false,
@@ -156,7 +163,7 @@ public class VmrCodeFlowerGetLastFlowsTests
             .Setup(x => x.IsAncestorCommit(LastForwardRepoSha, LastBackflowRepoSha))
             .ReturnsAsync(false);
 
-        var result = await _sut.GetLastFlowsAsync(
+        var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
             _repoClone.Object,
             currentIsBackflow: false,
@@ -188,7 +195,7 @@ public class VmrCodeFlowerGetLastFlowsTests
             .Setup(x => x.IsAncestorCommit(LastBackflowVmrSha, currentVmrSha))
             .ReturnsAsync(false);
 
-        var result = await _sut.GetLastFlowsAsync(
+        var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
             _repoClone.Object,
             currentIsBackflow: false,
@@ -211,7 +218,7 @@ public class VmrCodeFlowerGetLastFlowsTests
             .Setup(x => x.IsAncestorCommit(LastForwardVmrSha, LastBackflowVmrSha))
             .ReturnsAsync(false);
 
-        var result = await _sut.GetLastFlowsAsync(
+        var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
             _repoClone.Object,
             currentIsBackflow: true,
@@ -230,7 +237,7 @@ public class VmrCodeFlowerGetLastFlowsTests
             .Setup(x => x.IsAncestorCommit(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(false);
 
-        Func<Task> act = () => _sut.GetLastFlowsAsync(
+        Func<Task> act = () => _codeFlower.GetLastFlowsAsync(
             MappingName,
             _repoClone.Object,
             currentIsBackflow: false,
@@ -248,7 +255,7 @@ public class VmrCodeFlowerGetLastFlowsTests
             .Setup(x => x.IsAncestorCommit(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(false);
 
-        var result = await _sut.GetLastFlowsAsync(
+        var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
             _repoClone.Object,
             currentIsBackflow: false,
@@ -271,7 +278,7 @@ public class VmrCodeFlowerGetLastFlowsTests
             .Setup(x => x.GetObjectTypeAsync(LastForwardRepoSha))
             .ReturnsAsync(GitObjectType.Commit);
 
-        Func<Task> act = () => _sut.GetLastFlowsAsync(
+        Func<Task> act = () => _codeFlower.GetLastFlowsAsync(
             MappingName,
             _repoClone.Object,
             currentIsBackflow: false,
@@ -298,7 +305,7 @@ public class VmrCodeFlowerGetLastFlowsTests
             .Setup(x => x.GetObjectTypeAsync(sharedRepoSha))
             .ReturnsAsync(GitObjectType.Commit);
 
-        var result = await _sut.GetLastFlowsAsync(
+        var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
             _repoClone.Object,
             currentIsBackflow: false,
@@ -320,71 +327,5 @@ public class VmrCodeFlowerGetLastFlowsTests
     private void SetupCommitObjects(Mock<ILocalGitRepo> repo)
     {
         repo.Setup(x => x.GetObjectTypeAsync(It.IsAny<string>())).ReturnsAsync(GitObjectType.Commit);
-    }
-
-    /// <summary>
-    /// Test double that exposes <see cref="VmrCodeFlower.GetLastFlowsAsync"/> without requiring the
-    /// full flow-execution machinery. Abstract members that aren't exercised by the tested method
-    /// throw so that any accidental call is caught loudly.
-    /// </summary>
-    private sealed class TestVmrCodeFlower : VmrCodeFlower
-    {
-        public TestVmrCodeFlower(
-            IVmrInfo vmrInfo,
-            ISourceManifest sourceManifest,
-            IVmrDependencyTracker dependencyTracker,
-            ILocalGitClient localGitClient,
-            ILocalGitRepoFactory localGitRepoFactory,
-            IVersionDetailsParser versionDetailsParser,
-            IFileSystem fileSystem)
-            : base(
-                vmrInfo,
-                sourceManifest,
-                dependencyTracker,
-                localGitClient,
-                localGitRepoFactory,
-                versionDetailsParser,
-                fileSystem,
-                NullLogger<VmrCodeFlower>.Instance)
-        {
-        }
-
-        protected override Task<CodeFlowResult> SameDirectionFlowAsync(
-            CodeflowOptions codeflowOptions,
-            LastFlows lastFlows,
-            ILocalGitRepo repo,
-            bool headBranchExisted,
-            CancellationToken cancellationToken) => throw new NotImplementedException();
-
-        protected override Task<CodeFlowResult> OppositeDirectionFlowAsync(
-            CodeflowOptions codeflowOptions,
-            LastFlows lastFlows,
-            ILocalGitRepo sourceRepo,
-            bool headBranchExisted,
-            CancellationToken cancellationToken) => throw new NotImplementedException();
-
-        protected override Task<Codeflow?> DetectCrossingFlow(
-            Codeflow lastFlow,
-            Backflow? lastBackFlow,
-            ForwardFlow lastForwardFlow,
-            ILocalGitRepo repo) => Task.FromResult<Codeflow?>(null);
-
-        protected override Task<(Codeflow, LastFlows)> UnwindPreviousFlowAsync(
-            SourceMapping mapping,
-            ILocalGitRepo targetRepo,
-            LastFlows previousFlows,
-            string branchToCreate,
-            string targetBranch,
-            bool unsafeFlow,
-            CancellationToken cancellationToken) => throw new NotImplementedException();
-
-        protected override Task EnsureCodeflowLinearityAsync(
-            ILocalGitRepo repo,
-            Codeflow currentFlow,
-            LastFlows lastFlows) => Task.CompletedTask;
-
-        protected override NativePath GetEngCommonPath(NativePath sourceRepo) => sourceRepo / "eng" / "common";
-
-        protected override bool TargetRepoIsVmr() => false;
     }
 }

--- a/test/Darc/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrCodeFlowerGetLastFlowsTests.cs
+++ b/test/Darc/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrCodeFlowerGetLastFlowsTests.cs
@@ -1,0 +1,390 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.Models;
+using Microsoft.DotNet.DarcLib.Models.Darc;
+using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+
+#nullable enable
+namespace Microsoft.DotNet.DarcLib.Tests.VirtualMonoRepo;
+
+[TestFixture]
+public class VmrCodeFlowerGetLastFlowsTests
+{
+    private const string MappingName = "test-repo";
+    private const string RepoUri = "https://github.com/dotnet/test-repo";
+
+    private const string LastForwardRepoSha = "forward-repo-sha";
+    private const string LastForwardVmrSha = "forward-vmr-sha";
+    private const string LastBackflowRepoSha = "backflow-repo-sha";
+    private const string LastBackflowVmrSha = "backflow-vmr-sha";
+
+    private readonly NativePath _vmrPath = new("/data/vmr");
+    private readonly NativePath _repoPath = new("/data/repo");
+
+    private Mock<IVmrInfo> _vmrInfo = null!;
+    private Mock<ISourceManifest> _sourceManifest = null!;
+    private Mock<IVmrDependencyTracker> _dependencyTracker = null!;
+    private Mock<ILocalGitClient> _localGitClient = null!;
+    private Mock<ILocalGitRepoFactory> _localGitRepoFactory = null!;
+    private Mock<IVersionDetailsParser> _versionDetailsParser = null!;
+    private Mock<IFileSystem> _fileSystem = null!;
+    private Mock<ILocalGitRepo> _repoClone = null!;
+    private Mock<ILocalGitRepo> _vmrRepo = null!;
+    private Mock<ISourceComponent> _repoInVmr = null!;
+
+    private TestVmrCodeFlower _sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _vmrInfo = new Mock<IVmrInfo>();
+        _vmrInfo.SetupGet(x => x.VmrPath).Returns(_vmrPath);
+        _vmrInfo.SetupGet(x => x.SourceManifestPath).Returns(_vmrPath / VmrInfo.DefaultRelativeSourceManifestPath);
+
+        _sourceManifest = new Mock<ISourceManifest>();
+        _repoInVmr = new Mock<ISourceComponent>();
+        _repoInVmr.SetupGet(x => x.CommitSha).Returns(LastForwardRepoSha);
+        _sourceManifest.Setup(x => x.GetRepoVersion(MappingName)).Returns(_repoInVmr.Object);
+
+        _dependencyTracker = new Mock<IVmrDependencyTracker>();
+        _dependencyTracker
+            .Setup(x => x.RefreshMetadataAsync(It.IsAny<string?>()))
+            .Returns(Task.CompletedTask);
+
+        _localGitClient = new Mock<ILocalGitClient>();
+        // Last forward VMR sha comes from blaming source-manifest.json in the VMR.
+        _localGitClient
+            .Setup(x => x.BlameLineAsync(
+                (string)_vmrInfo.Object.SourceManifestPath,
+                It.IsAny<Func<string, bool>>(),
+                It.IsAny<string?>()))
+            .ReturnsAsync(LastForwardVmrSha);
+        // Last backflow repo sha comes from blaming Version.Details.xml in the repo.
+        _localGitClient
+            .Setup(x => x.BlameLineAsync(
+                (string)(_repoPath / VersionFiles.VersionDetailsXml),
+                It.IsAny<Func<string, bool>>(),
+                It.IsAny<string?>()))
+            .ReturnsAsync(LastBackflowRepoSha);
+
+        _repoClone = new Mock<ILocalGitRepo>();
+        _repoClone.SetupGet(x => x.Path).Returns(_repoPath);
+
+        _vmrRepo = new Mock<ILocalGitRepo>();
+        _vmrRepo.SetupGet(x => x.Path).Returns(_vmrPath);
+
+        _localGitRepoFactory = new Mock<ILocalGitRepoFactory>();
+        _localGitRepoFactory.Setup(x => x.Create(_vmrPath)).Returns(_vmrRepo.Object);
+
+        _versionDetailsParser = new Mock<IVersionDetailsParser>();
+        SetBackflowInVersionDetails(LastBackflowVmrSha);
+
+        _fileSystem = new Mock<IFileSystem>();
+
+        _sut = new TestVmrCodeFlower(
+            _vmrInfo.Object,
+            _sourceManifest.Object,
+            _dependencyTracker.Object,
+            _localGitClient.Object,
+            _localGitRepoFactory.Object,
+            _versionDetailsParser.Object,
+            _fileSystem.Object);
+    }
+
+    [Test]
+    public async Task GetLastFlowsAsync_ReturnsForwardFlow_WhenNoBackflowRecorded()
+    {
+        SetBackflowInVersionDetails(null);
+
+        var result = await _sut.GetLastFlowsAsync(
+            MappingName,
+            _repoClone.Object,
+            currentIsBackflow: false,
+            ignoreNonLinearFlow: false,
+            headBranchExisted: false);
+
+        result.LastBackFlow.Should().BeNull();
+        result.LastForwardFlow.Should().Be(new ForwardFlow(LastForwardRepoSha, LastForwardVmrSha));
+        result.LastFlow.Should().Be(result.LastForwardFlow);
+        result.CrossingFlow.Should().BeNull();
+    }
+
+    [Test]
+    public async Task GetLastFlowsAsync_ForwardFlowDirection_ReturnsLastBackflow_WhenBackflowIsNewer()
+    {
+        // In forward-flow direction we compare the repo SHAs of the two flows.
+        // backflow.RepoSha is newer means lastForward.RepoSha is an ancestor of lastBackflow.RepoSha.
+        SetupCommitObjects(_repoClone);
+        _repoClone
+            .Setup(x => x.IsAncestorCommit(LastForwardRepoSha, LastBackflowRepoSha))
+            .ReturnsAsync(true);
+        _repoClone
+            .Setup(x => x.IsAncestorCommit(LastBackflowRepoSha, LastForwardRepoSha))
+            .ReturnsAsync(false);
+
+        var result = await _sut.GetLastFlowsAsync(
+            MappingName,
+            _repoClone.Object,
+            currentIsBackflow: false,
+            ignoreNonLinearFlow: false,
+            headBranchExisted: true);
+
+        result.LastFlow.Should().Be(new Backflow(LastBackflowVmrSha, LastBackflowRepoSha));
+        result.LastBackFlow.Should().Be(new Backflow(LastBackflowVmrSha, LastBackflowRepoSha));
+        result.LastForwardFlow.Should().Be(new ForwardFlow(LastForwardRepoSha, LastForwardVmrSha));
+    }
+
+    [Test]
+    public async Task GetLastFlowsAsync_ForwardFlowDirection_ReturnsLastForwardFlow_WhenForwardFlowIsNewer()
+    {
+        SetupCommitObjects(_repoClone);
+        _repoClone
+            .Setup(x => x.IsAncestorCommit(LastBackflowRepoSha, LastForwardRepoSha))
+            .ReturnsAsync(true);
+        _repoClone
+            .Setup(x => x.IsAncestorCommit(LastForwardRepoSha, LastBackflowRepoSha))
+            .ReturnsAsync(false);
+
+        var result = await _sut.GetLastFlowsAsync(
+            MappingName,
+            _repoClone.Object,
+            currentIsBackflow: false,
+            ignoreNonLinearFlow: false,
+            headBranchExisted: false);
+
+        result.LastFlow.Should().Be(new ForwardFlow(LastForwardRepoSha, LastForwardVmrSha));
+    }
+
+    [Test]
+    public async Task GetLastFlowsAsync_ForwardFlowDirection_IgnoresBackflow_WhenItCameFromDifferentBranch()
+    {
+        // Simulate a preview-branch scenario: lastBackflow is newer (forward is older),
+        // but the current VMR HEAD is not a descendant of lastBackflow.VmrSha, meaning the
+        // backflow came from a different branch and should be ignored.
+        const string currentVmrSha = "current-vmr-head-sha";
+        SetupCommitObjects(_repoClone);
+        _repoClone
+            .Setup(x => x.IsAncestorCommit(LastForwardRepoSha, LastBackflowRepoSha))
+            .ReturnsAsync(true);
+        _repoClone
+            .Setup(x => x.IsAncestorCommit(LastBackflowRepoSha, LastForwardRepoSha))
+            .ReturnsAsync(false);
+
+        _vmrRepo
+            .Setup(x => x.GetShaForRefAsync(null))
+            .ReturnsAsync(currentVmrSha);
+        _vmrRepo
+            .Setup(x => x.IsAncestorCommit(LastBackflowVmrSha, currentVmrSha))
+            .ReturnsAsync(false);
+
+        var result = await _sut.GetLastFlowsAsync(
+            MappingName,
+            _repoClone.Object,
+            currentIsBackflow: false,
+            ignoreNonLinearFlow: false,
+            headBranchExisted: false);
+
+        result.LastFlow.Should().Be(new ForwardFlow(LastForwardRepoSha, LastForwardVmrSha));
+        result.LastBackFlow.Should().Be(new Backflow(LastBackflowVmrSha, LastBackflowRepoSha));
+    }
+
+    [Test]
+    public async Task GetLastFlowsAsync_BackflowDirection_ReturnsLastForwardFlow_WhenForwardFlowIsNewer()
+    {
+        // In backflow direction we compare VMR SHAs and source repo is the VMR.
+        SetupCommitObjects(_vmrRepo);
+        _vmrRepo
+            .Setup(x => x.IsAncestorCommit(LastBackflowVmrSha, LastForwardVmrSha))
+            .ReturnsAsync(true);
+        _vmrRepo
+            .Setup(x => x.IsAncestorCommit(LastForwardVmrSha, LastBackflowVmrSha))
+            .ReturnsAsync(false);
+
+        var result = await _sut.GetLastFlowsAsync(
+            MappingName,
+            _repoClone.Object,
+            currentIsBackflow: true,
+            ignoreNonLinearFlow: false,
+            headBranchExisted: true);
+
+        result.LastFlow.Should().Be(new ForwardFlow(LastForwardRepoSha, LastForwardVmrSha));
+    }
+
+    [Test]
+    public void GetLastFlowsAsync_ThrowsNonLinearCodeflowException_WhenHistoryIsNotLinear()
+    {
+        SetupCommitObjects(_repoClone);
+        // Neither commit is an ancestor of the other.
+        _repoClone
+            .Setup(x => x.IsAncestorCommit(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(false);
+
+        Func<Task> act = () => _sut.GetLastFlowsAsync(
+            MappingName,
+            _repoClone.Object,
+            currentIsBackflow: false,
+            ignoreNonLinearFlow: false,
+            headBranchExisted: false);
+
+        act.Should().ThrowAsync<NonLinearCodeflowException>();
+    }
+
+    [Test]
+    public async Task GetLastFlowsAsync_ReturnsOppositeDirectionFlow_WhenHistoryIsNotLinearAndIgnoreFlagSet()
+    {
+        SetupCommitObjects(_repoClone);
+        _repoClone
+            .Setup(x => x.IsAncestorCommit(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(false);
+
+        var result = await _sut.GetLastFlowsAsync(
+            MappingName,
+            _repoClone.Object,
+            currentIsBackflow: false,
+            ignoreNonLinearFlow: true,
+            headBranchExisted: false);
+
+        // In forward-flow direction, the same-direction flow (lastForwardFlow) is returned so that
+        // the upcoming flow is handled as a same-direction flow.
+        result.LastFlow.Should().Be(new ForwardFlow(LastForwardRepoSha, LastForwardVmrSha));
+        result.CrossingFlow.Should().BeNull();
+    }
+
+    [Test]
+    public void GetLastFlowsAsync_ThrowsInvalidSynchronization_WhenShaIsNotACommit()
+    {
+        _repoClone
+            .Setup(x => x.GetObjectTypeAsync(LastBackflowRepoSha))
+            .ReturnsAsync(GitObjectType.Tree);
+        _repoClone
+            .Setup(x => x.GetObjectTypeAsync(LastForwardRepoSha))
+            .ReturnsAsync(GitObjectType.Commit);
+
+        Func<Task> act = () => _sut.GetLastFlowsAsync(
+            MappingName,
+            _repoClone.Object,
+            currentIsBackflow: false,
+            ignoreNonLinearFlow: false,
+            headBranchExisted: false);
+
+        act.Should().ThrowAsync<InvalidSynchronizationException>();
+    }
+
+    [Test]
+    public async Task GetLastFlowsAsync_InflowCase_ReturnsLastForwardFlow_InForwardFlowDirection()
+    {
+        // An "inflow" commit: backflow and forward flow target the same repo SHA.
+        const string sharedRepoSha = "shared-repo-sha";
+        _repoInVmr.SetupGet(x => x.CommitSha).Returns(sharedRepoSha);
+        _localGitClient
+            .Setup(x => x.BlameLineAsync(
+                (string)(_repoPath / VersionFiles.VersionDetailsXml),
+                It.IsAny<Func<string, bool>>(),
+                It.IsAny<string?>()))
+            .ReturnsAsync(sharedRepoSha);
+
+        _repoClone
+            .Setup(x => x.GetObjectTypeAsync(sharedRepoSha))
+            .ReturnsAsync(GitObjectType.Commit);
+
+        var result = await _sut.GetLastFlowsAsync(
+            MappingName,
+            _repoClone.Object,
+            currentIsBackflow: false,
+            ignoreNonLinearFlow: false,
+            headBranchExisted: false);
+
+        result.LastFlow.Should().Be(new ForwardFlow(sharedRepoSha, LastForwardVmrSha));
+        result.LastBackFlow.Should().Be(new Backflow(LastBackflowVmrSha, sharedRepoSha));
+    }
+
+    private void SetBackflowInVersionDetails(string? vmrSha)
+    {
+        var source = vmrSha is null ? null : new SourceDependency(RepoUri, MappingName, vmrSha, BarId: null);
+        _versionDetailsParser
+            .Setup(x => x.ParseVersionDetailsFile(_repoPath / VersionFiles.VersionDetailsXml, It.IsAny<bool>()))
+            .Returns(new VersionDetails(Array.Empty<DependencyDetail>(), source));
+    }
+
+    private void SetupCommitObjects(Mock<ILocalGitRepo> repo)
+    {
+        repo.Setup(x => x.GetObjectTypeAsync(It.IsAny<string>())).ReturnsAsync(GitObjectType.Commit);
+    }
+
+    /// <summary>
+    /// Test double that exposes <see cref="VmrCodeFlower.GetLastFlowsAsync"/> without requiring the
+    /// full flow-execution machinery. Abstract members that aren't exercised by the tested method
+    /// throw so that any accidental call is caught loudly.
+    /// </summary>
+    private sealed class TestVmrCodeFlower : VmrCodeFlower
+    {
+        public TestVmrCodeFlower(
+            IVmrInfo vmrInfo,
+            ISourceManifest sourceManifest,
+            IVmrDependencyTracker dependencyTracker,
+            ILocalGitClient localGitClient,
+            ILocalGitRepoFactory localGitRepoFactory,
+            IVersionDetailsParser versionDetailsParser,
+            IFileSystem fileSystem)
+            : base(
+                vmrInfo,
+                sourceManifest,
+                dependencyTracker,
+                localGitClient,
+                localGitRepoFactory,
+                versionDetailsParser,
+                fileSystem,
+                NullLogger<VmrCodeFlower>.Instance)
+        {
+        }
+
+        protected override Task<CodeFlowResult> SameDirectionFlowAsync(
+            CodeflowOptions codeflowOptions,
+            LastFlows lastFlows,
+            ILocalGitRepo repo,
+            bool headBranchExisted,
+            CancellationToken cancellationToken) => throw new NotImplementedException();
+
+        protected override Task<CodeFlowResult> OppositeDirectionFlowAsync(
+            CodeflowOptions codeflowOptions,
+            LastFlows lastFlows,
+            ILocalGitRepo sourceRepo,
+            bool headBranchExisted,
+            CancellationToken cancellationToken) => throw new NotImplementedException();
+
+        protected override Task<Codeflow?> DetectCrossingFlow(
+            Codeflow lastFlow,
+            Backflow? lastBackFlow,
+            ForwardFlow lastForwardFlow,
+            ILocalGitRepo repo) => Task.FromResult<Codeflow?>(null);
+
+        protected override Task<(Codeflow, LastFlows)> UnwindPreviousFlowAsync(
+            SourceMapping mapping,
+            ILocalGitRepo targetRepo,
+            LastFlows previousFlows,
+            string branchToCreate,
+            string targetBranch,
+            bool unsafeFlow,
+            CancellationToken cancellationToken) => throw new NotImplementedException();
+
+        protected override Task EnsureCodeflowLinearityAsync(
+            ILocalGitRepo repo,
+            Codeflow currentFlow,
+            LastFlows lastFlows) => Task.CompletedTask;
+
+        protected override NativePath GetEngCommonPath(NativePath sourceRepo) => sourceRepo / "eng" / "common";
+
+        protected override bool TargetRepoIsVmr() => false;
+    }
+}

--- a/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
+++ b/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestUpdaterTests.cs
@@ -522,6 +522,15 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
             WithForwardFlowConflict(remote, [new UnixPath("src/conflict.txt")]);
         }
 
+        if (blockedFromFutureUpdates && !willFlowNewBuild)
+        {
+            remote
+                .Setup(x => x.CommentPullRequestAsync(
+                    prUrl,
+                    It.Is<string>(content => content.Contains("opposite codeflow merged"))))
+                .Returns(Task.CompletedTask);
+        }
+
         if (mockMergePolicyEvaluator)
         {
             var results = policyEvaluationStatus.HasValue
@@ -663,7 +672,8 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
         bool? sourceRepoNotified = null,
         UnixPath? relativeBasePath = null,
         string? url = null,
-        List<DependencyUpdateSummary>? dependencyUpdates = null)
+        List<DependencyUpdateSummary>? dependencyUpdates = null,
+        bool blockedFromFutureUpdates = false)
     {
         var prUrl = string.IsNullOrEmpty(url)
             ? Subscription.SourceEnabled
@@ -684,7 +694,8 @@ internal abstract class PullRequestUpdaterTests : SubscriptionOrPullRequestUpdat
                     assetFilter,
                     sourceRepoNotified: sourceRepoNotified,
                     relativeBasePath,
-                    dependencyUpdates: dependencyUpdates));
+                    dependencyUpdates: dependencyUpdates,
+                    blockedFromFutureUpdates: blockedFromFutureUpdates));
     }
 
     protected void ThenShouldHaveInProgressPullRequestState(Build forBuild, int nextBuildToProcess = 0, InProgressPullRequest? expectedState = null, bool? sourceRepoNotified = null, UnixPath? relativeBasePath = null)


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/5234
Also fix last flow detection when head branch exists and post comment every time a blocked flow is triggered

example PR https://github.com/maestro-auth-test/maestro-test-vmr/pull/6525