### PR TITLE
Improve how we cleanup repos

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/FileSystem.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/FileSystem.cs
@@ -19,35 +19,7 @@ public class FileSystem : IFileSystem
 
     public void DeleteFile(string path) => File.Delete(path);
 
-    public void DeleteDirectory(string path, bool recursive)
-    {
-        if (recursive && Directory.Exists(path))
-        {
-            // Git stores objects under .git/objects as read-only files. On Windows,
-            // Directory.Delete cannot remove read-only files and throws UnauthorizedAccessException,
-            // so we clear the attribute first.
-            ClearReadOnlyAttributes(path);
-        }
-
-        Directory.Delete(path, recursive);
-    }
-
-    private static void ClearReadOnlyAttributes(string path)
-    {
-        var dirInfo = new DirectoryInfo(path);
-        if ((dirInfo.Attributes & FileAttributes.ReadOnly) != 0)
-        {
-            dirInfo.Attributes &= ~FileAttributes.ReadOnly;
-        }
-
-        foreach (var file in dirInfo.EnumerateFiles("*", SearchOption.AllDirectories))
-        {
-            if ((file.Attributes & FileAttributes.ReadOnly) != 0)
-            {
-                file.Attributes &= ~FileAttributes.ReadOnly;
-            }
-        }
-    }
+    public void DeleteDirectory(string path, bool recursive) => Directory.Delete(path, recursive);
 
     public string? GetDirectoryName(string? path) => Path.GetDirectoryName(path);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/FileSystem.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/FileSystem.cs
@@ -19,7 +19,35 @@ public class FileSystem : IFileSystem
 
     public void DeleteFile(string path) => File.Delete(path);
 
-    public void DeleteDirectory(string path, bool recursive) => Directory.Delete(path, recursive);
+    public void DeleteDirectory(string path, bool recursive)
+    {
+        if (recursive && Directory.Exists(path))
+        {
+            // Git stores objects under .git/objects as read-only files. On Windows,
+            // Directory.Delete cannot remove read-only files and throws UnauthorizedAccessException,
+            // so we clear the attribute first.
+            ClearReadOnlyAttributes(path);
+        }
+
+        Directory.Delete(path, recursive);
+    }
+
+    private static void ClearReadOnlyAttributes(string path)
+    {
+        var dirInfo = new DirectoryInfo(path);
+        if ((dirInfo.Attributes & FileAttributes.ReadOnly) != 0)
+        {
+            dirInfo.Attributes &= ~FileAttributes.ReadOnly;
+        }
+
+        foreach (var file in dirInfo.EnumerateFiles("*", SearchOption.AllDirectories))
+        {
+            if ((file.Attributes & FileAttributes.ReadOnly) != 0)
+            {
+                file.Attributes &= ~FileAttributes.ReadOnly;
+            }
+        }
+    }
 
     public string? GetDirectoryName(string? path) => Path.GetDirectoryName(path);
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
@@ -258,6 +258,7 @@ public abstract class CloneManager : ICloneManager
                 if (!result.Succeeded)
                 {
                     _logger.LogWarning("Failed to clean up {clonePath}, re-cloning", clonePath);
+                    GitFile.MakeGitFilesDeletable(clonePath);
                     _fileSystem.DeleteDirectory(clonePath, recursive: true);
                     return await PrepareCloneInternal(remoteUri, dirName, performCleanup: true, cancellationToken);
                 }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
@@ -258,6 +258,7 @@ public abstract class CloneManager : ICloneManager
                 if (!result.Succeeded)
                 {
                     _logger.LogWarning("Failed to clean up {clonePath}, re-cloning", clonePath);
+
                     GitFile.MakeGitFilesDeletable(clonePath);
                     _fileSystem.DeleteDirectory(clonePath, recursive: true);
                     return await PrepareCloneInternal(remoteUri, dirName, performCleanup: true, cancellationToken);
@@ -273,6 +274,8 @@ public abstract class CloneManager : ICloneManager
             catch (Exception e) when (e.Message.Contains("fatal: not a git repository"))
             {
                 _logger.LogWarning("Clone at {clonePath} is not a git repository, re-cloning", clonePath);
+
+                GitFile.MakeGitFilesDeletable(clonePath);
                 _fileSystem.DeleteDirectory(clonePath, recursive: true);
                 return await PrepareCloneInternal(remoteUri, dirName, performCleanup: true, cancellationToken);
             }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CloneManager.cs
@@ -259,8 +259,7 @@ public abstract class CloneManager : ICloneManager
                 {
                     _logger.LogWarning("Failed to clean up {clonePath}, re-cloning", clonePath);
 
-                    GitFile.MakeGitFilesDeletable(clonePath);
-                    _fileSystem.DeleteDirectory(clonePath, recursive: true);
+                    DeleteCloneDirectory(clonePath);
                     return await PrepareCloneInternal(remoteUri, dirName, performCleanup: true, cancellationToken);
                 }
             }
@@ -275,8 +274,7 @@ public abstract class CloneManager : ICloneManager
             {
                 _logger.LogWarning("Clone at {clonePath} is not a git repository, re-cloning", clonePath);
 
-                GitFile.MakeGitFilesDeletable(clonePath);
-                _fileSystem.DeleteDirectory(clonePath, recursive: true);
+                DeleteCloneDirectory(clonePath);
                 return await PrepareCloneInternal(remoteUri, dirName, performCleanup: true, cancellationToken);
             }
 
@@ -293,4 +291,18 @@ public abstract class CloneManager : ICloneManager
     }
 
     protected virtual NativePath GetClonePath(string dirName) => _vmrInfo.TmpPath / dirName;
+
+    private void DeleteCloneDirectory(NativePath clonePath)
+    {
+        try
+        {
+            GitFile.MakeGitFilesDeletable(clonePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to make git files in {clonePath} deletable", clonePath);
+        }
+
+        _fileSystem.DeleteDirectory(clonePath, recursive: true);
+    }
 }


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/6135
when calling `resolve-conflicts` users have reported that operation failed when trying to delete the repo. (during initialization)

This is probably because these files are marked as readonly by git on Windows. When this happens we're not able to delete them and we get an exception https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.delete?view=net-10.0#:~:text=The%20directory%20is%20read%2Donly%20or%20contains%20a%20read%2Donly%20file.