### PR TITLE
Downgrade Nuget.Packaging so it doesn't break VMR bootstrap

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -77,7 +77,7 @@
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NRedisStack" Version="0.12.0" />
-    <PackageVersion Include="NuGet.Packaging" Version="7.3.1" />
+    <PackageVersion Include="NuGet.Packaging" Version="7.0.3" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="Octokit" Version="14.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -77,6 +77,7 @@
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NRedisStack" Version="0.12.0" />
+    <!-- Intentionally pinned for VMR bootstrap compatibility; only upgrade once bootstrap supports newer NuGet.Packaging versions. -->
     <PackageVersion Include="NuGet.Packaging" Version="7.0.3" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/pull/6197#issuecomment-4360445870
We were asked to downgrade in order to not break the VMR bootstrap.
Hopefully this is still find with CG, I can't find the original  https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-arcade-services?_a=history&typeId=6582243&alerts-view-option=active