### PR TITLE
Remove dn-bot-dnceng-build-rw-code-rw PAT from vmr-synchronization secret manifest

### DIFF
--- a/.vault-config/vmr-synchronization.1.yaml
+++ b/.vault-config/vmr-synchronization.1.yaml
@@ -30,15 +30,3 @@ secrets:
       name: dn-bot-all-orgs-code-r
       organizations: devdiv dnceng
       scopes: code
-
-  # Required in the dotnet-dotnet-synchronization pipeline for pushing code to the internal VMR
-  dn-bot-dnceng-build-rw-code-rw:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-dnceng-build
-      organizations: dnceng
-      scopes: build_execute code_write


### PR DESCRIPTION
AB#10139

Remove the `dn-bot-dnceng-build-rw-code-rw` PAT entry from `.vault-config/vmr-synchronization.1.yaml`. All pipeline consumers have been migrated to WIF service connections.

Companion PR: https://github.com/dotnet/arcade/pull/16766 (removes the same PAT from `product-builds-engkeyvault.yaml`)

Part of PAT migration work item: https://dev.azure.com/dnceng/internal/_workitems/edit/10139