### PR TITLE
Improve conflict resolution

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -614,18 +614,39 @@ public class LocalGitClient : ILocalGitClient
     public async Task ResolveConflict(string repoPath, string file, bool ours)
     {
         // Use porcelain status to determine the conflict shape. The first two
-        // characters (XY) tell us what each side did:
-        //   X = our side, Y = their side
-        // For unmerged paths the relevant codes are:
-        //   DD both deleted        AU added by us         UD deleted by them
-        //   UA added by them       DU deleted by us       AA both added
-        //   UU both modified
-        // Resolution rules:
-        //   - chosen side is 'D'  -> that side deleted; honor it with `rm`
-        //   - other side is 'D'   -> modify/delete; the working tree already has
-        //                            the non-deleter's content, just `git add`
-        //   - both sides have a blob (UU, AA) -> use `checkout --ours/--theirs`
-        //                                         to pick a side, then `add`
+        // characters (XY) tell us what each side did. For unmerged paths:
+        //
+        //   pair  meaning              stage 2 (us)  stage 3 (them)
+        //   ----  -------------------  ------------  --------------
+        //   DD    both deleted              -              -
+        //   AU    added by us               yes            -
+        //   UD    deleted by them           yes            -
+        //   UA    added by them             -              yes
+        //   DU    deleted by us             -              yes
+        //   AA    both added                yes            yes
+        //   UU    both modified             yes            yes
+        //
+        // Note that 'U' is overloaded: in UD/DU/UU the side with U has a blob
+        // (it modified the file), but in AU/UA the U side has no blob (the
+        // other side simply added something it doesn't have).
+        //
+        // Resolution rules driven by the chosen side:
+        //   - chosen side has no blob (D, or U paired with A) -> `rm`
+        //   - other side has no blob  (D, or U paired with A) -> `git add`
+        //     (working tree already contains the chosen side's content)
+        //   - both sides have a blob (AA, UU) -> `checkout --ours/--theirs` + `add`
+        //
+        // Resulting per-code behavior:
+        //
+        //   code  ours=true                       ours=false
+        //   ----  ------------------------------  ------------------------------
+        //   DD    rm                              rm
+        //   AU    add (keep our addition)         rm
+        //   UD    add (keep our modification)     rm
+        //   UA    rm                              add (keep their addition)
+        //   DU    rm                              add (keep their modification)
+        //   AA    checkout --ours + add           checkout --theirs + add
+        //   UU    checkout --ours + add           checkout --theirs + add
         var status = await _processManager.ExecuteGit(repoPath, "status", "--porcelain=v1", "--", file);
         status.ThrowIfFailed($"Failed to inspect status of {file} in {repoPath}");
 
@@ -637,13 +658,24 @@ public class LocalGitClient : ILocalGitClient
             throw new Exception($"Unexpected git status output for {file} in {repoPath}: '{line}'");
         }
 
-        var chosenSideCode = ours ? line[0] : line[1];
-        var otherSideCode = ours ? line[1] : line[0];
+        var usCode = line[0];
+        var themCode = line[1];
+
+        // A side has a blob unless it deleted the file ('D'), or it's marked
+        // unmerged ('U') because the *other* side added it from nothing ('A').
+        static bool SideHasBlob(char thisSide, char otherSide)
+            => thisSide != 'D' && !(thisSide == 'U' && otherSide == 'A');
+
+        var ourBlob = SideHasBlob(usCode, themCode);
+        var theirBlob = SideHasBlob(themCode, usCode);
+
+        var chosenHasBlob = ours ? ourBlob : theirBlob;
+        var otherHasBlob = ours ? theirBlob : ourBlob;
 
         ProcessExecutionResult result;
-        if (chosenSideCode == 'D')
+        if (!chosenHasBlob)
         {
-            // The chosen side deleted the file - accept the deletion.
+            // Chosen side has nothing - accept absence by removing the path.
             // Use --cached as a fallback if the working-tree copy is gone
             // (e.g. "deleted by us": git removes the working-tree file).
             result = await _processManager.ExecuteGit(repoPath, "rm", "-f", "--", file);
@@ -651,15 +683,14 @@ public class LocalGitClient : ILocalGitClient
             {
                 result = await _processManager.ExecuteGit(repoPath, "rm", "-f", "--cached", "--", file);
             }
-            result.ThrowIfFailed($"Failed to resolve delete/modify conflict in {file} in {repoPath}");
+            result.ThrowIfFailed($"Failed to remove {file} in {repoPath}");
         }
-        else if (otherSideCode == 'D')
+        else if (!otherHasBlob)
         {
-            // Modify/delete conflict where we're keeping the non-deleting side.
-            // The working tree already contains the chosen side's content,
-            // so a plain `git add` resolves it.
+            // Only the chosen side has content; the working tree already
+            // contains it (modify/delete or one-sided add), so `git add` is enough.
             result = await _processManager.ExecuteGit(repoPath, "add", "--", file);
-            result.ThrowIfFailed($"Failed to stage modify/delete resolution for {file} in {repoPath}");
+            result.ThrowIfFailed($"Failed to stage {file} in {repoPath}");
         }
         else
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -633,11 +633,11 @@ public class LocalGitClient : ILocalGitClient
         status.ThrowIfFailed($"Failed to inspect status of {file} in {repoPath}");
 
         var line = status.GetOutputLines().FirstOrDefault()
-            ?? throw new Exception($"No status entry found for {file} in {repoPath} - is it actually conflicted?");
+            ?? throw new InvalidOperationException($"No status entry found for {file} in {repoPath} - is it actually conflicted?");
 
         if (line.Length < 2)
         {
-            throw new Exception($"Unexpected git status output for {file} in {repoPath}: '{line}'");
+            throw new InvalidOperationException($"Unexpected git status output for {file} in {repoPath}: '{line}'");
         }
 
         var code = line[..2];

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -613,11 +613,63 @@ public class LocalGitClient : ILocalGitClient
 
     public async Task ResolveConflict(string repoPath, string file, bool ours)
     {
-        var result = await _processManager.ExecuteGit(repoPath, "checkout", ours ? "--ours" : "--theirs", file);
-        result.ThrowIfFailed($"Failed to resolve conflict in {file} in {repoPath}");
+        // Use porcelain status to determine the conflict shape. The first two
+        // characters (XY) tell us what each side did:
+        //   X = our side, Y = their side
+        // For unmerged paths the relevant codes are:
+        //   DD both deleted        AU added by us         UD deleted by them
+        //   UA added by them       DU deleted by us       AA both added
+        //   UU both modified
+        // Resolution rules:
+        //   - chosen side is 'D'  -> that side deleted; honor it with `rm`
+        //   - other side is 'D'   -> modify/delete; the working tree already has
+        //                            the non-deleter's content, just `git add`
+        //   - both sides have a blob (UU, AA) -> use `checkout --ours/--theirs`
+        //                                         to pick a side, then `add`
+        var status = await _processManager.ExecuteGit(repoPath, "status", "--porcelain=v1", "--", file);
+        status.ThrowIfFailed($"Failed to inspect status of {file} in {repoPath}");
 
-        result = await _processManager.ExecuteGit(repoPath, "add", file);
-        result.ThrowIfFailed($"Failed to stage resolved conflict in {file} in {repoPath}");
+        var line = status.GetOutputLines().FirstOrDefault()
+            ?? throw new Exception($"No status entry found for {file} in {repoPath} - is it actually conflicted?");
+
+        if (line.Length < 2)
+        {
+            throw new Exception($"Unexpected git status output for {file} in {repoPath}: '{line}'");
+        }
+
+        var chosenSideCode = ours ? line[0] : line[1];
+        var otherSideCode = ours ? line[1] : line[0];
+
+        ProcessExecutionResult result;
+        if (chosenSideCode == 'D')
+        {
+            // The chosen side deleted the file - accept the deletion.
+            // Use --cached as a fallback if the working-tree copy is gone
+            // (e.g. "deleted by us": git removes the working-tree file).
+            result = await _processManager.ExecuteGit(repoPath, "rm", "-f", "--", file);
+            if (!result.Succeeded)
+            {
+                result = await _processManager.ExecuteGit(repoPath, "rm", "-f", "--cached", "--", file);
+            }
+            result.ThrowIfFailed($"Failed to resolve delete/modify conflict in {file} in {repoPath}");
+        }
+        else if (otherSideCode == 'D')
+        {
+            // Modify/delete conflict where we're keeping the non-deleting side.
+            // The working tree already contains the chosen side's content,
+            // so a plain `git add` resolves it.
+            result = await _processManager.ExecuteGit(repoPath, "add", "--", file);
+            result.ThrowIfFailed($"Failed to stage modify/delete resolution for {file} in {repoPath}");
+        }
+        else
+        {
+            // Both sides contributed a blob - pick the chosen side and stage it.
+            result = await _processManager.ExecuteGit(repoPath, "checkout", ours ? "--ours" : "--theirs", "--", file);
+            result.ThrowIfFailed($"Failed to resolve conflict in {file} in {repoPath}");
+
+            result = await _processManager.ExecuteGit(repoPath, "add", "--", file);
+            result.ThrowIfFailed($"Failed to stage resolved conflict in {file} in {repoPath}");
+        }
     }
 
     public async Task<string> GetMergeBaseAsync(

--- a/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/LocalGitClient.cs
@@ -629,24 +629,6 @@ public class LocalGitClient : ILocalGitClient
         // Note that 'U' is overloaded: in UD/DU/UU the side with U has a blob
         // (it modified the file), but in AU/UA the U side has no blob (the
         // other side simply added something it doesn't have).
-        //
-        // Resolution rules driven by the chosen side:
-        //   - chosen side has no blob (D, or U paired with A) -> `rm`
-        //   - other side has no blob  (D, or U paired with A) -> `git add`
-        //     (working tree already contains the chosen side's content)
-        //   - both sides have a blob (AA, UU) -> `checkout --ours/--theirs` + `add`
-        //
-        // Resulting per-code behavior:
-        //
-        //   code  ours=true                       ours=false
-        //   ----  ------------------------------  ------------------------------
-        //   DD    rm                              rm
-        //   AU    add (keep our addition)         rm
-        //   UD    add (keep our modification)     rm
-        //   UA    rm                              add (keep their addition)
-        //   DU    rm                              add (keep their modification)
-        //   AA    checkout --ours + add           checkout --theirs + add
-        //   UU    checkout --ours + add           checkout --theirs + add
         var status = await _processManager.ExecuteGit(repoPath, "status", "--porcelain=v1", "--", file);
         status.ThrowIfFailed($"Failed to inspect status of {file} in {repoPath}");
 
@@ -658,16 +640,21 @@ public class LocalGitClient : ILocalGitClient
             throw new Exception($"Unexpected git status output for {file} in {repoPath}: '{line}'");
         }
 
-        var usCode = line[0];
-        var themCode = line[1];
+        var code = line[..2];
 
-        // A side has a blob unless it deleted the file ('D'), or it's marked
-        // unmerged ('U') because the *other* side added it from nothing ('A').
-        static bool SideHasBlob(char thisSide, char otherSide)
-            => thisSide != 'D' && !(thisSide == 'U' && otherSide == 'A');
-
-        var ourBlob = SideHasBlob(usCode, themCode);
-        var theirBlob = SideHasBlob(themCode, usCode);
+        // Map each unmerged status code to (ourBlob, theirBlob) - whether each
+        // side contributed a blob to the index.
+        var (ourBlob, theirBlob) = code switch
+        {
+            "DD" => (false, false),
+            "DU" => (false, true),
+            "UD" => (true, false),
+            "AU" => (true, false),
+            "UA" => (false, true),
+            "UU" => (true, true),
+            "AA" => (true, true),
+            _ => throw new Exception($"Unexpected unmerged status '{code}' for {file} in {repoPath}"),
+        };
 
         var chosenHasBlob = ours ? ourBlob : theirBlob;
         var otherHasBlob = ours ? theirBlob : ourBlob;
@@ -675,20 +662,12 @@ public class LocalGitClient : ILocalGitClient
         ProcessExecutionResult result;
         if (!chosenHasBlob)
         {
-            // Chosen side has nothing - accept absence by removing the path.
-            // Use --cached as a fallback if the working-tree copy is gone
-            // (e.g. "deleted by us": git removes the working-tree file).
             result = await _processManager.ExecuteGit(repoPath, "rm", "-f", "--", file);
-            if (!result.Succeeded)
-            {
-                result = await _processManager.ExecuteGit(repoPath, "rm", "-f", "--cached", "--", file);
-            }
             result.ThrowIfFailed($"Failed to remove {file} in {repoPath}");
         }
         else if (!otherHasBlob)
         {
-            // Only the chosen side has content; the working tree already
-            // contains it (modify/delete or one-sided add), so `git add` is enough.
+            // Only the chosen side has content
             result = await _processManager.ExecuteGit(repoPath, "add", "--", file);
             result.ThrowIfFailed($"Failed to stage {file} in {repoPath}");
         }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowConflictResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeFlowConflictResolver.cs
@@ -219,14 +219,125 @@ public abstract class CodeFlowConflictResolver
     {
         _logger.LogDebug("Trying to auto-resolve a conflict in {filePath} based on a crossing flow...", conflictedFile);
 
-        UnixPath vmrRepoPath = VmrInfo.GetRelativeRepoSourcesPath(codeflowOptions.Mapping.Name);
-        if (codeflowOptions.CurrentFlow.IsForwardFlow && !conflictedFile.Path.StartsWith(vmrRepoPath + '/'))
+        var crossingFlowPatch = await TryCreateCrossingFlowPatchAsync(codeflowOptions, vmr, repo, conflictedFile, crossingFlow, cancellationToken);
+        if (crossingFlowPatch is null)
         {
-            _logger.LogWarning("Conflict in {file} is not in the source repo, skipping auto-resolution", conflictedFile);
             return false;
         }
 
-        // Create patch for the file represent only the most current flow
+        var (targetRepo, patch) = crossingFlowPatch.Value;
+
+        try
+        {
+            await targetRepo.ResolveConflict(conflictedFile, ours: true);
+        }
+        // file does not exist in the target repo anymore
+        catch (ProcessFailedException e) when (e.Message.Contains("does not have our version"))
+        {
+            _logger.LogInformation("Detected conflicts in {filePath}", conflictedFile);
+            return false;
+        }
+
+        if (_fileSystem.GetFileInfo(patch.Path).Length == 0)
+        {
+            // This file did not change in the last flow
+            return true;
+        }
+
+        try
+        {
+            await _patchHandler.ApplyPatch(
+                patch,
+                targetRepo.Path,
+                removePatchAfter: true,
+                keepConflicts: false,
+                cancellationToken: cancellationToken);
+            _logger.LogDebug("Successfully auto-resolved a conflict in {filePath}", conflictedFile);
+
+            await targetRepo.ExecuteGitCommand(["restore", conflictedFile], cancellationToken);
+
+            return true;
+        }
+        catch (PatchApplicationFailedException)
+        {
+            // If the patch failed, we cannot resolve the conflict automatically
+            // We will just leave it as is and let the user resolve it manually
+            _logger.LogInformation("Detected conflicts in {filePath}", conflictedFile);
+
+            // Revert the file into the conflicted state for manual resolution
+            await targetRepo.ExecuteGitCommand(["checkout", "--conflict=merge", "--", conflictedFile], CancellationToken.None);
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Reapplies the changes from the crossing flow on top of a non-conflicted file.
+    /// </summary>
+    /// <returns>True when the patch was applied successfully (or was a no-op)</returns>
+    private async Task<bool> TryReapplyingCrossingFlowChangesAsync(
+        CodeflowOptions codeflowOptions,
+        ILocalGitRepo vmr,
+        ILocalGitRepo repo,
+        UnixPath file,
+        Codeflow crossingFlow,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Trying to reapply crossing-flow changes to {filePath}...", file);
+
+        var crossingFlowPatch = await TryCreateCrossingFlowPatchAsync(codeflowOptions, vmr, repo, file, crossingFlow, cancellationToken);
+        if (crossingFlowPatch is null)
+        {
+            return false;
+        }
+
+        var (targetRepo, patch) = crossingFlowPatch.Value;
+
+        if (_fileSystem.GetFileInfo(patch.Path).Length == 0)
+        {
+            // This file did not change in the last flow
+            return true;
+        }
+
+        try
+        {
+            await _patchHandler.ApplyPatch(
+                patch,
+                targetRepo.Path,
+                removePatchAfter: true,
+                keepConflicts: false,
+                cancellationToken: cancellationToken);
+            _logger.LogDebug("Successfully reapplied crossing-flow changes to {filePath}", file);
+            return true;
+        }
+        catch (PatchApplicationFailedException)
+        {
+            _logger.LogInformation("Failed to reapply crossing-flow changes to {filePath}", file);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Builds a patch capturing the source-side changes between the crossing flow and the current flow
+    /// for a single file. Returns null if the file is outside the source repo path (forward flow only),
+    /// throws if the resulting patch would be too large to handle.
+    /// </summary>
+    private async Task<(ILocalGitRepo TargetRepo, VmrIngestionPatch Patch)?> TryCreateCrossingFlowPatchAsync(
+        CodeflowOptions codeflowOptions,
+        ILocalGitRepo vmr,
+        ILocalGitRepo repo,
+        UnixPath file,
+        Codeflow crossingFlow,
+        CancellationToken cancellationToken)
+    {
+        UnixPath vmrRepoPath = VmrInfo.GetRelativeRepoSourcesPath(codeflowOptions.Mapping.Name);
+        if (codeflowOptions.CurrentFlow.IsForwardFlow && !file.Path.StartsWith(vmrRepoPath + '/'))
+        {
+            _logger.LogWarning("File {file} is not in the source repo, skipping crossing-flow auto-resolution", file);
+            return null;
+        }
+
+        // Create patch for the file representing only the most current flow
         var (fromSha, toSha) = codeflowOptions.CurrentFlow.IsForwardFlow
             ? (crossingFlow.RepoSha, codeflowOptions.CurrentFlow.RepoSha)
             : (crossingFlow.VmrSha, codeflowOptions.CurrentFlow.VmrSha);
@@ -237,8 +348,8 @@ public abstract class CodeFlowConflictResolver
             fromSha,
             toSha,
             path: codeflowOptions.CurrentFlow.IsForwardFlow
-                ? new UnixPath(conflictedFile.Path.Substring(vmrRepoPath.Length + 1))
-                : conflictedFile,
+                ? new UnixPath(file.Path.Substring(vmrRepoPath.Length + 1))
+                : file,
             filters: null,
             relativePaths: true,
             workingDir: codeflowOptions.CurrentFlow.IsForwardFlow
@@ -267,48 +378,7 @@ public abstract class CodeFlowConflictResolver
         }
 
         var targetRepo = codeflowOptions.CurrentFlow.IsForwardFlow ? vmr : repo;
-        try
-        {
-            await targetRepo.ResolveConflict(conflictedFile, ours: true);
-        }
-        // file does not exist in the target repo anymore
-        catch (ProcessFailedException e) when (e.Message.Contains("does not have our version"))
-        {
-            _logger.LogInformation("Detected conflicts in {filePath}", conflictedFile);
-            return false;
-        }
-
-        if (_fileSystem.GetFileInfo(patches.First().Path).Length == 0)
-        {
-            // This file did not change in the last flow
-            return true;
-        }
-
-        try
-        {
-            await _patchHandler.ApplyPatch(
-                patches[0],
-                targetRepo.Path,
-                removePatchAfter: true,
-                keepConflicts: false,
-                cancellationToken: cancellationToken);
-            _logger.LogDebug("Successfully auto-resolved a conflict in {filePath}", conflictedFile);
-
-            await targetRepo.ExecuteGitCommand(["restore", conflictedFile], cancellationToken);
-
-            return true;
-        }
-        catch (PatchApplicationFailedException)
-        {
-            // If the patch failed, we cannot resolve the conflict automatically
-            // We will just leave it as is and let the user resolve it manually
-            _logger.LogInformation("Detected conflicts in {filePath}", conflictedFile);
-
-            // Revert the file into the conflicted state for manual resolution
-            await targetRepo.ExecuteGitCommand(["checkout", "--conflict=merge", "--", conflictedFile], CancellationToken.None);
-
-            return false;
-        }
+        return (targetRepo, patches[0]);
     }
 
     /// <summary>
@@ -552,7 +622,7 @@ public abstract class CodeFlowConflictResolver
                 return;
             }
 
-            if (!await TryResolvingConflictWithCrossingFlow(
+            if (!await TryReapplyingCrossingFlowChangesAsync(
                 codeflowOptions,
                 vmr,
                 productRepo,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/ForwardFlowConflictResolver.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/ForwardFlowConflictResolver.cs
@@ -169,10 +169,19 @@ public class ForwardFlowConflictResolver : CodeFlowConflictResolver, IForwardFlo
             return true;
         }
 
+        var relativeRepoSourcePath = VmrInfo.GetRelativeRepoSourcesPath(codeflowOptions.Mapping);
+        // If there's a conflict outside of the repo folder we're flowing
+        // we don't want the changes
+        if (!conflictedFile.Path.StartsWith(relativeRepoSourcePath))
+        {
+            await vmr.ResolveConflict(conflictedFile.Path, ours: true);
+            return true;
+        }
+
         // eng/common is always preferred from the source side
         // In rebase mode: ours=true means keep the incoming changes (source)
         // In merge mode: ours=false means prefer theirs (source being merged in)
-        var engCommon = VmrInfo.GetRelativeRepoSourcesPath(codeflowOptions.Mapping) / Constants.CommonScriptFilesPath;
+        var engCommon = relativeRepoSourcePath / Constants.CommonScriptFilesPath;
         if (conflictedFile.Path.StartsWith(engCommon, StringComparison.InvariantCultureIgnoreCase))
         {
             await vmr.ResolveConflict(conflictedFile, ours: true);

--- a/test/Darc/Microsoft.DotNet.DarcLib.Tests/LocalGitClientResolveConflictTests.cs
+++ b/test/Darc/Microsoft.DotNet.DarcLib.Tests/LocalGitClientResolveConflictTests.cs
@@ -1,0 +1,401 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Maestro.Common;
+using Maestro.Common.Telemetry;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace Microsoft.DotNet.DarcLib.Tests;
+
+/// <summary>
+/// Tests for <see cref="LocalGitClient.ResolveConflict"/>.
+///
+/// Each test creates a fresh real git repository in a temp directory and crafts
+/// the unmerged index entries (stages 1/2/3) using git plumbing
+/// (<c>git hash-object</c> + <c>git update-index --index-info</c>) to produce
+/// each of the documented unmerged status codes:
+///
+///   DD - both deleted
+///   AU - added by us
+///   UD - modified by us, deleted by them
+///   UA - added by them
+///   DU - deleted by us, modified by them
+///   AA - both added
+///   UU - both modified
+///
+/// We verify that <c>git status --porcelain=v1</c> reports the expected code,
+/// then run <c>ResolveConflict</c> with both <c>ours: true</c> and
+/// <c>ours: false</c>, and assert the resulting index/working-tree state.
+/// </summary>
+[TestFixture]
+public class LocalGitClientResolveConflictTests
+{
+    private const string ConflictFile = "conflict.txt";
+    private const string BaseContent = "base-content\n";
+    private const string OursContent = "ours-content\n";
+    private const string TheirsContent = "theirs-content\n";
+
+    private string _repoPath = null!;
+    private IProcessManager _processManager = null!;
+    private LocalGitClient _gitClient = null!;
+
+    [SetUp]
+    public async Task SetUpAsync()
+    {
+        _repoPath = Path.Combine(Path.GetTempPath(), $"darclib-resolveconflict-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_repoPath);
+
+        _processManager = new ProcessManager(NullLogger<ProcessManager>.Instance, "git");
+        _gitClient = new LocalGitClient(
+            new RemoteTokenProvider(),
+            new NoTelemetryRecorder(),
+            _processManager,
+            new FileSystem(),
+            NullLogger<LocalGitClient>.Instance);
+
+        // Initialize the repo and make an initial commit so HEAD exists.
+        (await _processManager.ExecuteGit(_repoPath, "init", "-b", "main"))
+            .ThrowIfFailed("git init failed");
+        (await _processManager.ExecuteGit(_repoPath, "config", "user.email", "test@example.com"))
+            .ThrowIfFailed("git config user.email failed");
+        (await _processManager.ExecuteGit(_repoPath, "config", "user.name", "Test"))
+            .ThrowIfFailed("git config user.name failed");
+        (await _processManager.ExecuteGit(_repoPath, "config", "commit.gpgsign", "false"))
+            .ThrowIfFailed("git config commit.gpgsign failed");
+        // Disable line-ending conversion so blob contents on disk match exactly
+        // (otherwise on Windows `git checkout --ours/--theirs` converts LF -> CRLF).
+        (await _processManager.ExecuteGit(_repoPath, "config", "core.autocrlf", "false"))
+            .ThrowIfFailed("git config core.autocrlf failed");
+
+        var readmePath = Path.Combine(_repoPath, "README.md");
+        await File.WriteAllTextAsync(readmePath, "test\n");
+        (await _processManager.ExecuteGit(_repoPath, "add", "README.md"))
+            .ThrowIfFailed("git add failed");
+        (await _processManager.ExecuteGit(_repoPath, "commit", "-m", "initial"))
+            .ThrowIfFailed("git commit failed");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (string.IsNullOrEmpty(_repoPath) || !Directory.Exists(_repoPath))
+        {
+            return;
+        }
+
+        try
+        {
+            // .git contains read-only files (pack files, etc.) - clear attributes before delete.
+            var directory = new DirectoryInfo(_repoPath);
+            foreach (var file in directory.GetFiles("*", SearchOption.AllDirectories))
+            {
+                file.Attributes = FileAttributes.Normal;
+            }
+            Directory.Delete(_repoPath, recursive: true);
+        }
+        catch
+        {
+            // Ignore cleanup errors - tests can leave behind temp dirs occasionally.
+        }
+    }
+
+    // The conflict-marker mush a real merge would leave on disk in any UU/AA-
+    // shaped conflict. The exact contents don't matter for the SUT - we just
+    // need *some* file there to mimic what `git merge` produces.
+    private static string ConflictMarkerContent =>
+        "<<<<<<<\n" + OursContent + "=======\n" + TheirsContent + ">>>>>>>\n";
+
+    // === DD: both deleted ===
+
+    [Test]
+    public Task ResolveConflict_DD_Ours_RemovesFile() => VerifyDdAsync(ours: true);
+
+    [Test]
+    public Task ResolveConflict_DD_Theirs_RemovesFile() => VerifyDdAsync(ours: false);
+
+    private async Task VerifyDdAsync(bool ours)
+    {
+        await SetUpConflictAsync(
+            expectedStatusCode: "DD",
+            baseStage: BaseContent,
+            // Both branches deleted the file - no ours, no theirs, no working-tree file.
+            oursStage: null,
+            theirsStage: null,
+            workingTree: null);
+
+        await _gitClient.ResolveConflict(_repoPath, ConflictFile, ours);
+
+        await AssertResultAsync(expectFile: false, expectedContent: null);
+    }
+
+    // === AU: added by us only ===
+
+    [Test]
+    public Task ResolveConflict_AU_Ours_KeepsOurContent()
+        => VerifyAuAsync(ours: true, expectFile: true, expectedContent: OursContent);
+
+    [Test]
+    public Task ResolveConflict_AU_Theirs_RemovesFile()
+        => VerifyAuAsync(ours: false, expectFile: false, expectedContent: null);
+
+    private async Task VerifyAuAsync(bool ours, bool expectFile, string? expectedContent)
+    {
+        await SetUpConflictAsync(
+            expectedStatusCode: "AU",
+            baseStage: null,
+            oursStage: OursContent,
+            theirsStage: null,
+            // Our side added the file, so git leaves our content in the working tree.
+            workingTree: OursContent);
+
+        await _gitClient.ResolveConflict(_repoPath, ConflictFile, ours);
+
+        await AssertResultAsync(expectFile, expectedContent);
+    }
+
+    // === UA: added by them only ===
+
+    [Test]
+    public Task ResolveConflict_UA_Ours_RemovesFile()
+        => VerifyUaAsync(ours: true, expectFile: false, expectedContent: null);
+
+    [Test]
+    public Task ResolveConflict_UA_Theirs_KeepsTheirContent()
+        => VerifyUaAsync(ours: false, expectFile: true, expectedContent: TheirsContent);
+
+    private async Task VerifyUaAsync(bool ours, bool expectFile, string? expectedContent)
+    {
+        await SetUpConflictAsync(
+            expectedStatusCode: "UA",
+            baseStage: null,
+            oursStage: null,
+            theirsStage: TheirsContent,
+            // Their side added the file, so git leaves their content in the working tree.
+            workingTree: TheirsContent);
+
+        await _gitClient.ResolveConflict(_repoPath, ConflictFile, ours);
+
+        await AssertResultAsync(expectFile, expectedContent);
+    }
+
+    // === UD: modified by us, deleted by them ===
+
+    [Test]
+    public Task ResolveConflict_UD_Ours_KeepsOurContent()
+        => VerifyUdAsync(ours: true, expectFile: true, expectedContent: OursContent);
+
+    [Test]
+    public Task ResolveConflict_UD_Theirs_RemovesFile()
+        => VerifyUdAsync(ours: false, expectFile: false, expectedContent: null);
+
+    private async Task VerifyUdAsync(bool ours, bool expectFile, string? expectedContent)
+    {
+        await SetUpConflictAsync(
+            expectedStatusCode: "UD",
+            baseStage: BaseContent,
+            oursStage: OursContent,
+            theirsStage: null,
+            // We modified it, they deleted it - git keeps our version on disk.
+            workingTree: OursContent);
+
+        await _gitClient.ResolveConflict(_repoPath, ConflictFile, ours);
+
+        await AssertResultAsync(expectFile, expectedContent);
+    }
+
+    // === DU: deleted by us, modified by them ===
+
+    [Test]
+    public Task ResolveConflict_DU_Ours_RemovesFile()
+        => VerifyDuAsync(ours: true, expectFile: false, expectedContent: null);
+
+    [Test]
+    public Task ResolveConflict_DU_Theirs_KeepsTheirContent()
+        => VerifyDuAsync(ours: false, expectFile: true, expectedContent: TheirsContent);
+
+    private async Task VerifyDuAsync(bool ours, bool expectFile, string? expectedContent)
+    {
+        await SetUpConflictAsync(
+            expectedStatusCode: "DU",
+            baseStage: BaseContent,
+            oursStage: null,
+            theirsStage: TheirsContent,
+            // We deleted it, they modified it - git restores their version on disk.
+            workingTree: TheirsContent);
+
+        await _gitClient.ResolveConflict(_repoPath, ConflictFile, ours);
+
+        await AssertResultAsync(expectFile, expectedContent);
+    }
+
+    // === UU: both modified ===
+
+    [Test]
+    public Task ResolveConflict_UU_Ours_KeepsOurContent()
+        => VerifyUuAsync(ours: true, expectedContent: OursContent);
+
+    [Test]
+    public Task ResolveConflict_UU_Theirs_KeepsTheirContent()
+        => VerifyUuAsync(ours: false, expectedContent: TheirsContent);
+
+    private async Task VerifyUuAsync(bool ours, string expectedContent)
+    {
+        await SetUpConflictAsync(
+            expectedStatusCode: "UU",
+            baseStage: BaseContent,
+            oursStage: OursContent,
+            theirsStage: TheirsContent,
+            workingTree: ConflictMarkerContent);
+
+        await _gitClient.ResolveConflict(_repoPath, ConflictFile, ours);
+
+        await AssertResultAsync(expectFile: true, expectedContent);
+    }
+
+    // === AA: both added ===
+
+    [Test]
+    public Task ResolveConflict_AA_Ours_KeepsOurContent()
+        => VerifyAaAsync(ours: true, expectedContent: OursContent);
+
+    [Test]
+    public Task ResolveConflict_AA_Theirs_KeepsTheirContent()
+        => VerifyAaAsync(ours: false, expectedContent: TheirsContent);
+
+    private async Task VerifyAaAsync(bool ours, string expectedContent)
+    {
+        await SetUpConflictAsync(
+            expectedStatusCode: "AA",
+            // No base - both sides independently added a new file at this path.
+            baseStage: null,
+            oursStage: OursContent,
+            theirsStage: TheirsContent,
+            workingTree: ConflictMarkerContent);
+
+        await _gitClient.ResolveConflict(_repoPath, ConflictFile, ours);
+
+        await AssertResultAsync(expectFile: true, expectedContent);
+    }
+
+    // === Helpers ===
+
+    /// <summary>
+    /// Builds an unmerged index entry for <see cref="ConflictFile"/> with the
+    /// requested per-stage contents and working-tree content, then verifies
+    /// <c>git status --porcelain=v1</c> reports <paramref name="expectedStatusCode"/>.
+    ///
+    /// Each stage parameter (base / ours / theirs) installs a blob at stage
+    /// 1 / 2 / 3 respectively, or omits that stage when null. The working-tree
+    /// parameter writes <see cref="ConflictFile"/> on disk, or leaves it
+    /// missing when null. Together this lets each test declare exactly the
+    /// shape of unmerged entry it wants without hand-crafting
+    /// <c>update-index --index-info</c> lines.
+    /// </summary>
+    private async Task SetUpConflictAsync(
+        string expectedStatusCode,
+        string? baseStage,
+        string? oursStage,
+        string? theirsStage,
+        string? workingTree)
+    {
+        var indexInfo = new StringBuilder();
+        if (baseStage is not null)
+        {
+            indexInfo.Append($"100644 {await CreateBlobAsync(baseStage)} 1\t{ConflictFile}\n");
+        }
+        if (oursStage is not null)
+        {
+            indexInfo.Append($"100644 {await CreateBlobAsync(oursStage)} 2\t{ConflictFile}\n");
+        }
+        if (theirsStage is not null)
+        {
+            indexInfo.Append($"100644 {await CreateBlobAsync(theirsStage)} 3\t{ConflictFile}\n");
+        }
+
+        var updateIndex = await _processManager.ExecuteGit(
+            _repoPath,
+            ["update-index", "--index-info"],
+            standardInput: indexInfo.ToString());
+        updateIndex.ThrowIfFailed("git update-index --index-info failed");
+
+        var diskPath = Path.Combine(_repoPath, ConflictFile);
+        if (workingTree is not null)
+        {
+            await File.WriteAllTextAsync(diskPath, workingTree);
+        }
+        else if (File.Exists(diskPath))
+        {
+            File.Delete(diskPath);
+        }
+
+        await AssertStatusCodeAsync(expectedStatusCode);
+    }
+
+    /// <summary>
+    /// Creates a blob in the object database with the given content (without
+    /// touching the working tree's <see cref="ConflictFile"/>) and returns its
+    /// SHA - the address we use to install that blob at a specific stage in
+    /// the index via <c>update-index --index-info</c>.
+    /// </summary>
+    private async Task<string> CreateBlobAsync(string content)
+    {
+        var tempPath = Path.Combine(_repoPath, $".hash-tmp-{Guid.NewGuid():N}");
+        await File.WriteAllTextAsync(tempPath, content);
+        try
+        {
+            var result = await _processManager.ExecuteGit(_repoPath, "hash-object", "-w", tempPath);
+            result.ThrowIfFailed("git hash-object failed");
+            return result.StandardOutput.Trim();
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    private async Task AssertStatusCodeAsync(string expectedCode)
+    {
+        var status = await _processManager.ExecuteGit(_repoPath, "status", "--porcelain=v1", "--", ConflictFile);
+        status.ThrowIfFailed("git status failed");
+
+        var line = status.GetOutputLines().FirstOrDefault();
+        line.Should().NotBeNullOrEmpty($"expected an unmerged status entry for {ConflictFile}");
+        line.Substring(0, 2).Should().Be(expectedCode);
+    }
+
+    private async Task AssertResultAsync(bool expectFile, string? expectedContent)
+    {
+        var ls = await _processManager.ExecuteGit(_repoPath, "ls-files", "--stage", "--", ConflictFile);
+        ls.ThrowIfFailed("git ls-files failed");
+        var stageLines = ls.GetOutputLines();
+
+        var fileOnDisk = Path.Combine(_repoPath, ConflictFile);
+
+        if (expectFile)
+        {
+            stageLines.Should().HaveCount(1, "the conflict should be resolved with a single staged entry");
+            var stageLine = stageLines.First();
+            stageLine.Should().StartWith("100644");
+            // Stage column is the third whitespace-separated token before the tab-separated path.
+            stageLine.Should().Contain(" 0\t", "the entry should be at stage 0 (merged)");
+
+            File.Exists(fileOnDisk).Should().BeTrue();
+            (await File.ReadAllTextAsync(fileOnDisk)).Should().Be(expectedContent);
+        }
+        else
+        {
+            stageLines.Should().BeEmpty("the file should have been removed from the index");
+            File.Exists(fileOnDisk).Should().BeFalse("the file should have been removed from the working tree");
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/6265

It looks like some git weirdness is happening in the vstest flows.
We're rewinding previous flows, and by doing so the work branch is "losing" some changes outside of the `src/repo` we're flowing to, as expected. But when we try to rebase the workbranch on top of the origin branch, these files that we're lost on the workbranch conflict with the ones in the target branch.
Not sure what is causing this but it's easy enough to fix.

I'm also failing to replicate in a test.
I think it might have to do something with the unsafe flow? And git is not able to figure it out.
In any case this fixes the issue