### PR TITLE
Use anonymous PCS client to validate Minimum Darc Version

### DIFF
--- a/src/Microsoft.DotNet.Darc/Darc/DarcVersionValidator.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/DarcVersionValidator.cs
@@ -14,7 +14,7 @@ internal static class DarcVersionValidator
 {
     private const string DevVersionSuffix = "-dev";
 
-    public static async Task<bool> ValidateAsync(IProductConstructionServiceApi pcsClient, ILogger logger)
+    public static async Task<bool> ValidateAsync(string baseUri, ILogger logger)
     {
         var darcVersionString = GetDarcVersion();
 
@@ -24,6 +24,10 @@ internal static class DarcVersionValidator
         {
             return true;
         }
+
+        var pcsClient = string.IsNullOrEmpty(baseUri)
+            ? PcsApiFactory.GetAnonymous()
+            : PcsApiFactory.GetAnonymous(baseUri);
 
         string minVersionString;
         try

--- a/src/Microsoft.DotNet.Darc/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Program.cs
@@ -57,7 +57,7 @@ internal static class Program
                         opts.InitializeFromSettings(provider.GetRequiredService<ILogger>());
 
                         if (!await DarcVersionValidator.ValidateAsync(
-                                provider.GetRequiredService<IProductConstructionServiceApi>(),
+                                opts.BuildAssetRegistryBaseUri,
                                 provider.GetRequiredService<ILogger>()))
                         {
                             return Constants.ErrorCode;

--- a/src/Microsoft.DotNet.Darc/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/Darc/Program.cs
@@ -11,7 +11,6 @@ using Microsoft.DotNet.Darc.Operations;
 using Microsoft.DotNet.Darc.Options;
 using Microsoft.DotNet.Darc.Options.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib;
-using Microsoft.DotNet.ProductConstructionService.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/6168
The client we were using here was not anonymous, so it tried authenticating
https://dev.azure.com/dnceng-public/public/_build/results?buildId=1412710&view=logs&j=f8361ec4-8613-5f7f-2f10-d7dd7654e93f&s=9b073b6c-199e-5782-2adb-83c30ea48e21&t=9413ec1e-f0a4-5b86-5d45-d01638c00efa&l=407