### PR TITLE
Revert all false positive changes in opposite direction flows

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -407,7 +407,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
         {
             var vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
 
-            await RevertFalsePositiveAdditionsAndDeletionsAsync(
+            await RevertFalsePositiveChangesAsync(
                 codeflowOptions.Mapping,
                 lastFlows,
                 targetRepo,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -181,7 +181,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
     /// can revert the PR changes. We can check this by checking if these files have changed in the source repo. If they haven't,
     /// then we already attempted to flow the change, but it was reverted in PR, so we should drop them from this flow too.
     /// </summary>
-    protected async Task RevertFalsePositiveAdditionsAndDeletionsAsync(
+    protected async Task RevertFalsePositiveChangesAsync(
         SourceMapping mapping,
         LastFlows lastFlows,
         ILocalGitRepo targetRepo,
@@ -236,7 +236,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
 
     /// <summary>
     /// Returns true if the given target-repo-relative path should be skipped by
-    /// <see cref="RevertFalsePositiveAdditionsAndDeletionsAsync"/> (e.g. because it lives
+    /// <see cref="RevertFalsePositiveChangesAsync"/> (e.g. because it lives
     /// inside a submodule whose contents are not stored in the source repo).
     /// </summary>
     protected abstract bool ShouldSkipRevertCheck(string targetPath, SourceMapping mapping);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -177,7 +177,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
         CancellationToken cancellationToken);
 
     /// <summary>
-    /// If the last flow was adding or deleting a file, and this change was reverted in PR, the next opposite direction flow
+    /// If the last flow was adding, deleting or modifying a file, and this change was reverted in PR, the next opposite direction flow
     /// can revert the PR changes. We can check this by checking if these files have changed in the source repo. If they haven't,
     /// then we already attempted to flow the change, but it was reverted in PR, so we should drop them from this flow too.
     /// </summary>
@@ -211,18 +211,18 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
             }
         }
 
-        var deletedFiles = (await targetRepo.ExecuteGitCommand(["diff", "--staged", "--name-only", "--diff-filter=D"], cancellationToken)).GetOutputLines();
+        var modifiedOrDeletedFiles = (await targetRepo.ExecuteGitCommand(["diff", "--staged", "--name-only", "--diff-filter=MD"], cancellationToken)).GetOutputLines();
 
-        foreach (var deletedFile in deletedFiles.Where(file => !ShouldSkipRevertCheck(file, mapping)))
+        foreach (var file in modifiedOrDeletedFiles.Where(file => !ShouldSkipRevertCheck(file, mapping)))
         {
-            var sourcePath = ToSourceRepoPath(deletedFile, mapping);
+            var sourcePath = ToSourceRepoPath(file, mapping);
             var lastContent = await sourceRepo.GetFileFromGitAsync(sourcePath, lastSameDirectionSha);
             var currentContent = await sourceRepo.GetFileFromGitAsync(sourcePath, currentFlowSha);
 
             if (lastContent == currentContent)
             {
-                await targetRepo.ExecuteGitCommand(["checkout", Constants.HEAD, "--", deletedFile], cancellationToken);
-                _logger.LogInformation("File {file} was attempted to be deleted in the last flow, but got added back in the PR, adding it back in this flow", deletedFile);
+                await targetRepo.ExecuteGitCommand(["checkout", Constants.HEAD, "--", file], cancellationToken);
+                _logger.LogInformation("File {file} was attempted to be deleted or modified in the last flow, but the change got reverted in the PR, restoring it in this flow", file);
             }
         }
     }

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -229,7 +229,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
 
     /// <summary>
     /// Maps a path that is relative to the target repo of the current flow to a path that is
-    /// relative to the source repo. Used by RevertFalsePositiveAdditionsAndDeletionsAsync to
+    /// relative to the source repo. Used by RevertFalsePositiveChangesAsync to
     /// look up the equivalent file in the source repo.
     /// </summary>
     protected abstract string ToSourceRepoPath(string targetPath, SourceMapping mapping);

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -403,7 +403,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
 
         var vmrSourcesPath = VmrInfo.GetRelativeRepoSourcesPath(codeflowOptions.Mapping);
 
-        await RevertFalsePositiveAdditionsAndDeletionsAsync(
+        await RevertFalsePositiveChangesAsync(
             codeflowOptions.Mapping,
             lastFlows,
             vmr,

--- a/test/Darc/Microsoft.DotNet.DarcLib.Codeflow.Tests/TwoWayCodeflowTests.cs
+++ b/test/Darc/Microsoft.DotNet.DarcLib.Codeflow.Tests/TwoWayCodeflowTests.cs
@@ -1530,21 +1530,26 @@ internal class TwoWayCodeflowTests : CodeFlowTests
         var fileDeletedInBFPR = "fileee-deleted-in-pr.txt";
         var fileAddedBackInBFPR = "fileee-added-back-in-pr.txt";
         var fileAddedBackInBFPRContent = "not important";
+        var fileModifiedInBFPR = "fileee-modified-in-pr.txt";
+        var fileModifiedInBFPROriginalContent = "original content";
 
-        // Add a file that we'll delete in the repo, but add back in the BF PR, flow it
+        // Add a file that we'll delete in the repo, but add back in the BF PR,
+        // and a file that we'll modify in the repo, but revert the modification in the BF PR
         await GitOperations.Checkout(VmrPath, "main");
         await File.WriteAllTextAsync(_productRepoVmrPath / fileAddedBackInBFPR, fileAddedBackInBFPRContent);
-        await GitOperations.CommitAll(VmrPath, "Add fileee-added-back-in-pr.txt");
+        await File.WriteAllTextAsync(_productRepoVmrPath / fileModifiedInBFPR, fileModifiedInBFPROriginalContent);
+        await GitOperations.CommitAll(VmrPath, "Add fileee-added-back-in-pr.txt and fileee-modified-in-pr.txt");
         var codeFlowResult = await ChangeVmrFileAndFlowIt("1", bfBranchName);
         codeFlowResult.ShouldHaveUpdates();
         await FinalizeBackFlow(bfBranchName);
 
-        // Add a file that will later delete in the BF
-        // and delete the file we added above
+        // Add a file that will later delete in the BF, delete the file we added above,
+        // and modify the file we added above
         await GitOperations.Checkout(VmrPath, "main");
         await File.WriteAllTextAsync(_productRepoVmrPath / fileDeletedInBFPR, "text");
         File.Delete(_productRepoVmrPath / fileAddedBackInBFPR);
-        await GitOperations.CommitAll(VmrPath, "Add and delete a file");
+        await File.WriteAllTextAsync(_productRepoVmrPath / fileModifiedInBFPR, "modified in the vmr");
+        await GitOperations.CommitAll(VmrPath, "Add, delete, and modify a file");
 
         // now open up a bf, but don't merge it yet
         codeFlowResult = await ChangeVmrFileAndFlowIt("2", bfBranchName);
@@ -1559,14 +1564,17 @@ internal class TwoWayCodeflowTests : CodeFlowTests
         codeFlowResult.ShouldHaveUpdates();
         await FinalizeForwardFlow(ffBranchName);
 
-        // now checkout the BF branch in the repo, delete and bring back a file and merge the PR
+        // now checkout the BF branch in the repo, delete and bring back a file,
+        // revert the modification (deny the change in the PR), and merge the PR
         await GitOperations.Checkout(ProductRepoPath, bfBranchName);
         File.Delete(ProductRepoPath / fileDeletedInBFPR);
         await File.WriteAllTextAsync(ProductRepoPath / fileAddedBackInBFPR, fileAddedBackInBFPRContent);
-        await GitOperations.CommitAll(ProductRepoPath, "Delete and bring back file in BF");
+        await File.WriteAllTextAsync(ProductRepoPath / fileModifiedInBFPR, fileModifiedInBFPROriginalContent);
+        await GitOperations.CommitAll(ProductRepoPath, "Delete, bring back, and revert modified file in BF");
         await GitOperations.MergePrBranch(ProductRepoPath, bfBranchName);
 
-        // now do a second BF, the file we deleted in the PR shouldn't be there, while the file we added back should be there
+        // now do a second BF, the file we deleted in the PR shouldn't be there, the file we added back should be there,
+        // and the file whose modification we reverted should keep the original content
         codeFlowResult = await ChangeVmrFileAndFlowIt("3", bfBranchName);
         codeFlowResult.ShouldHaveUpdates();
         await FinalizeBackFlow(bfBranchName);
@@ -1574,6 +1582,7 @@ internal class TwoWayCodeflowTests : CodeFlowTests
         File.Exists(ProductRepoPath / fileDeletedInBFPR).Should().BeFalse();
         File.Exists(ProductRepoPath / fileAddedBackInBFPR).Should().BeTrue();
         File.ReadAllText(ProductRepoPath / fileAddedBackInBFPR).Should().Be(fileAddedBackInBFPRContent);
+        File.ReadAllText(ProductRepoPath / fileModifiedInBFPR).Should().Be(fileModifiedInBFPROriginalContent);
 
         // forward flow to make sure the files stay the same as in the repo
         codeFlowResult = await ChangeRepoFileAndFlowIt("4", ffBranchName);
@@ -1583,6 +1592,7 @@ internal class TwoWayCodeflowTests : CodeFlowTests
         File.Exists(_productRepoVmrPath / fileDeletedInBFPR).Should().BeFalse();
         File.Exists(_productRepoVmrPath / fileAddedBackInBFPR).Should().BeTrue();
         File.ReadAllText(_productRepoVmrPath / fileAddedBackInBFPR).Should().Be(fileAddedBackInBFPRContent);
+        File.ReadAllText(_productRepoVmrPath / fileModifiedInBFPR).Should().Be(fileModifiedInBFPROriginalContent);
     }
 
     [Test]


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/6304

In https://github.com/dotnet/arcade-services/pull/6121 we fixed this issue for files that were added or deleted in a PR, but for some reason I overlooked modified files. This fixes it