### PR TITLE
Add subscription trigger outcomes page

### DIFF
--- a/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/Generated/Models/SubscriptionTriggerOutcome.cs
+++ b/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/Generated/Models/SubscriptionTriggerOutcome.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.ProductConstructionService.Client.Models
 {
     public partial class SubscriptionTriggerOutcome
     {
-        public SubscriptionTriggerOutcome(Guid subscriptionId, int buildId, DateTimeOffset date, Models.OutcomeType type, string operationId, string message)
+        public SubscriptionTriggerOutcome(Guid subscriptionId, int buildId, DateTimeOffset date, Models.OutcomeType type, string operationId, string message, string sourceRepository, string targetRepository, string targetBranch)
         {
             SubscriptionId = subscriptionId;
             BuildId = buildId;
@@ -16,6 +16,9 @@ namespace Microsoft.DotNet.ProductConstructionService.Client.Models
             Type = type;
             OperationId = operationId;
             Message = message;
+            SourceRepository = sourceRepository;
+            TargetRepository = targetRepository;
+            TargetBranch = targetBranch;
         }
 
         [JsonProperty("operationId")]
@@ -35,6 +38,15 @@ namespace Microsoft.DotNet.ProductConstructionService.Client.Models
 
         [JsonProperty("type")]
         public OutcomeType Type { get; }
+
+        [JsonProperty("sourceRepository")]
+        public string SourceRepository { get; }
+
+        [JsonProperty("targetRepository")]
+        public string TargetRepository { get; }
+
+        [JsonProperty("targetBranch")]
+        public string TargetBranch { get; }
 
         [JsonIgnore]
         public bool IsValid

--- a/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/Generated/SubscriptionTriggerOutcomes.cs
+++ b/src/ProductConstructionService/Microsoft.DotNet.ProductConstructionService.Client/Generated/SubscriptionTriggerOutcomes.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.ProductConstructionService.Client
             DateTimeOffset? before = default,
             int? buildId = default,
             string operationId = default,
+            string search = default,
             string subscriptionId = default,
             string subscriptionOutcomeType = default,
             CancellationToken cancellationToken = default
@@ -53,6 +54,7 @@ namespace Microsoft.DotNet.ProductConstructionService.Client
             DateTimeOffset? before = default,
             int? buildId = default,
             string operationId = default,
+            string search = default,
             string subscriptionId = default,
             string subscriptionOutcomeType = default,
             CancellationToken cancellationToken = default
@@ -91,6 +93,10 @@ namespace Microsoft.DotNet.ProductConstructionService.Client
             if (!string.IsNullOrEmpty(operationId))
             {
                 _url.AppendQuery("operationId", Client.Serialize(operationId));
+            }
+            if (!string.IsNullOrEmpty(search))
+            {
+                _url.AppendQuery("search", Client.Serialize(search));
             }
             if (limit != default(int))
             {

--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/SubscriptionTriggerOutcomesController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/SubscriptionTriggerOutcomesController.cs
@@ -14,7 +14,7 @@ using DataModels = Maestro.Data.Models;
 namespace ProductConstructionService.Api.Api.v2020_02_20.Controllers;
 
 /// <summary>
-///   Exposes methods to Read <see cref="SubscriptionTriggerOutcome"/>s.
+///
 /// </summary>
 [Route("subscription-trigger-outcomes")]
 [ApiVersion("2020-02-20")]
@@ -121,7 +121,11 @@ public class SubscriptionTriggerOutcomesController : ControllerBase
             .Take(limit)
             .ToListAsync();
 
-        return Ok(results.Select(o => new SubscriptionTriggerOutcome(o)).ToList());
+        var subscriptions = await GetSubscriptionsAsync(results.Select(o => o.SubscriptionId));
+
+        return Ok(results
+            .Select(o => new SubscriptionTriggerOutcome(o, subscriptions.GetValueOrDefault(o.SubscriptionId)))
+            .ToList());
     }
 
     /// <summary>
@@ -142,6 +146,26 @@ public class SubscriptionTriggerOutcomesController : ControllerBase
             return NotFound();
         }
 
-        return Ok(new SubscriptionTriggerOutcome(outcome));
+        var subscriptions = await GetSubscriptionsAsync([outcome.SubscriptionId]);
+
+        return Ok(new SubscriptionTriggerOutcome(outcome, subscriptions.GetValueOrDefault(outcome.SubscriptionId)));
+    }
+
+    /// <summary>
+    ///   Fetches the <see cref="DataModels.Subscription"/>s for the given subscription ids, keyed by id.
+    /// </summary>
+    private async Task<Dictionary<Guid, DataModels.Subscription>> GetSubscriptionsAsync(IEnumerable<Guid> subscriptionIds)
+    {
+        var ids = subscriptionIds.Distinct().ToList();
+        if (ids.Count == 0)
+        {
+            return [];
+        }
+
+        var subscriptions = await _context.Subscriptions
+            .Where(s => ids.Contains(s.Id))
+            .ToListAsync();
+
+        return subscriptions.ToDictionary(s => s.Id);
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/SubscriptionTriggerOutcomesController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/SubscriptionTriggerOutcomesController.cs
@@ -39,6 +39,10 @@ public class SubscriptionTriggerOutcomesController : ControllerBase
     /// <param name="before">Return only outcomes on or before this date (inclusive upper bound). Include an explicit offset (e.g. "2025-01-15T12:00:00Z").</param>
     /// <param name="subscriptionOutcomeType">Filter by outcome type (e.g. "Updated", "NoUpdate", "Failure").</param>
     /// <param name="operationId">Filter by operation id.</param>
+    /// <param name="search">
+    ///   Free-text filter matched against the subscription's source repository, target repository and target branch.
+    ///   Matching subscriptions are resolved first and the outcome query is then restricted to their ids.
+    /// </param>
     /// <param name="limit">Maximum number of results to return.</param>
     [HttpGet]
     [SwaggerApiResponse(HttpStatusCode.OK, Type = typeof(List<SubscriptionTriggerOutcome>), Description = "The list of subscription outcomes")]
@@ -50,6 +54,7 @@ public class SubscriptionTriggerOutcomesController : ControllerBase
         DateTimeOffset? before = null,
         string? subscriptionOutcomeType = null,
         string? operationId = null,
+        string? search = null,
         [Range(1, MaxResultLimit)] int limit = DefaultResultLimit)
     {
         IQueryable<DataModels.SubscriptionOutcome> query = _context.SubscriptionOutcomes;
@@ -116,9 +121,7 @@ public class SubscriptionTriggerOutcomesController : ControllerBase
             query = query.Where(o => o.OperationId == operationId);
         }
 
-        var results = await query
-            .OrderByDescending(o => o.Date)
-            .Take(limit)
+        var joinedQuery = query
             .GroupJoin(
                 _context.Subscriptions,
                 outcome => outcome.SubscriptionId,
@@ -129,11 +132,27 @@ public class SubscriptionTriggerOutcomesController : ControllerBase
                 (joined, subscription) => new
                 {
                     Outcome = joined.outcome,
-                    subscription!.SourceRepository,
-                    subscription!.TargetRepository,
-                    subscription!.TargetBranch,
-                })
+                    Subscription = subscription,
+                });
+
+        if (!string.IsNullOrEmpty(search))
+        {
+            joinedQuery = joinedQuery.Where(x =>
+                x.Subscription!.SourceRepository.Contains(search)
+                || x.Subscription!.TargetRepository.Contains(search)
+                || x.Subscription!.TargetBranch.Contains(search));
+        }
+
+        var results = await joinedQuery
             .OrderByDescending(x => x.Outcome.Date)
+            .Take(limit)
+            .Select(x => new
+            {
+                Outcome = x.Outcome,
+                x.Subscription!.SourceRepository,
+                x.Subscription!.TargetRepository,
+                x.Subscription!.TargetBranch,
+            })
             .ToListAsync();
 
         return Ok(results

--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/SubscriptionTriggerOutcomesController.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Controllers/SubscriptionTriggerOutcomesController.cs
@@ -119,12 +119,25 @@ public class SubscriptionTriggerOutcomesController : ControllerBase
         var results = await query
             .OrderByDescending(o => o.Date)
             .Take(limit)
+            .GroupJoin(
+                _context.Subscriptions,
+                outcome => outcome.SubscriptionId,
+                subscription => subscription.Id,
+                (outcome, subscriptions) => new { outcome, subscriptions })
+            .SelectMany(
+                joined => joined.subscriptions.DefaultIfEmpty(),
+                (joined, subscription) => new
+                {
+                    Outcome = joined.outcome,
+                    subscription!.SourceRepository,
+                    subscription!.TargetRepository,
+                    subscription!.TargetBranch,
+                })
+            .OrderByDescending(x => x.Outcome.Date)
             .ToListAsync();
 
-        var subscriptions = await GetSubscriptionsAsync(results.Select(o => o.SubscriptionId));
-
         return Ok(results
-            .Select(o => new SubscriptionTriggerOutcome(o, subscriptions.GetValueOrDefault(o.SubscriptionId)))
+            .Select(x => new SubscriptionTriggerOutcome(x.Outcome, x.SourceRepository, x.TargetRepository, x.TargetBranch))
             .ToList());
     }
 

--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Models/SubscriptionTriggerOutcome.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Models/SubscriptionTriggerOutcome.cs
@@ -8,6 +8,11 @@ namespace ProductConstructionService.Api.v2020_02_20.Models;
 public class SubscriptionTriggerOutcome
 {
     public SubscriptionTriggerOutcome(Maestro.Data.Models.SubscriptionOutcome other, Maestro.Data.Models.Subscription subscription = null)
+        : this(other, subscription?.SourceRepository, subscription?.TargetRepository, subscription?.TargetBranch)
+    {
+    }
+
+    public SubscriptionTriggerOutcome(Maestro.Data.Models.SubscriptionOutcome other, string sourceRepository, string targetRepository, string targetBranch)
     {
         ArgumentNullException.ThrowIfNull(other);
 
@@ -17,9 +22,9 @@ public class SubscriptionTriggerOutcome
         Date = other.Date;
         Message = other.Message;
         Type = (OutcomeType)other.Type;
-        SourceRepository = subscription?.SourceRepository;
-        TargetRepository = subscription?.TargetRepository;
-        TargetBranch = subscription?.TargetBranch;
+        SourceRepository = sourceRepository;
+        TargetRepository = targetRepository;
+        TargetBranch = targetBranch;
     }
 
     public string OperationId { get; }

--- a/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Models/SubscriptionTriggerOutcome.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Api/v2020_02_20/Models/SubscriptionTriggerOutcome.cs
@@ -7,7 +7,7 @@ namespace ProductConstructionService.Api.v2020_02_20.Models;
 
 public class SubscriptionTriggerOutcome
 {
-    public SubscriptionTriggerOutcome(Maestro.Data.Models.SubscriptionOutcome other)
+    public SubscriptionTriggerOutcome(Maestro.Data.Models.SubscriptionOutcome other, Maestro.Data.Models.Subscription subscription = null)
     {
         ArgumentNullException.ThrowIfNull(other);
 
@@ -17,6 +17,9 @@ public class SubscriptionTriggerOutcome
         Date = other.Date;
         Message = other.Message;
         Type = (OutcomeType)other.Type;
+        SourceRepository = subscription?.SourceRepository;
+        TargetRepository = subscription?.TargetRepository;
+        TargetBranch = subscription?.TargetBranch;
     }
 
     public string OperationId { get; }
@@ -30,6 +33,12 @@ public class SubscriptionTriggerOutcome
     public string Message { get; }
 
     public OutcomeType Type { get; }
+
+    public string SourceRepository { get; }
+
+    public string TargetRepository { get; }
+
+    public string TargetBranch { get; }
 }
 
 public enum OutcomeType

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Code/Helpers/StringExtensions.cs
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Code/Helpers/StringExtensions.cs
@@ -2,11 +2,70 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace ProductConstructionService.BarViz.Code.Helpers;
 
-internal static class StringExtensions
+public static class StringExtensions
 {
+    private static readonly Regex UrlRegex = new(@"https?://[^\s<>""']+", RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// A segment of a message: either plain text or a URL.
+    /// </summary>
+    public readonly record struct TextSegment(string Text, bool IsUrl);
+
+    /// <summary>
+    /// Splits <paramref name="text"/> into consecutive segments of plain text and URLs so the
+    /// URLs can be rendered as links while the rest stays as text. Trailing punctuation that is
+    /// unlikely to be part of a URL (e.g. a sentence-ending '.', ')' or ',') is excluded from
+    /// the link and kept as text.
+    /// </summary>
+    public static IReadOnlyList<TextSegment> SplitIntoTextAndUrls(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return [];
+        }
+
+        var segments = new List<TextSegment>();
+        var lastIndex = 0;
+
+        foreach (Match match in UrlRegex.Matches(text))
+        {
+            var url = match.Value;
+            var trimmedLength = url.Length;
+            while (trimmedLength > 0 && IsTrailingPunctuation(url[trimmedLength - 1]))
+            {
+                trimmedLength--;
+            }
+
+            if (match.Index > lastIndex)
+            {
+                segments.Add(new TextSegment(text[lastIndex..match.Index], IsUrl: false));
+            }
+
+            segments.Add(new TextSegment(url[..trimmedLength], IsUrl: true));
+
+            if (trimmedLength < url.Length)
+            {
+                segments.Add(new TextSegment(url[trimmedLength..], IsUrl: false));
+            }
+
+            lastIndex = match.Index + url.Length;
+        }
+
+        if (lastIndex < text.Length)
+        {
+            segments.Add(new TextSegment(text[lastIndex..], IsUrl: false));
+        }
+
+        return segments;
+    }
+
+    private static bool IsTrailingPunctuation(char c)
+        => c is '.' or ',' or ';' or ':' or ')' or ']' or '}' or '!' or '?' or '"' or '\'';
+
     public static string[] ParseSearchTerms(string searchFilter)
     {
         var terms = new List<string>();

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Code/Helpers/SubscriptionOutcomeHelper.cs
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Code/Helpers/SubscriptionOutcomeHelper.cs
@@ -21,6 +21,47 @@ public static class SubscriptionOutcomeHelper
     public static bool IsUserError(SubscriptionTriggerOutcome? outcome)
         => outcome?.Type is OutcomeType.UserError;
 
+    /// <summary>
+    ///   Builds a short, human-readable blurb describing a subscription of the form "source → target"
+    ///   using the short repository names. Returns null when either repository is missing
+    ///   (e.g. the subscription no longer exists), so callers can fall back to another display.
+    /// </summary>
+    public static string? GetSubscriptionBlurb(string? sourceRepository, string? targetRepository, string targetBranch)
+    {
+        if (string.IsNullOrEmpty(sourceRepository)
+            || string.IsNullOrEmpty(targetRepository)
+            || string.IsNullOrEmpty(targetBranch))
+        {
+            return null;
+        }
+
+        var source = RepoShortName(sourceRepository);
+        var target = RepoShortName(targetRepository);
+
+        if (source == null || target == null)
+        {
+            return null;
+        }
+
+        return $"{source} → {target} ({targetBranch})";
+    }
+
+    /// <summary>
+    ///   Converts a repository URL to a readable "org/repo" short name
+    /// </summary>
+    public static string? RepoShortName(string repoUrl)
+    {
+        var slug = RepoUrlConverter.RepoUrlToSlug(repoUrl);
+        if (slug is null)
+        {
+            return null;
+        }
+
+        // Slugs look like "github:org:repo" or "azdo:org:project:repo"; drop the leading
+        // repo-type segment and join the rest as a readable "org/repo" path.
+        return string.Join('/', slug.Split(':').Skip(1));
+    }
+
     public static List<SubscriptionOutcomeError> GetErroredSubscriptions(
         IEnumerable<CodeflowSubscriptionStatus?> flows)
     {

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionDetailDialog.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionDetailDialog.razor
@@ -1,8 +1,9 @@
 ﻿@using Microsoft.DotNet.ProductConstructionService.Client
 @using Microsoft.DotNet.ProductConstructionService.Client.Models
+@using ProductConstructionService.BarViz.Model
 @inject IProductConstructionServiceApi PcsApi
 @inject IToastService ToastService
-@implements IDialogContentComponent<Subscription>
+@implements IDialogContentComponent<SubscriptionDetailData>
 
 <style>
     table.subscription-details {
@@ -43,104 +44,115 @@
 </FluentDialogHeader>
 
 <FluentDialogBody>
-    <table class="subscription-details">
-        <tbody>
-            <tr>
-                <td>Id</td>
-                <td>@Content.Id</td>
-            </tr>
-            <tr>
-                <td>Channel</td>
-                <td>@Content.Channel.Name</td>
-            </tr>
-            <tr>
-                <td>Source repository</td>
-                <td><FluentAnchor Href="@Content.SourceRepository" Target="_blank" Appearance="Appearance.Hypertext">@Content.SourceRepository</FluentAnchor></td>
-            </tr>
-            <tr>
-                <td>Target repository</td>
-                <td><FluentAnchor Href="@Content.TargetRepository" Target="_blank" Appearance="Appearance.Hypertext">@Content.TargetRepository</FluentAnchor></td>
-            </tr>
-            <tr>
-                <td>Target branch</td>
-                <td>@Content.TargetBranch</td>
-            </tr>
-            <tr>
-                <td>Update frequency</td>
-                <td>@Content.Policy.UpdateFrequency</td>
-            </tr>
-            <tr>
-                <td>Enabled</td>
-                <td>@(Content.Enabled ? "Yes" : "No")</td>
-            </tr>
-            <tr>
-                <td>Batchable</td>
-                <td>@(Content.Policy.Batchable ? "Yes" : "No")</td>
-            </tr>
-            <tr>
-                <td>Merge policies</td>
-                <td>
-                    @if (Content.Policy.MergePolicies == null || Content.Policy.MergePolicies.Count == 0)
-                    {
-                        <span>None</span>
-                    }
-                    else
-                    {
-                        <ul>
-                            @foreach (var policy in Content.Policy.MergePolicies)
-                            {
-                                <li>@policy.Name</li>
-                            }
-                        </ul>
-                    }
-                </td>
-            </tr>
-            <tr>
-                <td>Source-enabled</td>
-                <td>@(Content.SourceEnabled ? (string.IsNullOrEmpty(Content.SourceDirectory) ? "Yes (Forward flow)" : "Yes (Backflow)") : "No")</td>
-            </tr>
-            @if (!string.IsNullOrEmpty(Content.TargetDirectory))
-            {
+    @if (_loadError != null)
+    {
+        <FluentLabel Color="Color.Error" Style="display: block; margin: 20px 0;">@_loadError</FluentLabel>
+    }
+    else if (_subscription == null)
+    {
+        <PageLoadingStatus StatusText="Loading subscription details ..." />
+    }
+    else
+    {
+        <table class="subscription-details">
+            <tbody>
                 <tr>
-                    <td>Target directory</td>
-                    <td>@Content.TargetDirectory</td>
+                    <td>Id</td>
+                    <td>@_subscription.Id</td>
                 </tr>
-            }
-            @if (Content.SourceEnabled && !string.IsNullOrEmpty(Content.SourceDirectory))
-            {
                 <tr>
-                    <td>Source directory</td>
-                    <td>@Content.SourceDirectory</td>
+                    <td>Channel</td>
+                    <td>@_subscription.Channel.Name</td>
                 </tr>
-            }
-            <tr>
-                <td>ExcludedAssets</td>
-                <td>
-                    @if (Content.ExcludedAssets == null || Content.ExcludedAssets.Count == 0)
-                    {
-                        <span>None</span>
-                    }
-                    else
-                    {
-                        <ul>
-                            @foreach (var asset in Content.ExcludedAssets)
-                            {
-                                <li>@asset</li>
-                            }
-                        </ul>
-                    }
-                </td>
-            </tr>
-            <tr>
-                <td>PR notification tags</td>
-                <td>@Content.PullRequestFailureNotificationTags</td>
-            </tr>
-        </tbody>
-    </table>
+                <tr>
+                    <td>Source repository</td>
+                    <td><FluentAnchor Href="@_subscription.SourceRepository" Target="_blank" Appearance="Appearance.Hypertext">@_subscription.SourceRepository</FluentAnchor></td>
+                </tr>
+                <tr>
+                    <td>Target repository</td>
+                    <td><FluentAnchor Href="@_subscription.TargetRepository" Target="_blank" Appearance="Appearance.Hypertext">@_subscription.TargetRepository</FluentAnchor></td>
+                </tr>
+                <tr>
+                    <td>Target branch</td>
+                    <td>@_subscription.TargetBranch</td>
+                </tr>
+                <tr>
+                    <td>Update frequency</td>
+                    <td>@_subscription.Policy.UpdateFrequency</td>
+                </tr>
+                <tr>
+                    <td>Enabled</td>
+                    <td>@(_subscription.Enabled ? "Yes" : "No")</td>
+                </tr>
+                <tr>
+                    <td>Batchable</td>
+                    <td>@(_subscription.Policy.Batchable ? "Yes" : "No")</td>
+                </tr>
+                <tr>
+                    <td>Merge policies</td>
+                    <td>
+                        @if (_subscription.Policy.MergePolicies == null || _subscription.Policy.MergePolicies.Count == 0)
+                        {
+                            <span>None</span>
+                        }
+                        else
+                        {
+                            <ul>
+                                @foreach (var policy in _subscription.Policy.MergePolicies)
+                                {
+                                    <li>@policy.Name</li>
+                                }
+                            </ul>
+                        }
+                    </td>
+                </tr>
+                <tr>
+                    <td>Source-enabled</td>
+                    <td>@(_subscription.SourceEnabled ? (string.IsNullOrEmpty(_subscription.SourceDirectory) ? "Yes (Forward flow)" : "Yes (Backflow)") : "No")</td>
+                </tr>
+                @if (!string.IsNullOrEmpty(_subscription.TargetDirectory))
+                {
+                    <tr>
+                        <td>Target directory</td>
+                        <td>@_subscription.TargetDirectory</td>
+                    </tr>
+                }
+                @if (_subscription.SourceEnabled && !string.IsNullOrEmpty(_subscription.SourceDirectory))
+                {
+                    <tr>
+                        <td>Source directory</td>
+                        <td>@_subscription.SourceDirectory</td>
+                    </tr>
+                }
+                <tr>
+                    <td>ExcludedAssets</td>
+                    <td>
+                        @if (_subscription.ExcludedAssets == null || _subscription.ExcludedAssets.Count == 0)
+                        {
+                            <span>None</span>
+                        }
+                        else
+                        {
+                            <ul>
+                                @foreach (var asset in _subscription.ExcludedAssets)
+                                {
+                                    <li>@asset</li>
+                                }
+                            </ul>
+                        }
+                    </td>
+                </tr>
+                <tr>
+                    <td>PR notification tags</td>
+                    <td>@_subscription.PullRequestFailureNotificationTags</td>
+                </tr>
+            </tbody>
+        </table>
+    }
 </FluentDialogBody>
 
 <FluentDialogFooter>
-    <FluentButton Appearance="Appearance.Accent" OnClick="TriggerSubscriptionAsync">
+    <FluentButton Appearance="Appearance.Accent" OnClick="TriggerSubscriptionAsync" Disabled="@(_subscription == null)">
         Trigger Subscription
     </FluentButton>
     <FluentButton Appearance="Appearance.Neutral" OnClick="CloseAsync">
@@ -149,17 +161,48 @@
 </FluentDialogFooter>
 
 @code {
+    private Subscription? _subscription;
+    private string? _loadError;
+
     [Parameter]
-    public Subscription Content { get; set; } = default!;
+    public SubscriptionDetailData Content { get; set; } = default!;
 
     [CascadingParameter]
     public FluentDialog? Dialog { get; set; }
 
-    private async Task TriggerSubscriptionAsync()
+    protected override async Task OnInitializedAsync()
     {
+        if (Content.Subscription != null)
+        {
+            _subscription = Content.Subscription;
+            return;
+        }
+
         try
         {
-            await PcsApi.Subscriptions.TriggerSubscriptionAsync(Content.Id);
+            _subscription = await PcsApi.Subscriptions.GetSubscriptionAsync(Content.SubscriptionId);
+        }
+        catch (RestApiException e) when (e.Response.Status == (int)System.Net.HttpStatusCode.NotFound)
+        {
+            _loadError = $"Subscription {Content.SubscriptionId} no longer exists. "
+                + "It may have been deleted or recreated with a new ID (e.g. by a configuration change).";
+        }
+        catch
+        {
+            _loadError = "Failed to load subscription details.";
+        }
+    }
+
+    private async Task TriggerSubscriptionAsync()
+    {
+        if (_subscription == null)
+        {
+            return;
+        }
+
+        try
+        {
+            await PcsApi.Subscriptions.TriggerSubscriptionAsync(_subscription.Id);
             ToastService.ShowProgress("Subscription triggered");
         }
         catch

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionGrid.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionGrid.razor
@@ -2,6 +2,7 @@
 @using Microsoft.DotNet.ProductConstructionService.Client.Models;
 @using System.ComponentModel.DataAnnotations
 @using ProductConstructionService.BarViz.Code.Helpers
+@using ProductConstructionService.BarViz.Model
 @inject IProductConstructionServiceApi PcsApi
 @inject IDialogService DialogService
 
@@ -70,6 +71,6 @@
             PreventScroll = true,
         };
 
-        await DialogService.ShowDialogAsync<SubscriptionDetailDialog>(subscription, parameters);
+        await DialogService.ShowDialogAsync<SubscriptionDetailDialog>(SubscriptionDetailData.FromSubscription(subscription), parameters);
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionOutcomeContextMenu.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionOutcomeContextMenu.razor
@@ -1,0 +1,72 @@
+@using Microsoft.DotNet.ProductConstructionService.Client.Models
+@using TextCopy
+@inject IToastService ToastService
+@inject IClipboard Clipboard
+
+<FluentButton Id="@_id"
+              Appearance="Appearance.Lightweight"
+              OnClick="@(() => _isContextMenuOpen = !_isContextMenuOpen)"
+              Title="More actions"
+              Style="height: 20px; margin-bottom: -4px; position: relative; top: -4px">
+    <FluentIcon Value="@(new Icons.Filled.Size20.MoreHorizontal())" Width="16px" />
+</FluentButton>
+
+<FluentMenu Anchor="@_id" @bind-Open="@_isContextMenuOpen">
+    <FluentMenuItem Disabled="@(Outcome.BuildId <= 0)" OnClick="@CopyBuildIdAsync">
+        Copy build ID
+        <span slot="start">
+            <FluentIcon Value="@(new Icons.Regular.Size16.Copy())" Color="@Color.Neutral" />
+        </span>
+    </FluentMenuItem>
+
+    <FluentMenuItem OnClick="@CopyOperationIdAsync">
+        Copy operation ID
+        <span slot="start">
+            <FluentIcon Value="@(new Icons.Regular.Size16.Copy())" Color="@Color.Neutral" />
+        </span>
+    </FluentMenuItem>
+
+    <FluentMenuItem OnClick="@(() => ShowDetails(Outcome.SubscriptionId))">
+        Show subscription details
+        <span slot="start">
+            <FluentIcon Value="@(new Icons.Regular.Size16.DocumentOnePage())" Color="@Color.Neutral" />
+        </span>
+    </FluentMenuItem>
+</FluentMenu>
+
+@code {
+    private bool _isContextMenuOpen = false;
+    private readonly string _id = "more_" + Guid.NewGuid().ToString("N");
+
+    [Parameter, EditorRequired]
+    public required SubscriptionTriggerOutcome Outcome { get; set; }
+
+    [Parameter, EditorRequired]
+    public required Func<Guid, Task> ShowDetails { get; set; }
+
+    private async Task CopyBuildIdAsync()
+    {
+        try
+        {
+            await Clipboard.SetTextAsync(Outcome.BuildId.ToString());
+            ToastService.ShowSuccess("Copied build ID to clipboard");
+        }
+        catch (Exception ex)
+        {
+            ToastService.ShowError($"Failed to copy build ID: {ex.Message}");
+        }
+    }
+
+    private async Task CopyOperationIdAsync()
+    {
+        try
+        {
+            await Clipboard.SetTextAsync(Outcome.OperationId);
+            ToastService.ShowSuccess("Copied operation ID to clipboard");
+        }
+        catch (Exception ex)
+        {
+            ToastService.ShowError($"Failed to copy operation ID: {ex.Message}");
+        }
+    }
+}

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionOutcomeContextMenu.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionOutcomeContextMenu.razor
@@ -1,7 +1,11 @@
+@using Microsoft.DotNet.ProductConstructionService.Client
 @using Microsoft.DotNet.ProductConstructionService.Client.Models
+@using ProductConstructionService.BarViz.Code.Helpers
 @using TextCopy
+@inject IProductConstructionServiceApi PcsApi
 @inject IToastService ToastService
 @inject IClipboard Clipboard
+@inject IJSRuntime JSRuntime
 
 <FluentButton Id="@_id"
               Appearance="Appearance.Lightweight"
@@ -23,6 +27,34 @@
         Copy operation ID
         <span slot="start">
             <FluentIcon Value="@(new Icons.Regular.Size16.Copy())" Color="@Color.Neutral" />
+        </span>
+    </FluentMenuItem>
+
+    <FluentMenuItem OnClick="@CopySubscriptionIdAsync">
+        Copy subscription ID
+        <span slot="start">
+            <FluentIcon Value="@(new Icons.Regular.Size16.Copy())" Color="@Color.Neutral" />
+        </span>
+    </FluentMenuItem>
+
+    <FluentMenuItem OnClick="@(() => TriggerSubscriptionAsync(force: false))">
+        Trigger subscription
+        <span slot="start">
+            <FluentIcon Value="@(new Icons.Regular.Size16.Flash())" Color="@Color.Neutral" />
+        </span>
+    </FluentMenuItem>
+
+    <FluentMenuItem OnClick="@(() => TriggerSubscriptionAsync(force: true))">
+        Force-trigger subscription
+        <span slot="start">
+            <FluentIcon Value="@(new Icons.Regular.Size16.FlashCheckmark())" Color="@Color.Neutral" />
+        </span>
+    </FluentMenuItem>
+
+    <FluentMenuItem Disabled="@(Outcome.BuildId <= 0)" OnClick="@ShowBuildAsync">
+        Show build
+        <span slot="start">
+            <FluentIcon Value="@(new Icons.Regular.Size16.Flashlight())" Color="@Color.Neutral" />
         </span>
     </FluentMenuItem>
 
@@ -67,6 +99,54 @@
         catch (Exception ex)
         {
             ToastService.ShowError($"Failed to copy operation ID: {ex.Message}");
+        }
+    }
+
+    private async Task CopySubscriptionIdAsync()
+    {
+        try
+        {
+            await Clipboard.SetTextAsync(Outcome.SubscriptionId.ToString());
+            ToastService.ShowSuccess("Copied subscription ID to clipboard");
+        }
+        catch (Exception ex)
+        {
+            ToastService.ShowError($"Failed to copy subscription ID: {ex.Message}");
+        }
+    }
+
+    private async Task TriggerSubscriptionAsync(bool force)
+    {
+        try
+        {
+            await PcsApi.Subscriptions.TriggerSubscriptionAsync(Outcome.SubscriptionId, force);
+            ToastService.ShowProgress(force ? "Subscription force-triggered" : "Subscription triggered");
+        }
+        catch
+        {
+            ToastService.ShowError("Failed to trigger the subscription");
+        }
+    }
+
+    private async Task ShowBuildAsync()
+    {
+        try
+        {
+            var build = await PcsApi.Builds.GetBuildAsync(Outcome.BuildId);
+            var channelId = build.Channels?.FirstOrDefault()?.Id ?? 0;
+            var buildLink = build.GetLinkToBuildDetails(channelId);
+            if (buildLink != null)
+            {
+                await JSRuntime.OpenNewWindow(buildLink);
+            }
+            else
+            {
+                ToastService.ShowError("Could not determine the build details link");
+            }
+        }
+        catch (Exception ex)
+        {
+            ToastService.ShowError($"Failed to open build: {ex.Message}");
         }
     }
 }

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Layout/MainLayout.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Layout/MainLayout.razor
@@ -19,6 +19,10 @@
             <FluentAnchor Href="/pullrequests" Appearance="Appearance.Outline">
                 Tracked pull requests
             </FluentAnchor>
+
+            <FluentAnchor Href="/subscription-trigger-outcomes" Appearance="Appearance.Outline">
+                Subscription trigger outcomes
+            </FluentAnchor>
         </div>
 
         <FluentSpacer />

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Layout/MainLayout.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Layout/MainLayout.razor
@@ -20,7 +20,7 @@
                 Tracked pull requests
             </FluentAnchor>
 
-            <FluentAnchor Href="/subscription-trigger-outcomes" Appearance="Appearance.Outline">
+            <FluentAnchor Href="/subscription-trigger-history" Appearance="Appearance.Outline">
                 Subscription trigger history
             </FluentAnchor>
         </div>

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Layout/MainLayout.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Layout/MainLayout.razor
@@ -21,7 +21,7 @@
             </FluentAnchor>
 
             <FluentAnchor Href="/subscription-trigger-outcomes" Appearance="Appearance.Outline">
-                Subscription trigger outcomes
+                Subscription trigger history
             </FluentAnchor>
         </div>
 

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Model/SubscriptionDetailData.cs
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Model/SubscriptionDetailData.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.ProductConstructionService.Client.Models;
+
+namespace ProductConstructionService.BarViz.Model;
+
+/// <summary>
+/// Content for the <c>SubscriptionDetailDialog</c>. Carries either a fully loaded
+/// <see cref="Subscription"/> or just a subscription ID, in which case the dialog
+/// loads the subscription itself and shows a loading indicator while doing so.
+/// </summary>
+public record SubscriptionDetailData
+{
+    public Guid SubscriptionId { get; private init; }
+
+    public Subscription? Subscription { get; private init; }
+
+    public static SubscriptionDetailData FromSubscription(Subscription subscription)
+        => new() { SubscriptionId = subscription.Id, Subscription = subscription };
+
+    public static SubscriptionDetailData FromId(Guid subscriptionId)
+        => new() { SubscriptionId = subscriptionId };
+}

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/Codeflows.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/Codeflows.razor
@@ -322,7 +322,7 @@
             SecondaryAction = "Close",
         };
 
-        await DialogService.ShowDialogAsync<SubscriptionDetailDialog>(subscription, parameters);
+        await DialogService.ShowDialogAsync<SubscriptionDetailDialog>(SubscriptionDetailData.FromSubscription(subscription), parameters);
     }
 
     async Task<List<DefaultChannel>> GetDefaultChannelsAsync()

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerHistory.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerHistory.razor
@@ -141,10 +141,10 @@
                     <FluentLabel>No subscription trigger outcomes found</FluentLabel>
                 </EmptyContent>
                 <ChildContent>
-                    <TemplateColumn Title="Date" Width="0.35fr" Sortable="true" SortBy="SortBy(o => o.Date.UtcTicks)" Align="Align.Start">
+                    <TemplateColumn Title="Date" Width="140px" Sortable="true" SortBy="SortBy(o => o.Date.UtcTicks)" Align="Align.Start">
                         <FluentLabel Title="@context.Date.ToString("f")">@((DateTime.UtcNow - context.Date).ToTimeAgo())</FluentLabel>
                     </TemplateColumn>
-                    <TemplateColumn Title="Subscription" Width="0.9fr" Sortable="true" SortBy="SortBy(o => o.SubscriptionId.ToString())" Align="Align.Start">
+                    <TemplateColumn Title="Subscription" Width="335px" Sortable="true" SortBy="SortBy(o => o.SubscriptionId.ToString())" Align="Align.Start">
                         <FluentButton Appearance="Appearance.Lightweight"
                                       Class="copy-id-button"
                                       Title="Copy subscription ID"
@@ -155,7 +155,7 @@
                               title="Show subscription details"
                               @onclick="@(() => ShowSubscriptionDetailsAsync(context.SubscriptionId))">@context.SubscriptionId</span>
                     </TemplateColumn>
-                    <TemplateColumn Title="Outcome" Width="0.45fr" Sortable="true" SortBy="SortBy(o => o.Type.ToString())" Align="Align.Start">
+                    <TemplateColumn Title="Outcome" Width="175px" Sortable="true" SortBy="SortBy(o => o.Type.ToString())" Align="Align.Start">
                         <FluentLabel>
                             <span class="status-dot @GetStatusClass(context.Type)"></span>@GetStatusText(context.Type)
                         </FluentLabel>

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerHistory.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerHistory.razor
@@ -1,4 +1,4 @@
-@page "/subscription-trigger-outcomes"
+@page "/subscription-trigger-history"
 
 @using System.Linq.Expressions
 @using System.Globalization

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerHistory.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerHistory.razor
@@ -82,6 +82,13 @@
                      VerticalAlignment="VerticalAlignment.Bottom"
                      Wrap="true">
             <div>
+                <FluentTextField @bind-Value="_searchFilter"
+                                 @bind-Value:after="ApplyFiltersAsync"
+                                 Label="Search"
+                                 Placeholder="Source/target repo or branch"
+                                 Style="min-width: 280px;" />
+            </div>
+            <div>
                 <FluentTextField @bind-Value="_subscriptionIdFilter"
                                  @bind-Value:after="ApplyFiltersAsync"
                                  Label="Subscription ID"
@@ -214,6 +221,7 @@
     private bool _showLoadingMoreSpinner;
     private bool _reloading;
 
+    private string? _searchFilter;
     private string? _subscriptionIdFilter;
     private string? _subscriptionIdError;
     private string _outcomeTypeFilter = AllOutcomeTypes;
@@ -232,6 +240,9 @@
     [SupplyParameterFromQuery(Name = "before")]
     private string? BeforeQuery { get; set; }
 
+    [SupplyParameterFromQuery(Name = "search")]
+    private string? SearchQuery { get; set; }
+
     private DateTimeOffset? BeforeFilter => _beforeDate.HasValue
         ? new DateTimeOffset(_beforeDate.Value.Date, TimeSpan.Zero).AddDays(1).AddTicks(-1)
         : null;
@@ -243,6 +254,10 @@
     private string? OutcomeTypeParam => string.IsNullOrEmpty(_outcomeTypeFilter)
         ? null
         : _outcomeTypeFilter;
+
+    private string? SearchParam => string.IsNullOrWhiteSpace(_searchFilter)
+        ? null
+        : _searchFilter.Trim();
 
     private static GridSort<SubscriptionTriggerOutcome> SortBy<TProp>(Expression<Func<SubscriptionTriggerOutcome, TProp>> sorter)
         => GridSort<SubscriptionTriggerOutcome>.ByAscending(sorter);
@@ -312,6 +327,11 @@
         {
             _beforeDate = beforeDate.Date;
         }
+
+        if (!string.IsNullOrWhiteSpace(SearchQuery))
+        {
+            _searchFilter = SearchQuery.Trim();
+        }
     }
 
     private async Task ApplyFiltersAsync()
@@ -345,6 +365,7 @@
             ["outcomeType"] = OutcomeTypeParam,
             ["buildId"] = _buildIdFilter,
             ["before"] = _beforeDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            ["search"] = SearchParam,
         });
 
         NavManager.NavigateTo(newUri);
@@ -357,6 +378,7 @@
         _outcomeTypeFilter = AllOutcomeTypes;
         _buildIdFilter = null;
         _beforeDate = null;
+        _searchFilter = null;
 
         await ApplyFiltersAsync();
     }
@@ -381,7 +403,8 @@
             before: beforeDate,
             buildId: _buildIdFilter,
             subscriptionId: SubscriptionIdParam,
-            subscriptionOutcomeType: OutcomeTypeParam);
+            subscriptionOutcomeType: OutcomeTypeParam,
+            search: SearchParam);
 
         _hasMore = batch.Count == PageSize;
 

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerHistory.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerHistory.razor
@@ -144,16 +144,26 @@
                     <TemplateColumn Title="Date" Width="140px" Sortable="true" SortBy="SortBy(o => o.Date.UtcTicks)" Align="Align.Start">
                         <FluentLabel Title="@context.Date.ToString("f")">@((DateTime.UtcNow - context.Date).ToTimeAgo())</FluentLabel>
                     </TemplateColumn>
-                    <TemplateColumn Title="Subscription" Width="335px" Sortable="true" SortBy="SortBy(o => o.SubscriptionId.ToString())" Align="Align.Start">
+                    <TemplateColumn Title="Subscription" Width="440px" Sortable="true" SortBy="SortBy(o => GetSubscriptionBlurb(o) ?? o.SubscriptionId.ToString())" Align="Align.Start">
                         <FluentButton Appearance="Appearance.Lightweight"
                                       Class="copy-id-button"
                                       Title="Copy subscription ID"
                                       OnClick="@(() => CopySubscriptionIdAsync(context.SubscriptionId))">
                             <FluentIcon Value="@(new Icons.Regular.Size16.Copy())" Color="Color.Neutral" />
                         </FluentButton>
-                        <span class="subscription-link"
-                              title="Show subscription details"
-                              @onclick="@(() => ShowSubscriptionDetailsAsync(context.SubscriptionId))">@context.SubscriptionId</span>
+                        @{
+                            var blurb = GetSubscriptionBlurb(context);
+                        }
+                        @if (blurb != null)
+                        {
+                            <span class="subscription-link"
+                                  title="Show subscription details"
+                                  @onclick="@(() => ShowSubscriptionDetailsAsync(context.SubscriptionId))">@blurb</span>
+                        }
+                        else
+                        {
+                            <span title="@context.SubscriptionId">@context.SubscriptionId</span>
+                        }
                     </TemplateColumn>
                     <TemplateColumn Title="Outcome" Width="175px" Sortable="true" SortBy="SortBy(o => o.Type.ToString())" Align="Align.Start">
                         <FluentLabel>
@@ -242,6 +252,9 @@
 
     private static GridSort<SubscriptionTriggerOutcome> SortBy<TProp>(Expression<Func<SubscriptionTriggerOutcome, TProp>> sorter)
         => GridSort<SubscriptionTriggerOutcome>.ByAscending(sorter);
+
+    private static string? GetSubscriptionBlurb(SubscriptionTriggerOutcome outcome)
+        => SubscriptionOutcomeHelper.GetSubscriptionBlurb(outcome.SourceRepository, outcome.TargetRepository, outcome.TargetBranch);
 
     private async Task CopySubscriptionIdAsync(Guid subscriptionId)
     {

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerHistory.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerHistory.razor
@@ -145,12 +145,6 @@
                         <FluentLabel Title="@context.Date.ToString("f")">@((DateTime.UtcNow - context.Date).ToTimeAgo())</FluentLabel>
                     </TemplateColumn>
                     <TemplateColumn Title="Subscription" Width="440px" Sortable="true" SortBy="SortBy(o => GetSubscriptionBlurb(o) ?? o.SubscriptionId.ToString())" Align="Align.Start">
-                        <FluentButton Appearance="Appearance.Lightweight"
-                                      Class="copy-id-button"
-                                      Title="Copy subscription ID"
-                                      OnClick="@(() => CopySubscriptionIdAsync(context.SubscriptionId))">
-                            <FluentIcon Value="@(new Icons.Regular.Size16.Copy())" Color="Color.Neutral" />
-                        </FluentButton>
                         @{
                             var blurb = GetSubscriptionBlurb(context);
                         }

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerHistory.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerHistory.razor
@@ -173,7 +173,7 @@
                                 }
                             }</span>
                     </TemplateColumn>
-                    <TemplateColumn Width="60px">
+                    <TemplateColumn Width="80px">
                         <SubscriptionOutcomeContextMenu Outcome="@context" ShowDetails="@ShowSubscriptionDetailsAsync" />
                     </TemplateColumn>
                 </ChildContent>

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerOutcomes.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerOutcomes.razor
@@ -1,0 +1,421 @@
+@page "/subscription-trigger-outcomes"
+
+@using System.Linq.Expressions
+@using System.Globalization
+@using Microsoft.DotNet.ProductConstructionService.Client
+@using Microsoft.DotNet.ProductConstructionService.Client.Models
+@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@using TextCopy
+@inject IProductConstructionServiceApi PcsApi
+@inject IClipboard Clipboard
+@inject IToastService ToastService
+@inject NavigationManager NavManager
+
+<style>
+    .status-dot {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        vertical-align: middle;
+        margin-right: 4px;
+    }
+
+    .status-green {
+        background-color: #2da44e;
+    }
+
+    .status-grey {
+        background-color: #888;
+    }
+
+    .status-red {
+        background-color: #cf222e;
+    }
+
+    .status-yellow {
+        background-color: #d4a017;
+    }
+
+    .status-blue {
+        background-color: #0969da;
+    }
+
+    .operation-id {
+        font-family: monospace;
+        color: var(--neutral-foreground-hint);
+    }
+
+    .operation-id, .outcome-message {
+        display: inline-block;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        vertical-align: middle;
+        cursor: pointer;
+    }
+
+    .operation-id.expanded, .outcome-message.expanded {
+        max-width: 100%;
+        overflow: visible;
+        text-overflow: clip;
+        white-space: normal;
+        word-break: break-word;
+    }
+
+    /* The grid uses MultiLine="true" so cells are allowed to wrap and the row grows to
+       fit its tallest cell. By default the Message/Operation Id spans force a single
+       truncated line (nowrap + ellipsis above); when expanded they wrap and the cell/row
+       grows. Top-align the cells of a row that contains an expanded value so it stays tidy. */
+    #outcomesGrid td:has(.expanded) {
+        vertical-align: top;
+    }
+
+    /* MultiLine mode styles every cell as .multiline-text { overflow: auto }, which shows
+       a horizontal scrollbar whenever the (truncated) content is wider than the column.
+       Keep non-expanded cells clipped (no scrollbar); only expanded cells need to grow. */
+    #outcomesGrid td:not(:has(.expanded)) {
+        overflow: hidden;
+    }
+</style>
+
+<PageTitle>Subscription trigger outcomes – Maestro++</PageTitle>
+
+<GridViewTemplate ShowSkeleton="_outcomes == null">
+    <Content>
+        <FluentStack Class="filters"
+                     Orientation="Orientation.Horizontal"
+                     HorizontalGap="16"
+                     VerticalAlignment="VerticalAlignment.Bottom"
+                     Wrap="true">
+            <div>
+                <FluentTextField @bind-Value="_subscriptionIdFilter"
+                                 @bind-Value:after="ApplyFiltersAsync"
+                                 Label="Subscription ID"
+                                 Placeholder="Subscription GUID"
+                                 Style="min-width: 280px;" />
+                @if (_subscriptionIdError != null)
+                {
+                    <FluentLabel Color="Color.Error">@_subscriptionIdError</FluentLabel>
+                }
+            </div>
+            <div>
+                <FluentSelect TOption="string"
+                              Label="Outcome type"
+                              Items="_outcomeTypeOptions"
+                              OptionValue="@(o => o)"
+                              OptionText="@GetOutcomeTypeOptionText"
+                              @bind-SelectedOption="_outcomeTypeFilter"
+                              @bind-SelectedOption:after="ApplyFiltersAsync"
+                              Width="200px" />
+            </div>
+            <div>
+                <FluentNumberField TValue="int?"
+                                   @bind-Value="_buildIdFilter"
+                                   @bind-Value:after="ApplyFiltersAsync"
+                                   Label="Build ID"
+                                   Placeholder="Build ID" />
+            </div>
+            <div>
+                <FluentDatePicker @bind-Value="_beforeDate"
+                                  @bind-Value:after="ApplyFiltersAsync"
+                                  Label="Before date" />
+            </div>
+            <FluentButton Appearance="Appearance.Stealth"
+                          IconStart="@(new Icons.Regular.Size16.Dismiss())"
+                          OnClick="ClearFiltersAsync">
+                Clear filters
+            </FluentButton>
+        </FluentStack>
+
+        @if (_reloading)
+        {
+            <div class="show-more">
+                <FluentProgressRing Style="height: 32px; width: 32px;" />
+            </div>
+        }
+        else
+        {
+            <FluentDataGrid Id="outcomesGrid"
+                            Items="@_outcomes?.AsQueryable()"
+                            TGridItem=SubscriptionTriggerOutcome
+                            ShowHover="true"
+                            ResizableColumns="true"
+                            MultiLine="true"
+                            Style="width: 100%">
+                <EmptyContent>
+                    <FluentLabel>No subscription trigger outcomes found</FluentLabel>
+                </EmptyContent>
+                <ChildContent>
+                    <TemplateColumn Title="Date" Width="0.35fr" Sortable="true" SortBy="SortBy(o => o.Date.UtcTicks)" Align="Align.Start">
+                        <FluentLabel Title="@context.Date.ToString("f")">@((DateTime.UtcNow - context.Date).ToTimeAgo())</FluentLabel>
+                    </TemplateColumn>
+                    <TemplateColumn Title="Outcome" Width="0.45fr" Sortable="true" SortBy="SortBy(o => o.Type.ToString())" Align="Align.Start">
+                        <FluentLabel>
+                            <span class="status-dot @GetStatusClass(context.Type)"></span>@GetStatusText(context.Type)
+                        </FluentLabel>
+                    </TemplateColumn>
+                    <TemplateColumn Title="Subscription" Width="0.9fr" Sortable="true" SortBy="SortBy(o => o.SubscriptionId.ToString())" Align="Align.Start">
+                        <FluentButton Appearance="Appearance.Lightweight"
+                                      Class="copy-id-button"
+                                      Title="Copy subscription ID"
+                                      OnClick="@(() => CopySubscriptionIdAsync(context.SubscriptionId))">
+                            <FluentIcon Value="@(new Icons.Regular.Size16.Copy())" Color="Color.Neutral" />
+                        </FluentButton>
+                        <FluentAnchor Href="@($"/subscriptions?search={context.SubscriptionId}")" Appearance="Appearance.Hypertext">@context.SubscriptionId</FluentAnchor>
+                    </TemplateColumn>
+                    <TemplateColumn Title="Build" Width="0.2fr" Sortable="true" SortBy="SortBy(o => o.BuildId)" Align="Align.Start">
+                        <FluentLabel>@(context.BuildId > 0 ? context.BuildId.ToString() : "N/A")</FluentLabel>
+                    </TemplateColumn>
+                    <TemplateColumn Title="Message" Width="2fr" Align="Align.Start">
+                        <span class="outcome-message expanded"
+                              title="@context.Message"
+                              @onclick="@(() => ToggleExpanded(context, _messageExpanded))">@context.Message</span>
+                    </TemplateColumn>
+                    <TemplateColumn Title="Operation Id" Width="1fr" Align="Align.Start">
+                        <span class="operation-id @(IsExpanded(context, _operationIdExpanded) ? "expanded" : null)"
+                              title="@context.OperationId"
+                              @onclick="@(() => ToggleExpanded(context, _operationIdExpanded))">@context.OperationId</span>
+                    </TemplateColumn>
+                </ChildContent>
+            </FluentDataGrid>
+
+            @if (_outcomes != null && _hasMore)
+            {
+                <div class="show-more">
+                    @if (_showLoadingMoreSpinner)
+                    {
+                        <FluentProgressRing Style="height: 24px; width: 24px;" />
+                    }
+                    else
+                    {
+                        <FluentButton Appearance="Appearance.Lightweight" OnClick="LoadMoreAsync">Show more results…</FluentButton>
+                    }
+                </div>
+            }
+        }
+    </Content>
+</GridViewTemplate>
+
+@code {
+    private const int PageSize = 100;
+    private const string AllOutcomeTypes = "";
+
+    private static readonly string[] _outcomeTypeOptions =
+        [AllOutcomeTypes, .. Enum.GetNames<OutcomeType>()];
+
+    private List<SubscriptionTriggerOutcome>? _outcomes;
+    private readonly HashSet<(string OperationId, Guid SubscriptionId, int BuildId, long DateTicks)> _seenOutcomes = [];
+    private DateTimeOffset? _oldestDate;
+    private bool _hasMore;
+    private bool _showLoadingMoreSpinner;
+    private bool _reloading;
+
+    private string? _subscriptionIdFilter;
+    private string? _subscriptionIdError;
+    private string _outcomeTypeFilter = AllOutcomeTypes;
+    private int? _buildIdFilter;
+    private DateTime? _beforeDate;
+
+    [SupplyParameterFromQuery(Name = "subscriptionId")]
+    private string? SubscriptionIdQuery { get; set; }
+
+    [SupplyParameterFromQuery(Name = "outcomeType")]
+    private string? OutcomeTypeQuery { get; set; }
+
+    [SupplyParameterFromQuery(Name = "buildId")]
+    private string? BuildIdQuery { get; set; }
+
+    [SupplyParameterFromQuery(Name = "before")]
+    private string? BeforeQuery { get; set; }
+
+    private readonly HashSet<SubscriptionTriggerOutcome> _messageExpanded = [];
+    private readonly HashSet<SubscriptionTriggerOutcome> _operationIdExpanded = [];
+
+    private DateTimeOffset? BeforeFilter => _beforeDate.HasValue
+        ? new DateTimeOffset(_beforeDate.Value.Date, TimeSpan.Zero).AddDays(1).AddTicks(-1)
+        : null;
+
+    private string? SubscriptionIdParam => string.IsNullOrWhiteSpace(_subscriptionIdFilter)
+        ? null
+        : _subscriptionIdFilter.Trim();
+
+    private string? OutcomeTypeParam => string.IsNullOrEmpty(_outcomeTypeFilter)
+        ? null
+        : _outcomeTypeFilter;
+
+    private static GridSort<SubscriptionTriggerOutcome> SortBy<TProp>(Expression<Func<SubscriptionTriggerOutcome, TProp>> sorter)
+        => GridSort<SubscriptionTriggerOutcome>.ByAscending(sorter);
+
+    private static bool IsExpanded(SubscriptionTriggerOutcome outcome, HashSet<SubscriptionTriggerOutcome> expanded)
+        => expanded.Contains(outcome);
+
+    private void ToggleExpanded(SubscriptionTriggerOutcome outcome, HashSet<SubscriptionTriggerOutcome> expanded)
+    {
+        if (!expanded.Add(outcome))
+        {
+            expanded.Remove(outcome);
+        }
+    }
+
+    private async Task CopySubscriptionIdAsync(Guid subscriptionId)
+    {
+        try
+        {
+            await Clipboard.SetTextAsync(subscriptionId.ToString());
+            ToastService.ShowSuccess("Copied subscription ID to clipboard");
+        }
+        catch (Exception ex)
+        {
+            ToastService.ShowError($"Failed to copy subscription ID: {ex.Message}");
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        InitializeFiltersFromQuery();
+
+        await LoadOutcomesAsync();
+    }
+
+    private void InitializeFiltersFromQuery()
+    {
+        if (!string.IsNullOrWhiteSpace(SubscriptionIdQuery))
+        {
+            _subscriptionIdFilter = SubscriptionIdQuery.Trim();
+            if (!Guid.TryParse(_subscriptionIdFilter, out _))
+            {
+                _subscriptionIdError = "Enter a valid subscription GUID.";
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(OutcomeTypeQuery)
+            && Enum.TryParse<OutcomeType>(OutcomeTypeQuery.Trim(), ignoreCase: true, out var outcomeType))
+        {
+            _outcomeTypeFilter = outcomeType.ToString();
+        }
+
+        if (int.TryParse(BuildIdQuery, NumberStyles.Integer, CultureInfo.InvariantCulture, out var buildId))
+        {
+            _buildIdFilter = buildId;
+        }
+
+        if (DateTime.TryParse(BeforeQuery, CultureInfo.InvariantCulture, DateTimeStyles.None, out var beforeDate))
+        {
+            _beforeDate = beforeDate.Date;
+        }
+    }
+
+    private async Task ApplyFiltersAsync()
+    {
+        if (!string.IsNullOrWhiteSpace(_subscriptionIdFilter) && !Guid.TryParse(_subscriptionIdFilter.Trim(), out _))
+        {
+            _subscriptionIdError = "Enter a valid subscription GUID.";
+            StateHasChanged();
+            return;
+        }
+
+        _subscriptionIdError = null;
+        UpdateQueryParams();
+        _reloading = true;
+        StateHasChanged();
+
+        _seenOutcomes.Clear();
+        _messageExpanded.Clear();
+        _operationIdExpanded.Clear();
+        _oldestDate = null;
+        _outcomes = [];
+
+        await LoadOutcomesAsync();
+
+        _reloading = false;
+    }
+
+    private void UpdateQueryParams()
+    {
+        var newUri = NavManager.GetUriWithQueryParameters(new Dictionary<string, object?>
+        {
+            ["subscriptionId"] = SubscriptionIdParam,
+            ["outcomeType"] = OutcomeTypeParam,
+            ["buildId"] = _buildIdFilter,
+            ["before"] = _beforeDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        });
+
+        NavManager.NavigateTo(newUri);
+    }
+
+    private async Task ClearFiltersAsync()
+    {
+        _subscriptionIdFilter = null;
+        _subscriptionIdError = null;
+        _outcomeTypeFilter = AllOutcomeTypes;
+        _buildIdFilter = null;
+        _beforeDate = null;
+
+        await ApplyFiltersAsync();
+    }
+
+    private async Task LoadMoreAsync()
+    {
+        _showLoadingMoreSpinner = true;
+        StateHasChanged();
+
+        await LoadOutcomesAsync();
+
+        _showLoadingMoreSpinner = false;
+    }
+
+    private async Task LoadOutcomesAsync()
+    {
+        // for new queries, use BeforeFilter. for loading more elements, filter based on the last loaded element.
+        var beforeDate = _oldestDate ?? BeforeFilter;
+
+        var batch = await PcsApi.SubscriptionTriggerOutcomes.ListSubscriptionOutcomesAsync(
+            limit: PageSize,
+            before: beforeDate,
+            buildId: _buildIdFilter,
+            subscriptionId: SubscriptionIdParam,
+            subscriptionOutcomeType: OutcomeTypeParam);
+
+        _hasMore = batch.Count == PageSize;
+
+        _outcomes ??= [];
+
+        foreach (var outcome in batch)
+        {
+            var key = (outcome.OperationId, outcome.SubscriptionId, outcome.BuildId, outcome.Date.UtcTicks);
+            if (_seenOutcomes.Add(key))
+            {
+                _outcomes.Add(outcome);
+            }
+        }
+
+        if (_outcomes.Count > 0)
+        {
+            _oldestDate = _outcomes[^1].Date;
+        }
+    }
+
+    private static string GetOutcomeTypeOptionText(string option)
+        => string.IsNullOrEmpty(option) ? "All outcomes" : GetStatusText(Enum.Parse<OutcomeType>(option));
+
+    private static string GetStatusClass(OutcomeType type) => type switch
+    {
+        OutcomeType.Updated => "status-green",
+        OutcomeType.Failure => "status-red",
+        OutcomeType.UserError => "status-yellow",
+        OutcomeType.HasConflict => "status-yellow",
+        OutcomeType.Rescheduled => "status-blue",
+        _ => "status-grey",
+    };
+
+    private static string GetStatusText(OutcomeType type) => type switch
+    {
+        OutcomeType.UserError => "User Error",
+        OutcomeType.HasConflict => "Has conflicts",
+        OutcomeType.NoUpdate => "Nothing to update",
+        OutcomeType.NotUpdatable => "PR not updatable",
+        _ => type.ToString(),
+    };
+}

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerOutcomes.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerOutcomes.razor
@@ -5,6 +5,7 @@
 @using Microsoft.DotNet.ProductConstructionService.Client
 @using Microsoft.DotNet.ProductConstructionService.Client.Models
 @using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@using ProductConstructionService.BarViz.Code.Helpers
 @using ProductConstructionService.BarViz.Components
 @using ProductConstructionService.BarViz.Model
 @using TextCopy
@@ -159,9 +160,19 @@
                         </FluentLabel>
                     </TemplateColumn>
                     <TemplateColumn Title="Message" Width="2fr" Align="Align.Start">
-                        <span class="outcome-message" title="@context.Message">@context.Message</span>
+                        <span class="outcome-message" title="@context.Message">@foreach (var segment in StringExtensions.SplitIntoTextAndUrls(context.Message))
+                            {
+                                if (segment.IsUrl)
+                                {
+                                    <FluentAnchor Href="@segment.Text" Target="_blank" Appearance="Appearance.Hypertext">@segment.Text</FluentAnchor>
+                                }
+                                else
+                                {
+                                    @segment.Text
+                                }
+                            }</span>
                     </TemplateColumn>
-                    <TemplateColumn Width="0.1fr">
+                    <TemplateColumn Width="60px">
                         <SubscriptionOutcomeContextMenu Outcome="@context" ShowDetails="@ShowSubscriptionDetailsAsync" />
                     </TemplateColumn>
                 </ChildContent>

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerOutcomes.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerOutcomes.razor
@@ -5,10 +5,13 @@
 @using Microsoft.DotNet.ProductConstructionService.Client
 @using Microsoft.DotNet.ProductConstructionService.Client.Models
 @using Microsoft.FluentUI.AspNetCore.Components.Extensions
+@using ProductConstructionService.BarViz.Components
+@using ProductConstructionService.BarViz.Model
 @using TextCopy
 @inject IProductConstructionServiceApi PcsApi
 @inject IClipboard Clipboard
 @inject IToastService ToastService
+@inject IDialogService DialogService
 @inject NavigationManager NavManager
 
 <style>
@@ -41,41 +44,29 @@
         background-color: #0969da;
     }
 
-    .operation-id {
-        font-family: monospace;
-        color: var(--neutral-foreground-hint);
+    .subscription-link {
+        color: var(--accent-foreground-rest, #0969da);
+        cursor: pointer;
+        vertical-align: middle;
     }
 
-    .operation-id, .outcome-message {
+    .subscription-link:hover {
+        text-decoration: underline;
+    }
+
+    .outcome-message {
         display: inline-block;
         max-width: 100%;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        vertical-align: middle;
-        cursor: pointer;
-    }
-
-    .operation-id.expanded, .outcome-message.expanded {
-        max-width: 100%;
-        overflow: visible;
-        text-overflow: clip;
         white-space: normal;
         word-break: break-word;
+        vertical-align: middle;
     }
 
-    /* The grid uses MultiLine="true" so cells are allowed to wrap and the row grows to
-       fit its tallest cell. By default the Message/Operation Id spans force a single
-       truncated line (nowrap + ellipsis above); when expanded they wrap and the cell/row
-       grows. Top-align the cells of a row that contains an expanded value so it stays tidy. */
-    #outcomesGrid td:has(.expanded) {
+    /* The grid uses MultiLine="true" so cells wrap and the row grows to fit its tallest
+       cell. Top-align cells and clip MultiLine mode's per-cell overflow:auto so multi-line
+       rows stay tidy without horizontal scrollbars. */
+    #outcomesGrid td {
         vertical-align: top;
-    }
-
-    /* MultiLine mode styles every cell as .multiline-text { overflow: auto }, which shows
-       a horizontal scrollbar whenever the (truncated) content is wider than the column.
-       Keep non-expanded cells clipped (no scrollbar); only expanded cells need to grow. */
-    #outcomesGrid td:not(:has(.expanded)) {
         overflow: hidden;
     }
 </style>
@@ -151,11 +142,6 @@
                     <TemplateColumn Title="Date" Width="0.35fr" Sortable="true" SortBy="SortBy(o => o.Date.UtcTicks)" Align="Align.Start">
                         <FluentLabel Title="@context.Date.ToString("f")">@((DateTime.UtcNow - context.Date).ToTimeAgo())</FluentLabel>
                     </TemplateColumn>
-                    <TemplateColumn Title="Outcome" Width="0.45fr" Sortable="true" SortBy="SortBy(o => o.Type.ToString())" Align="Align.Start">
-                        <FluentLabel>
-                            <span class="status-dot @GetStatusClass(context.Type)"></span>@GetStatusText(context.Type)
-                        </FluentLabel>
-                    </TemplateColumn>
                     <TemplateColumn Title="Subscription" Width="0.9fr" Sortable="true" SortBy="SortBy(o => o.SubscriptionId.ToString())" Align="Align.Start">
                         <FluentButton Appearance="Appearance.Lightweight"
                                       Class="copy-id-button"
@@ -163,20 +149,20 @@
                                       OnClick="@(() => CopySubscriptionIdAsync(context.SubscriptionId))">
                             <FluentIcon Value="@(new Icons.Regular.Size16.Copy())" Color="Color.Neutral" />
                         </FluentButton>
-                        <FluentAnchor Href="@($"/subscriptions?search={context.SubscriptionId}")" Appearance="Appearance.Hypertext">@context.SubscriptionId</FluentAnchor>
+                        <span class="subscription-link"
+                              title="Show subscription details"
+                              @onclick="@(() => ShowSubscriptionDetailsAsync(context.SubscriptionId))">@context.SubscriptionId</span>
                     </TemplateColumn>
-                    <TemplateColumn Title="Build" Width="0.2fr" Sortable="true" SortBy="SortBy(o => o.BuildId)" Align="Align.Start">
-                        <FluentLabel>@(context.BuildId > 0 ? context.BuildId.ToString() : "N/A")</FluentLabel>
+                    <TemplateColumn Title="Outcome" Width="0.45fr" Sortable="true" SortBy="SortBy(o => o.Type.ToString())" Align="Align.Start">
+                        <FluentLabel>
+                            <span class="status-dot @GetStatusClass(context.Type)"></span>@GetStatusText(context.Type)
+                        </FluentLabel>
                     </TemplateColumn>
                     <TemplateColumn Title="Message" Width="2fr" Align="Align.Start">
-                        <span class="outcome-message expanded"
-                              title="@context.Message"
-                              @onclick="@(() => ToggleExpanded(context, _messageExpanded))">@context.Message</span>
+                        <span class="outcome-message" title="@context.Message">@context.Message</span>
                     </TemplateColumn>
-                    <TemplateColumn Title="Operation Id" Width="1fr" Align="Align.Start">
-                        <span class="operation-id @(IsExpanded(context, _operationIdExpanded) ? "expanded" : null)"
-                              title="@context.OperationId"
-                              @onclick="@(() => ToggleExpanded(context, _operationIdExpanded))">@context.OperationId</span>
+                    <TemplateColumn Width="0.1fr">
+                        <SubscriptionOutcomeContextMenu Outcome="@context" ShowDetails="@ShowSubscriptionDetailsAsync" />
                     </TemplateColumn>
                 </ChildContent>
             </FluentDataGrid>
@@ -230,9 +216,6 @@
     [SupplyParameterFromQuery(Name = "before")]
     private string? BeforeQuery { get; set; }
 
-    private readonly HashSet<SubscriptionTriggerOutcome> _messageExpanded = [];
-    private readonly HashSet<SubscriptionTriggerOutcome> _operationIdExpanded = [];
-
     private DateTimeOffset? BeforeFilter => _beforeDate.HasValue
         ? new DateTimeOffset(_beforeDate.Value.Date, TimeSpan.Zero).AddDays(1).AddTicks(-1)
         : null;
@@ -248,17 +231,6 @@
     private static GridSort<SubscriptionTriggerOutcome> SortBy<TProp>(Expression<Func<SubscriptionTriggerOutcome, TProp>> sorter)
         => GridSort<SubscriptionTriggerOutcome>.ByAscending(sorter);
 
-    private static bool IsExpanded(SubscriptionTriggerOutcome outcome, HashSet<SubscriptionTriggerOutcome> expanded)
-        => expanded.Contains(outcome);
-
-    private void ToggleExpanded(SubscriptionTriggerOutcome outcome, HashSet<SubscriptionTriggerOutcome> expanded)
-    {
-        if (!expanded.Add(outcome))
-        {
-            expanded.Remove(outcome);
-        }
-    }
-
     private async Task CopySubscriptionIdAsync(Guid subscriptionId)
     {
         try
@@ -270,6 +242,22 @@
         {
             ToastService.ShowError($"Failed to copy subscription ID: {ex.Message}");
         }
+    }
+
+    private async Task ShowSubscriptionDetailsAsync(Guid subscriptionId)
+    {
+        DialogParameters parameters = new()
+        {
+            Title = $"Subscription {subscriptionId}",
+            Width = "800px",
+            TrapFocus = true,
+            Modal = true,
+            PreventScroll = true,
+            PrimaryAction = null,
+            SecondaryAction = "Close",
+        };
+
+        await DialogService.ShowDialogAsync<SubscriptionDetailDialog>(SubscriptionDetailData.FromId(subscriptionId), parameters);
     }
 
     protected override async Task OnInitializedAsync()
@@ -322,8 +310,6 @@
         StateHasChanged();
 
         _seenOutcomes.Clear();
-        _messageExpanded.Clear();
-        _operationIdExpanded.Clear();
         _oldestDate = null;
         _outcomes = [];
 

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerOutcomes.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/SubscriptionTriggerOutcomes.razor
@@ -72,7 +72,7 @@
     }
 </style>
 
-<PageTitle>Subscription trigger outcomes – Maestro++</PageTitle>
+<PageTitle>Subscription trigger history – Maestro++</PageTitle>
 
 <GridViewTemplate ShowSkeleton="_outcomes == null">
     <Content>
@@ -85,7 +85,7 @@
                 <FluentTextField @bind-Value="_subscriptionIdFilter"
                                  @bind-Value:after="ApplyFiltersAsync"
                                  Label="Subscription ID"
-                                 Placeholder="Subscription GUID"
+                                 Placeholder="GUID"
                                  Style="min-width: 280px;" />
                 @if (_subscriptionIdError != null)
                 {
@@ -107,7 +107,8 @@
                                    @bind-Value="_buildIdFilter"
                                    @bind-Value:after="ApplyFiltersAsync"
                                    Label="Build ID"
-                                   Placeholder="Build ID" />
+                                   Placeholder="Build ID"
+                                   HideStep=true />
             </div>
             <div>
                 <FluentDatePicker @bind-Value="_beforeDate"

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/Subscriptions.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Pages/Subscriptions.razor
@@ -7,6 +7,7 @@
 @using Microsoft.FluentUI.AspNetCore.Components.Extensions
 @using ProductConstructionService.BarViz.Code.Helpers
 @using ProductConstructionService.BarViz.Components
+@using ProductConstructionService.BarViz.Model
 @using TextCopy
 @inject NavigationManager NavManager
 @inject IProductConstructionServiceApi PcsApi
@@ -325,7 +326,7 @@
             PreventScroll = true,
         };
 
-        await DialogService.ShowDialogAsync<SubscriptionDetailDialog>(subscription, parameters);
+        await DialogService.ShowDialogAsync<SubscriptionDetailDialog>(SubscriptionDetailData.FromSubscription(subscription), parameters);
     }
 
     private void UpdateQueryParams()

--- a/test/ProductConstructionService/ProductConstructionService.BarViz.Tests/StringExtensionsTests.cs
+++ b/test/ProductConstructionService/ProductConstructionService.BarViz.Tests/StringExtensionsTests.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using AwesomeAssertions;
+using NUnit.Framework;
+using ProductConstructionService.BarViz.Code.Helpers;
+
+namespace ProductConstructionService.BarViz.Tests;
+
+[TestFixture]
+public class StringExtensionsTests
+{
+    [Test]
+    public void SplitIntoTextAndUrls_NullOrEmpty_ReturnsEmpty()
+    {
+        StringExtensions.SplitIntoTextAndUrls(null).Should().BeEmpty();
+        StringExtensions.SplitIntoTextAndUrls(string.Empty).Should().BeEmpty();
+    }
+
+    [Test]
+    public void SplitIntoTextAndUrls_PlainText_ReturnsSingleTextSegment()
+    {
+        var segments = StringExtensions.SplitIntoTextAndUrls("no links here");
+
+        segments.Should().ContainSingle();
+        segments[0].IsUrl.Should().BeFalse();
+        segments[0].Text.Should().Be("no links here");
+    }
+
+    [Test]
+    public void SplitIntoTextAndUrls_UrlInMiddle_SplitsAroundUrl()
+    {
+        var segments = StringExtensions.SplitIntoTextAndUrls("See https://github.com/dotnet/arcade for details");
+
+        segments.Should().HaveCount(3);
+        segments[0].Should().Be(new StringExtensions.TextSegment("See ", false));
+        segments[1].Should().Be(new StringExtensions.TextSegment("https://github.com/dotnet/arcade", true));
+        segments[2].Should().Be(new StringExtensions.TextSegment(" for details", false));
+    }
+
+    [Test]
+    public void SplitIntoTextAndUrls_TrailingPunctuation_ExcludedFromUrl()
+    {
+        var segments = StringExtensions.SplitIntoTextAndUrls("Open https://example.com/path).");
+
+        segments.Should().HaveCount(3);
+        segments[0].Should().Be(new StringExtensions.TextSegment("Open ", false));
+        segments[1].Should().Be(new StringExtensions.TextSegment("https://example.com/path", true));
+        segments[2].Should().Be(new StringExtensions.TextSegment(").", false));
+    }
+
+    [Test]
+    public void SplitIntoTextAndUrls_MultipleUrls_AllDetected()
+    {
+        var segments = StringExtensions.SplitIntoTextAndUrls("a https://a.com b http://b.com");
+
+        segments.Should().HaveCount(4);
+        segments[0].Should().Be(new StringExtensions.TextSegment("a ", false));
+        segments[1].Should().Be(new StringExtensions.TextSegment("https://a.com", true));
+        segments[2].Should().Be(new StringExtensions.TextSegment(" b ", false));
+        segments[3].Should().Be(new StringExtensions.TextSegment("http://b.com", true));
+    }
+
+    [Test]
+    public void SplitIntoTextAndUrls_UrlOnly_ReturnsSingleUrlSegment()
+    {
+        var segments = StringExtensions.SplitIntoTextAndUrls("https://example.com");
+
+        segments.Should().ContainSingle();
+        segments[0].Should().Be(new StringExtensions.TextSegment("https://example.com", true));
+    }
+}


### PR DESCRIPTION
#6190

Features:
- Displays 100 latest outcomes based on filters
- Paging is implemented based on date. There is a "Load more" button that loads the next 100 results using the last result's date as the new date limit.
- Filters can be applied via URLs, allowing us to link to a specific subscription's outcomes on other BarViz pages
- Clicking a subscription id leads to the subscriptions page (I will change this so that it opens the small subscription popup instead)
- Each status has a color assigned

<img width="1057" height="718" alt="image" src="https://github.com/user-attachments/assets/879a04ad-89b2-4b50-9526-8def545829b7" />
