### PR TITLE
Fix failed subscritpion message display

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionErrorBanner.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionErrorBanner.razor
@@ -18,12 +18,30 @@
                             GridTemplateColumns="2fr 3fr"
                             Style="width: 100%; margin-bottom: 16px;">
                 <PropertyColumn Title="Subscription" Property="@(e => SubscriptionDisplay(e.Subscription))" Align="Align.Start" />
-                <PropertyColumn Title="Message" Property="@(e => e.Outcome.Message)" Align="Align.Start" />
+                <TemplateColumn Title="Message" Align="Align.Start">
+                    <div class="subscription-error-message" title="@context.Outcome.Message">
+                        @context.Outcome.Message
+                    </div>
+                </TemplateColumn>
             </FluentDataGrid>
         }
 
         <FluentDivider Style="margin: 16px 0;" />
     </div>
+
+    <style>
+        /* Keep the message inside its column: it stays on a single line but can
+           be scrolled horizontally, and the full text is shown on hover. */
+        .subscription-error-banner td {
+            overflow: hidden !important;
+        }
+
+        .subscription-error-banner .subscription-error-message {
+            max-width: 100%;
+            overflow-x: auto;
+            white-space: nowrap;
+        }
+    </style>
 }
 
 @code {


### PR DESCRIPTION
Currently if the message is too long, we don't see it fully
<img width="1950" height="112" alt="image" src="https://github.com/user-attachments/assets/1240b9f0-e84a-4894-9638-12259e01585e" />

This PR adds a slider so the error can be fully read
<img width="1999" height="96" alt="image" src="https://github.com/user-attachments/assets/fab4dfbb-4398-4714-a22b-7f97a3b8e83b" />

https://github.com/dotnet/arcade-services/issues/6334