### PR TITLE
Use fixed width for subscription name in error banner

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionErrorBanner.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionErrorBanner.razor
@@ -15,7 +15,7 @@
 
             <FluentDataGrid Items="@errorGroup.Errors.AsQueryable()"
                             TGridItem="SubscriptionOutcomeError"
-                            GridTemplateColumns="2fr 3fr"
+                            GridTemplateColumns="22rem 1fr"
                             Style="width: 100%; margin-bottom: 16px;">
                 <PropertyColumn Title="Subscription" Property="@(e => SubscriptionDisplay(e.Subscription))" Align="Align.Start" />
                 <TemplateColumn Title="Message" Align="Align.Start">

--- a/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionOutcomeAlertIcon.razor
+++ b/src/ProductConstructionService/ProductConstructionService.BarViz/Components/SubscriptionOutcomeAlertIcon.razor
@@ -51,7 +51,7 @@
             return null;
         }
 
-        lines.Insert(0, "Failing codeflows:");
+        lines.Insert(0, "Currently failing:");
         return string.Join("\n", lines);
     }
 


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/6334
Previously we were dedicating 40% of the screen to the sub name, which looked bad on both big and small screens. This makes it a fixed width
<img width="2420" height="190" alt="image" src="https://github.com/user-attachments/assets/38c2ff39-7450-41c4-91be-44c3ffee4882" />
