### PR TITLE
Use concrete credentials in local development

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/AzureAuthentication.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/AzureAuthentication.cs
@@ -23,7 +23,10 @@ public static class AzureAuthentication
     {
         if (isDevelopment)
         {
-            return new ChainedTokenCredential(new AzureCliCredential(), new VisualStudioCredential(), new VisualStudioCodeCredential()); // CodeQL [SM05137] This is non-production testing code which is not deployed
+            return new ChainedTokenCredential(
+                new AzureCliCredential(),
+                new VisualStudioCredential(),
+                new VisualStudioCodeCredential()); // CodeQL [SM05137] This is non-production testing code which is not deployed
         }
         else
         {

--- a/src/Microsoft.DotNet.Darc/DarcLib/Helpers/AzureAuthentication.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/Helpers/AzureAuthentication.cs
@@ -23,7 +23,7 @@ public static class AzureAuthentication
     {
         if (isDevelopment)
         {
-            return new DefaultAzureCredential(); // CodeQL [SM05137] This is non-production testing code which is not deployed
+            return new ChainedTokenCredential(new AzureCliCredential(), new VisualStudioCredential(), new VisualStudioCodeCredential()); // CodeQL [SM05137] This is non-production testing code which is not deployed
         }
         else
         {


### PR DESCRIPTION
I started getting errors around the managed identity credential erroring out and the service failed to start

Might have started after #6399