### PR TITLE
Update fromBranch message for clarity on availability

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -276,7 +276,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
         if (string.IsNullOrEmpty(currentDescription))
         {
             // if PR is new, create the new subscription update section along with the PR header
-            string fromBranch = subscription.LastAppliedBuild != null ? $"`{subscription.LastAppliedBuild.GetBranch()}`" : "branch";
+            string fromBranch = subscription.LastAppliedBuild != null ? $"{subscription.LastAppliedBuild.GetBranch()}" : "<branch not available>";
             var prHeader = unsafeFlow
                 ? $"""
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -276,7 +276,8 @@ internal class PullRequestBuilder : IPullRequestBuilder
         if (string.IsNullOrEmpty(currentDescription))
         {
             // if PR is new, create the new subscription update section along with the PR header
-            string fromBranch = subscription.LastAppliedBuild != null ? $"{subscription.LastAppliedBuild.GetBranch()}" : "<branch not available>";
+string? lastAppliedBranch = subscription.LastAppliedBuild?.GetBranch();
+string fromBranch = string.IsNullOrEmpty(lastAppliedBranch) ? "<branch not available>" : lastAppliedBranch;
             var prHeader = unsafeFlow
                 ? $"""
 

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -276,8 +276,8 @@ internal class PullRequestBuilder : IPullRequestBuilder
         if (string.IsNullOrEmpty(currentDescription))
         {
             // if PR is new, create the new subscription update section along with the PR header
-string? lastAppliedBranch = subscription.LastAppliedBuild?.GetBranch();
-string fromBranch = string.IsNullOrEmpty(lastAppliedBranch) ? "<branch not available>" : lastAppliedBranch;
+            string? lastAppliedBranch = subscription.LastAppliedBuild?.GetBranch();
+            string fromBranch = string.IsNullOrEmpty(lastAppliedBranch) ? "<branch not available>" : lastAppliedBranch;
             var prHeader = unsafeFlow
                 ? $"""
 


### PR DESCRIPTION
Right now you just get "... being divergent from the previously flown `branch`" which is misleading.

Also fix the double-escaping when the branch name is available, we already wrap the string in backticks in the PR message.

Related issue: https://github.com/dotnet/arcade-services/issues/6390