### PR TITLE
Fix last flow detection when last backflow was from a different branch

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrBackflower.cs
@@ -495,7 +495,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
                     cancellationToken);
             }
 
-            LastFlows lastFlows = await GetLastFlowsAsync(mapping.Name, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow, headBranchExisted);
+            LastFlows lastFlows = await GetLastFlowsAsync(mapping.Name, targetBranch, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow, headBranchExisted);
             return (headBranchExisted, mapping, lastFlows, targetRepo);
         }
         catch (NotFoundException)
@@ -531,7 +531,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
                 throw new TargetBranchNotFoundException($"Failed to find target branch {targetBranch} in {string.Join(", ", remotes)}", e);
             }
 
-            LastFlows lastFlows = await GetLastFlowsAsync(mapping.Name, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow, headBranchExisted);
+            LastFlows lastFlows = await GetLastFlowsAsync(mapping.Name, targetBranch, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow, headBranchExisted);
 
             await targetRepo.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
 
@@ -591,7 +591,7 @@ public class VmrBackFlower : VmrCodeFlower, IVmrBackFlower
             resetToRemote: false,
             cancellationToken);
 
-        previousFlows = await GetLastFlowsAsync(mapping.Name, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: true);
+        previousFlows = await GetLastFlowsAsync(mapping.Name, targetBranch, targetRepo, currentIsBackflow: true, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: true);
         previousFlow = previousFlows.LastBackFlow
             ?? throw new DarcException($"No more backflows found to recreate from {previousFlowSha}");
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -21,6 +21,7 @@ public interface IVmrCodeFlower
 {
     Task<LastFlows> GetLastFlowsAsync(
         string mappingName,
+        string targetBranch,
         ILocalGitRepo repoClone,
         bool currentIsBackflow,
         bool ignoreNonLinearFlow,
@@ -350,6 +351,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
     /// </summary>
     public async Task<LastFlows> GetLastFlowsAsync(
         string mappingName,
+        string targetBranch,
         ILocalGitRepo repoClone,
         bool currentIsBackflow,
         bool ignoreNonLinearFlow,
@@ -443,16 +445,14 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
         if (!currentIsBackflow && isForwardOlder)
         {
             var vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
-            var currentVmrSha = await vmr.GetShaForRefAsync();
 
-            // We can tell the above by checking if the current target VMR commit is a child of the last backflow commit.
-            // For normal flows it should be, but for the case described above it will be on a different branch.
-            if (!headBranchExisted && !await vmr.IsAncestorCommit(lastBackflow.VmrSha, currentVmrSha))
+            // We can tell the above by checking if the last backflown VMR sha belongs to the target branch
+            if (!await vmr.IsAncestorCommit(targetBranch, lastBackflow.VmrSha))
             {
-                _logger.LogWarning("Last detected backflow ({sha1}) from VMR is from a different branch than target VMR sha ({sha2}). " +
+                _logger.LogWarning("Last detected backflow ({sha1}) from VMR is from a different branch than target VMR branch {branch}. " +
                     "Ignoring backflow and considering the last forward flow to be the last flow.",
                     lastBackflow.VmrSha,
-                    currentVmrSha);
+                    targetBranch);
 
                 return new LastFlows(
                     LastFlow: lastForwardFlow,

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrCodeflower.cs
@@ -447,7 +447,7 @@ public abstract class VmrCodeFlower : IVmrCodeFlower
             var vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
 
             // We can tell the above by checking if the last backflown VMR sha belongs to the target branch
-            if (!await vmr.IsAncestorCommit(targetBranch, lastBackflow.VmrSha))
+            if (!await vmr.IsAncestorCommit(lastBackflow.VmrSha, targetBranch))
             {
                 _logger.LogWarning("Last detected backflow ({sha1}) from VMR is from a different branch than target VMR branch {branch}. " +
                     "Ignoring backflow and considering the last forward flow to be the last flow.",

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrForwardFlower.cs
@@ -223,7 +223,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 ShouldResetVmr,
                 cancellationToken);
 
-            LastFlows lastFlows = await GetLastFlowsAsync(mappingName, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow, headBranchExisted);
+            LastFlows lastFlows = await GetLastFlowsAsync(mappingName, baseBranch, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow, headBranchExisted);
             return (headBranchExisted, lastFlows);
         }
         catch (NotFoundException)
@@ -246,7 +246,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
                 throw new TargetBranchNotFoundException($"Failed to find target branch {baseBranch} in {vmrUri}", e);
             }
 
-            LastFlows lastFlows = await GetLastFlowsAsync(mappingName, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow, headBranchExisted);
+            LastFlows lastFlows = await GetLastFlowsAsync(mappingName, baseBranch, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow, headBranchExisted);
 
             await vmr.CreateBranchAsync(headBranch, overwriteExistingBranch: true);
 
@@ -502,7 +502,7 @@ public class VmrForwardFlower : VmrCodeFlower, IVmrForwardFlower
             cancellationToken);
 
         await sourceRepo.ForceCheckoutAsync(_sourceManifest.GetRepoVersion(mapping.Name).CommitSha);
-        previousFlows = await GetLastFlowsAsync(mapping.Name, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: true);
+        previousFlows = await GetLastFlowsAsync(mapping.Name, targetBranch, sourceRepo, currentIsBackflow: false, ignoreNonLinearFlow: unsafeFlow, headBranchExisted: true);
         previousFlow = previousFlows.LastForwardFlow;
 
         await vmr.CreateBranchAsync(branchToCreate, overwriteExistingBranch: true);

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestUpdaters/CodeFlowPullRequestUpdater.cs
@@ -895,26 +895,32 @@ internal class CodeFlowPullRequestUpdater : PullRequestUpdater
             _logger.LogInformation(
                 "Codeflow approval check for PR {prUrl} passed; approving the pull request",
                 pr.Url);
-            var previousSourceSha = codeflowApprovalCheck.PreviousSourceSha;
-            var currentSourceSha = codeflowApprovalCheck.CurrentSourceSha;
-            var commitDiffLink =
-                $"[{Commit.GetShortSha(previousSourceSha)}...{Commit.GetShortSha(currentSourceSha)}]" +
-                $"({subscription.SourceRepository}/compare/{previousSourceSha}...{currentSourceSha})";
-            try
-            {
-                await _pullRequestApprover.ApprovePullRequestAsync(
-                    pr.Url,
-                    $"This pull request only contains source updates from {subscription.SourceRepository}." +
-                    Environment.NewLine + Environment.NewLine +
-                    $"- **Commit Diff**: {commitDiffLink}",
-                    cancellationToken);
-            }
-            catch (InvalidOperationException e)
-            {
-                _logger.LogError(e, "Failed to approve PR {prUrl}; discarding the work item as non-retriable", pr.Url);
-                throw new NonRetriableException(
-                    $"Failed to approve pull request {pr.Url}: {e.Message}", e);
-            }
+            await remote.CommentPullRequestAsync(
+                pr.Url,
+                $"This pull request only contains source updates from {subscription.SourceRepository} " +
+                $"between commits {codeflowApprovalCheck.PreviousSourceSha} and {codeflowApprovalCheck.CurrentSourceSha}.");
+            // don't approve the PRs until we start signing and verifying the commits
+            // https://github.com/dotnet/arcade-services/issues/6482
+            //var previousSourceSha = codeflowApprovalCheck.PreviousSourceSha;
+            //var currentSourceSha = codeflowApprovalCheck.CurrentSourceSha;
+            //var commitDiffLink =
+            //    $"[{Commit.GetShortSha(previousSourceSha)}...{Commit.GetShortSha(currentSourceSha)}]" +
+            //    $"({subscription.SourceRepository}/compare/{previousSourceSha}...{currentSourceSha})";
+            //try
+            //{
+            //    await _pullRequestApprover.ApprovePullRequestAsync(
+            //        pr.Url,
+            //        $"This pull request only contains source updates from {subscription.SourceRepository}." +
+            //        Environment.NewLine + Environment.NewLine +
+            //        $"- **Commit Diff**: {commitDiffLink}",
+            //        cancellationToken);
+            //}
+            //catch (InvalidOperationException e)
+            //{
+            //    _logger.LogError(e, "Failed to approve PR {prUrl}; discarding the work item as non-retriable", pr.Url);
+            //    throw new NonRetriableException(
+            //        $"Failed to approve pull request {pr.Url}: {e.Message}", e);
+            //}
         }
         else
         {

--- a/test/Darc/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrCodeFlowerGetLastFlowsTests.cs
+++ b/test/Darc/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrCodeFlowerGetLastFlowsTests.cs
@@ -21,6 +21,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 {
     private const string MappingName = "test-repo";
     private const string RepoUri = "https://github.com/dotnet/test-repo";
+    private const string TargetBranch = "branch";
 
     private const string LastForwardRepoSha = "forward-repo-sha";
     private const string LastForwardVmrSha = "forward-vmr-sha";
@@ -116,7 +117,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
-            "branch",
+            TargetBranch,
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,
@@ -140,11 +141,11 @@ public class VmrCodeFlowerGetLastFlowsTests
         _repoClone
             .Setup(x => x.IsAncestorCommit(LastBackflowRepoSha, LastForwardRepoSha))
             .ReturnsAsync(false);
-        _vmrRepo.Setup(x => x.IsAncestorCommit(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
+        _vmrRepo.Setup(x => x.IsAncestorCommit(LastBackflowVmrSha, TargetBranch)).ReturnsAsync(true);
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
-            "branch",
+            TargetBranch,
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,
@@ -168,7 +169,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
-            "branch",
+            TargetBranch,
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,
@@ -195,13 +196,10 @@ public class VmrCodeFlowerGetLastFlowsTests
         _vmrRepo
             .Setup(x => x.GetShaForRefAsync(null))
             .ReturnsAsync(currentVmrSha);
-        _vmrRepo
-            .Setup(x => x.IsAncestorCommit(LastBackflowVmrSha, currentVmrSha))
-            .ReturnsAsync(false);
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
-            "branch",
+            TargetBranch,
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,
@@ -225,7 +223,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
-            "branch",
+            TargetBranch,
             _repoClone.Object,
             currentIsBackflow: true,
             ignoreNonLinearFlow: false,
@@ -245,7 +243,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         Func<Task> act = () => _codeFlower.GetLastFlowsAsync(
             MappingName,
-            "branch",
+            TargetBranch,
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,
@@ -264,7 +262,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
-            "branch",
+            TargetBranch,
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: true,
@@ -288,7 +286,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         Func<Task> act = () => _codeFlower.GetLastFlowsAsync(
             MappingName,
-            "branch",
+            TargetBranch,
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,
@@ -316,7 +314,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
-            "branch",
+            TargetBranch,
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,

--- a/test/Darc/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrCodeFlowerGetLastFlowsTests.cs
+++ b/test/Darc/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/VmrCodeFlowerGetLastFlowsTests.cs
@@ -116,6 +116,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
+            "branch",
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,
@@ -139,9 +140,11 @@ public class VmrCodeFlowerGetLastFlowsTests
         _repoClone
             .Setup(x => x.IsAncestorCommit(LastBackflowRepoSha, LastForwardRepoSha))
             .ReturnsAsync(false);
+        _vmrRepo.Setup(x => x.IsAncestorCommit(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
+            "branch",
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,
@@ -165,6 +168,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
+            "branch",
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,
@@ -197,6 +201,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
+            "branch",
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,
@@ -220,6 +225,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
+            "branch",
             _repoClone.Object,
             currentIsBackflow: true,
             ignoreNonLinearFlow: false,
@@ -239,6 +245,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         Func<Task> act = () => _codeFlower.GetLastFlowsAsync(
             MappingName,
+            "branch",
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,
@@ -257,6 +264,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
+            "branch",
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: true,
@@ -280,6 +288,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         Func<Task> act = () => _codeFlower.GetLastFlowsAsync(
             MappingName,
+            "branch",
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,
@@ -307,6 +316,7 @@ public class VmrCodeFlowerGetLastFlowsTests
 
         var result = await _codeFlower.GetLastFlowsAsync(
             MappingName,
+            "branch",
             _repoClone.Object,
             currentIsBackflow: false,
             ignoreNonLinearFlow: false,

--- a/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/CodeflowApprovalCheckTests.cs
+++ b/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/CodeflowApprovalCheckTests.cs
@@ -12,7 +12,8 @@ namespace ProductConstructionService.DependencyFlow.Tests;
 /// security-sensitive because a passing check produces an approving review, so we assert
 /// that an approval is requested only when the PR's diff matches the expected source diff.
 /// </summary>
-[TestFixture, NonParallelizable]
+[TestFixture, NonParallelizable, Ignore("TODO https://github.com/dotnet/arcade-services/issues/6482")]
+
 internal class CodeflowApprovalCheckTests : UpdateAssetsPullRequestUpdaterTests
 {
     private const string PreviousSourceSha = "previous.source.sha";


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/6390

Also disables the PR approval added in a previous PR. We'll re enable it after we start signing commits