### PR TITLE
Migrate PCS Redis to Azure Managed Redis (#8469)

### DIFF
--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -316,7 +316,7 @@ az account get-access-token --resource https://redis.azure.com --query accessTok
 Run the following command:
 
 ```bash
-redis-cli -h product-construction-service-redis-prod.redis.cache.windows.net -p 6380 --tls
+redis-cli -h product-construction-service-redis-prod.westus2.redis.azure.net -p 10000 --tls
 ```
 
 Once inside the CLI, authenticate using:

--- a/eng/pipelines/templates/stages/deploy.yaml
+++ b/eng/pipelines/templates/stages/deploy.yaml
@@ -75,7 +75,7 @@ stages:
     - name: authServiceConnection
       value: "Darc: Maestro Production"
     - name: redisConnectionString
-      value: "product-construction-service-redis-prod.redis.cache.windows.net,ssl=true"
+      value: "product-construction-service-redis-prod.westus2.redis.azure.net:10000,ssl=true"
 
   - ${{ else }}:
     - name: subscriptionId
@@ -89,7 +89,7 @@ stages:
     - name: authServiceConnection
       value: "Darc: Maestro Staging"
     - name: redisConnectionString
-      value: "product-construction-service-redis-int.redis.cache.windows.net:6380,ssl=true"
+      value: "product-construction-service-redis-int.westus2.redis.azure.net:10000,ssl=true"
 
   jobs:
   - job: DeployPCS

--- a/eng/service-templates/ProductConstructionService/redis.bicep
+++ b/eng/service-templates/ProductConstructionService/redis.bicep
@@ -3,42 +3,57 @@ param azureCacheRedisName string
 param pcsIdentityPrincipalId string
 param deploymentIdentityPrincipalId string
 
-resource redisCache 'Microsoft.Cache/redis@2024-03-01' = {
+// Azure Managed Redis (Microsoft.Cache/redisEnterprise). The classic
+// Microsoft.Cache/redis Basic/Standard/Premium tiers are retiring: no new
+// classic instances can be created after 1 Oct 2026, and all remaining
+// instances are disabled on 30 Sep 2028. See AzDO #8469.
+resource redisCache 'Microsoft.Cache/redisEnterprise@2025-05-01-preview' = {
   name: azureCacheRedisName
   location: location
+  sku: {
+      name: 'Balanced_B0'
+  }
   properties: {
-      enableNonSslPort: false
       minimumTlsVersion: '1.2'
-      sku: {
-          capacity: 0
-          family: 'C'
-          name: 'Basic'
-      }
-      redisConfiguration: {
-          'aad-enabled': 'true'
-      }
-      disableAccessKeyAuthentication: true
+      highAvailability: 'Disabled'
+  }
+}
+
+resource redisDatabase 'Microsoft.Cache/redisEnterprise/databases@2025-05-01-preview' = {
+  name: 'default'
+  parent: redisCache
+  properties: {
+      clientProtocol: 'Encrypted'
+      port: 10000
+      clusteringPolicy: 'OSSCluster'
+      evictionPolicy: 'NoEviction'
+      accessKeysAuthentication: 'Disabled'
   }
 }
 
 // allow redis cache read / write access to the service's identity
-resource pcsRedisDataContributorRoleAssignment 'Microsoft.Cache/redis/accessPolicyAssignments@2024-03-01' = {
-  name: guid(subscription().id, resourceGroup().id, 'pcsDataContributor')
-  parent: redisCache
+resource pcsRedisDataContributorRoleAssignment 'Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments@2025-05-01-preview' = {
+  name: 'pcsDataContributor'
+  parent: redisDatabase
   properties: {
-      accessPolicyName: 'Data Contributor'
-      objectId: pcsIdentityPrincipalId
-      objectIdAlias: 'PCS Managed Identity'
+      accessPolicyName: 'default'
+      user: {
+          objectId: pcsIdentityPrincipalId
+      }
   }
 }
 
-// allow redis cache read / write access to the service's identity
-resource deploymentRedisDataContributorRoleAssignment 'Microsoft.Cache/redis/accessPolicyAssignments@2024-03-01' = {
-  name: guid(subscription().id, resourceGroup().id, 'deploymentDataContributor')
-  parent: redisCache
+// allow redis cache read / write access to the deployment's identity
+resource deploymentRedisDataContributorRoleAssignment 'Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments@2025-05-01-preview' = {
+  name: 'deploymentDataContributor'
+  parent: redisDatabase
   properties: {
-      accessPolicyName: 'Data Contributor'
-      objectId: deploymentIdentityPrincipalId
-      objectIdAlias: 'PCS Managed Identity'
+      accessPolicyName: 'default'
+      user: {
+          objectId: deploymentIdentityPrincipalId
+      }
   }
 }
+
+output redisCacheHostName string = redisCache.properties.hostName
+output redisCachePort int = redisDatabase.properties.port

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Production.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Production.json
@@ -2,7 +2,7 @@
     "KeyVaultName": "ProductConstructionProd",
     "ConnectionStrings": {
         "queues": "https://productconstructionprod.queue.core.windows.net",
-        "redis": "product-construction-service-redis-prod.redis.cache.windows.net:6380,ssl=true,syncTimeout=10000"
+        "redis": "product-construction-service-redis-prod.westus2.redis.azure.net:10000,ssl=true,syncTimeout=10000"
     },
     "ManagedIdentityClientId": "e49bf24a-ec75-490b-803b-6fad99d19159",
     "BuildAssetRegistrySqlConnectionString": "Server=tcp:maestro-prod.database.windows.net,1433;Database=BuildAssetRegistry;Encrypt=True;TrustServerCertificate=False;Authentication=Active Directory Managed Identity;User Id=USER_ID_PLACEHOLDER",

--- a/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
+++ b/src/ProductConstructionService/ProductConstructionService.Api/appsettings.Staging.json
@@ -2,7 +2,7 @@
     "KeyVaultName": "ProductConstructionInt",
     "ConnectionStrings": {
         "queues": "https://productconstructionint.queue.core.windows.net",
-        "redis": "product-construction-service-redis-int.redis.cache.windows.net:6380,ssl=true,syncTimeout=10000"
+        "redis": "product-construction-service-redis-int.westus2.redis.azure.net:10000,ssl=true,syncTimeout=10000"
     },
     "ManagedIdentityClientId": "1d43ba8a-c2a6-4fad-b064-6d8c16fc0745",
     "BuildAssetRegistrySqlConnectionString": "Server=tcp:maestro-int-server.database.windows.net,1433;Database=BuildAssetRegistry;Encrypt=True;TrustServerCertificate=False;Authentication=Active Directory Managed Identity;User Id=USER_ID_PLACEHOLDER",


### PR DESCRIPTION
Migrates the Product Construction Service (PCS) Redis from the retiring classic **Azure Cache for Redis** (`Microsoft.Cache/redis`) to **Azure Managed Redis** (`Microsoft.Cache/redisEnterprise`), and cuts over every connection-string consumer.

**Why:** classic `Microsoft.Cache/redis` Basic/Standard/Premium tiers are retiring — no new instances can be created after **1 Oct 2026**, and all instances are disabled **30 Sep 2028**. PCS actively uses Redis (`PcsStartup` -> `RedisCacheExtensions.AddRedisCache`), so it must move to a supported product.

**No app-code change needed:** `AddRedisCache` is connection-string-driven and already uses `ConfigurationOptions.Parse` + `ConfigureForAzureAsync` (Entra auth via `Microsoft.Azure.StackExchangeRedis`). StackExchange.Redis handles the OSS-cluster endpoint transparently. Only the endpoint values change.

**Changes**
- `eng/service-templates/ProductConstructionService/redis.bicep`: classic `Microsoft.Cache/redis` -> `redisEnterprise` Balanced_B0 + `databases/default` (port 10000, OSS cluster, Encrypted, access keys disabled) + `accessPolicyAssignments` for the PCS and deployment identities (Entra data-plane access)
- `appsettings.Staging.json` / `appsettings.Production.json`: `redis` connection string -> `<name>.westus2.redis.azure.net:10000` (was `.redis.cache.windows.net:6380`)
- `eng/pipelines/templates/stages/deploy.yaml`: `redisConnectionString` pipeline vars (int + prod) -> new AMR endpoints
- `docs/DevGuide.md`: `redis-cli` example -> new host/port

**Cutover note:** AMR (`redisEnterprise`) and classic (`redis`) are different resource types, so the new instance is provisioned alongside the old one. After deploy verifies healthy, the orphaned classic instance must be manually deleted.

Work item: https://dnceng.visualstudio.com/internal/_workitems/edit/8469
