### PR TITLE
Allow hyphens in Azure DevOps organization names when parsing URIs

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/AzureDevOpsClient.cs
@@ -43,13 +43,13 @@ public class AzureDevOpsClient : RemoteRepoBase, IRemoteGitRepo, IAzureDevOpsCli
         "\n\n[//]: # (This identifies this comment as a Maestro++ comment)\n";
 
     private static readonly Regex RepositoryUriPattern = new(
-        $"^https://{AzureDevOpsHostPattern}/(?<account>[a-zA-Z0-9]+)/(?<project>[a-zA-Z0-9-]+)/_git/(?<repo>[a-zA-Z0-9-\\.]+)");
+        $"^https://{AzureDevOpsHostPattern}/(?<account>[a-zA-Z0-9-]+)/(?<project>[a-zA-Z0-9-]+)/_git/(?<repo>[a-zA-Z0-9-\\.]+)");
 
     private static readonly Regex LegacyRepositoryUriPattern = new(
-        @"^https://(?<account>[a-zA-Z0-9]+)\.visualstudio\.com/(?<project>[a-zA-Z0-9-]+)/_git/(?<repo>[a-zA-Z0-9-\.]+)");
+        @"^https://(?<account>[a-zA-Z0-9-]+)\.visualstudio\.com/(?<project>[a-zA-Z0-9-]+)/_git/(?<repo>[a-zA-Z0-9-\.]+)");
 
     private static readonly Regex PullRequestApiUriPattern = new(
-        $"^https://{AzureDevOpsHostPattern}/(?<account>[a-zA-Z0-9]+)/(?<project>[a-zA-Z0-9-]+)/_apis/git/repositories/(?<repo>[a-zA-Z0-9-\\.]+)/pullRequests/(?<id>\\d+)");
+        $"^https://{AzureDevOpsHostPattern}/(?<account>[a-zA-Z0-9-]+)/(?<project>[a-zA-Z0-9-]+)/_apis/git/repositories/(?<repo>[a-zA-Z0-9-\\.]+)/pullRequests/(?<id>\\d+)");
 
     // Azure DevOps uses this id when creating a new branch as well as when deleting a branch
     private static readonly string BaseObjectId = "0000000000000000000000000000000000000000";

--- a/test/Darc/Microsoft.DotNet.Darc.Tests/AzureDevOpsClientTests.cs
+++ b/test/Darc/Microsoft.DotNet.Darc.Tests/AzureDevOpsClientTests.cs
@@ -14,6 +14,8 @@ public class AzureDevOpsClientTests
     [TestCase("https://dev.azure.com/dnceng/public/_git/foo", "dnceng", "public", "foo")]
     [TestCase("https://borkbork.visualstudio.com/borky/_git/foo2", "borkbork", "borky", "foo2")]
     [TestCase("https://dev.azure.com/dcn2eng/public-s/_git/foo-23bar", "dcn2eng", "public-s", "foo-23bar")]
+    [TestCase("https://dev.azure.com/dcn-eng/public-s/_git/foo-23bar", "dcn-eng", "public-s", "foo-23bar")]
+    [TestCase("https://dcn-eng.visualstudio.com/public-s/_git/foo-23bar", "dcn-eng", "public-s", "foo-23bar")]
     [TestCase("https://dev.azure.com/foo/bar/_git/baz-bop", "foo", "bar", "baz-bop")]
     [TestCase("https://dnceng@dev.azure.com/foo/bar/_git/bebop", "foo", "bar", "bebop")]
     [TestCase("https://dnceng.visualstudio.com/int/_git/bebop", "dnceng", "int", "bebop")]
@@ -25,7 +27,6 @@ public class AzureDevOpsClientTests
         repo.Should().Be(expectedRepo);
     }
 
-    [TestCase("https://dev.azure.com/dcn-eng/public-s/_git/foo-23bar")]
     [TestCase("https://github.com/account/bar")]
     public void ParseInvalidRepoUriTests(string inputUri)
     {
@@ -33,6 +34,7 @@ public class AzureDevOpsClientTests
     }
 
     [TestCase("https://dev.azure.com/foo/bar/_apis/git/repositories/baz98-bop/pullRequests/112", "foo", "bar", "baz98-bop", 112)]
+    [TestCase("https://dev.azure.com/dcn-eng/bar/_apis/git/repositories/baz98-bop/pullRequests/112", "dcn-eng", "bar", "baz98-bop", 112)]
     [TestCase("https://dev.azure.com/foo/bar/_apis/git/repositories/kidz-bop/pullRequests/1133?_a=files", "foo", "bar", "kidz-bop", 1133)]
     [TestCase("https://dev.azure.com/foo/bar/_apis/git/repositories/baz-bop/pullRequests/141?_a=files&path=%2F.build%2Frestore.yaml", "foo", "bar", "baz-bop", 141)]
     public void ParseValidPullRequestUriTests(string inputUri, string expectedAccount,


### PR DESCRIPTION


`AzureDevOpsClient`'s URI regexes limit the `account` segment to `[a-zA-Z0-9]+`, while `project` and `repo` both allow hyphens. Azure DevOps [permits hyphens in organization names](https://learn.microsoft.com/en-us/azure/devops/organizations/settings/naming-restrictions?view=azure-devops), so any repo in a hyphenated org fails to parse:

AzureDevOpsClient.ParseRepoUri("https://dev.azure.com/my-org/my-project/_git/my-repo");
// System.ArgumentException: Repository URI should be in the form ...

Parsing happens before any network call, so every method taking a `repoUri` (`SearchPullRequestsAsync`, `DoesBranchExistAsync`, `CreateBranchAsync`, `CommitFilesWithNoCloningAsync`, `CreatePullRequestAsync`, ...) is unusable against those organizations. `GitHubClient` has no equivalent restriction; it accepts any owner via `[^/]+`.

## Fix

Add `-` to the account character class in `RepositoryUriPattern`, `LegacyRepositoryUriPattern` and `PullRequestApiUriPattern`. 

## Tests

The existing `dcn-eng` case moves from `ParseInvalidRepoUriTests` to `ParseValidRepoUriTests`, with added coverage for the legacy URL form and for a hyphenated org in a pull request API URI. `https://github.com/account/bar` still throws, so non-Azure DevOps URIs are unaffected.

<!-- #1 -->
