### PR TITLE
Scope PCS test client IDs

### DIFF
--- a/eng/pipelines/templates/jobs/e2e-pcs-tests.yml
+++ b/eng/pipelines/templates/jobs/e2e-pcs-tests.yml
@@ -14,9 +14,9 @@ jobs:
       name: NetCore1ESPool-Internal
       demands: ImageOverride -equals 1es-windows-2022
   variables:
-    # https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=20&path=Publish-Build-Assets
+    # https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=239&path=Arcade-Services-PCS-Client-Ids
     # Required for MaestroAppClientId, MaestroStagingAppClientId
-    - group: Publish-Build-Assets
+    - group: Arcade-Services-PCS-Client-Ids
     - ${{ if not(or(startsWith(variables['Build.SourceBranch'], 'refs/heads/production'), startsWith(variables['Build.SourceBranch'], 'refs/heads/production-'), eq(variables['Build.SourceBranch'], 'refs/heads/production'))) }}:
       - name: PcsTestEndpoint
         value: https://maestro.int-dot.net


### PR DESCRIPTION
## Summary
- load PCS deployment-test client IDs from a dedicated variable group
- limit the replacement group to the two arcade-services pipelines that run these tests
- stop exposing the staging client ID through the broad publishing group after cutover

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/10812