### PR TITLE
Fix version files paths in Meaningful Flow Detection, make it work outside of Pcs too

### DIFF
--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeflowChangeAnalyzer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeflowChangeAnalyzer.cs
@@ -75,6 +75,8 @@ public class CodeflowChangeAnalyzer : ICodeflowChangeAnalyzer
         ILocalGitRepo vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
 
         var commonAncestor = await vmr.GetMergeBaseAsync(headBranch, targetBranch);
+        // Codeflow changes may be committed on the checked-out branch (service) or staged in the index (darc).
+        // write-tree gives us the current index tree in either case for comparison with the common ancestor.
         var writeTreeResult = await vmr.ExecuteGitCommand(["write-tree"]);
         writeTreeResult.ThrowIfFailed("Failed to create a tree from the proposed code flow changes");
         var indexTree = writeTreeResult.StandardOutput.Trim();

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeflowChangeAnalyzer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeflowChangeAnalyzer.cs
@@ -75,14 +75,18 @@ public class CodeflowChangeAnalyzer : ICodeflowChangeAnalyzer
         ILocalGitRepo vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
 
         var commonAncestor = await vmr.GetMergeBaseAsync(headBranch, targetBranch);
-        var changedFiles = await vmr.GetChangedFilesAsync(commonAncestor, headBranch);
+        var writeTreeResult = await vmr.ExecuteGitCommand(["write-tree"]);
+        writeTreeResult.ThrowIfFailed("Failed to create a tree from the proposed code flow changes");
+        var indexTree = writeTreeResult.StandardOutput.Trim();
+
+        var changedFiles = await vmr.GetChangedFilesAsync(commonAncestor, indexTree);
 
         if (HasSourceChanges(mappingName, changedFiles))
         {
             return true;
         }
 
-        if (await HasMeaningfulVersioningChanges(mappingName, headBranch, commonAncestor))
+        if (await HasMeaningfulVersioningChanges(mappingName, indexTree, commonAncestor))
         {
             return true;
         }
@@ -129,12 +133,13 @@ public class CodeflowChangeAnalyzer : ICodeflowChangeAnalyzer
 
     private async Task<bool> HasMeaningfulVersioningChanges(
         string mappingName,
-        string headBranch,
+        string indexTree,
         string ancestorCommit)
     {
         ILocalGitRepo vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
 
         var versionFileInclusionRules = DependencyFileManager.CodeflowDependencyFiles
+            .Select(f => $"src/{mappingName}/{f}")
             .Select(VmrPatchHandler.GetInclusionRule)
             .ToList();
 
@@ -142,16 +147,16 @@ public class CodeflowChangeAnalyzer : ICodeflowChangeAnalyzer
         [
             "diff",
             "-U0",
-            $"{ancestorCommit}..{headBranch}",
+            $"{ancestorCommit}..{indexTree}",
             "--",
             ..versionFileInclusionRules
         ]);
 
-        result.ThrowIfFailed($"Failed to get the changes between {ancestorCommit} and {headBranch}");
+        result.ThrowIfFailed($"Failed to get the changes between {ancestorCommit} and the proposed code flow tree");
 
         // We load all different pieces of build information that would be expected in the diff output
         Build? build1 = await GetBuildFromSourceTag(vmr, mappingName, ancestorCommit);
-        Build? build2 = await GetBuildFromSourceTag(vmr, mappingName, headBranch);
+        Build? build2 = await GetBuildFromSourceTag(vmr, mappingName, indexTree);
 
         List<string> expectedContents =
         [

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeflowChangeAnalyzer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeflowChangeAnalyzer.cs
@@ -139,7 +139,7 @@ public class CodeflowChangeAnalyzer : ICodeflowChangeAnalyzer
         ILocalGitRepo vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
 
         var versionFileInclusionRules = DependencyFileManager.CodeflowDependencyFiles
-            .Select(f => $"src/{mappingName}/{f}")
+            .Select(f => (VmrInfo.GetRelativeRepoSourcesPath(mappingName) / f).ToString())
             .Select(VmrPatchHandler.GetInclusionRule)
             .ToList();
 

--- a/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeflowChangeAnalyzer.cs
+++ b/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/CodeflowChangeAnalyzer.cs
@@ -229,13 +229,14 @@ public class CodeflowChangeAnalyzer : ICodeflowChangeAnalyzer
             .Select(l => l.Location)
             .Distinct();
 
-        return
-        [
+        IEnumerable<string> ret = [
             b.Id.ToString(),
             b.Commit,
             b.GetRepository(),
             ..b.Assets.Select(a => a.Version).Distinct(),
             ..darcFeeds,
         ];
+
+        return ret.Where(s => !string.IsNullOrEmpty(s));
     }
 }

--- a/test/Darc/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/CodeflowChangeAnalyzerTests.cs
+++ b/test/Darc/Microsoft.DotNet.DarcLib.Tests/VirtualMonoRepo/CodeflowChangeAnalyzerTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using AwesomeAssertions;
 using Microsoft.DotNet.DarcLib.Helpers;
 using Microsoft.DotNet.DarcLib.Models;
-using Microsoft.DotNet.DarcLib.Models.VirtualMonoRepo;
 using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -24,6 +23,7 @@ public class CodeflowChangeAnalyzerTests
     private const string TestHeadBranch = "feature-branch";
     private const string TestTargetBranch = "main";
     private const string TestAncestorCommit = "ee69bb149b4824b93abb3d6b029aeacfa30d6207";
+    private const string TestProposedTree = "ba1f433a7881beacfea40f5e9403f7309eaae132";
     private static readonly NativePath TestVmrPath = new("/path/to/vmr");
 
     private Mock<ILocalGitRepoFactory> _localGitRepoFactory = null!;
@@ -49,6 +49,16 @@ public class CodeflowChangeAnalyzerTests
         _localGitRepo
             .Setup(x => x.GetMergeBaseAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(TestAncestorCommit);
+
+        _localGitRepo
+            .Setup(x => x.ExecuteGitCommand(It.Is<string[]>(args =>
+                args.Length == 1 &&
+                args[0] == "write-tree")))
+            .ReturnsAsync(new ProcessExecutionResult
+            {
+                StandardOutput = TestProposedTree,
+                ExitCode = 0,
+            });
 
         _analyzer = new CodeflowChangeAnalyzer(
             _localGitRepoFactory.Object,
@@ -207,7 +217,7 @@ public class CodeflowChangeAnalyzerTests
     private void SetChangedFiles(IReadOnlyCollection<string> changedFiles)
     {
         _localGitRepo
-            .Setup(x => x.GetChangedFilesAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(x => x.GetChangedFilesAsync(TestAncestorCommit, TestProposedTree))
             .ReturnsAsync(changedFiles);
     }
 
@@ -224,7 +234,7 @@ public class CodeflowChangeAnalyzerTests
                 args.Length > 2 &&
                 args[0] == "diff" &&
                 args[1] == "-U0" &&
-                args[2] == $"{TestAncestorCommit}..{TestHeadBranch}")))
+                args[2] == $"{TestAncestorCommit}..{TestProposedTree}")))
             .ReturnsAsync(result);
     }
 
@@ -243,7 +253,7 @@ public class CodeflowChangeAnalyzerTests
             .ReturnsAsync("<Dependencies><Source BarId=\"270662\" /></Dependencies>");
 
         _localGitRepo
-            .Setup(x => x.GetFileFromGitAsync("src/test-repo/eng/Version.Details.xml", TestHeadBranch, null))
+            .Setup(x => x.GetFileFromGitAsync("src/test-repo/eng/Version.Details.xml", TestProposedTree, null))
             .ReturnsAsync("<Dependencies><Source BarId=\"271018\" /></Dependencies>");
 
         _versionDetailsParser


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/6537

The test we have for this wasn't really doing anything previously, it was a false positive because we were looking at the head branch that had no diffs from the ancestorCommit, this PR fixes that and running the meaningful detection locally in general

Second, the version file paths were missing the relative source repo path.

Third, the expectedContents had empty strings for some reason, and they were causing the ContainsUnexpectedChange method to not work properly