### PR TITLE
Isolate Product Construction storage network access

### DIFF
--- a/eng/service-templates/ProductConstructionService/provision.bicep
+++ b/eng/service-templates/ProductConstructionService/provision.bicep
@@ -382,6 +382,7 @@ module storageAccountModule 'storage-account.bicep' = {
         subscriptionTriggererIdentityPrincipalId: managedIdentitiesModule.outputs.subscriptionTriggererIdentityPrincipalId
         blobContributorRole: blobContributorRole
         storageQueueContrubutorRole: storageQueueContrubutorRole
+        allowedSubnetId: virtualNetworkModule.outputs.productConstructionServiceSubnetId
     }
 }
 

--- a/eng/service-templates/ProductConstructionService/storage-account.bicep
+++ b/eng/service-templates/ProductConstructionService/storage-account.bicep
@@ -18,7 +18,6 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
       publicNetworkAccess: 'Enabled'
       allowSharedKeyAccess: false
       networkAcls: {
-          bypass: 'AzureServices'
           defaultAction: 'Deny'
           virtualNetworkRules: [
               {

--- a/eng/service-templates/ProductConstructionService/storage-account.bicep
+++ b/eng/service-templates/ProductConstructionService/storage-account.bicep
@@ -4,6 +4,7 @@ param pcsIdentityPrincipalId string
 param subscriptionTriggererIdentityPrincipalId string
 param storageQueueContrubutorRole string
 param blobContributorRole string
+param allowedSubnetId string
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   name: storageAccountName
@@ -17,7 +18,14 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
       publicNetworkAccess: 'Enabled'
       allowSharedKeyAccess: false
       networkAcls: {
+          bypass: 'AzureServices'
           defaultAction: 'Deny'
+          virtualNetworkRules: [
+              {
+                  action: 'Allow'
+                  id: allowedSubnetId
+              }
+          ]
       }
   }
 }

--- a/eng/service-templates/ProductConstructionService/virtual-network.bicep
+++ b/eng/service-templates/ProductConstructionService/virtual-network.bicep
@@ -32,6 +32,11 @@ resource productConstructionServiceSubnet 'Microsoft.Network/virtualNetworks/sub
               }
           }
       ]
+      serviceEndpoints: [
+          {
+              service: 'Microsoft.Storage'
+          }
+      ]
       networkSecurityGroup: {
           id: networkSecurityGroupId
       }


### PR DESCRIPTION
## Summary

- enable the `Microsoft.Storage` service endpoint on the Product Construction Container Apps subnet
- allow that subnet through the Product Construction storage account's virtual network rules
- preserve the storage account's existing infrastructure-as-code intent of `defaultAction: Deny`

## Why

Azure Policy audit coverage identified `productconstructionprod` as non-compliant because the deployed account has `defaultAction: Allow`. The service is active, so changing the firewall without first establishing an allowed network path would risk an outage.

The Container Apps environment is already VNet-integrated. This change makes that subnet the explicit storage data-plane path before the existing `Deny` declaration is reconciled.

## Validation

- `az bicep build` succeeds
- staging what-if confirms the subnet gains only the `Microsoft.Storage` service endpoint
- staging what-if confirms `productconstructionint` changes from `Allow` to `Deny` and gains the matching subnet virtual network rule

## Rollout

Deploy and validate staging first. Confirm the API, scheduled jobs, queue/blob transactions, and storage error metrics remain healthy before deploying production. Enabling a Storage service endpoint changes the source path for other regional Storage traffic from this subnet, so staging smoke tests should include any external artifact reads.

Work item: https://dev.azure.com/dnceng/internal/_workitems/edit/6339

AB#6339
