### PR TITLE
Lookup builds in which assets were produced to correctly determine origin repo

### DIFF
--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -16,6 +16,7 @@ using ProductConstructionService.DependencyFlow.Model;
 using ProductConstructionService.DependencyFlow.PullRequestUpdaters;
 using ProductConstructionService.DependencyFlow.WorkItems;
 
+using AssetDTO = Microsoft.DotNet.ProductConstructionService.Client.Models.Asset;
 using BuildDTO = Microsoft.DotNet.ProductConstructionService.Client.Models.Build;
 
 namespace ProductConstructionService.DependencyFlow;
@@ -408,7 +409,7 @@ internal class PullRequestBuilder : IPullRequestBuilder
         var sourceBranch = build.GetBranch();
 
         string sourceDiffText = CreateSourceDiffLink(build, previousSourceCommit);
-        string dependencyUpdateBlock = CreateDependencyUpdateBlock(dependencyUpdates, sourceRepoUri);
+        string dependencyUpdateBlock = await CreateDependencyUpdateBlockAsync(dependencyUpdates, build);
         return
             $"""
 
@@ -427,9 +428,71 @@ internal class PullRequestBuilder : IPullRequestBuilder
             """;
     }
 
-    internal static string CreateDependencyUpdateBlock(
+    private async Task<string> CreateDependencyUpdateBlockAsync(
         List<DependencyUpdateSummary> dependencyUpdateSummaries,
-        string repoUri)
+        BuildDTO sourceBuild)
+    {
+       Dictionary<int, BuildDTO> builds = new()
+        {
+            [sourceBuild.Id] = sourceBuild
+        };
+
+        return await CreateDependencyUpdateBlockAsync(
+            dependencyUpdateSummaries,
+            async dependency => (await GetProducingBuildAsync(dependency, builds)).GetRepository());
+    }
+
+    private async Task<BuildDTO> GetProducingBuildAsync(
+        DependencyUpdateSummary dependency,
+        Dictionary<int, BuildDTO> builds)
+    {
+        BuildDTO? producingBuild = builds.Values.FirstOrDefault(
+            build => BuildContainsDependency(build, dependency));
+        if (producingBuild != null)
+        {
+            return producingBuild;
+        }
+
+        IEnumerable<AssetDTO> matchingAssets = await _barClient.GetAssetsAsync(
+            dependency.DependencyName,
+            dependency.ToVersion);
+
+        foreach (int buildId in matchingAssets
+            .Select(asset => asset.BuildId)
+            .Distinct()
+            .OrderByDescending(buildId => buildId))
+        {
+            BuildDTO candidateBuild = await _barClient.GetBuildAsync(buildId)
+                ?? throw new InvalidOperationException(
+                    $"Could not find build '{buildId}' for asset '{dependency.DependencyName}'.");
+            builds.Add(candidateBuild.Id, candidateBuild);
+
+            if (candidateBuild.Commit == dependency.ToCommitSha)
+            {
+                return candidateBuild;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Could not find the build that produced asset '{dependency.DependencyName}' " +
+            $"version '{dependency.ToVersion}' at commit '{dependency.ToCommitSha}'.");
+    }
+
+    private static bool BuildContainsDependency(BuildDTO build, DependencyUpdateSummary dependency) =>
+        build.Assets.Any(asset =>
+            asset.Name == dependency.DependencyName &&
+            asset.Version == dependency.ToVersion);
+
+    internal static Task<string> CreateDependencyUpdateBlockForRepositoryAsync(
+        List<DependencyUpdateSummary> dependencyUpdateSummaries,
+        string repository) =>
+        CreateDependencyUpdateBlockAsync(
+            dependencyUpdateSummaries,
+            _ => Task.FromResult(repository));
+
+    private static async Task<string> CreateDependencyUpdateBlockAsync(
+        List<DependencyUpdateSummary> dependencyUpdateSummaries,
+        Func<DependencyUpdateSummary, Task<string>> getRepositoryAsync)
     {
         if (dependencyUpdateSummaries.Count == 0)
         {
@@ -442,10 +505,10 @@ internal class PullRequestBuilder : IPullRequestBuilder
         var dependencyGroups = dependencyUpdateSummaries
             .GroupBy(dep => new
             {
-                FromCommitSha = dep.FromCommitSha,
-                FromVersion = dep.FromVersion,
-                ToCommitSha = dep.ToCommitSha,
-                ToVersion = dep.ToVersion
+                dep.FromCommitSha,
+                dep.FromVersion,
+                dep.ToCommitSha,
+                dep.ToVersion
             })
             .ToList();
 
@@ -460,13 +523,17 @@ internal class PullRequestBuilder : IPullRequestBuilder
             stringBuilder.AppendLine("**New Dependencies**");
             foreach (var group in newDependencyGroups)
             {
-                var representative = group.First();
-                string? diffLink = GetLinkForDependencyItem(repoUri, representative.FromCommitSha, representative.ToCommitSha);
+                DependencyUpdateSummary representative = group.First();
+                string repository = await getRepositoryAsync(representative);
+                string? diffLink = GetLinkForDependencyItem(
+                    repository,
+                    representative.FromCommitSha,
+                    representative.ToCommitSha);
                 
                 stringBuilder.AppendLine($"- Added [{representative.ToVersion}]({diffLink})");
-                foreach (var dep in group.OrderBy(dep => dep.DependencyName))
+                foreach (DependencyUpdateSummary dependency in group.OrderBy(dep => dep.DependencyName))
                 {
-                    stringBuilder.AppendLine($"  - {dep.DependencyName}");
+                    stringBuilder.AppendLine($"  - {dependency.DependencyName}");
                 }
             }
         }
@@ -477,12 +544,12 @@ internal class PullRequestBuilder : IPullRequestBuilder
             stringBuilder.AppendLine("**Removed Dependencies**");
             foreach (var group in removedDependencyGroups)
             {
-                var representative = group.First();
+                DependencyUpdateSummary representative = group.First();
                 
                 stringBuilder.AppendLine($"- Removed {representative.FromVersion}");
-                foreach (var dep in group.OrderBy(dep => dep.DependencyName))
+                foreach (DependencyUpdateSummary dependency in group.OrderBy(dep => dep.DependencyName))
                 {
-                    stringBuilder.AppendLine($"  - {dep.DependencyName}");
+                    stringBuilder.AppendLine($"  - {dependency.DependencyName}");
                 }
             }
         }
@@ -494,13 +561,17 @@ internal class PullRequestBuilder : IPullRequestBuilder
 
             foreach (var group in updatedDependencyGroups)
             {
-                var representative = group.First();
-                string? diffLink = GetLinkForDependencyItem(repoUri, representative.FromCommitSha, representative.ToCommitSha);
+                DependencyUpdateSummary representative = group.First();
+                string repository = await getRepositoryAsync(representative);
+                string? diffLink = GetLinkForDependencyItem(
+                    repository,
+                    representative.FromCommitSha,
+                    representative.ToCommitSha);
                 
                 stringBuilder.AppendLine($"- From [{representative.FromVersion} to {representative.ToVersion}]({diffLink})");
-                foreach (var dep in group.OrderBy(dep => dep.DependencyName))
+                foreach (DependencyUpdateSummary dependency in group.OrderBy(dep => dep.DependencyName))
                 {
-                    stringBuilder.AppendLine($"  - {dep.DependencyName}");
+                    stringBuilder.AppendLine($"  - {dependency.DependencyName}");
                 }
             }
         }
@@ -1109,4 +1180,3 @@ internal class PullRequestBuilder : IPullRequestBuilder
         return null;
     }
 }
-

--- a/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
+++ b/src/ProductConstructionService/ProductConstructionService.DependencyFlow/PullRequestBuilder.cs
@@ -428,18 +428,97 @@ internal class PullRequestBuilder : IPullRequestBuilder
             """;
     }
 
-    private async Task<string> CreateDependencyUpdateBlockAsync(
+    internal async Task<string> CreateDependencyUpdateBlockAsync(
         List<DependencyUpdateSummary> dependencyUpdateSummaries,
         BuildDTO sourceBuild)
     {
-       Dictionary<int, BuildDTO> builds = new()
+        if (dependencyUpdateSummaries.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        Dictionary<int, BuildDTO> builds = new()
         {
             [sourceBuild.Id] = sourceBuild
         };
 
-        return await CreateDependencyUpdateBlockAsync(
-            dependencyUpdateSummaries,
-            async dependency => (await GetProducingBuildAsync(dependency, builds)).GetRepository());
+        StringBuilder stringBuilder = new();
+
+        // Group all dependencies by FromCommitSha, FromVersion, ToCommitSha, and ToVersion
+        var dependencyGroups = dependencyUpdateSummaries
+            .GroupBy(dep => new
+            {
+                dep.FromCommitSha,
+                dep.FromVersion,
+                dep.ToCommitSha,
+                dep.ToVersion
+            })
+            .ToList();
+
+        // Separate groups by dependency type
+        var newDependencyGroups = dependencyGroups.Where(g => string.IsNullOrEmpty(g.Key.FromVersion) && !string.IsNullOrEmpty(g.Key.ToVersion)).ToList();
+        var removedDependencyGroups = dependencyGroups.Where(g => string.IsNullOrEmpty(g.Key.ToVersion) && !string.IsNullOrEmpty(g.Key.FromVersion)).ToList();
+        var updatedDependencyGroups = dependencyGroups.Where(g => !string.IsNullOrEmpty(g.Key.FromVersion) && !string.IsNullOrEmpty(g.Key.ToVersion)).ToList();
+
+        if (newDependencyGroups.Count > 0)
+        {
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("**New Dependencies**");
+            foreach (var group in newDependencyGroups)
+            {
+                DependencyUpdateSummary representative = group.First();
+                string repository = (await GetProducingBuildAsync(representative, builds)).GetRepository();
+                string? diffLink = GetLinkForDependencyItem(
+                    repository,
+                    representative.FromCommitSha,
+                    representative.ToCommitSha);
+                
+                stringBuilder.AppendLine($"- Added [{representative.ToVersion}]({diffLink})");
+                foreach (DependencyUpdateSummary dependency in group.OrderBy(dep => dep.DependencyName))
+                {
+                    stringBuilder.AppendLine($"  - {dependency.DependencyName}");
+                }
+            }
+        }
+
+        if (removedDependencyGroups.Count > 0)
+        {
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("**Removed Dependencies**");
+            foreach (var group in removedDependencyGroups)
+            {
+                DependencyUpdateSummary representative = group.First();
+                
+                stringBuilder.AppendLine($"- Removed {representative.FromVersion}");
+                foreach (DependencyUpdateSummary dependency in group.OrderBy(dep => dep.DependencyName))
+                {
+                    stringBuilder.AppendLine($"  - {dependency.DependencyName}");
+                }
+            }
+        }
+
+        if (updatedDependencyGroups.Count > 0)
+        {
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("**Updated Dependencies**");
+
+            foreach (var group in updatedDependencyGroups)
+            {
+                DependencyUpdateSummary representative = group.First();
+                string repository = (await GetProducingBuildAsync(representative, builds)).GetRepository();
+                string? diffLink = GetLinkForDependencyItem(
+                    repository,
+                    representative.FromCommitSha,
+                    representative.ToCommitSha);
+                
+                stringBuilder.AppendLine($"- From [{representative.FromVersion} to {representative.ToVersion}]({diffLink})");
+                foreach (DependencyUpdateSummary dependency in group.OrderBy(dep => dep.DependencyName))
+                {
+                    stringBuilder.AppendLine($"  - {dependency.DependencyName}");
+                }
+            }
+        }
+        return stringBuilder.ToString();
     }
 
     private async Task<BuildDTO> GetProducingBuildAsync(
@@ -482,103 +561,6 @@ internal class PullRequestBuilder : IPullRequestBuilder
         build.Assets.Any(asset =>
             asset.Name == dependency.DependencyName &&
             asset.Version == dependency.ToVersion);
-
-    internal static Task<string> CreateDependencyUpdateBlockForRepositoryAsync(
-        List<DependencyUpdateSummary> dependencyUpdateSummaries,
-        string repository) =>
-        CreateDependencyUpdateBlockAsync(
-            dependencyUpdateSummaries,
-            _ => Task.FromResult(repository));
-
-    private static async Task<string> CreateDependencyUpdateBlockAsync(
-        List<DependencyUpdateSummary> dependencyUpdateSummaries,
-        Func<DependencyUpdateSummary, Task<string>> getRepositoryAsync)
-    {
-        if (dependencyUpdateSummaries.Count == 0)
-        {
-            return string.Empty;
-        }
-
-        StringBuilder stringBuilder = new();
-
-        // Group all dependencies by FromCommitSha, FromVersion, ToCommitSha, and ToVersion
-        var dependencyGroups = dependencyUpdateSummaries
-            .GroupBy(dep => new
-            {
-                dep.FromCommitSha,
-                dep.FromVersion,
-                dep.ToCommitSha,
-                dep.ToVersion
-            })
-            .ToList();
-
-        // Separate groups by dependency type
-        var newDependencyGroups = dependencyGroups.Where(g => string.IsNullOrEmpty(g.Key.FromVersion) && !string.IsNullOrEmpty(g.Key.ToVersion)).ToList();
-        var removedDependencyGroups = dependencyGroups.Where(g => string.IsNullOrEmpty(g.Key.ToVersion) && !string.IsNullOrEmpty(g.Key.FromVersion)).ToList();
-        var updatedDependencyGroups = dependencyGroups.Where(g => !string.IsNullOrEmpty(g.Key.FromVersion) && !string.IsNullOrEmpty(g.Key.ToVersion)).ToList();
-
-        if (newDependencyGroups.Count > 0)
-        {
-            stringBuilder.AppendLine();
-            stringBuilder.AppendLine("**New Dependencies**");
-            foreach (var group in newDependencyGroups)
-            {
-                DependencyUpdateSummary representative = group.First();
-                string repository = await getRepositoryAsync(representative);
-                string? diffLink = GetLinkForDependencyItem(
-                    repository,
-                    representative.FromCommitSha,
-                    representative.ToCommitSha);
-                
-                stringBuilder.AppendLine($"- Added [{representative.ToVersion}]({diffLink})");
-                foreach (DependencyUpdateSummary dependency in group.OrderBy(dep => dep.DependencyName))
-                {
-                    stringBuilder.AppendLine($"  - {dependency.DependencyName}");
-                }
-            }
-        }
-
-        if (removedDependencyGroups.Count > 0)
-        {
-            stringBuilder.AppendLine();
-            stringBuilder.AppendLine("**Removed Dependencies**");
-            foreach (var group in removedDependencyGroups)
-            {
-                DependencyUpdateSummary representative = group.First();
-                
-                stringBuilder.AppendLine($"- Removed {representative.FromVersion}");
-                foreach (DependencyUpdateSummary dependency in group.OrderBy(dep => dep.DependencyName))
-                {
-                    stringBuilder.AppendLine($"  - {dependency.DependencyName}");
-                }
-            }
-        }
-
-        if (updatedDependencyGroups.Count > 0)
-        {
-            stringBuilder.AppendLine();
-            stringBuilder.AppendLine("**Updated Dependencies**");
-
-            foreach (var group in updatedDependencyGroups)
-            {
-                DependencyUpdateSummary representative = group.First();
-                string repository = await getRepositoryAsync(representative);
-                string? diffLink = GetLinkForDependencyItem(
-                    repository,
-                    representative.FromCommitSha,
-                    representative.ToCommitSha);
-                
-                stringBuilder.AppendLine($"- From [{representative.FromVersion} to {representative.ToVersion}]({diffLink})");
-                foreach (DependencyUpdateSummary dependency in group.OrderBy(dep => dep.DependencyName))
-                {
-                    stringBuilder.AppendLine($"  - {dependency.DependencyName}");
-                }
-            }
-        }
-        return stringBuilder.ToString();
-    }
-
-
 
     private static string? GetLinkForDependencyItem(string repoUri, string? fromCommitSha, string? toCommitSha)
     {

--- a/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -468,7 +468,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             ToCommitSha = "xyz890"
         };
 
-        string dependencyBlock = await PullRequestBuilder.CreateDependencyUpdateBlockForRepositoryAsync(
+        string dependencyBlock = await CreateDependencyUpdateBlockForRepositoryAsync(
             [newDependency, removedDependency, updatedDependency],
             "https://github.com/Foo");
 
@@ -520,7 +520,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             ToCommitSha = "xyz890"
         };
 
-        string dependencyBlock = await PullRequestBuilder.CreateDependencyUpdateBlockForRepositoryAsync(
+        string dependencyBlock = await CreateDependencyUpdateBlockForRepositoryAsync(
             [groupedDependency1, groupedDependency2, separateDependency],
             "https://github.com/Foo");
 
@@ -569,7 +569,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
         };
 
         // Pass dependencies in Z, A, M order to verify alphabetical sorting
-        string dependencyBlock = await PullRequestBuilder.CreateDependencyUpdateBlockForRepositoryAsync(
+        string dependencyBlock = await CreateDependencyUpdateBlockForRepositoryAsync(
             [dependencyZ, dependencyA, dependencyM],
             "https://github.com/Foo");
 
@@ -969,7 +969,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
         };
 
         // Pass dependencies in non-alphabetical order to verify sorting within groups
-        string dependencyBlock = await PullRequestBuilder.CreateDependencyUpdateBlockForRepositoryAsync(
+        string dependencyBlock = await CreateDependencyUpdateBlockForRepositoryAsync(
             [
                 newDep2, newDep1, newDep3,  // new deps out of order
                 removedDep1, removedDep3, removedDep2,  // removed deps out of order
@@ -1021,6 +1021,46 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             });
 
         return description;
+    }
+
+    private async Task<string> CreateDependencyUpdateBlockForRepositoryAsync(
+        List<DependencyUpdateSummary> dependencies,
+        string repository)
+    {
+        List<Asset> assets = dependencies
+            .Where(dependency => !string.IsNullOrEmpty(dependency.ToVersion))
+            .Select((dependency, index) => new Asset(
+                index + 1,
+                1,
+                false,
+                dependency.DependencyName,
+                dependency.ToVersion,
+                []))
+            .ToList();
+        Build build = new(
+            id: 1,
+            dateProduced: DateTimeOffset.Now,
+            staleness: 0,
+            released: false,
+            stable: false,
+            commit: "commit",
+            channels: [],
+            assets: assets,
+            dependencies: [],
+            incoherencies: [])
+        {
+            GitHubRepository = repository
+        };
+
+        string dependencyBlock = null!;
+        await Execute(
+            async context =>
+            {
+                var builder = ActivatorUtilities.CreateInstance<PullRequestBuilder>(context);
+                dependencyBlock = await builder.CreateDependencyUpdateBlockAsync(dependencies, build);
+            });
+
+        return dependencyBlock;
     }
 
     [Test]

--- a/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
+++ b/test/ProductConstructionService/ProductConstructionService.DependencyFlow.Tests/PullRequestBuilderTests.cs
@@ -163,7 +163,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
         GivenACodeFlowSubscription(new());
         Subscription.ChannelId = 1234;
 
-        List<DependencyUpdateSummary> dependencyUpdates = GivenDependencyUpdateSummaries();
+        List<DependencyUpdateSummary> dependencyUpdates = GivenDependencyUpdateSummaries(build);
 
         List<UpstreamRepoDiff> upstreamRepoDiffs =
         [
@@ -258,6 +258,14 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             FromVersion = u.FromVersion,
             ToVersion = "3.0.0",
         })];
+        build.Assets.AddRange(dependencyUpdates.Select((dependency, index) =>
+            new Asset(
+                index + 1,
+                build.Id,
+                false,
+                dependency.DependencyName,
+                dependency.ToVersion,
+                [])));
 
         await Execute(
             async context =>
@@ -324,7 +332,114 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
     }
 
     [Test]
-    public void ShouldReturnCorrectDependencyUpdateBlock()
+    public async Task ShouldUseProducingBuildRepositoriesForDependencyLinksAndReuseBuild()
+    {
+        const string sourceRepository = "https://github.com/dotnet/dotnet";
+        const string firstProducingRepository = "https://github.com/dotnet/runtime";
+        const string secondProducingRepository = "https://github.com/dotnet/roslyn";
+        const string firstProducingCommit = "firstNewCommit";
+        const string secondProducingCommit = "secondNewCommit";
+        const string toVersion = "2.0.0";
+
+        Build sourceBuild = GivenANewBuildId(101, "sourceCommit");
+        sourceBuild.GitHubRepository = sourceRepository;
+        sourceBuild.GitHubBranch = "main";
+        sourceBuild.AzureDevOpsBuildNumber = "source-build";
+
+        Asset firstAsset = new(1, 202, false, "First.Dependency", toVersion, []);
+        Asset secondAsset = new(2, 202, false, "Second.Dependency", toVersion, []);
+        Build firstProducingBuild = GivenANewBuildId(202, firstProducingCommit);
+        firstProducingBuild.GitHubRepository = firstProducingRepository;
+        firstProducingBuild.Assets.AddRange([firstAsset, secondAsset]);
+
+        Asset thirdAsset = new(3, 303, false, "Third.Dependency", toVersion, []);
+        Build secondProducingBuild = GivenANewBuildId(303, secondProducingCommit);
+        secondProducingBuild.GitHubRepository = secondProducingRepository;
+        secondProducingBuild.Assets.Add(thirdAsset);
+        const string removedDependencyName = "Removed.Dependency";
+        const string removedDependencyVersion = "1.0.0";
+
+        _barClient
+            .Setup(client => client.GetAssetsAsync(firstAsset.Name, firstAsset.Version, null, null))
+            .ReturnsAsync([firstAsset]);
+        _barClient
+            .Setup(client => client.GetAssetsAsync(thirdAsset.Name, thirdAsset.Version, null, null))
+            .ReturnsAsync([thirdAsset]);
+
+        GivenACodeFlowSubscription(new());
+
+        List<DependencyUpdateSummary> dependencyUpdates =
+        [
+            new()
+            {
+                DependencyName = firstAsset.Name,
+                FromVersion = "1.0.0",
+                ToVersion = firstAsset.Version,
+                FromCommitSha = "oldCommit",
+                ToCommitSha = firstProducingCommit
+            },
+            new()
+            {
+                DependencyName = secondAsset.Name,
+                FromVersion = "1.0.0",
+                ToVersion = secondAsset.Version,
+                FromCommitSha = "oldCommit",
+                ToCommitSha = firstProducingCommit
+            },
+            new()
+            {
+                DependencyName = thirdAsset.Name,
+                FromVersion = "1.0.0",
+                ToVersion = thirdAsset.Version,
+                FromCommitSha = "oldCommit",
+                ToCommitSha = secondProducingCommit
+            },
+            new()
+            {
+                DependencyName = removedDependencyName,
+                FromVersion = removedDependencyVersion,
+                ToVersion = null,
+                FromCommitSha = "oldCommit",
+                ToCommitSha = null
+            }
+        ];
+
+        string? description = null;
+        await Execute(
+            async context =>
+            {
+                var builder = ActivatorUtilities.CreateInstance<PullRequestBuilder>(context);
+                description = await builder.GenerateCodeFlowPRDescription(
+                    sourceBuild,
+                    ToClientModelSubscription(Subscription),
+                    "pr-branch",
+                    "previousSourceCommit",
+                    dependencyUpdates,
+                    upstreamRepoDiffs: [],
+                    currentDescription: null,
+                    unsafeFlow: false);
+            });
+
+        description.Should().Contain(
+            $"{firstProducingRepository}/compare/oldCommit...{firstProducingCommit[..PullRequestBuilder.GitHubComparisonShaLength]}");
+        description.Should().Contain(
+            $"{secondProducingRepository}/compare/oldCommit...{secondProducingCommit[..PullRequestBuilder.GitHubComparisonShaLength]}");
+        description.Should().NotContain($"{sourceRepository}/compare/oldCommit...");
+        _barClient.Verify(
+            client => client.GetAssetsAsync(firstAsset.Name, firstAsset.Version, null, null),
+            Times.Once);
+        _barClient.Verify(
+            client => client.GetAssetsAsync(secondAsset.Name, secondAsset.Version, null, null),
+            Times.Never);
+        _barClient.Verify(
+            client => client.GetAssetsAsync(removedDependencyName, removedDependencyVersion, null, null),
+            Times.Never);
+        _barClient.Verify(client => client.GetBuildAsync(firstProducingBuild.Id), Times.Once);
+        _barClient.Verify(client => client.GetBuildAsync(secondProducingBuild.Id), Times.Once);
+    }
+
+    [Test]
+    public async Task ShouldReturnCorrectDependencyUpdateBlock()
     {
         DependencyUpdateSummary newDependency = new()
         {
@@ -353,7 +468,9 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             ToCommitSha = "xyz890"
         };
 
-        string dependencyBlock = PullRequestBuilder.CreateDependencyUpdateBlock([newDependency, removedDependency, updatedDependency], "https://github.com/Foo");
+        string dependencyBlock = await PullRequestBuilder.CreateDependencyUpdateBlockForRepositoryAsync(
+            [newDependency, removedDependency, updatedDependency],
+            "https://github.com/Foo");
 
         dependencyBlock.Should().Be(
             """
@@ -374,7 +491,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
     }
 
     [Test]
-    public void ShouldGroupDependenciesWithSameVersionRange()
+    public async Task ShouldGroupDependenciesWithSameVersionRange()
     {
         DependencyUpdateSummary groupedDependency1 = new()
         {
@@ -403,7 +520,9 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
             ToCommitSha = "xyz890"
         };
 
-        string dependencyBlock = PullRequestBuilder.CreateDependencyUpdateBlock([groupedDependency1, groupedDependency2, separateDependency], "https://github.com/Foo");
+        string dependencyBlock = await PullRequestBuilder.CreateDependencyUpdateBlockForRepositoryAsync(
+            [groupedDependency1, groupedDependency2, separateDependency],
+            "https://github.com/Foo");
 
         dependencyBlock.Should().Be(
             """
@@ -419,7 +538,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
     }
 
     [Test]
-    public void ShouldOrderDependenciesAlphabeticallyWithinGroups()
+    public async Task ShouldOrderDependenciesAlphabeticallyWithinGroups()
     {
         // Create dependencies in non-alphabetical order to verify sorting
         DependencyUpdateSummary dependencyZ = new()
@@ -450,7 +569,9 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
         };
 
         // Pass dependencies in Z, A, M order to verify alphabetical sorting
-        string dependencyBlock = PullRequestBuilder.CreateDependencyUpdateBlock([dependencyZ, dependencyA, dependencyM], "https://github.com/Foo");
+        string dependencyBlock = await PullRequestBuilder.CreateDependencyUpdateBlockForRepositoryAsync(
+            [dependencyZ, dependencyA, dependencyM],
+            "https://github.com/Foo");
 
         dependencyBlock.Should().Be(
             """
@@ -627,9 +748,9 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
         return dependencies;
     }
 
-    private static List<DependencyUpdateSummary> GivenDependencyUpdateSummaries()
+    private List<DependencyUpdateSummary> GivenDependencyUpdateSummaries(Build build)
     {
-        return [
+        List<DependencyUpdateSummary> dependencies = [
             new DependencyUpdateSummary
             {
                 DependencyName = "Foo.Bar",
@@ -655,6 +776,32 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
                 ToCommitSha = "xyz890"
             }
         ];
+
+        int nextBuildId = build.Id + 1;
+        foreach (IGrouping<string, DependencyUpdateSummary> dependencyGroup in dependencies.GroupBy(dependency => dependency.ToCommitSha))
+        {
+            List<Asset> assets = dependencyGroup
+                .Select((dependency, index) => new Asset(
+                    index + 1,
+                    nextBuildId,
+                    false,
+                    dependency.DependencyName,
+                    dependency.ToVersion,
+                    []))
+                .ToList();
+            Build producingBuild = GivenANewBuildId(nextBuildId, dependencyGroup.Key);
+            producingBuild.GitHubRepository = build.GitHubRepository;
+            producingBuild.Assets.AddRange(assets);
+
+            Asset firstAsset = assets[0];
+            _barClient
+                .Setup(client => client.GetAssetsAsync(firstAsset.Name, firstAsset.Version, null, null))
+                .ReturnsAsync([firstAsset]);
+
+            nextBuildId++;
+        }
+
+        return dependencies;
     }
 
     private static SubscriptionUpdateWorkItem GivenSubscriptionUpdate(
@@ -735,7 +882,7 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
     }
 
     [Test]
-    public void ShouldGroupAllTypesOfDependencyChanges()
+    public async Task ShouldGroupAllTypesOfDependencyChanges()
     {
         // New Dependencies - multiple packages with same version
         DependencyUpdateSummary newDep1 = new()
@@ -822,11 +969,13 @@ internal class PullRequestBuilderTests : SubscriptionOrPullRequestUpdaterTests
         };
 
         // Pass dependencies in non-alphabetical order to verify sorting within groups
-        string dependencyBlock = PullRequestBuilder.CreateDependencyUpdateBlock([
-            newDep2, newDep1, newDep3,  // new deps out of order
-            removedDep1, removedDep3, removedDep2,  // removed deps out of order
-            updatedDep2, updatedDep3, updatedDep1   // updated deps out of order
-        ], "https://github.com/Test");
+        string dependencyBlock = await PullRequestBuilder.CreateDependencyUpdateBlockForRepositoryAsync(
+            [
+                newDep2, newDep1, newDep3,  // new deps out of order
+                removedDep1, removedDep3, removedDep2,  // removed deps out of order
+                updatedDep2, updatedDep3, updatedDep1   // updated deps out of order
+            ],
+            "https://github.com/Test");
 
         dependencyBlock.Should().Be(
             """

--- a/tools/ProductConstructionService.ReproTool/Operations/CopyBuildOperation.cs
+++ b/tools/ProductConstructionService.ReproTool/Operations/CopyBuildOperation.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Maestro.Common;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.ProductConstructionService.Client;
+using Microsoft.DotNet.ProductConstructionService.Client.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ProductConstructionService.ReproTool.Options;
+using GitHubClient = Octokit.GitHubClient;
+
+namespace ProductConstructionService.ReproTool.Operations;
+
+internal class CopyBuildOperation(
+        CopyBuildOptions options,
+        IBarApiClient prodBarClient,
+        [FromKeyedServices("local")] IProductConstructionServiceApi localPcsApi,
+        GitHubClient ghClient,
+        ILogger<CopyBuildOperation> logger)
+    : Operation(logger, ghClient, localPcsApi)
+{
+    internal override async Task RunAsync()
+    {
+        logger.LogInformation("Fetching production BAR build {buildId}", options.BuildId);
+
+        Build productionBuild = await prodBarClient.GetBuildAsync(
+            options.BuildId,
+            includeAssetLocation: true);
+
+        string productionRepository = productionBuild.GetRepository();
+        (string repositoryName, _) = GitRepoUrlUtils.GetRepoNameAndOwner(productionRepository);
+        string localRepository = $"https://github.com/{MaestroAuthTestOrgName}/{repositoryName}";
+
+        List<AssetData> assets = productionBuild.Assets
+            .Select(asset => new AssetData(asset.NonShipping)
+            {
+                Name = asset.Name,
+                Version = asset.Version,
+                Locations = asset.Locations?
+                    .Select(location => new AssetLocationData(location.Type)
+                    {
+                        Location = location.Location
+                    })
+                    .ToList()
+            })
+            .ToList();
+
+        Build localBuild = await CreateBuildAsync(
+            localRepository,
+            productionBuild.GetBranch(),
+            productionBuild.Commit,
+            assets);
+
+        logger.LogInformation(
+            "Created local BAR build {localBuildId} from production build {productionBuildId} with {assetCount} assets",
+            localBuild.Id,
+            productionBuild.Id,
+            assets.Count);
+    }
+}

--- a/tools/ProductConstructionService.ReproTool/Options/CopyBuildOptions.cs
+++ b/tools/ProductConstructionService.ReproTool/Options/CopyBuildOptions.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using ProductConstructionService.ReproTool.Operations;
+
+namespace ProductConstructionService.ReproTool.Options;
+
+[Verb("copy-build", HelpText = "Copies a production BAR build into local PCS using its maestro-auth-test repository")]
+internal class CopyBuildOptions : Options
+{
+    [Option("build", HelpText = "Production BAR build ID to copy", Required = true)]
+    public int BuildId { get; init; }
+
+    internal override Operation GetOperation(IServiceProvider sp)
+        => ActivatorUtilities.CreateInstance<CopyBuildOperation>(sp, this);
+}

--- a/tools/ProductConstructionService.ReproTool/Program.cs
+++ b/tools/ProductConstructionService.ReproTool/Program.cs
@@ -15,6 +15,7 @@ Type[] options =
 [
     typeof(ReproOptions),
     typeof(FlowCommitOptions),
+    typeof(CopyBuildOptions),
 ];
 
 Parser.Default.ParseArguments(args, options)


### PR DESCRIPTION
repro https://github.com/maestro-auth-test/emsdk/pull/10, the llvm links are good, the node ones are not because I didn't mock that build

https://github.com/dotnet/arcade-services/issues/6617