### PR TITLE
Don't change Protocol Message `State` in asp middleware

### DIFF
--- a/eng/service-templates/ProductConstructionService/container-environment.bicep
+++ b/eng/service-templates/ProductConstructionService/container-environment.bicep
@@ -11,7 +11,7 @@ resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2021-12-01-previ
   name: logAnalyticsName
   location: location
   properties: any({
-      retentionInDays: 30
+      retentionInDays: 90
       features: {
           searchVersion: 1
       }

--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/AuthenticationConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/AuthenticationConfiguration.cs
@@ -9,6 +9,8 @@ namespace ProductConstructionService.Api.Configuration;
 
 internal static class AuthenticationConfiguration
 {
+    private static readonly TimeSpan SessionIdleTimeout = TimeSpan.FromMinutes(30);
+
     public const string EntraAuthorizationSchemeName = "Entra";
     public const string ApiAuthorizationPolicyName = "MsftApi";
     public const string WebAuthorizationPolicyName = "MsftWeb";
@@ -43,6 +45,8 @@ internal static class AuthenticationConfiguration
             // Allow /DependencyFlow pages to render for authenticated users in iframe on Azure DevOps dashboard
             // with browsers that support third-party cookies.
             cookieAuthOptions.Cookie.SameSite = SameSiteMode.None;
+            cookieAuthOptions.ExpireTimeSpan = SessionIdleTimeout;
+            cookieAuthOptions.SlidingExpiration = true;
         });
 
         // Register Entra based authentication

--- a/src/ProductConstructionService/ProductConstructionService.Api/Configuration/AuthenticationConfiguration.cs
+++ b/src/ProductConstructionService/ProductConstructionService.Api/Configuration/AuthenticationConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Identity.Web;
@@ -70,36 +69,7 @@ internal static class AuthenticationConfiguration
                 {
                     options.Events.OnRedirectToIdentityProvider += context =>
                     {
-                        var returnUrl = context.Request.Path + context.Request.QueryString;
                         context.ProtocolMessage.RedirectUri = redirectUri;
-                        context.ProtocolMessage.State = Convert.ToBase64String(Encoding.UTF8.GetBytes(returnUrl));
-                        return Task.CompletedTask;
-                    };
-
-                    options.Events.OnMessageReceived += context =>
-                    {
-                        // The redirect_uri is set to the one we have in the configuration, but we need to
-                        // redirect to the one that was used to authenticate.
-                        if (!string.IsNullOrEmpty(context.ProtocolMessage.State))
-                        {
-                            try
-                            {
-                                var returnUrl = Encoding.UTF8.GetString(Convert.FromBase64String(context.ProtocolMessage.State));
-                                context.Response.Redirect(returnUrl);
-                            }
-                            catch (FormatException)
-                            {
-                                // Handle malformed state value gracefully, e.g., redirect to a safe default or log the error
-                                // For now, redirect to root
-                                context.Response.Redirect("/");
-                            }
-                        }
-                        else
-                        {
-                            // If no state is provided, redirect to the root
-                            context.Response.Redirect("/");
-                        }
-
                         return Task.CompletedTask;
                     };
                 }


### PR DESCRIPTION
This shouldn't be needed, and we're overwriting protected data that Asp actually uses for extra security context.
https://github.com/dotnet/arcade-services/issues/6448